### PR TITLE
feat(kit): reconnect and foreground resync

### DIFF
--- a/Sources/HerdrKit/HerdrClient.swift
+++ b/Sources/HerdrKit/HerdrClient.swift
@@ -50,6 +50,17 @@ public actor HerdrClient {
         try await call("agent.list", EmptyParams(), as: AgentListResult.self).agents
     }
 
+    /// The complete pane set, as a value that carries its own provenance.
+    ///
+    /// `SessionRecovery.observe` takes this rather than `[AgentInfo]` because an
+    /// array can be filtered and a `PaneSnapshot` cannot be constructed outside
+    /// the module. A partial listing silently unsubscribes every omitted pane,
+    /// and their silence afterwards is indistinguishable from having no output —
+    /// so "this is the whole set" is enforced by where the value came from.
+    public func paneSnapshot() async throws -> PaneSnapshot {
+        PaneSnapshot(agents: try await agentList())
+    }
+
     struct ReadParams: Encodable {
         let target: String
         let source: ReadSource

--- a/Sources/HerdrKit/SessionRecovery.swift
+++ b/Sources/HerdrKit/SessionRecovery.swift
@@ -149,15 +149,30 @@ final class AttemptAuthority: @unchecked Sendable {
     }
 
     /// Admits the panes not already subscribed, records them, and returns ONLY
-    /// the newly admitted — nil when there is no adopted connection to
-    /// subscribe on. Check, record and connection gate share the section, so no
-    /// interleaving can admit a pane twice or emit for a dead transport.
-    func admitWhileConnected(_ panes: Set<String>) -> Set<String>? {
+    /// the newly admitted — nil when the data's provenance is not the currently
+    /// adopted attempt, or there is no adopted connection. Provenance, the
+    /// connection gate, the check and the record share one section: a delayed
+    /// snapshot or pane event from an abandoned attempt is indistinguishable
+    /// from current data by CONTENT, so the attempt that produced it is the
+    /// only thing that can reject it — and without this gate, a probe admitted
+    /// an abandoned attempt's closed pane onto the replacement's ledger,
+    /// irretractably.
+    func admitWhileConnected(_ panes: Set<String>, from attempt: AttemptID) -> Set<String>? {
         lock.lock(); defer { lock.unlock() }
-        guard _connectedSince != nil else { return nil }
+        guard attempt == _current, _connectedSince != nil else { return nil }
         let fresh = panes.subtracting(_subscribedPanes)
         _subscribedPanes.formUnion(fresh)
         return fresh
+    }
+
+    /// True iff the attempt is current — for gating KNOWLEDGE mutations from
+    /// transport-delivered data (snapshots, pane events) the same way
+    /// subscriptions are gated. Reading it and acting is two steps for
+    /// knowledge, acceptably: stale knowledge is bounded (next snapshot
+    /// corrects it), unlike a stale subscription, which nothing can retract.
+    func isCurrent(_ attempt: AttemptID) -> Bool {
+        lock.lock(); defer { lock.unlock() }
+        return attempt == _current
     }
 }
 
@@ -191,11 +206,15 @@ public enum ClientEvent: Equatable, Sendable {
     case networkChanged(at: Date)
     case backgrounded(at: Date)
     case foregrounded(at: Date)
-    /// The event stream reported a pane that did not exist before.
-    case paneCreated(String)
-    /// A pane went away. Without this, the only way to remove one is a wholesale
-    /// replacement, which is what made partial listings dangerous.
-    case paneClosed(String)
+    /// The event stream reported a pane that did not exist before. Carries the
+    /// attempt whose transport delivered it: a late event from an abandoned
+    /// attempt is indistinguishable from a current one by content, and without
+    /// provenance it could subscribe or mutate the replacement transport.
+    case paneCreated(String, from: AttemptID)
+    /// A pane went away, per the transport of the carried attempt. Without this
+    /// event, the only way to remove one is a wholesale replacement, which is
+    /// what made partial listings dangerous.
+    case paneClosed(String, from: AttemptID)
 }
 
 /// One step of recovery, in the order it must happen.
@@ -213,8 +232,11 @@ public enum RecoveryAction: Equatable, Sendable {
     /// Open a new transport, tagging it with this identifier. Every later
     /// `connected` or `transportFailed` must carry it back.
     case reconnect(AttemptID, after: TimeInterval)
-    /// Drop every cached pane generation and refetch.
-    case resyncAllPanes
+    /// Drop every cached pane generation and refetch — ON the carried
+    /// attempt's transport. The snapshot that comes back must be handed to
+    /// `observe` WITH this attempt, so a resync outlived by its attempt
+    /// produces data that is recognisably stale rather than silently admitted.
+    case resyncAllPanes(AttemptID)
     /// Open subscriptions for these panes. The pane-scoped subscription kinds
     /// have **no wildcard**, so a pane absent here is a pane nothing is
     /// watching. (`Wire.swift` also models non-pane-scoped subscription kinds;
@@ -360,8 +382,10 @@ public struct SessionRecovery: Sendable {
         /// authority, so a restored copy reports the LINEAGE's current attempt,
         /// not the one it was carrying when saved.
         public var currentAttempt: AttemptID? { authority.current }
-        /// Every pane the client believes exists. Subscriptions are pane-scoped,
-        /// so this is also the re-subscribe list on the next adoption.
+        /// Every pane the client believes exists. INFORMATIONAL ONLY: it is
+        /// never a subscription source — adoption emits resync alone, and every
+        /// replacement-transport subscription comes from the post-adoption
+        /// authoritative snapshot through `observe`.
         public internal(set) var knownPanes: Set<String> = []
         /// Panes with an open subscription on the CURRENT transport. Distinct
         /// from `knownPanes`, and the distinction is load-bearing: a snapshot
@@ -436,7 +460,7 @@ public struct SessionRecovery: Sendable {
                 // `observe`, whose atomic admission subscribes exactly what the
                 // server says exists. Remembered panes are never subscription
                 // targets — knowledge is not a decision input any more.
-                return RecoveryPlan([.resyncAllPanes])
+                return RecoveryPlan([.resyncAllPanes(attempt)])
             }
 
         case .transportFailed(let attempt, let at):
@@ -486,19 +510,22 @@ public struct SessionRecovery: Sendable {
             // follow on `connected`; there is no transport yet to run them on.
             return RecoveryPlan([.cancelTransport, .reconnect(state.authority.foregroundAndMint(), after: 0)])
 
-        case .paneCreated(let pane):
-            state.knownPanes.insert(pane)
-            // Admission is atomic on the authority: the connection gate, the
-            // already-subscribed check and the record are one critical section,
-            // so concurrent discoveries can neither drop a ledger entry nor
-            // subscribe a pane twice. Not connected -> the next adoption's
-            // full-set subscribe covers it.
-            guard let fresh = state.authority.admitWhileConnected([pane]), !fresh.isEmpty else {
+        case .paneCreated(let pane, let from):
+            // The atomic admission is the ONLY gate — provenance, connection,
+            // already-subscribed check and record in one section. Knowledge
+            // follows the verdict: an event a dead transport delivered is not
+            // knowledge either. An event arriving from the CURRENT attempt
+            // before its adoption is processed also admits nothing, and needs
+            // nothing — the post-adoption snapshot covers it via observe.
+            guard let fresh = state.authority.admitWhileConnected([pane], from: from) else {
                 return RecoveryPlan()
             }
+            state.knownPanes.insert(pane)
+            guard !fresh.isEmpty else { return RecoveryPlan() }
             return RecoveryPlan([.subscribe(fresh)])
 
-        case .paneClosed(let pane):
+        case .paneClosed(let pane, let from):
+            guard state.authority.isCurrent(from) else { return RecoveryPlan() }
             state.knownPanes.remove(pane)
             return RecoveryPlan()
         }
@@ -523,15 +550,27 @@ public struct SessionRecovery: Sendable {
     /// even the app-layer workaround closed: `paneCreated` for it returned
     /// nothing, since the pane was already known. Subscriptions are pane-scoped
     /// with no wildcard, so nothing else would ever cover it.
-    public func observe(_ snapshot: PaneSnapshot, state: inout State) -> RecoveryPlan {
+    public func observe(
+        _ snapshot: PaneSnapshot, from attempt: AttemptID, state: inout State
+    ) -> RecoveryPlan {
+        // ONE gate decides everything: atomic admission checks provenance, the
+        // connection, the ledger and records — and KNOWLEDGE follows its
+        // verdict. A first version had an outer isCurrent guard ahead of this,
+        // which was both a twin (the inner provenance check became unreachable
+        // — its mutation survived) and itself a two-acquisition split of the
+        // kind this review has repeatedly killed. Admission failing means the
+        // snapshot came from a dead transport or none: it is not knowledge
+        // either.
+        //
+        // The knowledge write lands after the section; a retirement between
+        // verdict and write leaves knowledge stale-but-bounded (the next
+        // current snapshot replaces it) — the documented, tolerable class,
+        // unlike a stale subscription, which nothing can retract.
+        guard let fresh = state.authority.admitWhileConnected(snapshot.paneIDs, from: attempt) else {
+            return RecoveryPlan()
+        }
         state.knownPanes = snapshot.paneIDs
-        // Atomic admission against the SUBSCRIPTION ledger, not prior
-        // knowledge: a pane this transport already watches must not be
-        // subscribed twice however many times snapshots forget and rediscover
-        // it, and a shrink leaves its open subscriptions in place because
-        // nothing on the wire can close one short of the connection itself.
-        guard let fresh = state.authority.admitWhileConnected(snapshot.paneIDs),
-              !fresh.isEmpty else { return RecoveryPlan() }
+        guard !fresh.isEmpty else { return RecoveryPlan() }
         return RecoveryPlan([.subscribe(fresh)])
     }
 }

--- a/Sources/HerdrKit/SessionRecovery.swift
+++ b/Sources/HerdrKit/SessionRecovery.swift
@@ -1,12 +1,26 @@
 import Foundation
 
-/// Something that happened to the connection or the app, which the client must
-/// react to.
+/// Identifies one connection attempt.
+///
+/// Without this, recovery cannot tell a completion it asked for from one it
+/// cancelled. A network change that abandons attempt A and starts B does not
+/// stop A from finishing: `connected(A)` would be adopted, emit a resync and
+/// subscriptions, and then `connected(B)` would do it all again — and a late
+/// `transportFailed(A)` would tear down the B that had already been adopted.
+///
+/// Ordering the actions did not fix that, and could not: order is about the
+/// steps inside one plan, and this is about which *attempt* a callback belongs
+/// to.
+public struct AttemptID: Equatable, Hashable, Sendable {
+    let value: UInt64
+}
+
+/// Something that happened to the connection or the app.
 public enum ClientEvent: Equatable, Sendable {
-    /// A transport finished establishing and is usable.
-    case connected(at: Date)
-    /// The transport dropped, or a request failed in a way that ends the session.
-    case transportFailed(at: Date)
+    /// The attempt with this identifier finished establishing.
+    case connected(AttemptID, at: Date)
+    /// The attempt with this identifier dropped or failed.
+    case transportFailed(AttemptID, at: Date)
     /// The interface changed — Wi-Fi to cellular, a VPN came up, the address moved.
     case networkChanged(at: Date)
     case backgrounded(at: Date)
@@ -30,7 +44,9 @@ public enum RecoveryAction: Equatable, Sendable {
     /// rather than adopting it: adopting means opening subscriptions on a
     /// transport nobody is going to read.
     case discardConnection
-    case reconnect(after: TimeInterval)
+    /// Open a new transport, tagging it with this identifier. Every later
+    /// `connected` or `transportFailed` must carry it back.
+    case reconnect(AttemptID, after: TimeInterval)
     /// Drop every cached pane generation and refetch.
     case resyncAllPanes
     /// Open subscriptions for these panes. herdr's subscriptions are pane-scoped
@@ -59,7 +75,13 @@ public struct RecoveryPlan: Equatable, Sendable {
     public func contains(_ action: RecoveryAction) -> Bool { actions.contains(action) }
 
     public var reconnectDelay: TimeInterval? {
-        for case .reconnect(let after) in actions { return after }
+        for case .reconnect(_, let after) in actions { return after }
+        return nil
+    }
+
+    /// The attempt this plan opens, if it opens one.
+    public var reconnectAttempt: AttemptID? {
+        for case .reconnect(let attempt, _) in actions { return attempt }
         return nil
     }
 
@@ -127,6 +149,13 @@ public struct SessionRecovery: Sendable {
         public internal(set) var consecutiveFailures: Int = 0
         public internal(set) var connectedSince: Date?
         public internal(set) var isForeground: Bool = true
+        /// The only attempt whose callbacks are still wanted. Cleared by
+        /// cancellation, backgrounding and network changes, so anything that
+        /// completes afterwards is recognisably stale.
+        public internal(set) var currentAttempt: AttemptID?
+        /// Monotonic, so an identifier is never reused and a late callback can
+        /// never be mistaken for a current one.
+        internal var nextAttemptValue: UInt64 = 0
         /// Every pane the client believes exists. Subscriptions are pane-scoped,
         /// so this is also the re-subscribe list.
         public internal(set) var knownPanes: Set<String> = []
@@ -151,16 +180,37 @@ public struct SessionRecovery: Sendable {
         return TimeInterval.random(in: 0..<capped, using: &generator)
     }
 
+    /// Issues the next attempt identifier and makes it the only current one.
+    ///
+    /// Every prior attempt becomes stale at this point, which is what makes a
+    /// late callback recognisable rather than plausible.
+    private func nextAttempt(_ state: inout State) -> AttemptID {
+        state.nextAttemptValue += 1
+        let id = AttemptID(value: state.nextAttemptValue)
+        state.currentAttempt = id
+        return id
+    }
+
+    /// Starts the first attempt of a cold launch, where no event triggered it.
+    public func beginInitialAttempt(state: inout State) -> RecoveryPlan {
+        RecoveryPlan([.reconnect(nextAttempt(&state), after: 0)])
+    }
+
     public func plan(
         for event: ClientEvent,
         state: inout State,
         using generator: inout some RandomNumberGenerator
     ) -> RecoveryPlan {
         switch event {
-        case .connected(let at):
-            // A connection that completes after the client backgrounded is not
-            // wanted: adopting it opens persistent subscriptions on a transport
-            // nobody will read, and iOS is about to suspend the process anyway.
+        case .connected(let attempt, let at):
+            // Stale completions are the reason attempts are identified at all: a
+            // cancelled attempt still finishes, and adopting it opens persistent
+            // subscriptions on a transport the client already replaced.
+            guard attempt == state.currentAttempt else {
+                return RecoveryPlan([.discardConnection])
+            }
+            // A connection completing after the client backgrounded is not wanted
+            // either — iOS is about to suspend the process.
             guard state.isForeground else { return RecoveryPlan([.discardConnection]) }
             state.connectedSince = at
             // THE ONLY PLACE resync and subscription are emitted. Every
@@ -168,7 +218,11 @@ public struct SessionRecovery: Sendable {
             // than also on `foregrounded` is what makes it exactly once.
             return RecoveryPlan([.resyncAllPanes, .subscribe(state.knownPanes)])
 
-        case .transportFailed(let at):
+        case .transportFailed(let attempt, let at):
+            // A stale failure must not tear down the attempt that replaced it,
+            // nor count against the backoff — it is news about a connection
+            // nobody is using.
+            guard attempt == state.currentAttempt else { return RecoveryPlan() }
             // A connection that lasted counts as healthy, so the next failure
             // starts from a short delay rather than inheriting an old streak.
             if let since = state.connectedSince, at.timeIntervalSince(since) >= stabilityInterval {
@@ -176,10 +230,12 @@ public struct SessionRecovery: Sendable {
             }
             state.connectedSince = nil
             state.consecutiveFailures += 1
-            guard state.isForeground else { return RecoveryPlan() }
-            return RecoveryPlan([
-                .reconnect(after: backoff(failures: state.consecutiveFailures, using: &generator))
-            ])
+            guard state.isForeground else {
+                state.currentAttempt = nil
+                return RecoveryPlan()
+            }
+            let delay = backoff(failures: state.consecutiveFailures, using: &generator)
+            return RecoveryPlan([.reconnect(nextAttempt(&state), after: delay)])
 
         case .networkChanged:
             // Reconnect, not migrate. Cancel first: the old socket is bound to an
@@ -187,12 +243,14 @@ public struct SessionRecovery: Sendable {
             // dead interface fails by timing out rather than by erroring.
             state.connectedSince = nil
             state.consecutiveFailures = 0
+            state.currentAttempt = nil
             guard state.isForeground else { return RecoveryPlan([.cancelTransport]) }
-            return RecoveryPlan([.cancelTransport, .reconnect(after: 0)])
+            return RecoveryPlan([.cancelTransport, .reconnect(nextAttempt(&state), after: 0)])
 
         case .backgrounded:
             state.isForeground = false
             state.connectedSince = nil
+            state.currentAttempt = nil
             // Cancel rather than leave it open. A suspended process cannot read
             // the socket, and the server reaps it anyway — so the choice is
             // between closing it deliberately and discovering it dead later.
@@ -205,7 +263,7 @@ public struct SessionRecovery: Sendable {
             // Reconnect ONLY. The resync and subscriptions follow on `connected`,
             // because there is no transport yet to run them on — emitting them
             // here as well is what produced duplicate subscriptions.
-            return RecoveryPlan([.reconnect(after: 0)])
+            return RecoveryPlan([.reconnect(nextAttempt(&state), after: 0)])
 
         case .paneCreated(let pane):
             let isNew = state.knownPanes.insert(pane).inserted
@@ -220,18 +278,31 @@ public struct SessionRecovery: Sendable {
         }
     }
 
-    /// Replaces the known-pane set from an **authoritative** listing.
+    /// Replaces the known-pane set from an authoritative snapshot.
     ///
-    /// Takes `AgentInfo` rather than `[String]` deliberately. The previous
-    /// signature accepted any array and replaced the set wholesale, so a caller
-    /// passing a filtered or paged listing silently forgot every omitted pane —
-    /// and those panes stayed unwatched after the next reconnect, their silence
-    /// indistinguishable from having no output. `agent.list` returns the whole
-    /// set, so requiring its result makes a partial listing something you have to
-    /// construct on purpose rather than something you pass by accident.
+    /// Takes `PaneSnapshot`, which callers outside this module **cannot
+    /// construct**, rather than an array they can filter. The previous signature
+    /// took `[AgentInfo]` and was described as making a partial listing hard to
+    /// pass — it did not: `result.filter { … }` is exactly as easy to write as
+    /// `result`, and the test written to defend it in fact demonstrated a
+    /// one-element array silently deleting two known panes.
     ///
     /// Incremental discovery goes through `.paneCreated` / `.paneClosed`.
-    public func observe(agentList: [AgentInfo], state: inout State) {
-        state.knownPanes = Set(agentList.map(\.paneID))
+    public func observe(_ snapshot: PaneSnapshot, state: inout State) {
+        state.knownPanes = snapshot.paneIDs
+    }
+}
+
+/// The complete pane set as the server reported it.
+///
+/// Only `HerdrClient` can make one, so "this is the whole set" is enforced by
+/// where the value came from rather than by asking callers to be careful.
+public struct PaneSnapshot: Equatable, Sendable {
+    public let paneIDs: Set<String>
+
+    /// Internal on purpose: a caller outside the module cannot mint one from a
+    /// filtered list, which is the entire guarantee.
+    init(agents: [AgentInfo]) {
+        self.paneIDs = Set(agents.map(\.paneID))
     }
 }

--- a/Sources/HerdrKit/SessionRecovery.swift
+++ b/Sources/HerdrKit/SessionRecovery.swift
@@ -26,9 +26,19 @@ final class AttemptAuthority: @unchecked Sendable {
     private var _current: AttemptID?
     private var _connectedSince: Date?
     private var _subscribedPanes: Set<String> = []
+    private var _isForeground = true
 
     var current: AttemptID? {
         lock.lock(); defer { lock.unlock() }; return _current
+    }
+
+    /// Foreground is a DECISION INPUT — whether to dial — so it lives here, not
+    /// in the value State. Value-stored, a saved foregrounded copy restored
+    /// after backgrounding read true and `beginInitialAttempt` dialed while
+    /// suspended, defeating the no-dialing-while-backgrounded rule through
+    /// ordinary replay.
+    var isForeground: Bool {
+        lock.lock(); defer { lock.unlock() }; return _isForeground
     }
 
     /// When the CURRENT attempt's connection was adopted, or nil. Lives here —
@@ -51,12 +61,12 @@ final class AttemptAuthority: @unchecked Sendable {
     /// rediscovery. State copies share this object and both types are Sendable,
     /// so concurrent use is the advertised surface, not an abuse of it.
 
-    /// Mints a new attempt and makes it current. Tears down transport-scoped
-    /// state in the same section: every mint is a new transport, and clearing
-    /// here is what keeps `connectedSince` unable to describe a non-current
-    /// attempt's transport.
-    func mint() -> AttemptID {
-        lock.lock(); defer { lock.unlock() }
+    /// Every mint is foreground-gated INSIDE the section, because the
+    /// foreground check and the mint were previously two operations — and a
+    /// value-replayed foreground bit sat between them. There is deliberately no
+    /// unconditional mint: no path may dial while backgrounded.
+
+    private func unsafeMint() -> AttemptID {
         let id = AttemptID(uuid: UUID())
         _current = id
         _connectedSince = nil
@@ -64,13 +74,39 @@ final class AttemptAuthority: @unchecked Sendable {
         return id
     }
 
-    /// Clears authority and transport state without minting — backgrounding
-    /// and disconnection, where nothing should be dialing.
-    func teardown() {
+    /// Cold launch / caller restart: mints only if foregrounded, else nothing.
+    func mintIfForeground() -> AttemptID? {
+        lock.lock(); defer { lock.unlock() }
+        guard _isForeground else { return nil }
+        return unsafeMint()
+    }
+
+    /// Network change: the old transport is dead either way, so transport state
+    /// tears down unconditionally; a replacement is minted only if foregrounded.
+    func teardownAndMintIfForeground() -> AttemptID? {
         lock.lock(); defer { lock.unlock() }
         _current = nil
         _connectedSince = nil
         _subscribedPanes = []
+        guard _isForeground else { return nil }
+        return unsafeMint()
+    }
+
+    /// Backgrounding: no attempt survives it, nothing dials after it.
+    func backgroundAndTeardown() {
+        lock.lock(); defer { lock.unlock() }
+        _isForeground = false
+        _current = nil
+        _connectedSince = nil
+        _subscribedPanes = []
+    }
+
+    /// Foregrounding: becomes foreground and mints, one section, so no
+    /// interleaved backgrounding can slip between the two.
+    func foregroundAndMint() -> AttemptID {
+        lock.lock(); defer { lock.unlock() }
+        _isForeground = true
+        return unsafeMint()
     }
 
     enum AdoptOutcome {
@@ -89,22 +125,21 @@ final class AttemptAuthority: @unchecked Sendable {
         return .adopted
     }
 
-    /// Staleness check and failure teardown in one section.
-    enum FailOutcome {
-        /// The failing attempt was not current; touch nothing.
-        case stale
-        /// The failure was real; carries the adoption time it ended, if any,
-        /// for stability accounting.
-        case failed(endedConnectionFrom: Date?)
-    }
-
-    func failIfCurrent(_ attempt: AttemptID) -> FailOutcome {
+    /// Validates the failed attempt, retires it, and mints its replacement in
+    /// ONE section. The split version (fail-teardown, then a separate mint
+    /// after backoff computation) left the FAILED attempt current in between:
+    /// a gated probe re-adopted connected(A) for the failed transport inside
+    /// that window, and eight concurrent transportFailed(A) callbacks each
+    /// passed the same current-attempt check and earned eight reconnects.
+    /// Retirement and replacement are one fact now — duplicates find A already
+    /// retired and are stale.
+    func retireAndReplace(_ attempt: AttemptID) -> (replacement: AttemptID, endedConnectionFrom: Date?)? {
         lock.lock(); defer { lock.unlock() }
-        guard attempt == _current else { return .stale }
+        guard attempt == _current else { return nil }
         let since = _connectedSince
-        _connectedSince = nil
-        _subscribedPanes = []
-        return .failed(endedConnectionFrom: since)
+        // The failed attempt is retired and its replacement is current before
+        // the lock releases; there is no observable in-between.
+        return (replacement: unsafeMint(), endedConnectionFrom: since)
     }
 
     /// Admits the panes not already subscribed, records them, and returns ONLY
@@ -282,20 +317,20 @@ public struct SessionRecovery: Sendable {
     /// Stated at that strength and no more, after a sweep refuted the stronger
     /// claim ("every transition goes through plan()"): two other methods mutate
     /// state, and value semantics plus the public initialiser mean a caller can
-    /// still REPLACE the whole value. What survives replay: attempt minting
-    /// (fresh UUIDs), attempt authority, the connection record and the
-    /// subscription ledger — all read through the lineage's shared
-    /// `AttemptAuthority`, so a restored copy cannot reauthorize a cancelled
-    /// attempt, present its transport as connected, or replay its ledger. What
-    /// replay DOES restore: pane knowledge (refreshed by the next snapshot)
-    /// and the failure streak (worst case, a wrong backoff delay — degradation,
-    /// not misdirection). A WHOLESALE `State()` rebuild is a fresh lineage:
-    /// everything before it goes stale, which is the safe direction.
+    /// still REPLACE the whole value. Every DECISION INPUT reads through the
+    /// lineage's shared `AttemptAuthority` — attempt identity, the connection
+    /// record, the subscription ledger, and the foreground bit (a value-stored
+    /// foreground was the last replay: a saved foregrounded copy dialed while
+    /// backgrounded) — so a restored copy cannot reauthorize a cancelled
+    /// attempt, present a dead transport as connected, replay its ledger, or
+    /// dial while suspended. What replay restores: pane knowledge (refreshed by
+    /// the next snapshot) and the failure streak (worst case, a wrong backoff
+    /// delay — degradation, not misdirection). A WHOLESALE `State()` rebuild is
+    /// a fresh lineage: everything before it goes stale, the safe direction.
     public struct State: Equatable, Sendable {
         public static func == (lhs: State, rhs: State) -> Bool {
             lhs.authority === rhs.authority
                 && lhs.consecutiveFailures == rhs.consecutiveFailures
-                && lhs.isForeground == rhs.isForeground
                 && lhs.knownPanes == rhs.knownPanes
         }
 
@@ -304,7 +339,7 @@ public struct SessionRecovery: Sendable {
         /// belongs to the attempt the authority says is current, so no replayed
         /// copy can present a cancelled transport as connected.
         public var connectedSince: Date? { authority.connectedSince }
-        public internal(set) var isForeground: Bool = true
+        public var isForeground: Bool { authority.isForeground }
         /// Shared by every copy of this State lineage — see `AttemptAuthority`
         /// for why authority must not live in replayable value contents.
         internal let authority = AttemptAuthority()
@@ -358,8 +393,8 @@ public struct SessionRecovery: Sendable {
     /// is foreground-guarded; each property was earned by an observed failure,
     /// recorded on the case bodies below.
     public func beginInitialAttempt(state: inout State) -> RecoveryPlan {
-        guard state.isForeground else { return RecoveryPlan() }
-        return RecoveryPlan([.cancelTransport, .reconnect(state.authority.mint(), after: 0)])
+        guard let minted = state.authority.mintIfForeground() else { return RecoveryPlan() }
+        return RecoveryPlan([.cancelTransport, .reconnect(minted, after: 0)])
     }
 
     public func plan(
@@ -390,46 +425,47 @@ public struct SessionRecovery: Sendable {
             // staleness check and the teardown share the authority's critical
             // section, and streak accounting runs only when the failure was
             // real.
-            guard case .failed(let endedConnectionFrom) = state.authority.failIfCurrent(attempt) else {
-                return RecoveryPlan()
-            }
+            // Retirement and replacement are ONE authority transition: the split
+            // version left the failed attempt current until a later mint, and
+            // in that window connected(A) re-adopted the failed transport while
+            // eight concurrent duplicate failures each earned a reconnect.
+            // Duplicates now find A already retired and are stale; streak
+            // accounting runs only for the one real retirement.
+            guard let retired = state.authority.retireAndReplace(attempt) else { return RecoveryPlan() }
             // A connection that lasted counts as healthy, so the next failure
             // starts from a short delay rather than inheriting an old streak.
-            if let since = endedConnectionFrom,
+            if let since = retired.endedConnectionFrom,
                at.timeIntervalSince(since) >= stabilityInterval {
                 state.consecutiveFailures = 0
             }
             state.consecutiveFailures += 1
             let delay = backoff(failures: state.consecutiveFailures, using: &generator)
-            return RecoveryPlan([.reconnect(state.authority.mint(), after: delay)])
+            return RecoveryPlan([.reconnect(retired.replacement, after: delay)])
 
         case .networkChanged:
             // Reconnect, not migrate. Cancel first: the old socket is bound to
             // an address that may no longer exist, and a half-open connection on
             // a dead interface fails by timing out rather than by erroring.
             state.consecutiveFailures = 0
-            guard state.isForeground else {
-                state.authority.teardown()
+            guard let minted = state.authority.teardownAndMintIfForeground() else {
                 return RecoveryPlan([.cancelTransport])
             }
-            return RecoveryPlan([.cancelTransport, .reconnect(state.authority.mint(), after: 0)])
+            return RecoveryPlan([.cancelTransport, .reconnect(minted, after: 0)])
 
         case .backgrounded:
-            state.isForeground = false
-            state.authority.teardown()
+            state.authority.backgroundAndTeardown()
             // Cancel rather than leave it open. A suspended process cannot read
             // the socket, and the server reaps it anyway — so the choice is
             // between closing it deliberately and discovering it dead later.
             return RecoveryPlan([.cancelTransport])
 
         case .foregrounded:
-            state.isForeground = true
             state.consecutiveFailures = 0
             // Cancel FIRST — foregrounding is not guaranteed to find a dead
             // transport, and dialing beside a live one previously leaked two
             // sockets reading the same panes forever. Resync and subscriptions
             // follow on `connected`; there is no transport yet to run them on.
-            return RecoveryPlan([.cancelTransport, .reconnect(state.authority.mint(), after: 0)])
+            return RecoveryPlan([.cancelTransport, .reconnect(state.authority.foregroundAndMint(), after: 0)])
 
         case .paneCreated(let pane):
             state.knownPanes.insert(pane)

--- a/Sources/HerdrKit/SessionRecovery.swift
+++ b/Sources/HerdrKit/SessionRecovery.swift
@@ -11,6 +11,26 @@ import Foundation
 /// Ordering the actions did not fix that, and could not: order is about the
 /// steps inside one plan, and this is about which *attempt* a callback belongs
 /// to.
+/// The authoritative record of which attempt is current, REFERENCE-backed.
+///
+/// This exists because State is a public copyable value, and three identity
+/// designs in a row fell to some form of replay — the last through ordinary
+/// value restoration: save a copy while attempt A is current, cancel A and
+/// mint B, restore the copy, and A was current again, reauthorized through the
+/// sole staleness guard. No identity scheme fixes that while the authority
+/// itself lives in replayable contents. So it does not: every copy of a State
+/// lineage shares this one object, and restoring an old copy restores
+/// bookkeeping but NOT authority — the shared reference still says B.
+final class AttemptAuthority: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _current: AttemptID?
+
+    var current: AttemptID? {
+        get { lock.lock(); defer { lock.unlock() }; return _current }
+        set { lock.lock(); _current = newValue; lock.unlock() }
+    }
+}
+
 public struct AttemptID: Equatable, Hashable, Sendable {
     /// A fresh UUID per mint, derived from NOTHING the State stores.
     ///
@@ -178,13 +198,28 @@ public struct SessionRecovery: Sendable {
     /// verbatim — the caller reinstating an abandoned attempt by hand — which
     /// no value-typed design prevents. Hold one `State` per client.
     public struct State: Equatable, Sendable {
+        public static func == (lhs: State, rhs: State) -> Bool {
+            lhs.authority === rhs.authority
+                && lhs.consecutiveFailures == rhs.consecutiveFailures
+                && lhs.connectedSince == rhs.connectedSince
+                && lhs.isForeground == rhs.isForeground
+                && lhs.knownPanes == rhs.knownPanes
+                && lhs.subscribedPanes == rhs.subscribedPanes
+        }
+
         public internal(set) var consecutiveFailures: Int = 0
         public internal(set) var connectedSince: Date?
         public internal(set) var isForeground: Bool = true
+        /// Shared by every copy of this State lineage — see `AttemptAuthority`
+        /// for why authority must not live in replayable value contents.
+        internal let authority = AttemptAuthority()
+
         /// The only attempt whose callbacks are still wanted. Cleared by
         /// cancellation, backgrounding and network changes, so anything that
-        /// completes afterwards is recognisably stale.
-        public internal(set) var currentAttempt: AttemptID?
+        /// completes afterwards is recognisably stale. Reads through the shared
+        /// authority, so a restored copy reports the LINEAGE's current attempt,
+        /// not the one it was carrying when saved.
+        public var currentAttempt: AttemptID? { authority.current }
         /// Every pane the client believes exists. Subscriptions are pane-scoped,
         /// so this is also the re-subscribe list on the next adoption.
         public internal(set) var knownPanes: Set<String> = []
@@ -225,7 +260,7 @@ public struct SessionRecovery: Sendable {
         // Never derived from State: see AttemptID's doc for the two identities
         // that were, and how each fell to replay.
         let id = AttemptID(uuid: UUID())
-        state.currentAttempt = id
+        state.authority.current = id
         return id
     }
 
@@ -314,7 +349,7 @@ public struct SessionRecovery: Sendable {
             state.connectedSince = nil
             state.subscribedPanes = []
             state.consecutiveFailures = 0
-            state.currentAttempt = nil
+            state.authority.current = nil
             guard state.isForeground else { return RecoveryPlan([.cancelTransport]) }
             return RecoveryPlan([.cancelTransport, .reconnect(nextAttempt(&state), after: 0)])
 
@@ -322,7 +357,7 @@ public struct SessionRecovery: Sendable {
             state.isForeground = false
             state.connectedSince = nil
             state.subscribedPanes = []
-            state.currentAttempt = nil
+            state.authority.current = nil
             // Cancel rather than leave it open. A suspended process cannot read
             // the socket, and the server reaps it anyway — so the choice is
             // between closing it deliberately and discovering it dead later.

--- a/Sources/HerdrKit/SessionRecovery.swift
+++ b/Sources/HerdrKit/SessionRecovery.swift
@@ -115,13 +115,19 @@ final class AttemptAuthority: @unchecked Sendable {
         case adopted
     }
 
-    /// Staleness check, repeat check, adoption and ledger seed in one section.
-    func adopt(_ attempt: AttemptID, at: Date, subscribing panes: Set<String>) -> AdoptOutcome {
+    /// Staleness check, repeat check and adoption in one section. The ledger
+    /// seeds EMPTY, deliberately: it used to seed from the caller's remembered
+    /// panes, and a replayed copy's memory could contain a pane the server had
+    /// closed — adoption then subscribed the fresh transport to it, and no
+    /// later snapshot could retract that (the wire has no unsubscribe).
+    /// Subscriptions on a new transport derive only from post-adoption
+    /// authoritative data, admitted through `admitWhileConnected`.
+    func adopt(_ attempt: AttemptID, at: Date) -> AdoptOutcome {
         lock.lock(); defer { lock.unlock() }
         guard attempt == _current else { return .stale }
         guard _connectedSince == nil else { return .repeated }
         _connectedSince = at
-        _subscribedPanes = panes
+        _subscribedPanes = []
         return .adopted
     }
 
@@ -224,11 +230,15 @@ public enum RecoveryAction: Equatable, Sendable {
 /// following both plans literally opened every persistent subscription twice and
 /// could start work on a transport that was already stale.
 ///
-/// `.resyncAllPanes` and the FULL-SET subscribe are emitted in exactly one
-/// place: on adoption of a current attempt. `paneCreated` and `observe` emit
-/// incremental subscribes for newly discovered panes while connected — so the
-/// invariant is not "one emission site" but **no pane's persistent
-/// subscription is opened twice within one recovery**.
+/// `.resyncAllPanes` is emitted in exactly one place: on adoption of a current
+/// attempt — and adoption emits NOTHING else. Every subscription derives from
+/// post-adoption authoritative data: the executor resyncs, then hands the
+/// fresh `PaneSnapshot` to `observe`, whose atomic admission subscribes what
+/// the server says exists; `paneCreated` admits event-driven discoveries the
+/// same way. The invariants: **no pane's persistent subscription is opened
+/// twice within one recovery**, and **no remembered pane is ever a
+/// subscription target** — remembered knowledge subscribed a closed pane onto
+/// a fresh transport once, irretractably, since the wire has no unsubscribe.
 public struct RecoveryPlan: Equatable, Sendable {
     public var actions: [RecoveryAction]
 
@@ -411,13 +421,22 @@ public struct SessionRecovery: Sendable {
             // guard was unreachable); a repeat ready for the adopted attempt is
             // news, not a new adoption, because platforms deliver
             // ready -> waiting -> ready without a failure between.
-            switch state.authority.adopt(attempt, at: at, subscribing: state.knownPanes) {
+            switch state.authority.adopt(attempt, at: at) {
             case .stale:
                 return RecoveryPlan([.discardConnection])
             case .repeated:
                 return RecoveryPlan()
             case .adopted:
-                return RecoveryPlan([.resyncAllPanes, .subscribe(state.knownPanes)])
+                // Resync ONLY — no subscribe. Adoption used to subscribe the
+                // remembered pane set, which turned replayed knowledge into
+                // transport misdirection: a copy saved before paneClosed(p2)
+                // re-subscribed the NEW transport to the closed pane, the
+                // ledger recorded it, and no snapshot could retract it. The
+                // executor resyncs, then feeds the authoritative snapshot to
+                // `observe`, whose atomic admission subscribes exactly what the
+                // server says exists. Remembered panes are never subscription
+                // targets — knowledge is not a decision input any more.
+                return RecoveryPlan([.resyncAllPanes])
             }
 
         case .transportFailed(let attempt, let at):

--- a/Sources/HerdrKit/SessionRecovery.swift
+++ b/Sources/HerdrKit/SessionRecovery.swift
@@ -366,6 +366,19 @@ public struct SessionRecovery: Sendable {
     /// probe proved the window reachable. `nil` on every production path.
     var afterAdmissionHook: (@Sendable () -> Void)?
 
+    /// THE emission site — the only place a subscribe action is built.
+    ///
+    /// One implementation, shared by `observe` and `paneCreated`, deliberately:
+    /// they briefly had one emission expression EACH, which meant one window
+    /// each — the review pinned observe's and the identical paneCreated mutation
+    /// still survived, a real gap wearing a duplicate. With a single site, the
+    /// pinned test guards every caller.
+    private func subscriptionPlan(for admitted: AttemptAuthority.Admission) -> RecoveryPlan {
+        afterAdmissionHook?()
+        guard !admitted.fresh.isEmpty else { return RecoveryPlan() }
+        return RecoveryPlan([.subscribe(admitted.fresh, on: admitted.attempt)])
+    }
+
     public init(
         baseDelay: TimeInterval = 0.5,
         maximumDelay: TimeInterval = 30,
@@ -555,10 +568,8 @@ public struct SessionRecovery: Sendable {
             guard let admitted = state.authority.admitWhileConnected([pane], from: from) else {
                 return RecoveryPlan()
             }
-            afterAdmissionHook?()
             state.knownPanes.insert(pane)
-            guard !admitted.fresh.isEmpty else { return RecoveryPlan() }
-            return RecoveryPlan([.subscribe(admitted.fresh, on: admitted.attempt)])
+            return subscriptionPlan(for: admitted)
 
         case .paneClosed(let pane, let from):
             guard state.authority.isCurrent(from) else { return RecoveryPlan() }
@@ -605,10 +616,8 @@ public struct SessionRecovery: Sendable {
         guard let admitted = state.authority.admitWhileConnected(snapshot.paneIDs, from: attempt) else {
             return RecoveryPlan()
         }
-        afterAdmissionHook?()
         state.knownPanes = snapshot.paneIDs
-        guard !admitted.fresh.isEmpty else { return RecoveryPlan() }
-        return RecoveryPlan([.subscribe(admitted.fresh, on: admitted.attempt)])
+        return subscriptionPlan(for: admitted)
     }
 }
 

--- a/Sources/HerdrKit/SessionRecovery.swift
+++ b/Sources/HerdrKit/SessionRecovery.swift
@@ -308,9 +308,11 @@ public struct SessionRecovery: Sendable {
 public struct PaneSnapshot: Equatable, Sendable {
     public let paneIDs: Set<String>
 
-    /// Deliberately not `public`. Widening this restores the filtered-list path
-    /// that `observe` exists to close, and `PaneSnapshotAccessTests` fails if it
-    /// is widened.
+    /// Deliberately not `public`. `PaneSnapshotAccessTests` checks the module's
+    /// compiler-derived surface, so it fails on **any** widening — this
+    /// initialiser or another one, `public` or `package`, however it is
+    /// formatted. An earlier textual version of that guard recognised exactly
+    /// one spelling and let three equivalent widenings through.
     init(agents: [AgentInfo]) {
         self.paneIDs = Set(agents.map(\.paneID))
     }

--- a/Sources/HerdrKit/SessionRecovery.swift
+++ b/Sources/HerdrKit/SessionRecovery.swift
@@ -237,11 +237,17 @@ public enum RecoveryAction: Equatable, Sendable {
     /// `observe` WITH this attempt, so a resync outlived by its attempt
     /// produces data that is recognisably stale rather than silently admitted.
     case resyncAllPanes(AttemptID)
-    /// Open subscriptions for these panes. The pane-scoped subscription kinds
-    /// have **no wildcard**, so a pane absent here is a pane nothing is
-    /// watching. (`Wire.swift` also models non-pane-scoped subscription kinds;
-    /// this plan carries pane identity only and does not express those.)
-    case subscribe(Set<String>)
+    /// Open subscriptions for these panes ON the carried attempt's transport,
+    /// and only there. Admission validates the DATA's provenance, but an
+    /// emitted action outlives the section that admitted it: a probe showed
+    /// A's subscribe({p1}) comparing EQUAL to B's after A was retired, so an
+    /// executor holding A's delayed plan could apply it to B. The executor must
+    /// bind or reject this action against the carried attempt at execution
+    /// time. (The pane-scoped subscription kinds have **no wildcard**, so a
+    /// pane absent from every subscribe is a pane nothing is watching;
+    /// `Wire.swift` also models non-pane-scoped kinds this plan does not
+    /// express.)
+    case subscribe(Set<String>, on: AttemptID)
 }
 
 /// An ordered list of steps. Order is the point.
@@ -283,7 +289,13 @@ public struct RecoveryPlan: Equatable, Sendable {
     }
 
     public var subscribes: Set<String>? {
-        for case .subscribe(let panes) in actions { return panes }
+        for case .subscribe(let panes, _) in actions { return panes }
+        return nil
+    }
+
+    /// The attempt a subscribe in this plan is bound to, if one exists.
+    public var subscribesOn: AttemptID? {
+        for case .subscribe(_, let attempt) in actions { return attempt }
         return nil
     }
 }
@@ -522,7 +534,7 @@ public struct SessionRecovery: Sendable {
             }
             state.knownPanes.insert(pane)
             guard !fresh.isEmpty else { return RecoveryPlan() }
-            return RecoveryPlan([.subscribe(fresh)])
+            return RecoveryPlan([.subscribe(fresh, on: from)])
 
         case .paneClosed(let pane, let from):
             guard state.authority.isCurrent(from) else { return RecoveryPlan() }
@@ -571,7 +583,7 @@ public struct SessionRecovery: Sendable {
         }
         state.knownPanes = snapshot.paneIDs
         guard !fresh.isEmpty else { return RecoveryPlan() }
-        return RecoveryPlan([.subscribe(fresh)])
+        return RecoveryPlan([.subscribe(fresh, on: attempt)])
     }
 }
 

--- a/Sources/HerdrKit/SessionRecovery.swift
+++ b/Sources/HerdrKit/SessionRecovery.swift
@@ -157,12 +157,27 @@ final class AttemptAuthority: @unchecked Sendable {
     /// only thing that can reject it — and without this gate, a probe admitted
     /// an abandoned attempt's closed pane onto the replacement's ledger,
     /// irretractably.
-    func admitWhileConnected(_ panes: Set<String>, from attempt: AttemptID) -> Set<String>? {
+    /// The admission verdict, carrying the attempt it was decided under.
+    ///
+    /// The attempt travels OUT of the critical section with the verdict so the
+    /// caller constructs actions exclusively from it. Returning panes alone
+    /// left a window: admission's lock releases before the caller builds the
+    /// subscribe, a concurrent retirement can mint a replacement inside that
+    /// gap, and an emission that consulted anything OTHER than this verdict
+    /// (the review's probe: `authority.current ?? attempt`) would tag A's
+    /// admitted panes as B's — accepted by B's executor, the exact
+    /// misdirection provenance exists to prevent.
+    struct Admission {
+        let fresh: Set<String>
+        let attempt: AttemptID
+    }
+
+    func admitWhileConnected(_ panes: Set<String>, from attempt: AttemptID) -> Admission? {
         lock.lock(); defer { lock.unlock() }
         guard attempt == _current, _connectedSince != nil else { return nil }
         let fresh = panes.subtracting(_subscribedPanes)
         _subscribedPanes.formUnion(fresh)
-        return fresh
+        return Admission(fresh: fresh, attempt: attempt)
     }
 
     /// True iff the attempt is current — for gating KNOWLEDGE mutations from
@@ -342,6 +357,14 @@ public struct SessionRecovery: Sendable {
     /// "succeeded" long enough to reset the counter. A connection has to *last*
     /// to prove anything.
     public var stabilityInterval: TimeInterval
+
+    /// Test seam: runs after admission returns and before the subscribe action
+    /// is constructed — the exact interval where a concurrent retirement can
+    /// mint a replacement. Exists because a mutant consulting live authority
+    /// state at emission time (`current ?? attempt`) is only distinguishable
+    /// from the verdict-bound construction INSIDE this window, and a review
+    /// probe proved the window reachable. `nil` on every production path.
+    var afterAdmissionHook: (@Sendable () -> Void)?
 
     public init(
         baseDelay: TimeInterval = 0.5,
@@ -529,12 +552,13 @@ public struct SessionRecovery: Sendable {
             // knowledge either. An event arriving from the CURRENT attempt
             // before its adoption is processed also admits nothing, and needs
             // nothing — the post-adoption snapshot covers it via observe.
-            guard let fresh = state.authority.admitWhileConnected([pane], from: from) else {
+            guard let admitted = state.authority.admitWhileConnected([pane], from: from) else {
                 return RecoveryPlan()
             }
+            afterAdmissionHook?()
             state.knownPanes.insert(pane)
-            guard !fresh.isEmpty else { return RecoveryPlan() }
-            return RecoveryPlan([.subscribe(fresh, on: from)])
+            guard !admitted.fresh.isEmpty else { return RecoveryPlan() }
+            return RecoveryPlan([.subscribe(admitted.fresh, on: admitted.attempt)])
 
         case .paneClosed(let pane, let from):
             guard state.authority.isCurrent(from) else { return RecoveryPlan() }
@@ -578,12 +602,13 @@ public struct SessionRecovery: Sendable {
         // verdict and write leaves knowledge stale-but-bounded (the next
         // current snapshot replaces it) — the documented, tolerable class,
         // unlike a stale subscription, which nothing can retract.
-        guard let fresh = state.authority.admitWhileConnected(snapshot.paneIDs, from: attempt) else {
+        guard let admitted = state.authority.admitWhileConnected(snapshot.paneIDs, from: attempt) else {
             return RecoveryPlan()
         }
+        afterAdmissionHook?()
         state.knownPanes = snapshot.paneIDs
-        guard !fresh.isEmpty else { return RecoveryPlan() }
-        return RecoveryPlan([.subscribe(fresh, on: attempt)])
+        guard !admitted.fresh.isEmpty else { return RecoveryPlan() }
+        return RecoveryPlan([.subscribe(admitted.fresh, on: admitted.attempt)])
     }
 }
 

--- a/Sources/HerdrKit/SessionRecovery.swift
+++ b/Sources/HerdrKit/SessionRecovery.swift
@@ -24,10 +24,37 @@ import Foundation
 final class AttemptAuthority: @unchecked Sendable {
     private let lock = NSLock()
     private var _current: AttemptID?
+    private var _connectedSince: Date?
+    private var _subscribedPanes: Set<String> = []
 
     var current: AttemptID? {
         get { lock.lock(); defer { lock.unlock() }; return _current }
         set { lock.lock(); _current = newValue; lock.unlock() }
+    }
+
+    /// When the CURRENT attempt's connection was adopted, or nil.
+    ///
+    /// Lives here — not in the value State — because a value copy saved while A
+    /// was connected replayed its date: `paneCreated` subscribed onto the
+    /// cancelled transport, and the real replacement's `connected(B)` was
+    /// classified as an already-adopted repeat and suppressed. Sharing is the
+    /// fix; the INVARIANT that keeps this honest is that every transition which
+    /// mints or clears `current` clears this first, so it can never describe a
+    /// non-current attempt's transport. A first draft also carried an attempt
+    /// tag as a second guard on the same property; the tag was unreachable
+    /// (mutation-verified: removing it changed nothing), and an unpinnable
+    /// twin guard is the trap this project has now hit three times.
+    var connectedSince: Date? {
+        get { lock.lock(); defer { lock.unlock() }; return _connectedSince }
+        set { lock.lock(); _connectedSince = newValue; lock.unlock() }
+    }
+
+    /// The subscription ledger, transport-scoped state like the connection —
+    /// a replayed copy's ledger described the CANCELLED transport's
+    /// subscriptions, which is the same poison one field over.
+    var subscribedPanes: Set<String> {
+        get { lock.lock(); defer { lock.unlock() }; return _subscribedPanes }
+        set { lock.lock(); _subscribedPanes = newValue; lock.unlock() }
     }
 }
 
@@ -42,10 +69,12 @@ public struct AttemptID: Equatable, Hashable, Sendable {
     /// identity replay cannot reproduce is one that never derives from
     /// replayable contents — so nothing about an AttemptID comes from State.
     ///
-    /// What this cannot fix, stated because it is inherent to value semantics:
-    /// restoring an old State copy restores its `currentAttempt`, making that
-    /// old attempt current again by the caller's own hand. Minting is
-    /// replay-proof; the caller's stored value is the caller's to misuse.
+    /// Minting is replay-proof (nothing here derives from State), and since the
+    /// authority moved into a shared reference, so is the record of WHICH
+    /// attempt is current and connected: restoring an old State copy restores
+    /// pane knowledge and streak bookkeeping, while attempt authority, the
+    /// connection and the subscription ledger all read through the lineage's
+    /// shared `AttemptAuthority` and cannot be replayed.
     let uuid: UUID
 }
 
@@ -191,24 +220,28 @@ public struct SessionRecovery: Sendable {
     /// Stated at that strength and no more, after a sweep refuted the stronger
     /// claim ("every transition goes through plan()"): two other methods mutate
     /// state, and value semantics plus the public initialiser mean a caller can
-    /// still REPLACE the whole value. Attempt MINTING survives that: identity
-    /// is a fresh UUID derived from nothing the State stores, so no
-    /// replacement or copy-restore can make a new mint collide with an old
-    /// one. What replay can still do is restore an old copy's `currentAttempt`
-    /// verbatim — the caller reinstating an abandoned attempt by hand — which
-    /// no value-typed design prevents. Hold one `State` per client.
+    /// still REPLACE the whole value. What survives replay: attempt minting
+    /// (fresh UUIDs), attempt authority, the connection record and the
+    /// subscription ledger — all read through the lineage's shared
+    /// `AttemptAuthority`, so a restored copy cannot reauthorize a cancelled
+    /// attempt, present its transport as connected, or replay its ledger. What
+    /// replay DOES restore: pane knowledge (refreshed by the next snapshot)
+    /// and the failure streak (worst case, a wrong backoff delay — degradation,
+    /// not misdirection). A WHOLESALE `State()` rebuild is a fresh lineage:
+    /// everything before it goes stale, which is the safe direction.
     public struct State: Equatable, Sendable {
         public static func == (lhs: State, rhs: State) -> Bool {
             lhs.authority === rhs.authority
                 && lhs.consecutiveFailures == rhs.consecutiveFailures
-                && lhs.connectedSince == rhs.connectedSince
                 && lhs.isForeground == rhs.isForeground
                 && lhs.knownPanes == rhs.knownPanes
-                && lhs.subscribedPanes == rhs.subscribedPanes
         }
 
         public internal(set) var consecutiveFailures: Int = 0
-        public internal(set) var connectedSince: Date?
+        /// Bound to the current attempt: a connection only counts while it
+        /// belongs to the attempt the authority says is current, so no replayed
+        /// copy can present a cancelled transport as connected.
+        public var connectedSince: Date? { authority.connectedSince }
         public internal(set) var isForeground: Bool = true
         /// Shared by every copy of this State lineage — see `AttemptAuthority`
         /// for why authority must not live in replayable value contents.
@@ -229,8 +262,10 @@ public struct SessionRecovery: Sendable {
         /// stays open (there is no unsubscribe verb on the wire — subscriptions
         /// end when their connection does). Without this ledger, that pane
         /// REAPPEARING got an incremental second subscription on top of its
-        /// still-open first.
-        public internal(set) var subscribedPanes: Set<String> = []
+        /// still-open first. Lives in the shared authority: it is
+        /// transport-scoped exactly like the connection, and a replayed value
+        /// copy of it described the cancelled transport's subscriptions.
+        public var subscribedPanes: Set<String> { authority.subscribedPanes }
 
         public init() {}
 
@@ -277,8 +312,8 @@ public struct SessionRecovery: Sendable {
     /// background guards elsewhere were reachable at all.
     public func beginInitialAttempt(state: inout State) -> RecoveryPlan {
         guard state.isForeground else { return RecoveryPlan() }
-        state.connectedSince = nil
-        state.subscribedPanes = []
+        state.authority.connectedSince = nil
+        state.authority.subscribedPanes = []
         return RecoveryPlan([.cancelTransport, .reconnect(nextAttempt(&state), after: 0)])
     }
 
@@ -310,8 +345,8 @@ public struct SessionRecovery: Sendable {
             // type exists to prevent — and overwrote `connectedSince`, silently
             // restarting the stability clock.
             guard state.connectedSince == nil else { return RecoveryPlan() }
-            state.connectedSince = at
-            state.subscribedPanes = state.knownPanes
+            state.authority.connectedSince = at
+            state.authority.subscribedPanes = state.knownPanes
             // The only emitter of `.resyncAllPanes`, and the only emitter of the
             // FULL-SET subscribe. Not the only `.subscribe` site: `paneCreated`
             // and `observe` emit incremental single-pane/added-pane subscribes
@@ -336,8 +371,8 @@ public struct SessionRecovery: Sendable {
             if let since = state.connectedSince, at.timeIntervalSince(since) >= stabilityInterval {
                 state.consecutiveFailures = 0
             }
-            state.connectedSince = nil
-            state.subscribedPanes = []
+            state.authority.connectedSince = nil
+            state.authority.subscribedPanes = []
             state.consecutiveFailures += 1
             let delay = backoff(failures: state.consecutiveFailures, using: &generator)
             return RecoveryPlan([.reconnect(nextAttempt(&state), after: delay)])
@@ -346,8 +381,8 @@ public struct SessionRecovery: Sendable {
             // Reconnect, not migrate. Cancel first: the old socket is bound to an
             // address that may no longer exist, and a half-open connection on a
             // dead interface fails by timing out rather than by erroring.
-            state.connectedSince = nil
-            state.subscribedPanes = []
+            state.authority.connectedSince = nil
+            state.authority.subscribedPanes = []
             state.consecutiveFailures = 0
             state.authority.current = nil
             guard state.isForeground else { return RecoveryPlan([.cancelTransport]) }
@@ -355,8 +390,8 @@ public struct SessionRecovery: Sendable {
 
         case .backgrounded:
             state.isForeground = false
-            state.connectedSince = nil
-            state.subscribedPanes = []
+            state.authority.connectedSince = nil
+            state.authority.subscribedPanes = []
             state.authority.current = nil
             // Cancel rather than leave it open. A suspended process cannot read
             // the socket, and the server reaps it anyway — so the choice is
@@ -366,8 +401,8 @@ public struct SessionRecovery: Sendable {
         case .foregrounded:
             state.isForeground = true
             state.consecutiveFailures = 0
-            state.connectedSince = nil
-            state.subscribedPanes = []
+            state.authority.connectedSince = nil
+            state.authority.subscribedPanes = []
             // Cancel FIRST. Foregrounding is not guaranteed to find a dead
             // transport: a foregrounded event with a connection still live (the
             // OS never suspended us, or a lifecycle bug delivered no
@@ -389,7 +424,7 @@ public struct SessionRecovery: Sendable {
             guard state.isConnected, !state.subscribedPanes.contains(pane) else {
                 return RecoveryPlan()
             }
-            state.subscribedPanes.insert(pane)
+            state.authority.subscribedPanes.insert(pane)
             return RecoveryPlan([.subscribe([pane])])
 
         case .paneClosed(let pane):
@@ -426,7 +461,7 @@ public struct SessionRecovery: Sendable {
         // one short of the connection itself.
         let unwatched = snapshot.paneIDs.subtracting(state.subscribedPanes)
         guard state.isConnected, !unwatched.isEmpty else { return RecoveryPlan() }
-        state.subscribedPanes.formUnion(unwatched)
+        state.authority.subscribedPanes.formUnion(unwatched)
         return RecoveryPlan([.subscribe(unwatched)])
     }
 }

--- a/Sources/HerdrKit/SessionRecovery.swift
+++ b/Sources/HerdrKit/SessionRecovery.swift
@@ -12,14 +12,21 @@ import Foundation
 /// steps inside one plan, and this is about which *attempt* a callback belongs
 /// to.
 public struct AttemptID: Equatable, Hashable, Sendable {
-    /// Random per `State` lifetime. A bare counter restarts at 1 when a caller
-    /// replaces the State value — `state = SessionRecovery.State()` — after
-    /// which a late callback minted by the DISCARDED state matched the new
-    /// state's first attempt and was adopted, defeating the stale-callback
-    /// protection entirely. Identity must survive the identity-holder being
-    /// rebuilt, so it carries an epoch the rebuild cannot reproduce.
-    let epoch: UInt64
-    let value: UInt64
+    /// A fresh UUID per mint, derived from NOTHING the State stores.
+    ///
+    /// Two prior identities each fell to state replay. A bare counter restarted
+    /// at 1 when a caller rebuilt the State, so a discarded state's callback
+    /// matched the rebuild's first attempt. A per-State random epoch fixed the
+    /// rebuild and fell to the copy: State is a value, so save-copy → mint →
+    /// restore-copy → mint reproduced the identical (epoch, counter). The only
+    /// identity replay cannot reproduce is one that never derives from
+    /// replayable contents — so nothing about an AttemptID comes from State.
+    ///
+    /// What this cannot fix, stated because it is inherent to value semantics:
+    /// restoring an old State copy restores its `currentAttempt`, making that
+    /// old attempt current again by the caller's own hand. Minting is
+    /// replay-proof; the caller's stored value is the caller's to misuse.
+    let uuid: UUID
 }
 
 /// Something that happened to the connection or the app.
@@ -164,11 +171,12 @@ public struct SessionRecovery: Sendable {
     /// Stated at that strength and no more, after a sweep refuted the stronger
     /// claim ("every transition goes through plan()"): two other methods mutate
     /// state, and value semantics plus the public initialiser mean a caller can
-    /// still REPLACE the whole value. Attempt identity survives that: each
-    /// State draws a random epoch at init and every AttemptID carries it, so a
-    /// callback minted before a replacement cannot match anything minted after
-    /// — it goes stale instead of being adopted. Replacement still discards
-    /// pane and connection bookkeeping; hold one `State` per client.
+    /// still REPLACE the whole value. Attempt MINTING survives that: identity
+    /// is a fresh UUID derived from nothing the State stores, so no
+    /// replacement or copy-restore can make a new mint collide with an old
+    /// one. What replay can still do is restore an old copy's `currentAttempt`
+    /// verbatim — the caller reinstating an abandoned attempt by hand — which
+    /// no value-typed design prevents. Hold one `State` per client.
     public struct State: Equatable, Sendable {
         public internal(set) var consecutiveFailures: Int = 0
         public internal(set) var connectedSince: Date?
@@ -177,13 +185,6 @@ public struct SessionRecovery: Sendable {
         /// cancellation, backgrounding and network changes, so anything that
         /// completes afterwards is recognisably stale.
         public internal(set) var currentAttempt: AttemptID?
-        /// Counter within this State's epoch; the pair (epoch, value) is what
-        /// identifies an attempt, so replacing the State value changes the
-        /// epoch and every callback minted before the replacement goes stale.
-        internal var nextAttemptValue: UInt64 = 0
-        /// Drawn at init. Two State values agreeing by chance is a 1-in-2^64
-        /// event, not a caller mistake away.
-        internal var attemptEpoch: UInt64 = UInt64.random(in: UInt64.min...UInt64.max)
         /// Every pane the client believes exists. Subscriptions are pane-scoped,
         /// so this is also the re-subscribe list on the next adoption.
         public internal(set) var knownPanes: Set<String> = []
@@ -221,8 +222,9 @@ public struct SessionRecovery: Sendable {
     /// Every prior attempt becomes stale at this point, which is what makes a
     /// late callback recognisable rather than plausible.
     private func nextAttempt(_ state: inout State) -> AttemptID {
-        state.nextAttemptValue += 1
-        let id = AttemptID(epoch: state.attemptEpoch, value: state.nextAttemptValue)
+        // Never derived from State: see AttemptID's doc for the two identities
+        // that were, and how each fell to replay.
+        let id = AttemptID(uuid: UUID())
         state.currentAttempt = id
         return id
     }

--- a/Sources/HerdrKit/SessionRecovery.swift
+++ b/Sources/HerdrKit/SessionRecovery.swift
@@ -49,8 +49,10 @@ public enum RecoveryAction: Equatable, Sendable {
     case reconnect(AttemptID, after: TimeInterval)
     /// Drop every cached pane generation and refetch.
     case resyncAllPanes
-    /// Open subscriptions for these panes. herdr's subscriptions are pane-scoped
-    /// with **no wildcard**, so a pane absent here is a pane nothing is watching.
+    /// Open subscriptions for these panes. The pane-scoped subscription kinds
+    /// have **no wildcard**, so a pane absent here is a pane nothing is
+    /// watching. (`Wire.swift` also models non-pane-scoped subscription kinds;
+    /// this plan carries pane identity only and does not express those.)
     case subscribe(Set<String>)
 }
 
@@ -62,8 +64,11 @@ public enum RecoveryAction: Equatable, Sendable {
 /// following both plans literally opened every persistent subscription twice and
 /// could start work on a transport that was already stale.
 ///
-/// Resync and subscription now happen in exactly one place: on `connected`,
-/// while in the foreground. Nothing else emits them.
+/// `.resyncAllPanes` and the FULL-SET subscribe are emitted in exactly one
+/// place: on adoption of a current attempt. `paneCreated` and `observe` emit
+/// incremental subscribes for newly discovered panes while connected — so the
+/// invariant is not "one emission site" but **no pane's persistent
+/// subscription is opened twice within one recovery**.
 public struct RecoveryPlan: Equatable, Sendable {
     public var actions: [RecoveryAction]
 
@@ -96,27 +101,30 @@ public struct RecoveryPlan: Equatable, Sendable {
 ///
 /// ## Why there is no "resume from sequence" here
 ///
-/// An earlier version of this comment said the client sees sequence numbers
-/// "perfectly continuous with the ones it remembers". **That was invented.** The
-/// client sees no sequence numbers at all, and checking the wire types is what
-/// established it:
+/// **Scoped precisely, after two wrong versions.** The first invented a wire
+/// fact ("the client sees perfectly continuous sequence numbers" — it sees
+/// none on the stream). The second overcorrected into "a client cannot record
+/// a position even if it wanted one" — also false, and false in the dangerous
+/// direction: `AgentInfo` carries monotonic per-pane counters
+/// (`stateChangeSeq`, `turnEpoch`, `revision`), `RefreshCoordinator` records
+/// exactly such a position, and `invalidateAll()` exists because that
+/// remembered position WOULD mislead across a gap.
 ///
-/// - `Subscription` (`Wire.swift`) encodes exactly `type` and `pane_id`. There is
-///   **no cursor field**, so there is no way to ask for "everything since X".
-/// - Event envelopes carry no sequence, so a client cannot record a position even
-///   if it wanted one.
-/// - herdr's 512-entry ring is server-private. A subscription silently starts
-///   from whatever history the server chooses to replay, with no signal about
-///   what was skipped.
+/// What is actually true, checked against the wire types:
 ///
-/// So resumption is not *unwise* here, it is **unexpressible** — and the real
-/// consequence is stronger than the invented one. After any gap the only way to
-/// learn the current state is to ask again: `agent.list` plus fresh reads. Not
-/// because a remembered position would mislead, but because there is none to
-/// remember.
+/// - **Stream resumption is unexpressible.** `Subscription` (`Wire.swift`)
+///   encodes exactly `type` and `pane_id` — no cursor, so there is no way to
+///   ask for "everything since X". Event envelopes carry no sequence. herdr's
+///   512-entry ring is server-private, and a subscription silently starts from
+///   whatever the server chooses, with no signal about what was skipped.
+/// - **Positions a client CAN remember must not be trusted across a gap.**
+///   That is `RefreshCoordinator`'s job, and it is why every adoption here
+///   emits `.resyncAllPanes` — the action that drives `invalidateAll()` —
+///   rather than letting cached generations stand.
 ///
-/// The one thing worth persisting across a gap is which pane the reader had
-/// selected. Everything else is re-established by asking.
+/// So after any gap the only way to learn current state is to ask again:
+/// `agent.list` plus fresh reads. This type persists pane identity and
+/// connection bookkeeping, nothing stream-positional.
 public struct SessionRecovery: Sendable {
     /// First retry delay.
     public var baseDelay: TimeInterval
@@ -143,8 +151,18 @@ public struct SessionRecovery: Sendable {
 
     /// Mutable recovery state. Kept separate from the policy so the policy stays
     /// a value with no hidden history.
-    /// Fields are read-only to callers: every transition goes through `plan`, so
-    /// there is no second way to reach this state that the policy does not see.
+    /// Field WRITES are closed to callers — `internal(set)` — so state changes
+    /// go through this type's methods: `plan`, `beginInitialAttempt`, `observe`.
+    ///
+    /// Stated at that strength and no more, after a sweep refuted the stronger
+    /// claim ("every transition goes through plan()"): two other methods mutate
+    /// state, and value semantics plus the public initialiser mean a caller can
+    /// still REPLACE the whole value — `state = SessionRecovery.State()` resets
+    /// the attempt counter, after which a pre-reset attempt's identifier can be
+    /// re-minted and a late callback mistaken for current. Wholesale
+    /// replacement is the caller destroying their own session tracking, and no
+    /// access level on fields prevents it; hold one `State` per client and
+    /// never rebuild it mid-session.
     public struct State: Equatable, Sendable {
         public internal(set) var consecutiveFailures: Int = 0
         public internal(set) var connectedSince: Date?
@@ -153,8 +171,10 @@ public struct SessionRecovery: Sendable {
         /// cancellation, backgrounding and network changes, so anything that
         /// completes afterwards is recognisably stale.
         public internal(set) var currentAttempt: AttemptID?
-        /// Monotonic, so an identifier is never reused and a late callback can
-        /// never be mistaken for a current one.
+        /// Monotonic within one `State` value's lifetime, so an identifier is
+        /// not reused and a late callback is not mistaken for a current one —
+        /// see the type doc for the wholesale-replacement caveat that bounds
+        /// this claim.
         internal var nextAttemptValue: UInt64 = 0
         /// Every pane the client believes exists. Subscriptions are pane-scoped,
         /// so this is also the re-subscribe list.
@@ -191,9 +211,21 @@ public struct SessionRecovery: Sendable {
         return id
     }
 
-    /// Starts the first attempt of a cold launch, where no event triggered it.
+    /// Starts an attempt no event triggered — a cold launch, or a caller-driven
+    /// restart.
+    ///
+    /// Three properties earned by adversarial sweep, each from an observed
+    /// failure: it **cancels first**, because calling it while a connection was
+    /// live abandoned that transport with its subscriptions open, forever; it
+    /// **clears `connectedSince`**, because the stale date made `paneCreated`
+    /// emit subscribes for a transport the policy had just walked away from; and
+    /// it is **foreground-guarded**, because it was the one mint that ignored
+    /// backgrounding — which also made it the only path by which the redundant
+    /// background guards elsewhere were reachable at all.
     public func beginInitialAttempt(state: inout State) -> RecoveryPlan {
-        RecoveryPlan([.reconnect(nextAttempt(&state), after: 0)])
+        guard state.isForeground else { return RecoveryPlan() }
+        state.connectedSince = nil
+        return RecoveryPlan([.cancelTransport, .reconnect(nextAttempt(&state), after: 0)])
     }
 
     public func plan(
@@ -203,25 +235,46 @@ public struct SessionRecovery: Sendable {
     ) -> RecoveryPlan {
         switch event {
         case .connected(let attempt, let at):
-            // Stale completions are the reason attempts are identified at all: a
-            // cancelled attempt still finishes, and adopting it opens persistent
-            // subscriptions on a transport the client already replaced.
+            // Staleness is the ONE mechanism here, deliberately. A cancelled
+            // attempt still finishes, and adopting it opens persistent
+            // subscriptions on a transport the client already replaced — and
+            // because backgrounding, network changes and cancellation all clear
+            // `currentAttempt`, this same guard is what discards a connection
+            // completing while backgrounded. An earlier version also kept a
+            // separate `isForeground` guard for that case; it was unreachable
+            // (nothing mints an attempt while backgrounded), and an unreachable
+            // twin guard is the two-guards-one-property trap this project has
+            // now hit twice: neither copy is individually pinnable.
             guard attempt == state.currentAttempt else {
                 return RecoveryPlan([.discardConnection])
             }
-            // A connection completing after the client backgrounded is not wanted
-            // either — iOS is about to suspend the process.
-            guard state.isForeground else { return RecoveryPlan([.discardConnection]) }
+            // A REPEAT connected for the already-adopted attempt is news, not a
+            // new adoption. Platforms deliver it: a connection can go
+            // ready -> waiting -> ready across a viability blip without failing,
+            // so nothing guarantees one connected per attempt. Re-adopting
+            // re-emitted resync and the full subscribe set — the duplicate this
+            // type exists to prevent — and overwrote `connectedSince`, silently
+            // restarting the stability clock.
+            guard state.connectedSince == nil else { return RecoveryPlan() }
             state.connectedSince = at
-            // THE ONLY PLACE resync and subscription are emitted. Every
-            // reconnection is a gap of unknown length, and doing it here rather
-            // than also on `foregrounded` is what makes it exactly once.
+            // The only emitter of `.resyncAllPanes`, and the only emitter of the
+            // FULL-SET subscribe. Not the only `.subscribe` site: `paneCreated`
+            // and `observe` emit incremental single-pane/added-pane subscribes
+            // while connected. The invariant actually held is narrower than an
+            // earlier comment claimed: no pane's persistent subscription is
+            // opened twice within one recovery.
             return RecoveryPlan([.resyncAllPanes, .subscribe(state.knownPanes)])
 
         case .transportFailed(let attempt, let at):
             // A stale failure must not tear down the attempt that replaced it,
             // nor count against the backoff — it is news about a connection
             // nobody is using.
+            // The staleness guard is also the background protection: backgrounding
+            // clears `currentAttempt`, so a failure arriving while backgrounded
+            // can never match it. An earlier version kept a second
+            // `isForeground` branch below this guard; every mint requires the
+            // foreground, so the branch was unreachable — dead defense that no
+            // test could pin.
             guard attempt == state.currentAttempt else { return RecoveryPlan() }
             // A connection that lasted counts as healthy, so the next failure
             // starts from a short delay rather than inheriting an old streak.
@@ -230,10 +283,6 @@ public struct SessionRecovery: Sendable {
             }
             state.connectedSince = nil
             state.consecutiveFailures += 1
-            guard state.isForeground else {
-                state.currentAttempt = nil
-                return RecoveryPlan()
-            }
             let delay = backoff(failures: state.consecutiveFailures, using: &generator)
             return RecoveryPlan([.reconnect(nextAttempt(&state), after: delay)])
 
@@ -260,10 +309,16 @@ public struct SessionRecovery: Sendable {
             state.isForeground = true
             state.consecutiveFailures = 0
             state.connectedSince = nil
-            // Reconnect ONLY. The resync and subscriptions follow on `connected`,
-            // because there is no transport yet to run them on — emitting them
-            // here as well is what produced duplicate subscriptions.
-            return RecoveryPlan([.reconnect(nextAttempt(&state), after: 0)])
+            // Cancel FIRST. Foregrounding is not guaranteed to find a dead
+            // transport: a foregrounded event with a connection still live (the
+            // OS never suspended us, or a lifecycle bug delivered no
+            // backgrounded) previously minted a replacement while the old
+            // transport stayed open and subscribed — two sockets reading the
+            // same panes, double-applied events, and nothing in any later plan
+            // would ever close the first one. Then reconnect; resync and
+            // subscriptions follow on `connected`, since there is no transport
+            // yet to run them on.
+            return RecoveryPlan([.cancelTransport, .reconnect(nextAttempt(&state), after: 0)])
 
         case .paneCreated(let pane):
             let isNew = state.knownPanes.insert(pane).inserted
@@ -288,8 +343,20 @@ public struct SessionRecovery: Sendable {
     /// one-element array silently deleting two known panes.
     ///
     /// Incremental discovery goes through `.paneCreated` / `.paneClosed`.
-    public func observe(_ snapshot: PaneSnapshot, state: inout State) {
+    ///
+    /// Returns a plan, because the previous `Void` signature had a hole the
+    /// sweep reproduced: a pane created during a disconnection gap arrives via
+    /// the post-reconnect snapshot, not via `paneCreated` — and the snapshot
+    /// merely recorded it. The pane was then on the "re-subscribe list" and
+    /// unsubscribed until the NEXT reconnect, silent the whole session, with
+    /// even the app-layer workaround closed: `paneCreated` for it returned
+    /// nothing, since the pane was already known. Subscriptions are pane-scoped
+    /// with no wildcard, so nothing else would ever cover it.
+    public func observe(_ snapshot: PaneSnapshot, state: inout State) -> RecoveryPlan {
+        let added = snapshot.paneIDs.subtracting(state.knownPanes)
         state.knownPanes = snapshot.paneIDs
+        guard state.isConnected, !added.isEmpty else { return RecoveryPlan() }
+        return RecoveryPlan([.subscribe(added)])
     }
 }
 
@@ -300,6 +367,11 @@ public struct SessionRecovery: Sendable {
 /// filtered list. Inside the module any code can use the initializer, and
 /// `HerdrClient.paneSnapshot()` is the intended source by convention rather than
 /// by enforcement.
+///
+/// This guards ONE of the two routes to a shrunken pane set, and that is the
+/// intended shape: the other route, `.paneClosed`, removes panes one at a time
+/// on server-reported events — per-event removal driven by the wire, not a
+/// caller-supplied list, which is the failure mode snapshots had.
 ///
 /// An earlier comment here said "only `HerdrClient` can make one". That was
 /// wrong, and wrong in the direction that makes a weak guarantee sound like a

--- a/Sources/HerdrKit/SessionRecovery.swift
+++ b/Sources/HerdrKit/SessionRecovery.swift
@@ -28,33 +28,95 @@ final class AttemptAuthority: @unchecked Sendable {
     private var _subscribedPanes: Set<String> = []
 
     var current: AttemptID? {
-        get { lock.lock(); defer { lock.unlock() }; return _current }
-        set { lock.lock(); _current = newValue; lock.unlock() }
+        lock.lock(); defer { lock.unlock() }; return _current
     }
 
-    /// When the CURRENT attempt's connection was adopted, or nil.
-    ///
-    /// Lives here — not in the value State — because a value copy saved while A
-    /// was connected replayed its date: `paneCreated` subscribed onto the
-    /// cancelled transport, and the real replacement's `connected(B)` was
-    /// classified as an already-adopted repeat and suppressed. Sharing is the
-    /// fix; the INVARIANT that keeps this honest is that every transition which
-    /// mints or clears `current` clears this first, so it can never describe a
-    /// non-current attempt's transport. A first draft also carried an attempt
-    /// tag as a second guard on the same property; the tag was unreachable
-    /// (mutation-verified: removing it changed nothing), and an unpinnable
-    /// twin guard is the trap this project has now hit three times.
+    /// When the CURRENT attempt's connection was adopted, or nil. Lives here —
+    /// not in the value State — because a value copy saved while connected
+    /// replayed its date, subscribing onto a cancelled transport and
+    /// suppressing the real replacement's adoption as a "repeat".
     var connectedSince: Date? {
-        get { lock.lock(); defer { lock.unlock() }; return _connectedSince }
-        set { lock.lock(); _connectedSince = newValue; lock.unlock() }
+        lock.lock(); defer { lock.unlock() }; return _connectedSince
     }
 
-    /// The subscription ledger, transport-scoped state like the connection —
-    /// a replayed copy's ledger described the CANCELLED transport's
-    /// subscriptions, which is the same poison one field over.
     var subscribedPanes: Set<String> {
-        get { lock.lock(); defer { lock.unlock() }; return _subscribedPanes }
-        set { lock.lock(); _subscribedPanes = newValue; lock.unlock() }
+        lock.lock(); defer { lock.unlock() }; return _subscribedPanes
+    }
+
+    /// Every transition below is ONE critical section, deliberately. The first
+    /// version exposed get/set accessors and let the policy compose them —
+    /// which made every check-then-update a non-atomic read-modify-write across
+    /// two lock acquisitions. A concurrent 10,000-pane probe retained ~1,400
+    /// ledger entries, and each lost pane could then be subscribed AGAIN on
+    /// rediscovery. State copies share this object and both types are Sendable,
+    /// so concurrent use is the advertised surface, not an abuse of it.
+
+    /// Mints a new attempt and makes it current. Tears down transport-scoped
+    /// state in the same section: every mint is a new transport, and clearing
+    /// here is what keeps `connectedSince` unable to describe a non-current
+    /// attempt's transport.
+    func mint() -> AttemptID {
+        lock.lock(); defer { lock.unlock() }
+        let id = AttemptID(uuid: UUID())
+        _current = id
+        _connectedSince = nil
+        _subscribedPanes = []
+        return id
+    }
+
+    /// Clears authority and transport state without minting — backgrounding
+    /// and disconnection, where nothing should be dialing.
+    func teardown() {
+        lock.lock(); defer { lock.unlock() }
+        _current = nil
+        _connectedSince = nil
+        _subscribedPanes = []
+    }
+
+    enum AdoptOutcome {
+        case stale
+        case repeated
+        case adopted
+    }
+
+    /// Staleness check, repeat check, adoption and ledger seed in one section.
+    func adopt(_ attempt: AttemptID, at: Date, subscribing panes: Set<String>) -> AdoptOutcome {
+        lock.lock(); defer { lock.unlock() }
+        guard attempt == _current else { return .stale }
+        guard _connectedSince == nil else { return .repeated }
+        _connectedSince = at
+        _subscribedPanes = panes
+        return .adopted
+    }
+
+    /// Staleness check and failure teardown in one section.
+    enum FailOutcome {
+        /// The failing attempt was not current; touch nothing.
+        case stale
+        /// The failure was real; carries the adoption time it ended, if any,
+        /// for stability accounting.
+        case failed(endedConnectionFrom: Date?)
+    }
+
+    func failIfCurrent(_ attempt: AttemptID) -> FailOutcome {
+        lock.lock(); defer { lock.unlock() }
+        guard attempt == _current else { return .stale }
+        let since = _connectedSince
+        _connectedSince = nil
+        _subscribedPanes = []
+        return .failed(endedConnectionFrom: since)
+    }
+
+    /// Admits the panes not already subscribed, records them, and returns ONLY
+    /// the newly admitted — nil when there is no adopted connection to
+    /// subscribe on. Check, record and connection gate share the section, so no
+    /// interleaving can admit a pane twice or emit for a dead transport.
+    func admitWhileConnected(_ panes: Set<String>) -> Set<String>? {
+        lock.lock(); defer { lock.unlock() }
+        guard _connectedSince != nil else { return nil }
+        let fresh = panes.subtracting(_subscribedPanes)
+        _subscribedPanes.formUnion(fresh)
+        return fresh
     }
 }
 
@@ -291,30 +353,13 @@ public struct SessionRecovery: Sendable {
     ///
     /// Every prior attempt becomes stale at this point, which is what makes a
     /// late callback recognisable rather than plausible.
-    private func nextAttempt(_ state: inout State) -> AttemptID {
-        // Never derived from State: see AttemptID's doc for the two identities
-        // that were, and how each fell to replay.
-        let id = AttemptID(uuid: UUID())
-        state.authority.current = id
-        return id
-    }
-
     /// Starts an attempt no event triggered — a cold launch, or a caller-driven
-    /// restart.
-    ///
-    /// Three properties earned by adversarial sweep, each from an observed
-    /// failure: it **cancels first**, because calling it while a connection was
-    /// live abandoned that transport with its subscriptions open, forever; it
-    /// **clears `connectedSince`**, because the stale date made `paneCreated`
-    /// emit subscribes for a transport the policy had just walked away from; and
-    /// it is **foreground-guarded**, because it was the one mint that ignored
-    /// backgrounding — which also made it the only path by which the redundant
-    /// background guards elsewhere were reachable at all.
+    /// restart. Cancels first, clears adoption state (via mint's teardown), and
+    /// is foreground-guarded; each property was earned by an observed failure,
+    /// recorded on the case bodies below.
     public func beginInitialAttempt(state: inout State) -> RecoveryPlan {
         guard state.isForeground else { return RecoveryPlan() }
-        state.authority.connectedSince = nil
-        state.authority.subscribedPanes = []
-        return RecoveryPlan([.cancelTransport, .reconnect(nextAttempt(&state), after: 0)])
+        return RecoveryPlan([.cancelTransport, .reconnect(state.authority.mint(), after: 0)])
     }
 
     public func plan(
@@ -324,75 +369,54 @@ public struct SessionRecovery: Sendable {
     ) -> RecoveryPlan {
         switch event {
         case .connected(let attempt, let at):
-            // Staleness is the ONE mechanism here, deliberately. A cancelled
-            // attempt still finishes, and adopting it opens persistent
-            // subscriptions on a transport the client already replaced — and
-            // because backgrounding, network changes and cancellation all clear
-            // `currentAttempt`, this same guard is what discards a connection
-            // completing while backgrounded. An earlier version also kept a
-            // separate `isForeground` guard for that case; it was unreachable
-            // (nothing mints an attempt while backgrounded), and an unreachable
-            // twin guard is the two-guards-one-property trap this project has
-            // now hit twice: neither copy is individually pinnable.
-            guard attempt == state.currentAttempt else {
+            // Staleness, repeat-detection and adoption are ONE atomic
+            // transition on the shared authority. Staleness is the sole
+            // background protection (backgrounding clears the authority, so a
+            // late completion cannot match — the removed isForeground twin
+            // guard was unreachable); a repeat ready for the adopted attempt is
+            // news, not a new adoption, because platforms deliver
+            // ready -> waiting -> ready without a failure between.
+            switch state.authority.adopt(attempt, at: at, subscribing: state.knownPanes) {
+            case .stale:
                 return RecoveryPlan([.discardConnection])
+            case .repeated:
+                return RecoveryPlan()
+            case .adopted:
+                return RecoveryPlan([.resyncAllPanes, .subscribe(state.knownPanes)])
             }
-            // A REPEAT connected for the already-adopted attempt is news, not a
-            // new adoption. Platforms deliver it: a connection can go
-            // ready -> waiting -> ready across a viability blip without failing,
-            // so nothing guarantees one connected per attempt. Re-adopting
-            // re-emitted resync and the full subscribe set — the duplicate this
-            // type exists to prevent — and overwrote `connectedSince`, silently
-            // restarting the stability clock.
-            guard state.connectedSince == nil else { return RecoveryPlan() }
-            state.authority.connectedSince = at
-            state.authority.subscribedPanes = state.knownPanes
-            // The only emitter of `.resyncAllPanes`, and the only emitter of the
-            // FULL-SET subscribe. Not the only `.subscribe` site: `paneCreated`
-            // and `observe` emit incremental single-pane/added-pane subscribes
-            // while connected. The invariant actually held is narrower than an
-            // earlier comment claimed: no pane's persistent subscription is
-            // opened twice within one recovery.
-            return RecoveryPlan([.resyncAllPanes, .subscribe(state.knownPanes)])
 
         case .transportFailed(let attempt, let at):
-            // A stale failure must not tear down the attempt that replaced it,
-            // nor count against the backoff — it is news about a connection
-            // nobody is using.
-            // The staleness guard is also the background protection: backgrounding
-            // clears `currentAttempt`, so a failure arriving while backgrounded
-            // can never match it. An earlier version kept a second
-            // `isForeground` branch below this guard; every mint requires the
-            // foreground, so the branch was unreachable — dead defense that no
-            // test could pin.
-            guard attempt == state.currentAttempt else { return RecoveryPlan() }
+            // Stale failures are news about a connection nobody is using; the
+            // staleness check and the teardown share the authority's critical
+            // section, and streak accounting runs only when the failure was
+            // real.
+            guard case .failed(let endedConnectionFrom) = state.authority.failIfCurrent(attempt) else {
+                return RecoveryPlan()
+            }
             // A connection that lasted counts as healthy, so the next failure
             // starts from a short delay rather than inheriting an old streak.
-            if let since = state.connectedSince, at.timeIntervalSince(since) >= stabilityInterval {
+            if let since = endedConnectionFrom,
+               at.timeIntervalSince(since) >= stabilityInterval {
                 state.consecutiveFailures = 0
             }
-            state.authority.connectedSince = nil
-            state.authority.subscribedPanes = []
             state.consecutiveFailures += 1
             let delay = backoff(failures: state.consecutiveFailures, using: &generator)
-            return RecoveryPlan([.reconnect(nextAttempt(&state), after: delay)])
+            return RecoveryPlan([.reconnect(state.authority.mint(), after: delay)])
 
         case .networkChanged:
-            // Reconnect, not migrate. Cancel first: the old socket is bound to an
-            // address that may no longer exist, and a half-open connection on a
-            // dead interface fails by timing out rather than by erroring.
-            state.authority.connectedSince = nil
-            state.authority.subscribedPanes = []
+            // Reconnect, not migrate. Cancel first: the old socket is bound to
+            // an address that may no longer exist, and a half-open connection on
+            // a dead interface fails by timing out rather than by erroring.
             state.consecutiveFailures = 0
-            state.authority.current = nil
-            guard state.isForeground else { return RecoveryPlan([.cancelTransport]) }
-            return RecoveryPlan([.cancelTransport, .reconnect(nextAttempt(&state), after: 0)])
+            guard state.isForeground else {
+                state.authority.teardown()
+                return RecoveryPlan([.cancelTransport])
+            }
+            return RecoveryPlan([.cancelTransport, .reconnect(state.authority.mint(), after: 0)])
 
         case .backgrounded:
             state.isForeground = false
-            state.authority.connectedSince = nil
-            state.authority.subscribedPanes = []
-            state.authority.current = nil
+            state.authority.teardown()
             // Cancel rather than leave it open. A suspended process cannot read
             // the socket, and the server reaps it anyway — so the choice is
             // between closing it deliberately and discovering it dead later.
@@ -401,31 +425,23 @@ public struct SessionRecovery: Sendable {
         case .foregrounded:
             state.isForeground = true
             state.consecutiveFailures = 0
-            state.authority.connectedSince = nil
-            state.authority.subscribedPanes = []
-            // Cancel FIRST. Foregrounding is not guaranteed to find a dead
-            // transport: a foregrounded event with a connection still live (the
-            // OS never suspended us, or a lifecycle bug delivered no
-            // backgrounded) previously minted a replacement while the old
-            // transport stayed open and subscribed — two sockets reading the
-            // same panes, double-applied events, and nothing in any later plan
-            // would ever close the first one. Then reconnect; resync and
-            // subscriptions follow on `connected`, since there is no transport
-            // yet to run them on.
-            return RecoveryPlan([.cancelTransport, .reconnect(nextAttempt(&state), after: 0)])
+            // Cancel FIRST — foregrounding is not guaranteed to find a dead
+            // transport, and dialing beside a live one previously leaked two
+            // sockets reading the same panes forever. Resync and subscriptions
+            // follow on `connected`; there is no transport yet to run them on.
+            return RecoveryPlan([.cancelTransport, .reconnect(state.authority.mint(), after: 0)])
 
         case .paneCreated(let pane):
             state.knownPanes.insert(pane)
-            // Subscribe only if there is a connection AND this transport does
-            // not already hold a subscription for the pane. The second check is
-            // the reappearing-pane case: a snapshot shrink forgets a pane while
-            // its subscription stays open (no unsubscribe verb exists), so
-            // "newly known" is not "unwatched".
-            guard state.isConnected, !state.subscribedPanes.contains(pane) else {
+            // Admission is atomic on the authority: the connection gate, the
+            // already-subscribed check and the record are one critical section,
+            // so concurrent discoveries can neither drop a ledger entry nor
+            // subscribe a pane twice. Not connected -> the next adoption's
+            // full-set subscribe covers it.
+            guard let fresh = state.authority.admitWhileConnected([pane]), !fresh.isEmpty else {
                 return RecoveryPlan()
             }
-            state.authority.subscribedPanes.insert(pane)
-            return RecoveryPlan([.subscribe([pane])])
+            return RecoveryPlan([.subscribe(fresh)])
 
         case .paneClosed(let pane):
             state.knownPanes.remove(pane)
@@ -454,15 +470,14 @@ public struct SessionRecovery: Sendable {
     /// with no wildcard, so nothing else would ever cover it.
     public func observe(_ snapshot: PaneSnapshot, state: inout State) -> RecoveryPlan {
         state.knownPanes = snapshot.paneIDs
-        // Diffed against the SUBSCRIPTION ledger, not prior knowledge: a pane
-        // this transport already watches must not be subscribed twice however
-        // many times snapshots forget and rediscover it, and a shrink leaves
-        // its open subscriptions in place because nothing on the wire can close
-        // one short of the connection itself.
-        let unwatched = snapshot.paneIDs.subtracting(state.subscribedPanes)
-        guard state.isConnected, !unwatched.isEmpty else { return RecoveryPlan() }
-        state.authority.subscribedPanes.formUnion(unwatched)
-        return RecoveryPlan([.subscribe(unwatched)])
+        // Atomic admission against the SUBSCRIPTION ledger, not prior
+        // knowledge: a pane this transport already watches must not be
+        // subscribed twice however many times snapshots forget and rediscover
+        // it, and a shrink leaves its open subscriptions in place because
+        // nothing on the wire can close one short of the connection itself.
+        guard let fresh = state.authority.admitWhileConnected(snapshot.paneIDs),
+              !fresh.isEmpty else { return RecoveryPlan() }
+        return RecoveryPlan([.subscribe(fresh)])
     }
 }
 

--- a/Sources/HerdrKit/SessionRecovery.swift
+++ b/Sources/HerdrKit/SessionRecovery.swift
@@ -12,6 +12,13 @@ import Foundation
 /// steps inside one plan, and this is about which *attempt* a callback belongs
 /// to.
 public struct AttemptID: Equatable, Hashable, Sendable {
+    /// Random per `State` lifetime. A bare counter restarts at 1 when a caller
+    /// replaces the State value — `state = SessionRecovery.State()` — after
+    /// which a late callback minted by the DISCARDED state matched the new
+    /// state's first attempt and was adopted, defeating the stale-callback
+    /// protection entirely. Identity must survive the identity-holder being
+    /// rebuilt, so it carries an epoch the rebuild cannot reproduce.
+    let epoch: UInt64
     let value: UInt64
 }
 
@@ -157,12 +164,11 @@ public struct SessionRecovery: Sendable {
     /// Stated at that strength and no more, after a sweep refuted the stronger
     /// claim ("every transition goes through plan()"): two other methods mutate
     /// state, and value semantics plus the public initialiser mean a caller can
-    /// still REPLACE the whole value — `state = SessionRecovery.State()` resets
-    /// the attempt counter, after which a pre-reset attempt's identifier can be
-    /// re-minted and a late callback mistaken for current. Wholesale
-    /// replacement is the caller destroying their own session tracking, and no
-    /// access level on fields prevents it; hold one `State` per client and
-    /// never rebuild it mid-session.
+    /// still REPLACE the whole value. Attempt identity survives that: each
+    /// State draws a random epoch at init and every AttemptID carries it, so a
+    /// callback minted before a replacement cannot match anything minted after
+    /// — it goes stale instead of being adopted. Replacement still discards
+    /// pane and connection bookkeeping; hold one `State` per client.
     public struct State: Equatable, Sendable {
         public internal(set) var consecutiveFailures: Int = 0
         public internal(set) var connectedSince: Date?
@@ -171,14 +177,24 @@ public struct SessionRecovery: Sendable {
         /// cancellation, backgrounding and network changes, so anything that
         /// completes afterwards is recognisably stale.
         public internal(set) var currentAttempt: AttemptID?
-        /// Monotonic within one `State` value's lifetime, so an identifier is
-        /// not reused and a late callback is not mistaken for a current one —
-        /// see the type doc for the wholesale-replacement caveat that bounds
-        /// this claim.
+        /// Counter within this State's epoch; the pair (epoch, value) is what
+        /// identifies an attempt, so replacing the State value changes the
+        /// epoch and every callback minted before the replacement goes stale.
         internal var nextAttemptValue: UInt64 = 0
+        /// Drawn at init. Two State values agreeing by chance is a 1-in-2^64
+        /// event, not a caller mistake away.
+        internal var attemptEpoch: UInt64 = UInt64.random(in: UInt64.min...UInt64.max)
         /// Every pane the client believes exists. Subscriptions are pane-scoped,
-        /// so this is also the re-subscribe list.
+        /// so this is also the re-subscribe list on the next adoption.
         public internal(set) var knownPanes: Set<String> = []
+        /// Panes with an open subscription on the CURRENT transport. Distinct
+        /// from `knownPanes`, and the distinction is load-bearing: a snapshot
+        /// that shrinks removes a pane from knowledge while its subscription
+        /// stays open (there is no unsubscribe verb on the wire — subscriptions
+        /// end when their connection does). Without this ledger, that pane
+        /// REAPPEARING got an incremental second subscription on top of its
+        /// still-open first.
+        public internal(set) var subscribedPanes: Set<String> = []
 
         public init() {}
 
@@ -206,7 +222,7 @@ public struct SessionRecovery: Sendable {
     /// late callback recognisable rather than plausible.
     private func nextAttempt(_ state: inout State) -> AttemptID {
         state.nextAttemptValue += 1
-        let id = AttemptID(value: state.nextAttemptValue)
+        let id = AttemptID(epoch: state.attemptEpoch, value: state.nextAttemptValue)
         state.currentAttempt = id
         return id
     }
@@ -225,6 +241,7 @@ public struct SessionRecovery: Sendable {
     public func beginInitialAttempt(state: inout State) -> RecoveryPlan {
         guard state.isForeground else { return RecoveryPlan() }
         state.connectedSince = nil
+        state.subscribedPanes = []
         return RecoveryPlan([.cancelTransport, .reconnect(nextAttempt(&state), after: 0)])
     }
 
@@ -257,6 +274,7 @@ public struct SessionRecovery: Sendable {
             // restarting the stability clock.
             guard state.connectedSince == nil else { return RecoveryPlan() }
             state.connectedSince = at
+            state.subscribedPanes = state.knownPanes
             // The only emitter of `.resyncAllPanes`, and the only emitter of the
             // FULL-SET subscribe. Not the only `.subscribe` site: `paneCreated`
             // and `observe` emit incremental single-pane/added-pane subscribes
@@ -282,6 +300,7 @@ public struct SessionRecovery: Sendable {
                 state.consecutiveFailures = 0
             }
             state.connectedSince = nil
+            state.subscribedPanes = []
             state.consecutiveFailures += 1
             let delay = backoff(failures: state.consecutiveFailures, using: &generator)
             return RecoveryPlan([.reconnect(nextAttempt(&state), after: delay)])
@@ -291,6 +310,7 @@ public struct SessionRecovery: Sendable {
             // address that may no longer exist, and a half-open connection on a
             // dead interface fails by timing out rather than by erroring.
             state.connectedSince = nil
+            state.subscribedPanes = []
             state.consecutiveFailures = 0
             state.currentAttempt = nil
             guard state.isForeground else { return RecoveryPlan([.cancelTransport]) }
@@ -299,6 +319,7 @@ public struct SessionRecovery: Sendable {
         case .backgrounded:
             state.isForeground = false
             state.connectedSince = nil
+            state.subscribedPanes = []
             state.currentAttempt = nil
             // Cancel rather than leave it open. A suspended process cannot read
             // the socket, and the server reaps it anyway — so the choice is
@@ -309,6 +330,7 @@ public struct SessionRecovery: Sendable {
             state.isForeground = true
             state.consecutiveFailures = 0
             state.connectedSince = nil
+            state.subscribedPanes = []
             // Cancel FIRST. Foregrounding is not guaranteed to find a dead
             // transport: a foregrounded event with a connection still live (the
             // OS never suspended us, or a lifecycle bug delivered no
@@ -321,10 +343,16 @@ public struct SessionRecovery: Sendable {
             return RecoveryPlan([.cancelTransport, .reconnect(nextAttempt(&state), after: 0)])
 
         case .paneCreated(let pane):
-            let isNew = state.knownPanes.insert(pane).inserted
-            // Only worth subscribing now if there is a connection to subscribe
-            // on; otherwise the next `connected` picks it up in the full set.
-            guard isNew, state.isConnected else { return RecoveryPlan() }
+            state.knownPanes.insert(pane)
+            // Subscribe only if there is a connection AND this transport does
+            // not already hold a subscription for the pane. The second check is
+            // the reappearing-pane case: a snapshot shrink forgets a pane while
+            // its subscription stays open (no unsubscribe verb exists), so
+            // "newly known" is not "unwatched".
+            guard state.isConnected, !state.subscribedPanes.contains(pane) else {
+                return RecoveryPlan()
+            }
+            state.subscribedPanes.insert(pane)
             return RecoveryPlan([.subscribe([pane])])
 
         case .paneClosed(let pane):
@@ -353,10 +381,16 @@ public struct SessionRecovery: Sendable {
     /// nothing, since the pane was already known. Subscriptions are pane-scoped
     /// with no wildcard, so nothing else would ever cover it.
     public func observe(_ snapshot: PaneSnapshot, state: inout State) -> RecoveryPlan {
-        let added = snapshot.paneIDs.subtracting(state.knownPanes)
         state.knownPanes = snapshot.paneIDs
-        guard state.isConnected, !added.isEmpty else { return RecoveryPlan() }
-        return RecoveryPlan([.subscribe(added)])
+        // Diffed against the SUBSCRIPTION ledger, not prior knowledge: a pane
+        // this transport already watches must not be subscribed twice however
+        // many times snapshots forget and rediscover it, and a shrink leaves
+        // its open subscriptions in place because nothing on the wire can close
+        // one short of the connection itself.
+        let unwatched = snapshot.paneIDs.subtracting(state.subscribedPanes)
+        guard state.isConnected, !unwatched.isEmpty else { return RecoveryPlan() }
+        state.subscribedPanes.formUnion(unwatched)
+        return RecoveryPlan([.subscribe(unwatched)])
     }
 }
 

--- a/Sources/HerdrKit/SessionRecovery.swift
+++ b/Sources/HerdrKit/SessionRecovery.swift
@@ -13,27 +13,59 @@ public enum ClientEvent: Equatable, Sendable {
     case foregrounded(at: Date)
     /// The event stream reported a pane that did not exist before.
     case paneCreated(String)
+    /// A pane went away. Without this, the only way to remove one is a wholesale
+    /// replacement, which is what made partial listings dangerous.
+    case paneClosed(String)
 }
 
-/// What the client should do next.
-public struct RecoveryPlan: Equatable, Sendable {
-    /// Drop every cached pane generation and refetch from scratch.
-    public var resyncAllPanes: Bool
-    /// Panes that need a subscription opened. herdr's subscriptions are
-    /// pane-scoped with **no wildcard**, so a pane absent from this set is a
-    /// pane nothing is watching.
-    public var subscribe: Set<String>
-    /// Delay before the next connection attempt, or `nil` for "do not attempt".
-    public var reconnectAfter: TimeInterval?
+/// One step of recovery, in the order it must happen.
+public enum RecoveryAction: Equatable, Sendable {
+    /// Tear down the current or in-flight transport before anything else.
+    ///
+    /// A half-open socket on an interface that no longer exists fails by timing
+    /// out rather than erroring, so leaving it in place makes the most
+    /// recoverable case the slowest one to notice.
+    case cancelTransport
+    /// A connection that completed when the client no longer wants one. Close it
+    /// rather than adopting it: adopting means opening subscriptions on a
+    /// transport nobody is going to read.
+    case discardConnection
+    case reconnect(after: TimeInterval)
+    /// Drop every cached pane generation and refetch.
+    case resyncAllPanes
+    /// Open subscriptions for these panes. herdr's subscriptions are pane-scoped
+    /// with **no wildcard**, so a pane absent here is a pane nothing is watching.
+    case subscribe(Set<String>)
+}
 
-    public init(
-        resyncAllPanes: Bool = false,
-        subscribe: Set<String> = [],
-        reconnectAfter: TimeInterval? = nil
-    ) {
-        self.resyncAllPanes = resyncAllPanes
-        self.subscribe = subscribe
-        self.reconnectAfter = reconnectAfter
+/// An ordered list of steps. Order is the point.
+///
+/// The previous version was three independent fields, which could not say
+/// whether to cancel before reconnecting, and had `foregrounded` requesting a
+/// resync and subscriptions that `connected` then requested again — so a client
+/// following both plans literally opened every persistent subscription twice and
+/// could start work on a transport that was already stale.
+///
+/// Resync and subscription now happen in exactly one place: on `connected`,
+/// while in the foreground. Nothing else emits them.
+public struct RecoveryPlan: Equatable, Sendable {
+    public var actions: [RecoveryAction]
+
+    public init(_ actions: [RecoveryAction] = []) { self.actions = actions }
+
+    public var isEmpty: Bool { actions.isEmpty }
+
+    /// Convenience for callers and tests that only care whether a step is present.
+    public func contains(_ action: RecoveryAction) -> Bool { actions.contains(action) }
+
+    public var reconnectDelay: TimeInterval? {
+        for case .reconnect(let after) in actions { return after }
+        return nil
+    }
+
+    public var subscribes: Set<String>? {
+        for case .subscribe(let panes) in actions { return panes }
+        return nil
     }
 }
 
@@ -42,19 +74,27 @@ public struct RecoveryPlan: Equatable, Sendable {
 ///
 /// ## Why there is no "resume from sequence" here
 ///
-/// herdr's EventHub is a **512-entry ring with no gap signal**. A client that
-/// was away long enough falls off the back of it and **cannot detect that it
-/// did** — the sequence numbers it sees afterwards are perfectly continuous with
-/// the ones it remembers, and simply describe a different stretch of history.
+/// An earlier version of this comment said the client sees sequence numbers
+/// "perfectly continuous with the ones it remembers". **That was invented.** The
+/// client sees no sequence numbers at all, and checking the wire types is what
+/// established it:
 ///
-/// So this type does not offer a way to resume from a remembered position, and
-/// that absence is the design. An API that accepted a last-seen sequence would
-/// be used, would look correct in every test written against a server that had
-/// not wrapped, and would silently show stale panes in exactly the case it was
-/// added for: a phone that was in someone's pocket.
+/// - `Subscription` (`Wire.swift`) encodes exactly `type` and `pane_id`. There is
+///   **no cursor field**, so there is no way to ask for "everything since X".
+/// - Event envelopes carry no sequence, so a client cannot record a position even
+///   if it wanted one.
+/// - herdr's 512-entry ring is server-private. A subscription silently starts
+///   from whatever history the server chooses to replay, with no signal about
+///   what was skipped.
 ///
-/// Only two things are worth persisting across a gap: which pane the reader had
-/// selected, and nothing else. Revisions are re-established by asking.
+/// So resumption is not *unwise* here, it is **unexpressible** — and the real
+/// consequence is stronger than the invented one. After any gap the only way to
+/// learn the current state is to ask again: `agent.list` plus fresh reads. Not
+/// because a remembered position would mislead, but because there is none to
+/// remember.
+///
+/// The one thing worth persisting across a gap is which pane the reader had
+/// selected. Everything else is re-established by asking.
 public struct SessionRecovery: Sendable {
     /// First retry delay.
     public var baseDelay: TimeInterval
@@ -81,15 +121,19 @@ public struct SessionRecovery: Sendable {
 
     /// Mutable recovery state. Kept separate from the policy so the policy stays
     /// a value with no hidden history.
+    /// Fields are read-only to callers: every transition goes through `plan`, so
+    /// there is no second way to reach this state that the policy does not see.
     public struct State: Equatable, Sendable {
-        public var consecutiveFailures: Int = 0
-        public var connectedSince: Date?
-        public var isForeground: Bool = true
+        public internal(set) var consecutiveFailures: Int = 0
+        public internal(set) var connectedSince: Date?
+        public internal(set) var isForeground: Bool = true
         /// Every pane the client believes exists. Subscriptions are pane-scoped,
         /// so this is also the re-subscribe list.
-        public var knownPanes: Set<String> = []
+        public internal(set) var knownPanes: Set<String> = []
 
         public init() {}
+
+        var isConnected: Bool { connectedSince != nil }
     }
 
     /// Full-jitter backoff: a delay drawn uniformly from `0 ..< capped`.
@@ -114,14 +158,15 @@ public struct SessionRecovery: Sendable {
     ) -> RecoveryPlan {
         switch event {
         case .connected(let at):
+            // A connection that completes after the client backgrounded is not
+            // wanted: adopting it opens persistent subscriptions on a transport
+            // nobody will read, and iOS is about to suspend the process anyway.
+            guard state.isForeground else { return RecoveryPlan([.discardConnection]) }
             state.connectedSince = at
-            // Every reconnection is a gap of unknown length, so it resyncs and
-            // re-subscribes. There is no cheaper path on purpose.
-            return RecoveryPlan(
-                resyncAllPanes: true,
-                subscribe: state.knownPanes,
-                reconnectAfter: nil
-            )
+            // THE ONLY PLACE resync and subscription are emitted. Every
+            // reconnection is a gap of unknown length, and doing it here rather
+            // than also on `foregrounded` is what makes it exactly once.
+            return RecoveryPlan([.resyncAllPanes, .subscribe(state.knownPanes)])
 
         case .transportFailed(let at):
             // A connection that lasted counts as healthy, so the next failure
@@ -132,48 +177,61 @@ public struct SessionRecovery: Sendable {
             state.connectedSince = nil
             state.consecutiveFailures += 1
             guard state.isForeground else { return RecoveryPlan() }
-            return RecoveryPlan(
-                reconnectAfter: backoff(failures: state.consecutiveFailures, using: &generator)
-            )
+            return RecoveryPlan([
+                .reconnect(after: backoff(failures: state.consecutiveFailures, using: &generator))
+            ])
 
         case .networkChanged:
-            // Reconnect, not migrate. The old socket is bound to an address that
-            // may no longer exist, and a half-open connection on a dead interface
-            // fails by timing out rather than by erroring — which is the slowest
-            // possible way to discover it.
+            // Reconnect, not migrate. Cancel first: the old socket is bound to an
+            // address that may no longer exist, and a half-open connection on a
+            // dead interface fails by timing out rather than by erroring.
             state.connectedSince = nil
             state.consecutiveFailures = 0
-            guard state.isForeground else { return RecoveryPlan() }
-            return RecoveryPlan(reconnectAfter: 0)
+            guard state.isForeground else { return RecoveryPlan([.cancelTransport]) }
+            return RecoveryPlan([.cancelTransport, .reconnect(after: 0)])
 
         case .backgrounded:
             state.isForeground = false
-            // No reconnect scheduling while suspended: the attempt would not run,
-            // and on return it would look like a fresh failure streak.
-            return RecoveryPlan()
+            state.connectedSince = nil
+            // Cancel rather than leave it open. A suspended process cannot read
+            // the socket, and the server reaps it anyway — so the choice is
+            // between closing it deliberately and discovering it dead later.
+            return RecoveryPlan([.cancelTransport])
 
         case .foregrounded:
             state.isForeground = true
             state.consecutiveFailures = 0
-            // Unconditional resync. The client cannot tell how long it was away,
-            // and cannot tell whether it fell off the ring — so it must not try.
-            return RecoveryPlan(
-                resyncAllPanes: true,
-                subscribe: state.knownPanes,
-                reconnectAfter: 0
-            )
+            state.connectedSince = nil
+            // Reconnect ONLY. The resync and subscriptions follow on `connected`,
+            // because there is no transport yet to run them on — emitting them
+            // here as well is what produced duplicate subscriptions.
+            return RecoveryPlan([.reconnect(after: 0)])
 
         case .paneCreated(let pane):
             let isNew = state.knownPanes.insert(pane).inserted
-            // Subscriptions are pane-scoped with no wildcard, so a new pane is
-            // unwatched until something subscribes to it specifically.
-            return RecoveryPlan(subscribe: isNew ? [pane] : [])
+            // Only worth subscribing now if there is a connection to subscribe
+            // on; otherwise the next `connected` picks it up in the full set.
+            guard isNew, state.isConnected else { return RecoveryPlan() }
+            return RecoveryPlan([.subscribe([pane])])
+
+        case .paneClosed(let pane):
+            state.knownPanes.remove(pane)
+            return RecoveryPlan()
         }
     }
 
-    /// Seeds the pane set from a listing, so a resync re-subscribes to panes the
-    /// client learned about by asking rather than by event.
-    public func observe(panes: [String], state: inout State) {
-        state.knownPanes = Set(panes)
+    /// Replaces the known-pane set from an **authoritative** listing.
+    ///
+    /// Takes `AgentInfo` rather than `[String]` deliberately. The previous
+    /// signature accepted any array and replaced the set wholesale, so a caller
+    /// passing a filtered or paged listing silently forgot every omitted pane —
+    /// and those panes stayed unwatched after the next reconnect, their silence
+    /// indistinguishable from having no output. `agent.list` returns the whole
+    /// set, so requiring its result makes a partial listing something you have to
+    /// construct on purpose rather than something you pass by accident.
+    ///
+    /// Incremental discovery goes through `.paneCreated` / `.paneClosed`.
+    public func observe(agentList: [AgentInfo], state: inout State) {
+        state.knownPanes = Set(agentList.map(\.paneID))
     }
 }

--- a/Sources/HerdrKit/SessionRecovery.swift
+++ b/Sources/HerdrKit/SessionRecovery.swift
@@ -1,0 +1,179 @@
+import Foundation
+
+/// Something that happened to the connection or the app, which the client must
+/// react to.
+public enum ClientEvent: Equatable, Sendable {
+    /// A transport finished establishing and is usable.
+    case connected(at: Date)
+    /// The transport dropped, or a request failed in a way that ends the session.
+    case transportFailed(at: Date)
+    /// The interface changed — Wi-Fi to cellular, a VPN came up, the address moved.
+    case networkChanged(at: Date)
+    case backgrounded(at: Date)
+    case foregrounded(at: Date)
+    /// The event stream reported a pane that did not exist before.
+    case paneCreated(String)
+}
+
+/// What the client should do next.
+public struct RecoveryPlan: Equatable, Sendable {
+    /// Drop every cached pane generation and refetch from scratch.
+    public var resyncAllPanes: Bool
+    /// Panes that need a subscription opened. herdr's subscriptions are
+    /// pane-scoped with **no wildcard**, so a pane absent from this set is a
+    /// pane nothing is watching.
+    public var subscribe: Set<String>
+    /// Delay before the next connection attempt, or `nil` for "do not attempt".
+    public var reconnectAfter: TimeInterval?
+
+    public init(
+        resyncAllPanes: Bool = false,
+        subscribe: Set<String> = [],
+        reconnectAfter: TimeInterval? = nil
+    ) {
+        self.resyncAllPanes = resyncAllPanes
+        self.subscribe = subscribe
+        self.reconnectAfter = reconnectAfter
+    }
+}
+
+/// Decides how a client recovers from disconnection, network change and
+/// backgrounding.
+///
+/// ## Why there is no "resume from sequence" here
+///
+/// herdr's EventHub is a **512-entry ring with no gap signal**. A client that
+/// was away long enough falls off the back of it and **cannot detect that it
+/// did** — the sequence numbers it sees afterwards are perfectly continuous with
+/// the ones it remembers, and simply describe a different stretch of history.
+///
+/// So this type does not offer a way to resume from a remembered position, and
+/// that absence is the design. An API that accepted a last-seen sequence would
+/// be used, would look correct in every test written against a server that had
+/// not wrapped, and would silently show stale panes in exactly the case it was
+/// added for: a phone that was in someone's pocket.
+///
+/// Only two things are worth persisting across a gap: which pane the reader had
+/// selected, and nothing else. Revisions are re-established by asking.
+public struct SessionRecovery: Sendable {
+    /// First retry delay.
+    public var baseDelay: TimeInterval
+    /// Ceiling on the backoff, before jitter.
+    public var maximumDelay: TimeInterval
+    /// How long a connection must survive before it counts as healthy.
+    ///
+    /// Resetting the backoff the moment a connection is *established* is the
+    /// classic form of this bug: a server that accepts and immediately drops
+    /// produces an unbounded stream of fast reconnects, because every attempt
+    /// "succeeded" long enough to reset the counter. A connection has to *last*
+    /// to prove anything.
+    public var stabilityInterval: TimeInterval
+
+    public init(
+        baseDelay: TimeInterval = 0.5,
+        maximumDelay: TimeInterval = 30,
+        stabilityInterval: TimeInterval = 10
+    ) {
+        self.baseDelay = baseDelay
+        self.maximumDelay = maximumDelay
+        self.stabilityInterval = stabilityInterval
+    }
+
+    /// Mutable recovery state. Kept separate from the policy so the policy stays
+    /// a value with no hidden history.
+    public struct State: Equatable, Sendable {
+        public var consecutiveFailures: Int = 0
+        public var connectedSince: Date?
+        public var isForeground: Bool = true
+        /// Every pane the client believes exists. Subscriptions are pane-scoped,
+        /// so this is also the re-subscribe list.
+        public var knownPanes: Set<String> = []
+
+        public init() {}
+    }
+
+    /// Full-jitter backoff: a delay drawn uniformly from `0 ..< capped`.
+    ///
+    /// Jittered because a fleet of clients dropped by one network event would
+    /// otherwise return in lockstep, and the reconnect storm arrives exactly when
+    /// the server is least able to absorb it. Full jitter rather than a fixed
+    /// fraction: it is the variant that actually decorrelates clients.
+    public func backoff(
+        failures: Int, using generator: inout some RandomNumberGenerator
+    ) -> TimeInterval {
+        guard failures > 0 else { return 0 }
+        let exponential = baseDelay * pow(2, Double(failures - 1))
+        let capped = min(exponential, maximumDelay)
+        return TimeInterval.random(in: 0..<capped, using: &generator)
+    }
+
+    public func plan(
+        for event: ClientEvent,
+        state: inout State,
+        using generator: inout some RandomNumberGenerator
+    ) -> RecoveryPlan {
+        switch event {
+        case .connected(let at):
+            state.connectedSince = at
+            // Every reconnection is a gap of unknown length, so it resyncs and
+            // re-subscribes. There is no cheaper path on purpose.
+            return RecoveryPlan(
+                resyncAllPanes: true,
+                subscribe: state.knownPanes,
+                reconnectAfter: nil
+            )
+
+        case .transportFailed(let at):
+            // A connection that lasted counts as healthy, so the next failure
+            // starts from a short delay rather than inheriting an old streak.
+            if let since = state.connectedSince, at.timeIntervalSince(since) >= stabilityInterval {
+                state.consecutiveFailures = 0
+            }
+            state.connectedSince = nil
+            state.consecutiveFailures += 1
+            guard state.isForeground else { return RecoveryPlan() }
+            return RecoveryPlan(
+                reconnectAfter: backoff(failures: state.consecutiveFailures, using: &generator)
+            )
+
+        case .networkChanged:
+            // Reconnect, not migrate. The old socket is bound to an address that
+            // may no longer exist, and a half-open connection on a dead interface
+            // fails by timing out rather than by erroring — which is the slowest
+            // possible way to discover it.
+            state.connectedSince = nil
+            state.consecutiveFailures = 0
+            guard state.isForeground else { return RecoveryPlan() }
+            return RecoveryPlan(reconnectAfter: 0)
+
+        case .backgrounded:
+            state.isForeground = false
+            // No reconnect scheduling while suspended: the attempt would not run,
+            // and on return it would look like a fresh failure streak.
+            return RecoveryPlan()
+
+        case .foregrounded:
+            state.isForeground = true
+            state.consecutiveFailures = 0
+            // Unconditional resync. The client cannot tell how long it was away,
+            // and cannot tell whether it fell off the ring — so it must not try.
+            return RecoveryPlan(
+                resyncAllPanes: true,
+                subscribe: state.knownPanes,
+                reconnectAfter: 0
+            )
+
+        case .paneCreated(let pane):
+            let isNew = state.knownPanes.insert(pane).inserted
+            // Subscriptions are pane-scoped with no wildcard, so a new pane is
+            // unwatched until something subscribes to it specifically.
+            return RecoveryPlan(subscribe: isNew ? [pane] : [])
+        }
+    }
+
+    /// Seeds the pane set from a listing, so a resync re-subscribes to panes the
+    /// client learned about by asking rather than by event.
+    public func observe(panes: [String], state: inout State) {
+        state.knownPanes = Set(panes)
+    }
+}

--- a/Sources/HerdrKit/SessionRecovery.swift
+++ b/Sources/HerdrKit/SessionRecovery.swift
@@ -295,13 +295,22 @@ public struct SessionRecovery: Sendable {
 
 /// The complete pane set as the server reported it.
 ///
-/// Only `HerdrClient` can make one, so "this is the whole set" is enforced by
-/// where the value came from rather than by asking callers to be careful.
+/// The guarantee is exactly what `internal` provides and no more: **code outside
+/// this module cannot construct one**, so an app cannot hand `observe` a
+/// filtered list. Inside the module any code can use the initializer, and
+/// `HerdrClient.paneSnapshot()` is the intended source by convention rather than
+/// by enforcement.
+///
+/// An earlier comment here said "only `HerdrClient` can make one". That was
+/// wrong, and wrong in the direction that makes a weak guarantee sound like a
+/// strong one — which matters because the whole point of this type is that its
+/// provenance is enforced rather than trusted.
 public struct PaneSnapshot: Equatable, Sendable {
     public let paneIDs: Set<String>
 
-    /// Internal on purpose: a caller outside the module cannot mint one from a
-    /// filtered list, which is the entire guarantee.
+    /// Deliberately not `public`. Widening this restores the filtered-list path
+    /// that `observe` exists to close, and `PaneSnapshotAccessTests` fails if it
+    /// is widened.
     init(agents: [AgentInfo]) {
         self.paneIDs = Set(agents.map(\.paneID))
     }

--- a/Tests/HerdrKitTests/SessionRecoveryTests.swift
+++ b/Tests/HerdrKitTests/SessionRecoveryTests.swift
@@ -1,6 +1,14 @@
 import XCTest
 @testable import HerdrKit
 
+/// A generator that always yields the same bits, so `random(in:)` returns a
+/// fixed fraction of its range. Jitter then cannot hide whether the RANGE grew,
+/// which is what the growth test needs and what the previous one lacked.
+private struct ConstantGenerator: RandomNumberGenerator {
+    let bits: UInt64
+    mutating func next() -> UInt64 { bits }
+}
+
 /// Deterministic generator, so a jitter test asserts a distribution property
 /// rather than hoping.
 private struct SeededGenerator: RandomNumberGenerator {
@@ -31,8 +39,18 @@ final class SessionRecoveryTests: XCTestCase {
 
     private func seeded(_ ids: [String]) throws -> SessionRecovery.State {
         var state = SessionRecovery.State()
-        recovery.observe(agentList: try panes(ids), state: &state)
+        recovery.observe(PaneSnapshot(agents: try panes(ids)), state: &state)
         return state
+    }
+
+    /// Opens an attempt the way production does, and hands back its identifier
+    /// so a test can answer with the right one — or deliberately the wrong one.
+    private func connect(
+        _ state: inout SessionRecovery.State, at when: Date = Date()
+    ) -> AttemptID {
+        let opened = recovery.beginInitialAttempt(state: &state).reconnectAttempt!
+        _ = plan(.connected(opened, at: when), &state)
+        return opened
     }
 
     /// THE AXIS for task 4: a client that missed events resyncs rather than
@@ -52,10 +70,11 @@ final class SessionRecoveryTests: XCTestCase {
         // Short enough that "surely nothing was missed" is tempting — which is
         // exactly the reasoning this must not embody.
         let resumed = plan(.foregrounded(at: Date().addingTimeInterval(0.2)), &state)
-        XCTAssertEqual(resumed.actions, [.reconnect(after: 0)],
-                       "foregrounding has no transport to resync on yet")
+        XCTAssertEqual(resumed.actions.count, 1, "foregrounding has no transport to resync on yet")
+        XCTAssertEqual(resumed.reconnectDelay, 0)
 
-        let connected = plan(.connected(at: Date().addingTimeInterval(0.3)), &state)
+        let attempt = resumed.reconnectAttempt!
+        let connected = plan(.connected(attempt, at: Date().addingTimeInterval(0.3)), &state)
         XCTAssertEqual(connected.actions, [.resyncAllPanes, .subscribe(["p1", "p2"])],
                        "resync must precede subscription, and both happen once")
 
@@ -74,10 +93,46 @@ final class SessionRecoveryTests: XCTestCase {
         var state = try seeded(["p1"])
         _ = plan(.backgrounded(at: Date()), &state)
 
-        let late = plan(.connected(at: Date().addingTimeInterval(0.1)), &state)
+        let late = plan(.connected(AttemptID(value: 99), at: Date().addingTimeInterval(0.1)), &state)
         XCTAssertEqual(late.actions, [.discardConnection])
         XCTAssertFalse(late.contains(.resyncAllPanes), "no work may start on an unwanted connection")
         XCTAssertNil(late.subscribes, "no subscription may open on an unwanted connection")
+    }
+
+    /// AXIS: a network change mid-attempt yields EXACTLY ONE adoption, however
+    /// the abandoned attempt's callbacks arrive afterwards.
+    ///
+    /// Ordering the actions did not fix this and could not: order governs steps
+    /// within one plan, and this is about which *attempt* a callback belongs to.
+    /// Attempt A is abandoned by the network change, but nothing stops it
+    /// finishing — so `connected(A)` must be discarded, `connected(B)` adopted,
+    /// and a late `transportFailed(A)` must not tear down the B already in use.
+    func testStaleAttemptCallbacksNeitherAdoptNorTearDown() throws {
+        var state = try seeded(["p1"])
+        let attemptA = recovery.beginInitialAttempt(state: &state).reconnectAttempt!
+
+        let changed = plan(.networkChanged(at: Date()), &state)
+        let attemptB = changed.reconnectAttempt!
+        XCTAssertNotEqual(attemptA, attemptB, "a new attempt must not reuse the abandoned identifier")
+
+        // A finishes anyway.
+        let lateA = plan(.connected(attemptA, at: Date()), &state)
+        XCTAssertEqual(lateA.actions, [.discardConnection], "an abandoned attempt must not be adopted")
+
+        let adoptedB = plan(.connected(attemptB, at: Date()), &state)
+        XCTAssertEqual(adoptedB.actions, [.resyncAllPanes, .subscribe(["p1"])])
+
+        // ...and then A reports its failure, after B is already in use.
+        let failedA = plan(.transportFailed(attemptA, at: Date()), &state)
+        XCTAssertTrue(failedA.isEmpty, "a stale failure must not schedule a reconnect")
+        XCTAssertEqual(state.consecutiveFailures, 0, "a stale failure must not count against the backoff")
+        XCTAssertNotNil(state.connectedSince, "a stale failure must not tear down the adopted connection")
+
+        let everything = lateA.actions + adoptedB.actions + failedA.actions
+        XCTAssertEqual(everything.filter { $0 == .resyncAllPanes }.count, 1,
+                       "exactly one adoption may resync")
+        XCTAssertEqual(everything.filter { if case .subscribe = $0 { return true }; return false }.count, 1,
+                       "exactly one adoption may subscribe")
     }
 
     /// AXIS: no field on `State` can hold a resume position.
@@ -89,21 +144,55 @@ final class SessionRecoveryTests: XCTestCase {
     func testRecoveryStateHasNoFieldThatCouldHoldAResumePosition() {
         let fields = Mirror(reflecting: SessionRecovery.State())
             .children.compactMap(\.label).sorted()
+        // Updated once, deliberately, when attempt identity was added — and that
+        // is the guard working. `currentAttempt` and `nextAttemptValue` identify
+        // a LOCAL connection attempt, a counter this client mints and compares
+        // only against itself. Neither is a server position: nothing puts them on
+        // the wire, and no herdr API would accept one. The point of this list is
+        // that a new field forces that judgement out loud instead of arriving
+        // unexamined.
         XCTAssertEqual(
-            fields, ["connectedSince", "consecutiveFailures", "isForeground", "knownPanes"],
+            fields,
+            ["connectedSince", "consecutiveFailures", "currentAttempt",
+             "isForeground", "knownPanes", "nextAttemptValue"],
             "SessionRecovery.State grew a field; if it can hold a stream position, resumption just became expressible"
         )
     }
 
-    /// AXIS: backoff grows, and is capped.
-    func testBackoffGrowsAndIsCapped() {
-        var generator = SeededGenerator(seed: 7)
+    /// AXIS: the backoff RANGE grows exponentially until the cap, then stops.
+    ///
+    /// The previous version asserted only that each random draw was ≤ the cap.
+    /// That is true of a schedule with no growth at all — the reviewer replaced
+    /// the exponential ceiling with `maximumDelay` at every failure count and the
+    /// test stayed green, so the implementation could lose exponential backoff
+    /// while the axis it claimed remained "covered".
+    ///
+    /// Holding the generator constant makes each draw a fixed fraction of the
+    /// range, so growth in the delays IS growth in the range.
+    func testBackoffRangeGrowsExponentiallyThenHoldsAtTheCap() {
+        var delays: [TimeInterval] = []
         for failures in 1...12 {
-            let delay = recovery.backoff(failures: failures, using: &generator)
-            XCTAssertGreaterThanOrEqual(delay, 0)
-            XCTAssertLessThanOrEqual(delay, recovery.maximumDelay,
-                                     "delay \(delay)s at failure \(failures) exceeded the cap")
+            var generator = ConstantGenerator(bits: UInt64.max / 2)
+            delays.append(recovery.backoff(failures: failures, using: &generator))
         }
+
+        // Doubling while below the cap.
+        for index in 1..<delays.count where delays[index] < recovery.maximumDelay * 0.4 {
+            XCTAssertEqual(
+                delays[index], delays[index - 1] * 2, accuracy: delays[index] * 0.02,
+                "delay \(index + 1) did not double: \(delays[index - 1]) -> \(delays[index])"
+            )
+        }
+        // Growth actually happened, rather than every value sitting at the cap.
+        XCTAssertGreaterThan(delays[3], delays[0], "the range never grew")
+        XCTAssertLessThan(delays[0], recovery.maximumDelay * 0.1, "the first delay is already at the cap")
+        // Constant once capped.
+        XCTAssertEqual(delays[11], delays[10], accuracy: 0.001, "delays must stop growing at the cap")
+        for delay in delays {
+            XCTAssertLessThanOrEqual(delay, recovery.maximumDelay)
+        }
+
+        var generator = ConstantGenerator(bits: 0)
         XCTAssertEqual(recovery.backoff(failures: 0, using: &generator), 0, "no failures, no delay")
     }
 
@@ -129,10 +218,12 @@ final class SessionRecoveryTests: XCTestCase {
     func testFlappingConnectionDoesNotResetTheBackoff() {
         var state = SessionRecovery.State()
         let start = Date()
+        var opened = recovery.beginInitialAttempt(state: &state).reconnectAttempt!
         for attempt in 0..<5 {
             let at = start.addingTimeInterval(Double(attempt) * 0.1)
-            _ = plan(.connected(at: at), &state)
-            _ = plan(.transportFailed(at: at.addingTimeInterval(0.05)), &state, seed: 99)
+            _ = plan(.connected(opened, at: at), &state)
+            let failed = plan(.transportFailed(opened, at: at.addingTimeInterval(0.05)), &state, seed: 99)
+            opened = failed.reconnectAttempt ?? opened
         }
         XCTAssertEqual(state.consecutiveFailures, 5,
                        "five flaps counted \(state.consecutiveFailures) failures; a short-lived connection must not count as healthy")
@@ -142,13 +233,14 @@ final class SessionRecoveryTests: XCTestCase {
     func testAHealthyConnectionResetsTheBackoff() {
         var state = SessionRecovery.State()
         let start = Date()
-        _ = plan(.connected(at: start), &state)
-        _ = plan(.transportFailed(at: start.addingTimeInterval(0.05)), &state)
+        let first = connect(&state, at: start)
+        let retry = plan(.transportFailed(first, at: start.addingTimeInterval(0.05)), &state)
         XCTAssertEqual(state.consecutiveFailures, 1)
 
         let recovered = start.addingTimeInterval(1)
-        _ = plan(.connected(at: recovered), &state)
-        _ = plan(.transportFailed(at: recovered.addingTimeInterval(recovery.stabilityInterval + 1)), &state)
+        let second = retry.reconnectAttempt!
+        _ = plan(.connected(second, at: recovered), &state)
+        _ = plan(.transportFailed(second, at: recovered.addingTimeInterval(recovery.stabilityInterval + 1)), &state)
         XCTAssertEqual(state.consecutiveFailures, 1,
                        "a connection that lasted past the stability window must clear the streak")
     }
@@ -161,7 +253,7 @@ final class SessionRecoveryTests: XCTestCase {
         XCTAssertTrue(plan(.paneCreated("p9"), &state).isEmpty, "no connection, nothing to subscribe on")
         XCTAssertTrue(state.knownPanes.contains("p9"), "but it must still be remembered")
 
-        _ = plan(.connected(at: Date()), &state)
+        _ = connect(&state)
         XCTAssertEqual(plan(.paneCreated("p8"), &state).subscribes, ["p8"])
         XCTAssertTrue(plan(.paneCreated("p8"), &state).isEmpty, "a repeat must not re-subscribe")
     }
@@ -173,7 +265,8 @@ final class SessionRecoveryTests: XCTestCase {
     func testPanesLearnedDuringASessionAreResubscribedAfterReconnect() throws {
         var state = try seeded(["p1"])
         _ = plan(.paneCreated("p2"), &state)
-        XCTAssertEqual(plan(.connected(at: Date()), &state).subscribes, ["p1", "p2"],
+        let opened = recovery.beginInitialAttempt(state: &state).reconnectAttempt!
+        XCTAssertEqual(plan(.connected(opened, at: Date()), &state).subscribes, ["p1", "p2"],
                        "a pane discovered mid-session must be re-subscribed, not forgotten")
     }
 
@@ -185,18 +278,21 @@ final class SessionRecoveryTests: XCTestCase {
     func testClosedPanesAreDroppedIncrementally() throws {
         var state = try seeded(["p1", "p2"])
         _ = plan(.paneClosed("p2"), &state)
-        XCTAssertEqual(plan(.connected(at: Date()), &state).subscribes, ["p1"])
+        let opened = recovery.beginInitialAttempt(state: &state).reconnectAttempt!
+        XCTAssertEqual(plan(.connected(opened, at: Date()), &state).subscribes, ["p1"])
     }
 
-    /// AXIS: observation takes an authoritative listing, not any array.
+    /// AXIS: only an authoritative snapshot can replace the pane set.
     ///
-    /// The old signature accepted `[String]` and replaced the set wholesale, so a
-    /// filtered listing silently forgot the rest. Requiring `agent.list`'s own
-    /// result makes a partial set something you construct deliberately.
-    func testObservationTakesTheAuthoritativeListing() throws {
+    /// Two earlier signatures failed this. `[String]` replaced wholesale, so a
+    /// filtered listing silently forgot the rest; `[AgentInfo]` was described as
+    /// making that hard and did not — `result.filter { … }` is exactly as easy to
+    /// write as `result`. `PaneSnapshot` cannot be constructed outside the
+    /// module, so provenance is enforced by the type rather than by care.
+    func testOnlyAnAuthoritativeSnapshotCanReplaceThePaneSet() throws {
         var state = try seeded(["p1", "p2", "p3"])
         XCTAssertEqual(state.knownPanes, ["p1", "p2", "p3"])
-        recovery.observe(agentList: try panes(["p1"]), state: &state)
+        recovery.observe(PaneSnapshot(agents: try panes(["p1"])), state: &state)
         XCTAssertEqual(state.knownPanes, ["p1"], "an authoritative listing is still authoritative")
     }
 
@@ -205,7 +301,7 @@ final class SessionRecoveryTests: XCTestCase {
         var state = try seeded(["p1"])
         _ = plan(.backgrounded(at: Date()), &state)
 
-        XCTAssertNil(plan(.transportFailed(at: Date()), &state).reconnectDelay)
+        XCTAssertNil(plan(.transportFailed(AttemptID(value: 1), at: Date()), &state).reconnectDelay)
         XCTAssertNil(plan(.networkChanged(at: Date()), &state).reconnectDelay)
 
         let resumed = plan(.foregrounded(at: Date()), &state)
@@ -221,13 +317,14 @@ final class SessionRecoveryTests: XCTestCase {
     /// discovering it by timeout, which is the slowest possible way.
     func testNetworkChangeCancelsThenReconnectsImmediately() throws {
         var state = try seeded(["p1"])
-        _ = plan(.connected(at: Date()), &state)
-        _ = plan(.transportFailed(at: Date().addingTimeInterval(0.01)), &state)
+        let opened = connect(&state)
+        _ = plan(.transportFailed(opened, at: Date().addingTimeInterval(0.01)), &state)
         XCTAssertEqual(state.consecutiveFailures, 1)
 
         let changed = plan(.networkChanged(at: Date()), &state)
-        XCTAssertEqual(changed.actions, [.cancelTransport, .reconnect(after: 0)],
+        XCTAssertEqual(changed.actions.first, .cancelTransport,
                        "the dead transport must be cancelled before a new one opens")
+        XCTAssertEqual(changed.reconnectDelay, 0, "a network change must not back off")
         XCTAssertEqual(state.consecutiveFailures, 0)
     }
 }

--- a/Tests/HerdrKitTests/SessionRecoveryTests.swift
+++ b/Tests/HerdrKitTests/SessionRecoveryTests.swift
@@ -367,36 +367,76 @@ final class ResyncInvalidationTests: XCTestCase {
 }
 
 
-/// Access control is the provenance guarantee, so it is checked as access
-/// control rather than through behaviour.
+/// Access control is the provenance guarantee, so it is checked against the
+/// COMPILER'S OWN view of the module surface.
 ///
-/// A behavioural test cannot observe who is *allowed* to call an initializer —
-/// the previous provenance test passed with `PaneSnapshot.init` made public,
-/// which is precisely the change that reopens the filtered-list path. Reading
-/// the declaration is crude, and it is the only thing here that fails when the
-/// invariant is broken.
+/// Two weaker versions preceded this. A behavioural test could not see access
+/// control at all and passed with the initialiser made public. A textual scan
+/// then caught that exact spelling and nothing else: `public` on the preceding
+/// line, `package` instead of `public`, or an added `public init(paneIDs:)` all
+/// compiled and all survived it — and the last two genuinely reopen the path
+/// this type exists to close.
+///
+/// `swift symbolgraph-extract` reports what is actually visible outside the
+/// module, so formatting, access-level spelling and additional initialisers are
+/// all covered by construction rather than by enumeration.
 final class PaneSnapshotAccessTests: XCTestCase {
-    func testPaneSnapshotInitialiserIsNotPublic() throws {
-        let source = URL(fileURLWithPath: #filePath)
-            .deletingLastPathComponent()   // HerdrKitTests
-            .deletingLastPathComponent()   // Tests
-            .deletingLastPathComponent()   // repo root
-            .appendingPathComponent("Sources/HerdrKit/SessionRecovery.swift")
-        let text = try String(contentsOf: source, encoding: .utf8)
+    func testPaneSnapshotExposesNoInitialiserOutsideTheModule() throws {
+        let root = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent()
+        let build = root.appendingPathComponent(".build")
 
-        guard let declaration = text.range(of: "public struct PaneSnapshot") else {
-            return XCTFail("PaneSnapshot moved; this guard no longer looks where it thinks it does")
-        }
-        let body = text[declaration.lowerBound...]
-        guard let end = body.range(of: "\n}") else {
-            return XCTFail("could not delimit PaneSnapshot")
-        }
-        let snapshot = body[..<end.lowerBound]
+        // The triple is the directory name, so this does not hardcode a platform.
+        let modules = try FileManager.default
+            .contentsOfDirectory(atPath: build.path)
+            .map { build.appendingPathComponent($0).appendingPathComponent("debug/Modules") }
+            .first { FileManager.default.fileExists(atPath: $0.appendingPathComponent("HerdrKit.swiftmodule").path) }
+        let moduleDir = try XCTUnwrap(
+            modules, "no built HerdrKit.swiftmodule; the access invariant went UNCHECKED"
+        )
+        let triple = moduleDir.deletingLastPathComponent().deletingLastPathComponent().lastPathComponent
 
-        XCTAssertTrue(snapshot.contains("init(agents:"), "the initialiser this guard exists for is gone")
-        XCTAssertFalse(
-            snapshot.contains("public init(agents:"),
-            "PaneSnapshot.init became public — code outside HerdrKit can now build one from a filtered list, which is the exact path observe() exists to close"
+        let output = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("herdrkit-symbolgraph-\(triple)")
+        try? FileManager.default.createDirectory(at: output, withIntermediateDirectories: true)
+
+        let swift = ["/opt/swift/usr/bin/swift", "/usr/bin/swift"]
+            .first { FileManager.default.isExecutableFile(atPath: $0) }
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: try XCTUnwrap(
+            swift, "no swift toolchain found; the access invariant went UNCHECKED"
+        ))
+        process.arguments = [
+            "symbolgraph-extract", "-module-name", "HerdrKit", "-target", triple,
+            "-I", moduleDir.path,
+            "-I", root.appendingPathComponent("Sources/CSSH").path,
+            "-output-dir", output.path, "-minimum-access-level", "package",
+        ]
+        process.standardOutput = Pipe()
+        process.standardError = Pipe()
+        try process.run()
+        process.waitUntilExit()
+
+        let graph = output.appendingPathComponent("HerdrKit.symbols.json")
+        guard let data = try? Data(contentsOf: graph) else {
+            return XCTFail("symbolgraph-extract produced no graph; the access invariant went UNCHECKED")
+        }
+        let decoded = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        let symbols = try XCTUnwrap(decoded?["symbols"] as? [[String: Any]])
+
+        // Sanity: the extraction has to have seen the type, or an empty result
+        // would look like a pass.
+        let snapshotSymbols = symbols.filter {
+            (($0["pathComponents"] as? [String])?.first) == "PaneSnapshot"
+        }
+        XCTAssertFalse(snapshotSymbols.isEmpty, "PaneSnapshot is not in the surface at all; wrong module or stale build")
+
+        let initialisers = snapshotSymbols.filter {
+            (($0["kind"] as? [String: Any])?["identifier"] as? String)?.hasPrefix("swift.init") == true
+        }
+        XCTAssertTrue(
+            initialisers.isEmpty,
+            "PaneSnapshot exposes \(initialisers.count) initialiser(s) at package access or above; code outside HerdrKit can now build one from a filtered list, which is the exact path observe() exists to close"
         )
     }
 }

--- a/Tests/HerdrKitTests/SessionRecoveryTests.swift
+++ b/Tests/HerdrKitTests/SessionRecoveryTests.swift
@@ -291,6 +291,64 @@ final class SessionRecoveryTests: XCTestCase {
                        "the replacement transport must open the full current set")
     }
 
+    /// AXIS: a saved foregrounded copy cannot dial after backgrounding.
+    ///
+    /// The reviewer's replay probe: isForeground was value-stored, so saving a
+    /// foregrounded State, processing backgrounded, restoring the copy and
+    /// calling beginInitialAttempt emitted cancel+reconnect — dialing while
+    /// suspended, against the explicit rule. Foreground is a decision input and
+    /// lives in the shared authority now.
+    func testASavedForegroundedCopyCannotDialAfterBackgrounding() throws {
+        var state = try seeded(["p1"])
+        let saved = state                       // foregrounded copy
+
+        _ = plan(.backgrounded(at: Date()), &state)
+        state = saved                           // the replay
+
+        XCTAssertTrue(recovery.beginInitialAttempt(state: &state).isEmpty,
+                      "a replayed foreground bit let a backgrounded client dial")
+        XCTAssertFalse(state.isForeground, "the restored copy must read the lineage's foreground state")
+
+        let resumed = plan(.foregrounded(at: Date()), &state)
+        XCTAssertNotNil(resumed.reconnectAttempt, "a real foregrounding must still dial")
+    }
+
+    /// AXIS: retirement and replacement are one fact — duplicate failures earn
+    /// ONE reconnect, and the failed attempt is never current once its failure
+    /// begins processing.
+    ///
+    /// The reviewer's gated probes: the split fail-then-mint left the failed
+    /// attempt current in the backoff window, where connected(A) re-adopted the
+    /// failed transport, and eight concurrent transportFailed(A) each passed
+    /// the current-attempt check and earned eight reconnects.
+    func testDuplicateFailuresEarnOneReconnectAndNoReadoption() throws {
+        var state = try seeded(["p1"])
+        let attemptA = connect(&state)
+
+        // Sequential half: after ONE failure is processed, the failed attempt
+        // is already retired — its own late connected must be stale.
+        let first = plan(.transportFailed(attemptA, at: Date()), &state)
+        XCTAssertNotNil(first.reconnectDelay, "the real failure schedules the retry")
+        XCTAssertEqual(plan(.connected(attemptA, at: Date()), &state).actions, [.discardConnection],
+                       "the failed attempt was re-adopted inside the backoff window")
+
+        // Concurrent half: eight duplicate failure callbacks, one reconnect.
+        var fresh = try seeded(["p1"])
+        let attemptB = connect(&fresh)
+        let counted = NSLock()
+        var reconnects = 0
+        DispatchQueue.concurrentPerform(iterations: 8) { lane in
+            var copy = fresh
+            var generator = SeededGenerator(seed: UInt64(lane) + 40)
+            let outcome = recovery.plan(for: .transportFailed(attemptB, at: Date()), state: &copy, using: &generator)
+            if outcome.reconnectAttempt != nil {
+                counted.lock(); reconnects += 1; counted.unlock()
+            }
+        }
+        XCTAssertEqual(reconnects, 1,
+                       "\(reconnects) of 8 duplicate failure callbacks earned a reconnect; retirement must be one fact")
+    }
+
     /// AXIS: concurrent discoveries neither lose ledger entries nor emit a
     /// pane's subscription twice.
     ///
@@ -478,9 +536,14 @@ final class SessionRecoveryTests: XCTestCase {
         // connectedSince and subscribedPanes left the stored list: both are
         // computed through the shared authority now, precisely so a value copy
         // cannot replay them. Mirror sees stored fields only.
+        // isForeground moved INTO the authority: it is a decision input
+        // (whether to dial), and value-stored it was replayable — a saved
+        // foregrounded copy dialed while backgrounded. Stored value fields are
+        // down to accounting (streak) and knowledge (panes), both documented as
+        // replayable with bounded consequence.
         XCTAssertEqual(
             fields,
-            ["authority", "consecutiveFailures", "isForeground", "knownPanes"],
+            ["authority", "consecutiveFailures", "knownPanes"],
             "SessionRecovery.State grew a field; if it can hold a stream position, resumption just became expressible"
         )
         // One level down too: State stores AttemptID, so a position smuggled

--- a/Tests/HerdrKitTests/SessionRecoveryTests.swift
+++ b/Tests/HerdrKitTests/SessionRecoveryTests.swift
@@ -380,6 +380,63 @@ final class SessionRecoveryTests: XCTestCase {
         XCTAssertNotEqual(plansA.subscribesOn, plansB.subscribesOn)
     }
 
+    /// AXIS: retirement INSIDE the admission-to-emission window cannot relabel
+    /// the action — it stays bound to the attempt that admitted it.
+    ///
+    /// The reviewer's ninth probe, which also refuted my equivalence claim: I
+    /// argued binding to `authority.current ?? attempt` was equivalent because
+    /// admission guarantees the two coincide — but admission's lock releases
+    /// before emission constructs the action, and a concurrent retirement in
+    /// that gap makes them diverge. The action is now constructed exclusively
+    /// from the admission VERDICT (which carries its attempt out of the
+    /// critical section), and this test drives the exact interleaving through
+    /// the seam: pause A after admission, retire A and adopt B, resume.
+    func testRetirementInsideTheEmissionWindowCannotRelabelTheAction() throws {
+        var state = try seeded(["p1"])
+        let attemptA = recovery.beginInitialAttempt(state: &state).reconnectAttempt!
+        _ = plan(.connected(attemptA, at: Date()), &state)
+
+        let paused = DispatchSemaphore(value: 0)
+        let resume = DispatchSemaphore(value: 0)
+        var instrumented = recovery
+        instrumented.afterAdmissionHook = {
+            paused.signal()
+            _ = resume.wait(timeout: .now() + 5.0)
+        }
+
+        let emitted = NSLock()
+        var plansA: RecoveryPlan?
+        var lane = state                       // shares the lineage's authority
+        let worker = Thread { [instrumented] in
+            var laneState = lane
+            var generator = SeededGenerator(seed: 7)
+            _ = generator                       // observe takes no generator
+            let plan = instrumented.observe(
+                PaneSnapshot(agents: try! self.panes(["p1", "pnew"])), from: attemptA, state: &laneState)
+            emitted.lock(); plansA = plan; emitted.unlock()
+        }
+        worker.start()
+        XCTAssertEqual(paused.wait(timeout: .now() + 5.0), .success, "never reached the window")
+
+        // Inside A's window: retire A, adopt B.
+        _ = plan(.networkChanged(at: Date()), &state)
+        let attemptB = recovery.beginInitialAttempt(state: &state).reconnectAttempt!
+        _ = plan(.connected(attemptB, at: Date()), &state)
+
+        resume.signal()
+        let deadline = Date().addingTimeInterval(5)
+        while Date() < deadline {
+            emitted.lock(); let done = plansA != nil; emitted.unlock()
+            if done { break }
+            usleep(10_000)
+        }
+
+        emitted.lock(); let final = plansA; emitted.unlock()
+        let boundTo = try XCTUnwrap(final).subscribesOn
+        XCTAssertEqual(boundTo, attemptA,
+                       "the action admitted under A was relabeled \(boundTo == attemptB ? "as B" : "unexpectedly") inside the emission window")
+    }
+
     /// AXIS: a delayed snapshot from an abandoned attempt admits nothing onto
     /// its replacement.
     ///

--- a/Tests/HerdrKitTests/SessionRecoveryTests.swift
+++ b/Tests/HerdrKitTests/SessionRecoveryTests.swift
@@ -156,6 +156,55 @@ final class SessionRecoveryTests: XCTestCase {
         XCTAssertEqual(plan(.connected(opened, at: Date()), &offline).subscribes, ["p1", "p4"])
     }
 
+    /// AXIS: a callback minted before a State replacement can never be adopted
+    /// by the replacement.
+    ///
+    /// A bare counter restarted at 1 in a fresh State, so the DISCARDED state's
+    /// first attempt matched the new state's first attempt and a late connected
+    /// was adopted — defeating the stale-callback protection at the exact
+    /// moment (a caller rebuilding state) it was needed. Identity now carries a
+    /// per-State random epoch.
+    func testCallbacksFromAReplacedStateAreStale() throws {
+        var state = try seeded(["p1"])
+        let preReplacement = recovery.beginInitialAttempt(state: &state).reconnectAttempt!
+
+        state = try seeded(["p1"])   // the caller rebuilds their state
+        let postReplacement = recovery.beginInitialAttempt(state: &state).reconnectAttempt!
+        XCTAssertNotEqual(preReplacement, postReplacement,
+                          "a rebuilt State reminted an identical attempt identity")
+
+        let late = plan(.connected(preReplacement, at: Date()), &state)
+        XCTAssertEqual(late.actions, [.discardConnection],
+                       "a callback from the discarded state was adopted as current")
+    }
+
+    /// AXIS: a pane forgotten by a snapshot shrink and later rediscovered is
+    /// NOT subscribed a second time on the same transport.
+    ///
+    /// There is no unsubscribe verb on the wire — a subscription ends when its
+    /// connection does — so the shrink leaves the first subscription open, and
+    /// the rediscovery previously stacked a second one on top of it.
+    func testAPaneReappearingAfterASnapshotShrinkIsNotDoubleSubscribed() throws {
+        var state = try seeded(["p1", "p2"])
+        _ = connect(&state)   // subscribes {p1, p2}
+
+        // The snapshot forgets p2; its subscription on this transport stays open.
+        XCTAssertTrue(recovery.observe(PaneSnapshot(agents: try panes(["p1"])), state: &state).isEmpty)
+
+        // p2 reappears — via event and via snapshot. Neither may re-subscribe.
+        XCTAssertTrue(plan(.paneCreated("p2"), &state).isEmpty,
+                      "paneCreated re-subscribed a pane this transport already watches")
+        XCTAssertTrue(recovery.observe(PaneSnapshot(agents: try panes(["p1", "p2"])), state: &state).isEmpty,
+                      "observe re-subscribed a pane this transport already watches")
+
+        // A NEW transport starts from nothing: the full set is re-subscribed.
+        _ = plan(.networkChanged(at: Date()), &state)
+        let readopted = recovery.beginInitialAttempt(state: &state).reconnectAttempt
+            ?? state.currentAttempt!
+        XCTAssertEqual(plan(.connected(readopted, at: Date()), &state).subscribes, ["p1", "p2"],
+                       "the replacement transport must open the full current set")
+    }
+
     /// AXIS: the stability window measures EVENT time, not wall-clock time.
     ///
     /// Every prior test used event times near Date(), so `connectedSince =
@@ -230,7 +279,7 @@ final class SessionRecoveryTests: XCTestCase {
         var state = try seeded(["p1"])
         _ = plan(.backgrounded(at: Date()), &state)
 
-        let late = plan(.connected(AttemptID(value: 99), at: Date().addingTimeInterval(0.1)), &state)
+        let late = plan(.connected(AttemptID(epoch: 0, value: 99), at: Date().addingTimeInterval(0.1)), &state)
         XCTAssertEqual(late.actions, [.discardConnection])
         XCTAssertFalse(late.contains(.resyncAllPanes), "no work may start on an unwanted connection")
         XCTAssertNil(late.subscribes, "no subscription may open on an unwanted connection")
@@ -288,17 +337,22 @@ final class SessionRecoveryTests: XCTestCase {
         // the wire, and no herdr API would accept one. The point of this list is
         // that a new field forces that judgement out loud instead of arriving
         // unexamined.
+        // subscribedPanes: pane identity only (which panes THIS transport
+        // watches), no ordering, no position. attemptEpoch: random identity
+        // salt, never on the wire. Judged here out loud, which is this guard's
+        // whole job.
         XCTAssertEqual(
             fields,
-            ["connectedSince", "consecutiveFailures", "currentAttempt",
-             "isForeground", "knownPanes", "nextAttemptValue"],
+            ["attemptEpoch", "connectedSince", "consecutiveFailures",
+             "currentAttempt", "isForeground", "knownPanes", "nextAttemptValue",
+             "subscribedPanes"],
             "SessionRecovery.State grew a field; if it can hold a stream position, resumption just became expressible"
         )
         // One level down too: State stores AttemptID, so a position smuggled
         // into AttemptID's fields would be invisible to the check above.
-        let attemptFields = Mirror(reflecting: AttemptID(value: 0))
+        let attemptFields = Mirror(reflecting: AttemptID(epoch: 0, value: 0))
             .children.compactMap(\.label).sorted()
-        XCTAssertEqual(attemptFields, ["value"],
+        XCTAssertEqual(attemptFields, ["epoch", "value"],
                        "AttemptID grew a field; a stream position could hide inside State through it")
     }
 
@@ -444,7 +498,7 @@ final class SessionRecoveryTests: XCTestCase {
     func testASnapshotReplacesThePaneSetWholesale() throws {
         var state = try seeded(["p1", "p2", "p3"])
         XCTAssertEqual(state.knownPanes, ["p1", "p2", "p3"])
-        recovery.observe(PaneSnapshot(agents: try panes(["p1"])), state: &state)
+        _ = recovery.observe(PaneSnapshot(agents: try panes(["p1"])), state: &state)
         XCTAssertEqual(state.knownPanes, ["p1"], "an authoritative listing is still authoritative")
     }
 
@@ -621,6 +675,24 @@ final class PaneSnapshotAccessTests: XCTestCase {
              "swift.property PaneSnapshot.paneIDs",
              "swift.struct PaneSnapshot"],
             "PaneSnapshot's package-visible surface changed; anything that can CONSTRUCT one from caller data reopens the filtered-list path observe() exists to close"
+        )
+
+        // The WHOLE module, not just PaneSnapshot's members. The member-only
+        // version let a package-level `public func makeSnapshot([AgentInfo]) ->
+        // PaneSnapshot` compile and pass — construction laundered through a free
+        // function is still construction. Any visible symbol anywhere in
+        // HerdrKit whose signature RETURNS a PaneSnapshot is a construction
+        // path, and exactly one is intended.
+        let returners = symbols.compactMap { symbol -> String? in
+            guard let signature = symbol["functionSignature"] as? [String: Any],
+                  let returns = signature["returns"] as? [[String: Any]],
+                  returns.contains(where: { ($0["spelling"] as? String)?.contains("PaneSnapshot") == true }),
+                  let path = symbol["pathComponents"] as? [String] else { return nil }
+            return path.joined(separator: ".")
+        }.sorted()
+        XCTAssertEqual(
+            returners, ["HerdrClient.paneSnapshot()"],
+            "a new package-visible symbol returns PaneSnapshot; every such symbol is a construction path, and only HerdrClient.paneSnapshot() is the authoritative source"
         )
     }
 }

--- a/Tests/HerdrKitTests/SessionRecoveryTests.swift
+++ b/Tests/HerdrKitTests/SessionRecoveryTests.swift
@@ -1,0 +1,250 @@
+import XCTest
+@testable import HerdrKit
+
+/// Deterministic generator, so a jitter test asserts a distribution property
+/// rather than hoping.
+private struct SeededGenerator: RandomNumberGenerator {
+    private var state: UInt64
+    init(seed: UInt64) { self.state = seed &* 6364136223846793005 &+ 1442695040888963407 }
+    mutating func next() -> UInt64 {
+        state ^= state << 13; state ^= state >> 7; state ^= state << 17
+        return state
+    }
+}
+
+final class SessionRecoveryTests: XCTestCase {
+    let recovery = SessionRecovery()
+
+    private func plan(
+        _ event: ClientEvent, _ state: inout SessionRecovery.State, seed: UInt64 = 1
+    ) -> RecoveryPlan {
+        var generator = SeededGenerator(seed: seed)
+        return recovery.plan(for: event, state: &state, using: &generator)
+    }
+
+    /// THE AXIS for task 4: a client that missed events resyncs rather than
+    /// continuing from a stale sequence.
+    ///
+    /// herdr's ring holds 512 events and signals nothing when it drops older
+    /// ones, so continuity across a background period is unknowable. This asserts
+    /// the resync happens **unconditionally** — not "when a gap is detected",
+    /// because detecting the gap is the thing that cannot be done.
+    func testForegroundingAlwaysResyncsRatherThanTrustingContinuity() {
+        var state = SessionRecovery.State()
+        recovery.observe(panes: ["p1", "p2"], state: &state)
+
+        // A background period so short that "surely nothing was missed" is
+        // exactly the reasoning this must not embody.
+        _ = plan(.backgrounded(at: Date()), &state)
+        let resumed = plan(.foregrounded(at: Date().addingTimeInterval(0.2)), &state)
+
+        XCTAssertTrue(
+            resumed.resyncAllPanes,
+            "a short absence is indistinguishable from a long one; resync must not be conditional"
+        )
+        XCTAssertEqual(
+            resumed.subscribe, ["p1", "p2"],
+            "subscriptions are pane-scoped with no wildcard, so every known pane must be re-subscribed"
+        )
+    }
+
+    /// The absence IS the feature: nothing here accepts a remembered position.
+    ///
+    /// A `resume(from:)` would pass every test written against a server that had
+    /// not wrapped its ring, and fail only on a phone that was in a pocket.
+    func testNoAPIAcceptsARememberedSequence() {
+        // RecoveryPlan carries no sequence, revision or cursor to resume from —
+        // its whole surface is these three fields.
+        let plan = RecoveryPlan(resyncAllPanes: true, subscribe: ["p1"], reconnectAfter: 1)
+        XCTAssertEqual(plan, RecoveryPlan(resyncAllPanes: true, subscribe: ["p1"], reconnectAfter: 1))
+        // And State persists only pane identity and connection bookkeeping.
+        var state = SessionRecovery.State()
+        recovery.observe(panes: ["p1"], state: &state)
+        XCTAssertEqual(state.knownPanes, ["p1"])
+    }
+
+    /// AXIS: backoff grows, and is capped.
+    func testBackoffGrowsAndIsCapped() {
+        var generator = SeededGenerator(seed: 7)
+        var previousCeiling = 0.0
+        for failures in 1...12 {
+            let delay = recovery.backoff(failures: failures, using: &generator)
+            XCTAssertGreaterThanOrEqual(delay, 0)
+            XCTAssertLessThanOrEqual(
+                delay, recovery.maximumDelay,
+                "delay \(delay)s at failure \(failures) exceeded the cap"
+            )
+            let ceiling = min(recovery.baseDelay * pow(2, Double(failures - 1)), recovery.maximumDelay)
+            XCTAssertGreaterThanOrEqual(ceiling, previousCeiling, "ceiling must not shrink")
+            previousCeiling = ceiling
+        }
+        XCTAssertEqual(recovery.backoff(failures: 0, using: &generator), 0, "no failures, no delay")
+    }
+
+    /// AXIS: the delay is actually jittered.
+    ///
+    /// Asserting only "delay ≤ cap" would pass on a fixed schedule, which is the
+    /// bug jitter exists to prevent — a fleet dropped by one network event
+    /// returning in lockstep. So this asserts the delays SPREAD.
+    func testBackoffIsJitteredNotFixed() {
+        var delays: Set<Double> = []
+        for seed in UInt64(1)...40 {
+            var generator = SeededGenerator(seed: seed)
+            delays.insert(recovery.backoff(failures: 6, using: &generator))
+        }
+        XCTAssertGreaterThan(
+            delays.count, 30,
+            "40 clients drew only \(delays.count) distinct delays; they would reconnect in lockstep"
+        )
+    }
+
+    /// AXIS: a connection that drops immediately does not reset the backoff.
+    ///
+    /// Resetting on *established* is the classic form of this bug: a server that
+    /// accepts and instantly drops looks like a success every time, so the delay
+    /// never grows and the client hammers it. The connection has to LAST.
+    func testFlappingConnectionDoesNotResetTheBackoff() {
+        var state = SessionRecovery.State()
+        let start = Date()
+        var lastDelay = 0.0
+
+        for attempt in 0..<5 {
+            let at = start.addingTimeInterval(Double(attempt) * 0.1)
+            _ = plan(.connected(at: at), &state)
+            // Drops 50ms later — far inside the stability window.
+            let dropped = plan(.transportFailed(at: at.addingTimeInterval(0.05)), &state, seed: 99)
+            lastDelay = try! XCTUnwrap(dropped.reconnectAfter)
+        }
+
+        XCTAssertEqual(
+            state.consecutiveFailures, 5,
+            "five flaps counted \(state.consecutiveFailures) failures; a short-lived connection must not count as healthy"
+        )
+        XCTAssertGreaterThan(lastDelay, 0, "the fifth flap must still be delayed")
+    }
+
+    /// AXIS: a connection that survived the stability window DOES reset it, so a
+    /// client that has been fine for hours is not punished for one drop.
+    func testAHealthyConnectionResetsTheBackoff() {
+        var state = SessionRecovery.State()
+        let start = Date()
+        _ = plan(.connected(at: start), &state)
+        _ = plan(.transportFailed(at: start.addingTimeInterval(0.05)), &state)
+        XCTAssertEqual(state.consecutiveFailures, 1)
+
+        // Reconnects and stays up well past the stability interval.
+        let recovered = start.addingTimeInterval(1)
+        _ = plan(.connected(at: recovered), &state)
+        _ = plan(
+            .transportFailed(at: recovered.addingTimeInterval(recovery.stabilityInterval + 1)),
+            &state
+        )
+        XCTAssertEqual(
+            state.consecutiveFailures, 1,
+            "a connection that lasted past the stability window must clear the streak"
+        )
+    }
+
+    /// AXIS: a new pane gets a subscription, because there is no wildcard.
+    func testPaneCreatedSubscribesToThatPane() {
+        var state = SessionRecovery.State()
+        XCTAssertEqual(plan(.paneCreated("p9"), &state).subscribe, ["p9"])
+        XCTAssertTrue(state.knownPanes.contains("p9"))
+        // Idempotent: a repeat does not re-subscribe.
+        XCTAssertEqual(plan(.paneCreated("p9"), &state).subscribe, [])
+    }
+
+    /// AXIS: a pane learned about while connected survives into the next resync.
+    ///
+    /// Without this, a pane created during a session becomes unwatched after the
+    /// next reconnect, and its silence is indistinguishable from having no output.
+    func testPanesLearnedDuringASessionAreResubscribedAfterReconnect() {
+        var state = SessionRecovery.State()
+        recovery.observe(panes: ["p1"], state: &state)
+        _ = plan(.paneCreated("p2"), &state)
+
+        let reconnected = plan(.connected(at: Date()), &state)
+        XCTAssertEqual(
+            reconnected.subscribe, ["p1", "p2"],
+            "a pane discovered mid-session must be re-subscribed, not forgotten"
+        )
+    }
+
+    /// AXIS: a backgrounded client schedules no reconnect.
+    ///
+    /// The attempt would not run while suspended, and on return the failures it
+    /// accrued would look like a fresh streak — so the client would come back
+    /// slow at the exact moment the reader is looking at it.
+    func testBackgroundedClientSchedulesNoReconnect() {
+        var state = SessionRecovery.State()
+        _ = plan(.backgrounded(at: Date()), &state)
+
+        XCTAssertNil(plan(.transportFailed(at: Date()), &state).reconnectAfter)
+        XCTAssertNil(plan(.networkChanged(at: Date()), &state).reconnectAfter)
+
+        let resumed = plan(.foregrounded(at: Date()), &state)
+        XCTAssertEqual(resumed.reconnectAfter, 0, "returning must reconnect immediately")
+        XCTAssertEqual(state.consecutiveFailures, 0, "time spent suspended is not a failure streak")
+    }
+
+    /// AXIS: a network change reconnects immediately rather than backing off.
+    ///
+    /// It is not a failure — it is a different network, and the old socket is
+    /// bound to an address that may no longer exist. Backing off would make the
+    /// most recoverable case the slowest.
+    func testNetworkChangeReconnectsImmediately() {
+        var state = SessionRecovery.State()
+        _ = plan(.connected(at: Date()), &state)
+        _ = plan(.transportFailed(at: Date().addingTimeInterval(0.01)), &state)
+        XCTAssertEqual(state.consecutiveFailures, 1)
+
+        let changed = plan(.networkChanged(at: Date()), &state)
+        XCTAssertEqual(changed.reconnectAfter, 0, "a network change is not a failure to back off from")
+        XCTAssertEqual(state.consecutiveFailures, 0)
+    }
+
+    /// AXIS: reconnecting resyncs. A reconnect is a gap of unknown length, and
+    /// the ring gives no way to learn what was missed during it.
+    func testReconnectingResyncs() {
+        var state = SessionRecovery.State()
+        recovery.observe(panes: ["p1"], state: &state)
+        let reconnected = plan(.connected(at: Date()), &state)
+        XCTAssertTrue(reconnected.resyncAllPanes, "a reconnect must not resume from cached generations")
+    }
+}
+
+/// The other half of the resync: `RefreshCoordinator` must actually forget.
+final class ResyncInvalidationTests: XCTestCase {
+    /// AXIS: after invalidateAll, the next plan FETCHES rather than skipping.
+    ///
+    /// Asserting the internal state was cleared would test the setter. What
+    /// matters is the observable consequence: a pane whose counters have not
+    /// moved must still be refetched, because the counters are exactly what
+    /// cannot be trusted across a gap.
+    func testInvalidationForcesAFetchEvenWhenCountersDidNotMove() throws {
+        var coordinator = RefreshCoordinator()
+        let json = """
+        {"id":"x","result":{"agents":[{"pane_id":"p1","agent":"claude","state_change_seq":1092,\
+        "turn_epoch":4,"composer":{"state":"idle"}}]}}
+        """
+        let agent = try JSONDecoder()
+            .decode(ResultEnvelope<AgentListResult>.self, from: Data(json.utf8)).result.agents[0]
+
+        let now = Date()
+        _ = coordinator.plan(agents: [agent], focusedPane: "p1", now: now)
+        coordinator.recordFetch(pane: "p1", generation: PaneGeneration(agent), at: now)
+
+        // Nothing moved, and we are inside every interval: normally a skip.
+        let quiet = coordinator.plan(agents: [agent], focusedPane: "p1", now: now.addingTimeInterval(0.01))
+        XCTAssertEqual(quiet["p1"], .skip, "precondition: an unchanged pane skips, or this proves nothing")
+
+        coordinator.invalidateAll()
+        let afterResync = coordinator.plan(
+            agents: [agent], focusedPane: "p1", now: now.addingTimeInterval(0.02)
+        )
+        XCTAssertEqual(
+            afterResync["p1"], .fetch,
+            "after a gap the pane must be refetched; identical counters are not evidence of no change"
+        )
+    }
+}

--- a/Tests/HerdrKitTests/SessionRecoveryTests.swift
+++ b/Tests/HerdrKitTests/SessionRecoveryTests.swift
@@ -178,6 +178,29 @@ final class SessionRecoveryTests: XCTestCase {
                        "a callback from the discarded state was adopted as current")
     }
 
+    /// AXIS: restoring a SAVED COPY of State and minting again cannot
+    /// reproduce a previously minted identity.
+    ///
+    /// The epoch design survived a rebuilt State and fell to this: State is a
+    /// value, so save -> mint A -> restore the save -> mint replays the same
+    /// (epoch, counter) and A's late callback impersonated the current
+    /// attempt. Identity is now a per-mint UUID derived from nothing State
+    /// stores, so no replay of stored contents can reproduce it.
+    func testMintingAfterASavedCopyRestoreCannotReproduceAnIdentity() throws {
+        var state = try seeded(["p1"])
+        let saved = state
+        let minted = recovery.beginInitialAttempt(state: &state).reconnectAttempt!
+
+        state = saved   // the replay
+        let reminted = recovery.beginInitialAttempt(state: &state).reconnectAttempt!
+        XCTAssertNotEqual(minted, reminted,
+                          "a saved-copy restore reproduced a previously minted identity")
+
+        let late = plan(.connected(minted, at: Date()), &state)
+        XCTAssertEqual(late.actions, [.discardConnection],
+                       "the pre-restore attempt's callback was adopted as current")
+    }
+
     /// AXIS: a pane forgotten by a snapshot shrink and later rediscovered is
     /// NOT subscribed a second time on the same transport.
     ///
@@ -279,7 +302,7 @@ final class SessionRecoveryTests: XCTestCase {
         var state = try seeded(["p1"])
         _ = plan(.backgrounded(at: Date()), &state)
 
-        let late = plan(.connected(AttemptID(epoch: 0, value: 99), at: Date().addingTimeInterval(0.1)), &state)
+        let late = plan(.connected(AttemptID(uuid: UUID()), at: Date().addingTimeInterval(0.1)), &state)
         XCTAssertEqual(late.actions, [.discardConnection])
         XCTAssertFalse(late.contains(.resyncAllPanes), "no work may start on an unwanted connection")
         XCTAssertNil(late.subscribes, "no subscription may open on an unwanted connection")
@@ -343,16 +366,15 @@ final class SessionRecoveryTests: XCTestCase {
         // whole job.
         XCTAssertEqual(
             fields,
-            ["attemptEpoch", "connectedSince", "consecutiveFailures",
-             "currentAttempt", "isForeground", "knownPanes", "nextAttemptValue",
-             "subscribedPanes"],
+            ["connectedSince", "consecutiveFailures", "currentAttempt",
+             "isForeground", "knownPanes", "subscribedPanes"],
             "SessionRecovery.State grew a field; if it can hold a stream position, resumption just became expressible"
         )
         // One level down too: State stores AttemptID, so a position smuggled
         // into AttemptID's fields would be invisible to the check above.
-        let attemptFields = Mirror(reflecting: AttemptID(epoch: 0, value: 0))
+        let attemptFields = Mirror(reflecting: AttemptID(uuid: UUID()))
             .children.compactMap(\.label).sorted()
-        XCTAssertEqual(attemptFields, ["epoch", "value"],
+        XCTAssertEqual(attemptFields, ["uuid"],
                        "AttemptID grew a field; a stream position could hide inside State through it")
     }
 
@@ -677,22 +699,29 @@ final class PaneSnapshotAccessTests: XCTestCase {
             "PaneSnapshot's package-visible surface changed; anything that can CONSTRUCT one from caller data reopens the filtered-list path observe() exists to close"
         )
 
-        // The WHOLE module, not just PaneSnapshot's members. The member-only
-        // version let a package-level `public func makeSnapshot([AgentInfo]) ->
-        // PaneSnapshot` compile and pass — construction laundered through a free
-        // function is still construction. Any visible symbol anywhere in
-        // HerdrKit whose signature RETURNS a PaneSnapshot is a construction
-        // path, and exactly one is intended.
-        let returners = symbols.compactMap { symbol -> String? in
-            guard let signature = symbol["functionSignature"] as? [String: Any],
-                  let returns = signature["returns"] as? [[String: Any]],
-                  returns.contains(where: { ($0["spelling"] as? String)?.contains("PaneSnapshot") == true }),
-                  let path = symbol["pathComponents"] as? [String] else { return nil }
+        // Every symbol whose DECLARATION mentions the type, not just function
+        // returns. Two narrower versions each let a construction path through:
+        // member-only missed a free function, and returns-only missed a public
+        // computed property (`public var empty: PaneSnapshot` yields instances
+        // without having a functionSignature at all). Closures, subscripts and
+        // variables would slip the same net, so the check is: any visible
+        // symbol that mentions PaneSnapshot in its declaration is judged here,
+        // out loud, against an exact whitelist — producers AND consumers,
+        // because telling them apart per-kind is precisely the fragile part.
+        let mentioners = symbols.compactMap { symbol -> String? in
+            guard let path = symbol["pathComponents"] as? [String] else { return nil }
+            if path.first == "PaneSnapshot" { return nil }   // members audited above
+            let fragments = ((symbol["declarationFragments"] as? [[String: Any]]) ?? [])
+                + (((symbol["functionSignature"] as? [String: Any])?["returns"] as? [[String: Any]]) ?? [])
+            guard fragments.contains(where: {
+                ($0["spelling"] as? String)?.contains("PaneSnapshot") == true
+            }) else { return nil }
             return path.joined(separator: ".")
         }.sorted()
         XCTAssertEqual(
-            returners, ["HerdrClient.paneSnapshot()"],
-            "a new package-visible symbol returns PaneSnapshot; every such symbol is a construction path, and only HerdrClient.paneSnapshot() is the authoritative source"
+            mentioners,
+            ["HerdrClient.paneSnapshot()", "SessionRecovery.observe(_:state:)"],
+            "a new package-visible symbol mentions PaneSnapshot; if it can yield one from caller data it is a construction path, and only HerdrClient.paneSnapshot() may produce"
         )
     }
 }

--- a/Tests/HerdrKitTests/SessionRecoveryTests.swift
+++ b/Tests/HerdrKitTests/SessionRecoveryTests.swift
@@ -38,8 +38,13 @@ final class SessionRecoveryTests: XCTestCase {
     }
 
     private func seeded(_ ids: [String]) throws -> SessionRecovery.State {
+        // Planted directly: in production knowledge arrives via a transport's
+        // snapshot (observe now REQUIRES provenance), but a test legitimately
+        // starts with knowledge already held. knownPanes is informational, so
+        // direct planting cannot leak into subscriptions.
         var state = SessionRecovery.State()
-        _ = recovery.observe(PaneSnapshot(agents: try panes(ids)), state: &state)
+        state.knownPanes = Set(ids)
+        _ = try panes(ids)   // keep the fixture honest about decodability
         return state
     }
 
@@ -53,7 +58,8 @@ final class SessionRecoveryTests: XCTestCase {
     ) -> AttemptID {
         let opened = recovery.beginInitialAttempt(state: &state).reconnectAttempt!
         _ = plan(.connected(opened, at: when), &state)
-        _ = recovery.observe(PaneSnapshot(agents: try! panes(Array(state.knownPanes))), state: &state)
+        _ = recovery.observe(
+            PaneSnapshot(agents: try! panes(Array(state.knownPanes))), from: opened, state: &state)
         return opened
     }
 
@@ -116,7 +122,7 @@ final class SessionRecoveryTests: XCTestCase {
         let restarted = recovery.beginInitialAttempt(state: &state)
         XCTAssertEqual(restarted.actions.first, .cancelTransport)
         XCTAssertNil(state.connectedSince, "stale adoption state leaks subscribes to a dead transport")
-        XCTAssertTrue(plan(.paneCreated("p9"), &state).isEmpty,
+        XCTAssertTrue(plan(.paneCreated("p9", from: state.currentAttempt ?? AttemptID(uuid: UUID())), &state).isEmpty,
                       "no subscribe may target the transport that was just abandoned")
     }
 
@@ -146,19 +152,25 @@ final class SessionRecoveryTests: XCTestCase {
     /// because the pane was already known.
     func testSnapshotGrowthWhileConnectedSubscribesTheAddedPanes() throws {
         var state = try seeded(["p1"])
-        _ = connect(&state)
+        let opened = connect(&state)
 
-        let grown = recovery.observe(PaneSnapshot(agents: try panes(["p1", "p3"])), state: &state)
+        let grown = recovery.observe(PaneSnapshot(agents: try panes(["p1", "p3"])), from: opened, state: &state)
         XCTAssertEqual(grown.subscribes, ["p3"], "exactly the added panes, not the whole set")
 
-        // While disconnected the snapshot only records; the next adoption's
-        // full-set subscribe covers it.
+        // A snapshot from an attempt that is no longer current is ignored
+        // WHOLLY — no subscriptions and no knowledge mutation. Disconnected
+        // discovery has no other path: snapshots only arrive over transports.
         var offline = try seeded(["p1"])
-        let recorded = recovery.observe(PaneSnapshot(agents: try panes(["p1", "p4"])), state: &offline)
-        XCTAssertTrue(recorded.isEmpty, "no transport, nothing to subscribe on")
-        let opened = recovery.beginInitialAttempt(state: &offline).reconnectAttempt!
-        XCTAssertEqual(plan(.connected(opened, at: Date()), &offline).actions, [.resyncAllPanes])
-        let resub = recovery.observe(PaneSnapshot(agents: try panes(["p1", "p4"])), state: &offline)
+        let stale = recovery.beginInitialAttempt(state: &offline).reconnectAttempt!
+        _ = plan(.networkChanged(at: Date()), &offline)   // stale is abandoned
+        let ignored = recovery.observe(PaneSnapshot(agents: try panes(["p1", "p4"])), from: stale, state: &offline)
+        XCTAssertTrue(ignored.isEmpty, "an abandoned attempt's snapshot must admit nothing")
+        XCTAssertEqual(offline.knownPanes, ["p1"], "nor may it mutate knowledge")
+
+        // The CURRENT attempt's snapshot supplies both knowledge and subscriptions.
+        let fresh = recovery.beginInitialAttempt(state: &offline).reconnectAttempt!
+        XCTAssertEqual(plan(.connected(fresh, at: Date()), &offline).actions, [.resyncAllPanes(fresh)])
+        let resub = recovery.observe(PaneSnapshot(agents: try panes(["p1", "p4"])), from: fresh, state: &offline)
         XCTAssertEqual(resub.subscribes, ["p1", "p4"])
     }
 
@@ -231,7 +243,7 @@ final class SessionRecoveryTests: XCTestCase {
                        "a cancelled attempt was reauthorized by value restoration")
 
         let adoptedB = plan(.connected(attemptB, at: Date()), &state)
-        XCTAssertEqual(adoptedB.actions.first, .resyncAllPanes,
+        XCTAssertEqual(adoptedB.actions, [.resyncAllPanes(attemptB)],
                        "the lineage's real current attempt must still adopt")
     }
 
@@ -259,14 +271,14 @@ final class SessionRecoveryTests: XCTestCase {
         state = saved                           // the replay
 
         // No incremental subscribe may target the cancelled transport.
-        XCTAssertTrue(plan(.paneCreated("p9"), &state).isEmpty,
+        XCTAssertTrue(plan(.paneCreated("p9", from: state.currentAttempt ?? AttemptID(uuid: UUID())), &state).isEmpty,
                       "a replayed connectedSince let paneCreated subscribe onto a cancelled transport")
 
         // And B's adoption must not be suppressed as a repeat.
         let adoptedB = plan(.connected(attemptB, at: Date()), &state)
-        XCTAssertEqual(adoptedB.actions, [.resyncAllPanes],
+        XCTAssertEqual(adoptedB.actions, [.resyncAllPanes(attemptB)],
                        "the replayed connectedSince classified B's adoption as a repeat and suppressed it")
-        let subscribed = recovery.observe(PaneSnapshot(agents: try panes(["p1", "p9"])), state: &state)
+        let subscribed = recovery.observe(PaneSnapshot(agents: try panes(["p1", "p9"])), from: attemptB, state: &state)
         XCTAssertEqual(subscribed.subscribes, ["p1", "p9"],
                        "B subscribes what the authoritative snapshot says, including the pane learned mid-replay")
     }
@@ -279,23 +291,23 @@ final class SessionRecoveryTests: XCTestCase {
     /// the rediscovery previously stacked a second one on top of it.
     func testAPaneReappearingAfterASnapshotShrinkIsNotDoubleSubscribed() throws {
         var state = try seeded(["p1", "p2"])
-        _ = connect(&state)   // subscribes {p1, p2}
+        let opened = connect(&state)   // subscribes {p1, p2}
 
         // The snapshot forgets p2; its subscription on this transport stays open.
-        XCTAssertTrue(recovery.observe(PaneSnapshot(agents: try panes(["p1"])), state: &state).isEmpty)
+        XCTAssertTrue(recovery.observe(PaneSnapshot(agents: try panes(["p1"])), from: opened, state: &state).isEmpty)
 
         // p2 reappears — via event and via snapshot. Neither may re-subscribe.
-        XCTAssertTrue(plan(.paneCreated("p2"), &state).isEmpty,
+        XCTAssertTrue(plan(.paneCreated("p2", from: opened), &state).isEmpty,
                       "paneCreated re-subscribed a pane this transport already watches")
-        XCTAssertTrue(recovery.observe(PaneSnapshot(agents: try panes(["p1", "p2"])), state: &state).isEmpty,
+        XCTAssertTrue(recovery.observe(PaneSnapshot(agents: try panes(["p1", "p2"])), from: opened, state: &state).isEmpty,
                       "observe re-subscribed a pane this transport already watches")
 
         // A NEW transport starts from nothing: the snapshot re-subscribes the set.
         _ = plan(.networkChanged(at: Date()), &state)
         let readopted = recovery.beginInitialAttempt(state: &state).reconnectAttempt
             ?? state.currentAttempt!
-        XCTAssertEqual(plan(.connected(readopted, at: Date()), &state).actions, [.resyncAllPanes])
-        let resub = recovery.observe(PaneSnapshot(agents: try panes(["p1", "p2"])), state: &state)
+        XCTAssertEqual(plan(.connected(readopted, at: Date()), &state).actions, [.resyncAllPanes(readopted)])
+        let resub = recovery.observe(PaneSnapshot(agents: try panes(["p1", "p2"])), from: readopted, state: &state)
         XCTAssertEqual(resub.subscribes, ["p1", "p2"],
                        "the replacement transport subscribes the authoritative set")
     }
@@ -316,18 +328,18 @@ final class SessionRecoveryTests: XCTestCase {
         _ = connect(&state)
         let saved = state
 
-        _ = plan(.paneClosed("p2"), &state)
+        _ = plan(.paneClosed("p2", from: state.currentAttempt ?? AttemptID(uuid: UUID())), &state)
         let changed = plan(.networkChanged(at: Date()), &state)
         let attemptB = changed.reconnectAttempt!
 
         state = saved                           // the replay: memory says p2 exists
 
         let adopted = plan(.connected(attemptB, at: Date()), &state)
-        XCTAssertEqual(adopted.actions, [.resyncAllPanes],
+        XCTAssertEqual(adopted.actions, [.resyncAllPanes(attemptB)],
                        "adoption must not convert remembered panes into subscriptions")
 
         // The authoritative snapshot — the server knows p2 is gone.
-        let subscribed = recovery.observe(PaneSnapshot(agents: try panes(["p1"])), state: &state)
+        let subscribed = recovery.observe(PaneSnapshot(agents: try panes(["p1"])), from: attemptB, state: &state)
         XCTAssertEqual(subscribed.subscribes, ["p1"])
 
         // Nothing anywhere targeted p2, and the ledger never held it.
@@ -338,6 +350,52 @@ final class SessionRecoveryTests: XCTestCase {
         }
         XCTAssertFalse(state.subscribedPanes.contains("p2"),
                        "the ledger recorded a subscription to a closed pane — irretractable on this wire")
+    }
+
+    /// AXIS: a delayed snapshot from an abandoned attempt admits nothing onto
+    /// its replacement.
+    ///
+    /// The reviewer's seventh probe: adopt A and start its resync,
+    /// networkChanged to B, adopt B, then A's slow snapshot finally arrives.
+    /// Without provenance it was indistinguishable from B's data — its pane
+    /// was subscribed and recorded on B's ledger, and B's own later snapshot
+    /// could not retract it. Snapshots now carry the attempt whose transport
+    /// produced them, and admission verifies it in the same critical section.
+    func testADelayedSnapshotFromAnAbandonedAttemptAdmitsNothing() throws {
+        var state = try seeded(["p1"])
+        let attemptA = recovery.beginInitialAttempt(state: &state).reconnectAttempt!
+        _ = plan(.connected(attemptA, at: Date()), &state)   // A's resync is now in flight
+
+        let changed = plan(.networkChanged(at: Date()), &state)
+        let attemptB = changed.reconnectAttempt!
+        _ = plan(.connected(attemptB, at: Date()), &state)
+
+        // A's delayed snapshot lands — it saw a pane B's world does not have.
+        let stale = recovery.observe(
+            PaneSnapshot(agents: try panes(["p1", "ghost"])), from: attemptA, state: &state)
+        XCTAssertTrue(stale.isEmpty, "an abandoned attempt's snapshot subscribed panes onto its replacement")
+        XCTAssertFalse(state.subscribedPanes.contains("ghost"), "B's ledger recorded A's pane")
+        XCTAssertFalse(state.knownPanes.contains("ghost"), "A's stale knowledge overwrote B's")
+
+        // B's own snapshot works exactly as before.
+        let current = recovery.observe(PaneSnapshot(agents: try panes(["p1"])), from: attemptB, state: &state)
+        XCTAssertEqual(current.subscribes, ["p1"])
+    }
+
+    /// AXIS: a late pane event from an abandoned attempt neither subscribes nor
+    /// mutates knowledge on its replacement.
+    func testALatePaneEventFromAnAbandonedAttemptActsOnNothing() throws {
+        var state = try seeded(["p1"])
+        let attemptA = connect(&state)
+        _ = plan(.networkChanged(at: Date()), &state)
+        let attemptB = recovery.beginInitialAttempt(state: &state).reconnectAttempt!
+        _ = plan(.connected(attemptB, at: Date()), &state)
+        _ = recovery.observe(PaneSnapshot(agents: try panes(["p1"])), from: attemptB, state: &state)
+
+        XCTAssertTrue(plan(.paneCreated("late", from: attemptA), &state).isEmpty)
+        XCTAssertFalse(state.knownPanes.contains("late"), "a dead transport's event became knowledge")
+        XCTAssertTrue(plan(.paneClosed("p1", from: attemptA), &state).isEmpty)
+        XCTAssertTrue(state.knownPanes.contains("p1"), "a dead transport's event removed live knowledge")
     }
 
     /// AXIS: a saved foregrounded copy cannot dial after backgrounding.
@@ -410,7 +468,7 @@ final class SessionRecoveryTests: XCTestCase {
     /// admission with nothing lost.
     func testConcurrentDiscoveriesAreAdmittedExactlyOnce() throws {
         var seed = try seeded(["p0"])
-        _ = connect(&seed)
+        let attempt = connect(&seed)
 
         let paneCount = 1_000
         let lanes = 8
@@ -427,7 +485,7 @@ final class SessionRecoveryTests: XCTestCase {
             var generator = SeededGenerator(seed: UInt64(lane) + 1)
             for index in 0..<paneCount {
                 let plan = recovery.plan(
-                    for: .paneCreated("pane-\(index)"), state: &copy, using: &generator)
+                    for: .paneCreated("pane-\(index)", from: attempt), state: &copy, using: &generator)
                 if let fresh = plan.subscribes, !fresh.isEmpty {
                     collected.lock(); emitted.append(contentsOf: fresh); collected.unlock()
                 }
@@ -489,21 +547,22 @@ final class SessionRecoveryTests: XCTestCase {
         XCTAssertEqual(resumed.actions.first, .cancelTransport,
                        "whatever transport may exist is torn down before dialing")
         XCTAssertEqual(resumed.reconnectDelay, 0)
-        XCTAssertFalse(resumed.contains(.resyncAllPanes), "no transport yet to resync on")
+        XCTAssertFalse(resumed.actions.contains { if case .resyncAllPanes = $0 { return true }; return false },
+                       "no transport yet to resync on")
         XCTAssertNil(resumed.subscribes, "no transport yet to subscribe on")
 
         let attempt = resumed.reconnectAttempt!
         let connected = plan(.connected(attempt, at: Date().addingTimeInterval(0.3)), &state)
-        XCTAssertEqual(connected.actions, [.resyncAllPanes],
+        XCTAssertEqual(connected.actions, [.resyncAllPanes(attempt)],
                        "adoption emits resync ONLY; subscriptions derive from the snapshot it fetches")
 
         // The executor's next step: the resync's authoritative snapshot.
-        let snapshot = recovery.observe(PaneSnapshot(agents: try panes(["p1", "p2"])), state: &state)
+        let snapshot = recovery.observe(PaneSnapshot(agents: try panes(["p1", "p2"])), from: attempt, state: &state)
         XCTAssertEqual(snapshot.subscribes, ["p1", "p2"],
                        "the fresh transport subscribes what the server says exists")
 
         let everything = backgrounded.actions + resumed.actions + connected.actions + snapshot.actions
-        XCTAssertEqual(everything.filter { $0 == .resyncAllPanes }.count, 1,
+        XCTAssertEqual(everything.filter { if case .resyncAllPanes = $0 { return true }; return false }.count, 1,
                        "a recovery emitted more than one resync")
         XCTAssertEqual(everything.filter { if case .subscribe = $0 { return true }; return false }.count, 1,
                        "subscriptions are persistent; emitting them twice opens each pane twice")
@@ -522,7 +581,8 @@ final class SessionRecoveryTests: XCTestCase {
 
         let late = plan(.connected(AttemptID(uuid: UUID()), at: Date().addingTimeInterval(0.1)), &state)
         XCTAssertEqual(late.actions, [.discardConnection])
-        XCTAssertFalse(late.contains(.resyncAllPanes), "no work may start on an unwanted connection")
+        XCTAssertFalse(late.actions.contains { if case .resyncAllPanes = $0 { return true }; return false },
+                       "no work may start on an unwanted connection")
         XCTAssertNil(late.subscribes, "no subscription may open on an unwanted connection")
     }
 
@@ -547,9 +607,9 @@ final class SessionRecoveryTests: XCTestCase {
         XCTAssertEqual(lateA.actions, [.discardConnection], "an abandoned attempt must not be adopted")
 
         let adoptedB = plan(.connected(attemptB, at: Date()), &state)
-        XCTAssertEqual(adoptedB.actions, [.resyncAllPanes],
+        XCTAssertEqual(adoptedB.actions, [.resyncAllPanes(attemptB)],
                        "adoption resyncs only; subscriptions come from the snapshot")
-        let subscribed = recovery.observe(PaneSnapshot(agents: try panes(["p1"])), state: &state)
+        let subscribed = recovery.observe(PaneSnapshot(agents: try panes(["p1"])), from: attemptB, state: &state)
         XCTAssertEqual(subscribed.subscribes, ["p1"])
 
         // ...and then A reports its failure, after B is already in use.
@@ -559,7 +619,7 @@ final class SessionRecoveryTests: XCTestCase {
         XCTAssertNotNil(state.connectedSince, "a stale failure must not tear down the adopted connection")
 
         let everything = lateA.actions + adoptedB.actions + subscribed.actions + failedA.actions
-        XCTAssertEqual(everything.filter { $0 == .resyncAllPanes }.count, 1,
+        XCTAssertEqual(everything.filter { if case .resyncAllPanes = $0 { return true }; return false }.count, 1,
                        "exactly one adoption may resync")
         XCTAssertEqual(everything.filter { if case .subscribe = $0 { return true }; return false }.count, 1,
                        "exactly one snapshot-derived subscribe per recovery")
@@ -705,17 +765,20 @@ final class SessionRecoveryTests: XCTestCase {
                        "a connection that lasted past the stability window must clear the streak")
     }
 
-    /// AXIS: a pane discovered while connected is subscribed immediately; one
-    /// discovered while disconnected waits for the resync rather than opening a
-    /// subscription on a transport that does not exist.
-    func testPaneCreatedSubscribesOnlyWhenThereIsAConnection() throws {
+    /// AXIS: pane events act only when their provenance is the current,
+    /// connected attempt — a non-current event neither subscribes NOR is
+    /// remembered, since an abandoned transport's events are not knowledge.
+    func testPaneCreatedActsOnlyWithCurrentProvenance() throws {
         var state = try seeded([])
-        XCTAssertTrue(plan(.paneCreated("p9"), &state).isEmpty, "no connection, nothing to subscribe on")
-        XCTAssertTrue(state.knownPanes.contains("p9"), "but it must still be remembered")
+        let foreign = AttemptID(uuid: UUID())   // never minted by this lineage
+        XCTAssertTrue(plan(.paneCreated("p9", from: foreign), &state).isEmpty)
+        XCTAssertFalse(state.knownPanes.contains("p9"),
+                       "an event from a non-current attempt must not mutate knowledge")
 
-        _ = connect(&state)
-        XCTAssertEqual(plan(.paneCreated("p8"), &state).subscribes, ["p8"])
-        XCTAssertTrue(plan(.paneCreated("p8"), &state).isEmpty, "a repeat must not re-subscribe")
+        let opened = connect(&state)
+        XCTAssertEqual(plan(.paneCreated("p8", from: opened), &state).subscribes, ["p8"])
+        XCTAssertTrue(plan(.paneCreated("p8", from: opened), &state).isEmpty,
+                      "a repeat must not re-subscribe")
     }
 
     /// AXIS: a pane learned about mid-session survives into the next resync.
@@ -724,11 +787,14 @@ final class SessionRecoveryTests: XCTestCase {
     /// silence is indistinguishable from having no output.
     func testPanesLearnedDuringASessionAreResubscribedAfterReconnect() throws {
         var state = try seeded(["p1"])
-        _ = plan(.paneCreated("p2"), &state)
-        let opened = recovery.beginInitialAttempt(state: &state).reconnectAttempt!
-        XCTAssertEqual(plan(.connected(opened, at: Date()), &state).actions, [.resyncAllPanes])
+        let first = connect(&state)
+        _ = plan(.paneCreated("p2", from: first), &state)   // learned mid-session
+
+        _ = plan(.networkChanged(at: Date()), &state)
+        let second = recovery.beginInitialAttempt(state: &state).reconnectAttempt!
+        XCTAssertEqual(plan(.connected(second, at: Date()), &state).actions, [.resyncAllPanes(second)])
         // The server still has p2, so the authoritative snapshot carries it.
-        let resub = recovery.observe(PaneSnapshot(agents: try panes(["p1", "p2"])), state: &state)
+        let resub = recovery.observe(PaneSnapshot(agents: try panes(["p1", "p2"])), from: second, state: &state)
         XCTAssertEqual(resub.subscribes, ["p1", "p2"],
                        "a pane discovered mid-session comes back via the snapshot, not memory")
     }
@@ -740,10 +806,10 @@ final class SessionRecoveryTests: XCTestCase {
     /// partial listings dangerous — there was no other way to drop one.
     func testClosedPanesAreDroppedIncrementally() throws {
         var state = try seeded(["p1", "p2"])
-        _ = plan(.paneClosed("p2"), &state)
+        _ = plan(.paneClosed("p2", from: state.currentAttempt ?? AttemptID(uuid: UUID())), &state)
         let opened = recovery.beginInitialAttempt(state: &state).reconnectAttempt!
-        XCTAssertEqual(plan(.connected(opened, at: Date()), &state).actions, [.resyncAllPanes])
-        let resub = recovery.observe(PaneSnapshot(agents: try panes(["p1"])), state: &state)
+        XCTAssertEqual(plan(.connected(opened, at: Date()), &state).actions, [.resyncAllPanes(opened)])
+        let resub = recovery.observe(PaneSnapshot(agents: try panes(["p1"])), from: opened, state: &state)
         XCTAssertEqual(resub.subscribes, ["p1"])
     }
 
@@ -758,7 +824,8 @@ final class SessionRecoveryTests: XCTestCase {
     func testASnapshotReplacesThePaneSetWholesale() throws {
         var state = try seeded(["p1", "p2", "p3"])
         XCTAssertEqual(state.knownPanes, ["p1", "p2", "p3"])
-        _ = recovery.observe(PaneSnapshot(agents: try panes(["p1"])), state: &state)
+        let opened = connect(&state)
+        _ = recovery.observe(PaneSnapshot(agents: try panes(["p1"])), from: opened, state: &state)
         XCTAssertEqual(state.knownPanes, ["p1"], "an authoritative listing is still authoritative")
     }
 
@@ -964,7 +1031,7 @@ final class PaneSnapshotAccessTests: XCTestCase {
         }.sorted()
         XCTAssertEqual(
             mentioners,
-            ["HerdrClient.paneSnapshot()", "SessionRecovery.observe(_:state:)"],
+            ["HerdrClient.paneSnapshot()", "SessionRecovery.observe(_:from:state:)"],
             "a new package-visible symbol mentions PaneSnapshot; if it can yield one from caller data it is a construction path, and only HerdrClient.paneSnapshot() may produce"
         )
     }

--- a/Tests/HerdrKitTests/SessionRecoveryTests.swift
+++ b/Tests/HerdrKitTests/SessionRecoveryTests.swift
@@ -344,12 +344,40 @@ final class SessionRecoveryTests: XCTestCase {
 
         // Nothing anywhere targeted p2, and the ledger never held it.
         for action in adopted.actions + subscribed.actions {
-            if case .subscribe(let panes) = action {
+            if case .subscribe(let panes, _) = action {
                 XCTAssertFalse(panes.contains("p2"), "a closed pane was subscribed onto the fresh transport")
             }
         }
         XCTAssertFalse(state.subscribedPanes.contains("p2"),
                        "the ledger recorded a subscription to a closed pane — irretractable on this wire")
+    }
+
+    /// AXIS: a subscription action is bound to the attempt that admitted it —
+    /// A's delayed plan can never be mistaken for B's.
+    ///
+    /// The reviewer's eighth probe closed the OUTPUT side of the asynchronous
+    /// boundary: input data carried provenance, but the emitted subscribe
+    /// discarded it after admission, so A's subscribe({p1}) compared EQUAL to
+    /// B's and an executor holding A's delayed plan could apply it to B.
+    func testASubscriptionActionIsBoundToItsAttempt() throws {
+        var state = try seeded(["p1"])
+        let attemptA = recovery.beginInitialAttempt(state: &state).reconnectAttempt!
+        _ = plan(.connected(attemptA, at: Date()), &state)
+        let plansA = recovery.observe(PaneSnapshot(agents: try panes(["p1"])), from: attemptA, state: &state)
+        XCTAssertEqual(plansA.subscribesOn, attemptA)
+
+        _ = plan(.networkChanged(at: Date()), &state)   // retires A
+        let attemptB = recovery.beginInitialAttempt(state: &state).reconnectAttempt!
+        _ = plan(.connected(attemptB, at: Date()), &state)
+        let plansB = recovery.observe(PaneSnapshot(agents: try panes(["p1"])), from: attemptB, state: &state)
+        XCTAssertEqual(plansB.subscribes, ["p1"], "B's own subscription executes once")
+        XCTAssertEqual(plansB.subscribesOn, attemptB)
+
+        // The two plans name the same panes and MUST NOT compare equal: the
+        // binding is what lets an executor reject A's delayed action.
+        XCTAssertNotEqual(plansA, plansB,
+                          "identical pane sets from different attempts compared equal; a delayed plan could target the replacement")
+        XCTAssertNotEqual(plansA.subscribesOn, plansB.subscribesOn)
     }
 
     /// AXIS: a delayed snapshot from an abandoned attempt admits nothing onto

--- a/Tests/HerdrKitTests/SessionRecoveryTests.swift
+++ b/Tests/HerdrKitTests/SessionRecoveryTests.swift
@@ -30,6 +30,23 @@ final class SessionRecoveryTests: XCTestCase {
         return recovery.plan(for: event, state: &state, using: &generator)
     }
 
+    /// Lock-protected result carrier: the compiler cannot verify a captured
+    /// mutable local across threads, and under strict concurrency the pattern
+    /// is a build error even when an NSLock makes it operationally sound.
+    final class PlanBox: @unchecked Sendable {
+        private let lock = NSLock()
+        private var plan: RecoveryPlan?
+        func set(_ value: RecoveryPlan) { lock.lock(); plan = value; lock.unlock() }
+        func snapshot() -> RecoveryPlan? { lock.lock(); defer { lock.unlock() }; return plan }
+    }
+
+    static func decodePanes(_ ids: [String]) throws -> [AgentInfo] {
+        let entries = ids.map { "{\"pane_id\":\"\($0)\",\"agent\":\"claude\"}" }.joined(separator: ",")
+        let json = "{\"id\":\"x\",\"result\":{\"agents\":[\(entries)]}}"
+        return try JSONDecoder()
+            .decode(ResultEnvelope<AgentListResult>.self, from: Data(json.utf8)).result.agents
+    }
+
     private func panes(_ ids: [String]) throws -> [AgentInfo] {
         let entries = ids.map { "{\"pane_id\":\"\($0)\",\"agent\":\"claude\"}" }.joined(separator: ",")
         let json = "{\"id\":\"x\",\"result\":{\"agents\":[\(entries)]}}"
@@ -404,16 +421,13 @@ final class SessionRecoveryTests: XCTestCase {
             _ = resume.wait(timeout: .now() + 5.0)
         }
 
-        let emitted = NSLock()
-        var plansA: RecoveryPlan?
-        var lane = state                       // shares the lineage's authority
-        let worker = Thread { [instrumented] in
+        let box = PlanBox()
+        let lane = state                       // shares the lineage's authority
+        let worker = Thread { [instrumented, lane] in
             var laneState = lane
-            var generator = SeededGenerator(seed: 7)
-            _ = generator                       // observe takes no generator
             let plan = instrumented.observe(
-                PaneSnapshot(agents: try! self.panes(["p1", "pnew"])), from: attemptA, state: &laneState)
-            emitted.lock(); plansA = plan; emitted.unlock()
+                PaneSnapshot(agents: try! Self.decodePanes(["p1", "pnew"])), from: attemptA, state: &laneState)
+            box.set(plan)
         }
         worker.start()
         XCTAssertEqual(paused.wait(timeout: .now() + 5.0), .success, "never reached the window")
@@ -425,14 +439,9 @@ final class SessionRecoveryTests: XCTestCase {
 
         resume.signal()
         let deadline = Date().addingTimeInterval(5)
-        while Date() < deadline {
-            emitted.lock(); let done = plansA != nil; emitted.unlock()
-            if done { break }
-            usleep(10_000)
-        }
+        while Date() < deadline, box.snapshot() == nil { usleep(10_000) }
 
-        emitted.lock(); let final = plansA; emitted.unlock()
-        let boundTo = try XCTUnwrap(final).subscribesOn
+        let boundTo = try XCTUnwrap(box.snapshot()).subscribesOn
         XCTAssertEqual(boundTo, attemptA,
                        "the action admitted under A was relabeled \(boundTo == attemptB ? "as B" : "unexpectedly") inside the emission window")
     }

--- a/Tests/HerdrKitTests/SessionRecoveryTests.swift
+++ b/Tests/HerdrKitTests/SessionRecoveryTests.swift
@@ -229,6 +229,38 @@ final class SessionRecoveryTests: XCTestCase {
                        "the lineage's real current attempt must still adopt")
     }
 
+    /// AXIS: a copy saved AFTER A connected cannot poison B's lifecycle.
+    ///
+    /// The reviewer's fifth replay probe, now the regression. Their previous
+    /// probe copied State before A connected, so its bookkeeping was empty and
+    /// could not expose this: a copy saved WHILE CONNECTED replayed
+    /// connectedSince, so paneCreated subscribed onto the cancelled transport
+    /// (isConnected read the replayed date) and connected(B) was classified as
+    /// an already-adopted repeat and suppressed entirely. Connection truth now
+    /// lives in the shared authority, tagged with its attempt.
+    func testACopySavedWhileConnectedCannotPoisonTheReplacementAttempt() throws {
+        var state = try seeded(["p1"])
+        let attemptA = recovery.beginInitialAttempt(state: &state).reconnectAttempt!
+        _ = plan(.connected(attemptA, at: Date()), &state)
+        let saved = state                       // connected bookkeeping aboard
+
+        let changed = plan(.networkChanged(at: Date()), &state)   // cancels A, mints B
+        let attemptB = changed.reconnectAttempt!
+
+        state = saved                           // the replay
+
+        // No incremental subscribe may target the cancelled transport.
+        XCTAssertTrue(plan(.paneCreated("p9"), &state).isEmpty,
+                      "a replayed connectedSince let paneCreated subscribe onto a cancelled transport")
+
+        // And B's adoption must not be suppressed as a repeat.
+        let adoptedB = plan(.connected(attemptB, at: Date()), &state)
+        XCTAssertEqual(adoptedB.actions.first, .resyncAllPanes,
+                       "the replayed connectedSince classified B's adoption as a repeat and suppressed it")
+        XCTAssertEqual(adoptedB.subscribes, ["p1", "p9"],
+                       "B must open the full current set, including the pane learned mid-replay")
+    }
+
     /// AXIS: a pane forgotten by a snapshot shrink and later rediscovered is
     /// NOT subscribed a second time on the same transport.
     ///
@@ -397,10 +429,12 @@ final class SessionRecoveryTests: XCTestCase {
         // precisely so authority is NOT replayable value contents. Judged out
         // loud, as this guard requires. (`currentAttempt` left the list: it is
         // computed through the authority now, and Mirror sees stored fields.)
+        // connectedSince and subscribedPanes left the stored list: both are
+        // computed through the shared authority now, precisely so a value copy
+        // cannot replay them. Mirror sees stored fields only.
         XCTAssertEqual(
             fields,
-            ["authority", "connectedSince", "consecutiveFailures",
-             "isForeground", "knownPanes", "subscribedPanes"],
+            ["authority", "consecutiveFailures", "isForeground", "knownPanes"],
             "SessionRecovery.State grew a field; if it can hold a stream position, resumption just became expressible"
         )
         // One level down too: State stores AttemptID, so a position smuggled

--- a/Tests/HerdrKitTests/SessionRecoveryTests.swift
+++ b/Tests/HerdrKitTests/SessionRecoveryTests.swift
@@ -22,61 +22,87 @@ final class SessionRecoveryTests: XCTestCase {
         return recovery.plan(for: event, state: &state, using: &generator)
     }
 
-    /// THE AXIS for task 4: a client that missed events resyncs rather than
-    /// continuing from a stale sequence.
-    ///
-    /// herdr's ring holds 512 events and signals nothing when it drops older
-    /// ones, so continuity across a background period is unknowable. This asserts
-    /// the resync happens **unconditionally** — not "when a gap is detected",
-    /// because detecting the gap is the thing that cannot be done.
-    func testForegroundingAlwaysResyncsRatherThanTrustingContinuity() {
-        var state = SessionRecovery.State()
-        recovery.observe(panes: ["p1", "p2"], state: &state)
-
-        // A background period so short that "surely nothing was missed" is
-        // exactly the reasoning this must not embody.
-        _ = plan(.backgrounded(at: Date()), &state)
-        let resumed = plan(.foregrounded(at: Date().addingTimeInterval(0.2)), &state)
-
-        XCTAssertTrue(
-            resumed.resyncAllPanes,
-            "a short absence is indistinguishable from a long one; resync must not be conditional"
-        )
-        XCTAssertEqual(
-            resumed.subscribe, ["p1", "p2"],
-            "subscriptions are pane-scoped with no wildcard, so every known pane must be re-subscribed"
-        )
+    private func panes(_ ids: [String]) throws -> [AgentInfo] {
+        let entries = ids.map { "{\"pane_id\":\"\($0)\",\"agent\":\"claude\"}" }.joined(separator: ",")
+        let json = "{\"id\":\"x\",\"result\":{\"agents\":[\(entries)]}}"
+        return try JSONDecoder()
+            .decode(ResultEnvelope<AgentListResult>.self, from: Data(json.utf8)).result.agents
     }
 
-    /// The absence IS the feature: nothing here accepts a remembered position.
-    ///
-    /// A `resume(from:)` would pass every test written against a server that had
-    /// not wrapped its ring, and fail only on a phone that was in a pocket.
-    func testNoAPIAcceptsARememberedSequence() {
-        // RecoveryPlan carries no sequence, revision or cursor to resume from —
-        // its whole surface is these three fields.
-        let plan = RecoveryPlan(resyncAllPanes: true, subscribe: ["p1"], reconnectAfter: 1)
-        XCTAssertEqual(plan, RecoveryPlan(resyncAllPanes: true, subscribe: ["p1"], reconnectAfter: 1))
-        // And State persists only pane identity and connection bookkeeping.
+    private func seeded(_ ids: [String]) throws -> SessionRecovery.State {
         var state = SessionRecovery.State()
-        recovery.observe(panes: ["p1"], state: &state)
-        XCTAssertEqual(state.knownPanes, ["p1"])
+        recovery.observe(agentList: try panes(ids), state: &state)
+        return state
+    }
+
+    /// THE AXIS for task 4: a client that missed events resyncs rather than
+    /// continuing, and does it EXACTLY ONCE per recovery.
+    ///
+    /// The previous version asserted the plan for `foregrounded` alone, which
+    /// pinned a pre-connect action rather than the completed sequence — and hid
+    /// that `foregrounded` and `connected` each emitted a resync and a
+    /// subscription set, so a client following both opened every persistent
+    /// subscription twice.
+    func testForegroundingThenConnectingResyncsAndSubscribesExactlyOnce() throws {
+        var state = try seeded(["p1", "p2"])
+
+        let backgrounded = plan(.backgrounded(at: Date()), &state)
+        XCTAssertEqual(backgrounded.actions, [.cancelTransport], "the stale transport must be torn down first")
+
+        // Short enough that "surely nothing was missed" is tempting — which is
+        // exactly the reasoning this must not embody.
+        let resumed = plan(.foregrounded(at: Date().addingTimeInterval(0.2)), &state)
+        XCTAssertEqual(resumed.actions, [.reconnect(after: 0)],
+                       "foregrounding has no transport to resync on yet")
+
+        let connected = plan(.connected(at: Date().addingTimeInterval(0.3)), &state)
+        XCTAssertEqual(connected.actions, [.resyncAllPanes, .subscribe(["p1", "p2"])],
+                       "resync must precede subscription, and both happen once")
+
+        let everything = backgrounded.actions + resumed.actions + connected.actions
+        XCTAssertEqual(everything.filter { $0 == .resyncAllPanes }.count, 1,
+                       "a recovery emitted more than one resync")
+        XCTAssertEqual(everything.filter { if case .subscribe = $0 { return true }; return false }.count, 1,
+                       "subscriptions are persistent; emitting them twice opens each pane twice")
+    }
+
+    /// AXIS: a connection completing after backgrounding is discarded, not adopted.
+    ///
+    /// Adopting it opens persistent subscriptions on a transport nobody will
+    /// read, on a process about to be suspended.
+    func testConnectionCompletingWhileBackgroundedIsDiscarded() throws {
+        var state = try seeded(["p1"])
+        _ = plan(.backgrounded(at: Date()), &state)
+
+        let late = plan(.connected(at: Date().addingTimeInterval(0.1)), &state)
+        XCTAssertEqual(late.actions, [.discardConnection])
+        XCTAssertFalse(late.contains(.resyncAllPanes), "no work may start on an unwanted connection")
+        XCTAssertNil(late.subscribes, "no subscription may open on an unwanted connection")
+    }
+
+    /// AXIS: no field on `State` can hold a resume position.
+    ///
+    /// The previous version of this test asserted that two identical values were
+    /// equal. It pinned nothing — a mutation ADDING `State.rememberedSequence`
+    /// compiled and passed it. A behavioural assertion cannot pin the ABSENCE of
+    /// API, so this reflects over the surface instead and fails when it grows.
+    func testRecoveryStateHasNoFieldThatCouldHoldAResumePosition() {
+        let fields = Mirror(reflecting: SessionRecovery.State())
+            .children.compactMap(\.label).sorted()
+        XCTAssertEqual(
+            fields, ["connectedSince", "consecutiveFailures", "isForeground", "knownPanes"],
+            "SessionRecovery.State grew a field; if it can hold a stream position, resumption just became expressible"
+        )
     }
 
     /// AXIS: backoff grows, and is capped.
     func testBackoffGrowsAndIsCapped() {
         var generator = SeededGenerator(seed: 7)
-        var previousCeiling = 0.0
         for failures in 1...12 {
             let delay = recovery.backoff(failures: failures, using: &generator)
             XCTAssertGreaterThanOrEqual(delay, 0)
-            XCTAssertLessThanOrEqual(
-                delay, recovery.maximumDelay,
-                "delay \(delay)s at failure \(failures) exceeded the cap"
-            )
-            let ceiling = min(recovery.baseDelay * pow(2, Double(failures - 1)), recovery.maximumDelay)
-            XCTAssertGreaterThanOrEqual(ceiling, previousCeiling, "ceiling must not shrink")
-            previousCeiling = ceiling
+            XCTAssertLessThanOrEqual(delay, recovery.maximumDelay,
+                                     "delay \(delay)s at failure \(failures) exceeded the cap")
         }
         XCTAssertEqual(recovery.backoff(failures: 0, using: &generator), 0, "no failures, no delay")
     }
@@ -84,47 +110,35 @@ final class SessionRecoveryTests: XCTestCase {
     /// AXIS: the delay is actually jittered.
     ///
     /// Asserting only "delay ≤ cap" would pass on a fixed schedule, which is the
-    /// bug jitter exists to prevent — a fleet dropped by one network event
-    /// returning in lockstep. So this asserts the delays SPREAD.
+    /// lockstep reconnect storm jitter exists to prevent. So this asserts SPREAD.
     func testBackoffIsJitteredNotFixed() {
         var delays: Set<Double> = []
         for seed in UInt64(1)...40 {
             var generator = SeededGenerator(seed: seed)
             delays.insert(recovery.backoff(failures: 6, using: &generator))
         }
-        XCTAssertGreaterThan(
-            delays.count, 30,
-            "40 clients drew only \(delays.count) distinct delays; they would reconnect in lockstep"
-        )
+        XCTAssertGreaterThan(delays.count, 30,
+                             "40 clients drew only \(delays.count) distinct delays; they would reconnect in lockstep")
     }
 
     /// AXIS: a connection that drops immediately does not reset the backoff.
     ///
     /// Resetting on *established* is the classic form of this bug: a server that
     /// accepts and instantly drops looks like a success every time, so the delay
-    /// never grows and the client hammers it. The connection has to LAST.
+    /// never grows. The connection has to LAST.
     func testFlappingConnectionDoesNotResetTheBackoff() {
         var state = SessionRecovery.State()
         let start = Date()
-        var lastDelay = 0.0
-
         for attempt in 0..<5 {
             let at = start.addingTimeInterval(Double(attempt) * 0.1)
             _ = plan(.connected(at: at), &state)
-            // Drops 50ms later — far inside the stability window.
-            let dropped = plan(.transportFailed(at: at.addingTimeInterval(0.05)), &state, seed: 99)
-            lastDelay = try! XCTUnwrap(dropped.reconnectAfter)
+            _ = plan(.transportFailed(at: at.addingTimeInterval(0.05)), &state, seed: 99)
         }
-
-        XCTAssertEqual(
-            state.consecutiveFailures, 5,
-            "five flaps counted \(state.consecutiveFailures) failures; a short-lived connection must not count as healthy"
-        )
-        XCTAssertGreaterThan(lastDelay, 0, "the fifth flap must still be delayed")
+        XCTAssertEqual(state.consecutiveFailures, 5,
+                       "five flaps counted \(state.consecutiveFailures) failures; a short-lived connection must not count as healthy")
     }
 
-    /// AXIS: a connection that survived the stability window DOES reset it, so a
-    /// client that has been fine for hours is not punished for one drop.
+    /// AXIS: a connection that survived the stability window DOES reset it.
     func testAHealthyConnectionResetsTheBackoff() {
         var state = SessionRecovery.State()
         let start = Date()
@@ -132,84 +146,89 @@ final class SessionRecoveryTests: XCTestCase {
         _ = plan(.transportFailed(at: start.addingTimeInterval(0.05)), &state)
         XCTAssertEqual(state.consecutiveFailures, 1)
 
-        // Reconnects and stays up well past the stability interval.
         let recovered = start.addingTimeInterval(1)
         _ = plan(.connected(at: recovered), &state)
-        _ = plan(
-            .transportFailed(at: recovered.addingTimeInterval(recovery.stabilityInterval + 1)),
-            &state
-        )
-        XCTAssertEqual(
-            state.consecutiveFailures, 1,
-            "a connection that lasted past the stability window must clear the streak"
-        )
+        _ = plan(.transportFailed(at: recovered.addingTimeInterval(recovery.stabilityInterval + 1)), &state)
+        XCTAssertEqual(state.consecutiveFailures, 1,
+                       "a connection that lasted past the stability window must clear the streak")
     }
 
-    /// AXIS: a new pane gets a subscription, because there is no wildcard.
-    func testPaneCreatedSubscribesToThatPane() {
-        var state = SessionRecovery.State()
-        XCTAssertEqual(plan(.paneCreated("p9"), &state).subscribe, ["p9"])
-        XCTAssertTrue(state.knownPanes.contains("p9"))
-        // Idempotent: a repeat does not re-subscribe.
-        XCTAssertEqual(plan(.paneCreated("p9"), &state).subscribe, [])
+    /// AXIS: a pane discovered while connected is subscribed immediately; one
+    /// discovered while disconnected waits for the resync rather than opening a
+    /// subscription on a transport that does not exist.
+    func testPaneCreatedSubscribesOnlyWhenThereIsAConnection() throws {
+        var state = try seeded([])
+        XCTAssertTrue(plan(.paneCreated("p9"), &state).isEmpty, "no connection, nothing to subscribe on")
+        XCTAssertTrue(state.knownPanes.contains("p9"), "but it must still be remembered")
+
+        _ = plan(.connected(at: Date()), &state)
+        XCTAssertEqual(plan(.paneCreated("p8"), &state).subscribes, ["p8"])
+        XCTAssertTrue(plan(.paneCreated("p8"), &state).isEmpty, "a repeat must not re-subscribe")
     }
 
-    /// AXIS: a pane learned about while connected survives into the next resync.
+    /// AXIS: a pane learned about mid-session survives into the next resync.
     ///
-    /// Without this, a pane created during a session becomes unwatched after the
-    /// next reconnect, and its silence is indistinguishable from having no output.
-    func testPanesLearnedDuringASessionAreResubscribedAfterReconnect() {
-        var state = SessionRecovery.State()
-        recovery.observe(panes: ["p1"], state: &state)
+    /// Without this it becomes unwatched after the next reconnect, and its
+    /// silence is indistinguishable from having no output.
+    func testPanesLearnedDuringASessionAreResubscribedAfterReconnect() throws {
+        var state = try seeded(["p1"])
         _ = plan(.paneCreated("p2"), &state)
+        XCTAssertEqual(plan(.connected(at: Date()), &state).subscribes, ["p1", "p2"],
+                       "a pane discovered mid-session must be re-subscribed, not forgotten")
+    }
 
-        let reconnected = plan(.connected(at: Date()), &state)
-        XCTAssertEqual(
-            reconnected.subscribe, ["p1", "p2"],
-            "a pane discovered mid-session must be re-subscribed, not forgotten"
-        )
+    /// AXIS: a closed pane stops being re-subscribed, WITHOUT needing a wholesale
+    /// replacement of the set.
+    ///
+    /// Removal used to require passing a fresh full listing, which is what made
+    /// partial listings dangerous — there was no other way to drop one.
+    func testClosedPanesAreDroppedIncrementally() throws {
+        var state = try seeded(["p1", "p2"])
+        _ = plan(.paneClosed("p2"), &state)
+        XCTAssertEqual(plan(.connected(at: Date()), &state).subscribes, ["p1"])
+    }
+
+    /// AXIS: observation takes an authoritative listing, not any array.
+    ///
+    /// The old signature accepted `[String]` and replaced the set wholesale, so a
+    /// filtered listing silently forgot the rest. Requiring `agent.list`'s own
+    /// result makes a partial set something you construct deliberately.
+    func testObservationTakesTheAuthoritativeListing() throws {
+        var state = try seeded(["p1", "p2", "p3"])
+        XCTAssertEqual(state.knownPanes, ["p1", "p2", "p3"])
+        recovery.observe(agentList: try panes(["p1"]), state: &state)
+        XCTAssertEqual(state.knownPanes, ["p1"], "an authoritative listing is still authoritative")
     }
 
     /// AXIS: a backgrounded client schedules no reconnect.
-    ///
-    /// The attempt would not run while suspended, and on return the failures it
-    /// accrued would look like a fresh streak — so the client would come back
-    /// slow at the exact moment the reader is looking at it.
-    func testBackgroundedClientSchedulesNoReconnect() {
-        var state = SessionRecovery.State()
+    func testBackgroundedClientSchedulesNoReconnect() throws {
+        var state = try seeded(["p1"])
         _ = plan(.backgrounded(at: Date()), &state)
 
-        XCTAssertNil(plan(.transportFailed(at: Date()), &state).reconnectAfter)
-        XCTAssertNil(plan(.networkChanged(at: Date()), &state).reconnectAfter)
+        XCTAssertNil(plan(.transportFailed(at: Date()), &state).reconnectDelay)
+        XCTAssertNil(plan(.networkChanged(at: Date()), &state).reconnectDelay)
 
         let resumed = plan(.foregrounded(at: Date()), &state)
-        XCTAssertEqual(resumed.reconnectAfter, 0, "returning must reconnect immediately")
+        XCTAssertEqual(resumed.reconnectDelay, 0, "returning must reconnect immediately")
         XCTAssertEqual(state.consecutiveFailures, 0, "time spent suspended is not a failure streak")
     }
 
-    /// AXIS: a network change reconnects immediately rather than backing off.
+    /// AXIS: a network change cancels the old transport BEFORE reconnecting, and
+    /// does not back off.
     ///
     /// It is not a failure — it is a different network, and the old socket is
-    /// bound to an address that may no longer exist. Backing off would make the
-    /// most recoverable case the slowest.
-    func testNetworkChangeReconnectsImmediately() {
-        var state = SessionRecovery.State()
+    /// bound to an address that may no longer exist. Leaving it open means
+    /// discovering it by timeout, which is the slowest possible way.
+    func testNetworkChangeCancelsThenReconnectsImmediately() throws {
+        var state = try seeded(["p1"])
         _ = plan(.connected(at: Date()), &state)
         _ = plan(.transportFailed(at: Date().addingTimeInterval(0.01)), &state)
         XCTAssertEqual(state.consecutiveFailures, 1)
 
         let changed = plan(.networkChanged(at: Date()), &state)
-        XCTAssertEqual(changed.reconnectAfter, 0, "a network change is not a failure to back off from")
+        XCTAssertEqual(changed.actions, [.cancelTransport, .reconnect(after: 0)],
+                       "the dead transport must be cancelled before a new one opens")
         XCTAssertEqual(state.consecutiveFailures, 0)
-    }
-
-    /// AXIS: reconnecting resyncs. A reconnect is a gap of unknown length, and
-    /// the ring gives no way to learn what was missed during it.
-    func testReconnectingResyncs() {
-        var state = SessionRecovery.State()
-        recovery.observe(panes: ["p1"], state: &state)
-        let reconnected = plan(.connected(at: Date()), &state)
-        XCTAssertTrue(reconnected.resyncAllPanes, "a reconnect must not resume from cached generations")
     }
 }
 

--- a/Tests/HerdrKitTests/SessionRecoveryTests.swift
+++ b/Tests/HerdrKitTests/SessionRecoveryTests.swift
@@ -201,6 +201,34 @@ final class SessionRecoveryTests: XCTestCase {
                        "the pre-restore attempt's callback was adopted as current")
     }
 
+    /// AXIS: restoring a copied State cannot REAUTHORIZE a cancelled attempt.
+    ///
+    /// The reviewer's public-API probe, now the regression: mint A, copy State
+    /// while A is current, networkChanged (cancels A, mints B), restore the
+    /// copy, deliver connected(A) — and A was adopted, resync and subscriptions
+    /// emitted for a transport the policy had cancelled. Fresh-UUID minting
+    /// could not stop it because the AUTHORITY itself lived in replayable value
+    /// contents. It now lives in a reference shared by every copy of the
+    /// lineage: restoring the copy restores bookkeeping, but the shared
+    /// authority still says B.
+    func testRestoringACopiedStateCannotReauthorizeACancelledAttempt() throws {
+        var state = try seeded(["p1"])
+        let attemptA = recovery.beginInitialAttempt(state: &state).reconnectAttempt!
+        let saved = state                      // A is current in this copy
+
+        let changed = plan(.networkChanged(at: Date()), &state)   // cancels A, mints B
+        let attemptB = changed.reconnectAttempt!
+
+        state = saved                          // the replay
+        let lateA = plan(.connected(attemptA, at: Date()), &state)
+        XCTAssertEqual(lateA.actions, [.discardConnection],
+                       "a cancelled attempt was reauthorized by value restoration")
+
+        let adoptedB = plan(.connected(attemptB, at: Date()), &state)
+        XCTAssertEqual(adoptedB.actions.first, .resyncAllPanes,
+                       "the lineage's real current attempt must still adopt")
+    }
+
     /// AXIS: a pane forgotten by a snapshot shrink and later rediscovered is
     /// NOT subscribed a second time on the same transport.
     ///
@@ -364,9 +392,14 @@ final class SessionRecoveryTests: XCTestCase {
         // watches), no ordering, no position. attemptEpoch: random identity
         // salt, never on the wire. Judged here out loud, which is this guard's
         // whole job.
+        // `authority` is a reference to the lineage's live attempt record —
+        // it holds one AttemptID and nothing pane- or stream-shaped; it exists
+        // precisely so authority is NOT replayable value contents. Judged out
+        // loud, as this guard requires. (`currentAttempt` left the list: it is
+        // computed through the authority now, and Mirror sees stored fields.)
         XCTAssertEqual(
             fields,
-            ["connectedSince", "consecutiveFailures", "currentAttempt",
+            ["authority", "connectedSince", "consecutiveFailures",
              "isForeground", "knownPanes", "subscribedPanes"],
             "SessionRecovery.State grew a field; if it can hold a stream position, resumption just became expressible"
         )
@@ -650,6 +683,12 @@ final class PaneSnapshotAccessTests: XCTestCase {
         ))
         process.arguments = [
             "symbolgraph-extract", "-module-name", "HerdrKit", "-target", triple,
+            // Without this, @_spi(Anything) public symbols are OMITTED from the
+            // graph — and an SPI initializer is callable outside the module by
+            // any @_spi import, so its absence made the audit's "outside the
+            // module" claim quietly narrower than stated. Verified both ways by
+            // compiler probe before adding.
+            "-include-spi-symbols",
             "-I", moduleDir.path,
             "-I", root.appendingPathComponent("Sources/CSSH").path,
             "-output-dir", output.path, "-minimum-access-level", "package",

--- a/Tests/HerdrKitTests/SessionRecoveryTests.swift
+++ b/Tests/HerdrKitTests/SessionRecoveryTests.swift
@@ -45,11 +45,15 @@ final class SessionRecoveryTests: XCTestCase {
 
     /// Opens an attempt the way production does, and hands back its identifier
     /// so a test can answer with the right one — or deliberately the wrong one.
+    /// Mimics the executor's adoption flow: connect, then feed the
+    /// authoritative snapshot (here: current knownPanes as the server's answer)
+    /// through observe — which is where subscriptions come from now.
     private func connect(
         _ state: inout SessionRecovery.State, at when: Date = Date()
     ) -> AttemptID {
         let opened = recovery.beginInitialAttempt(state: &state).reconnectAttempt!
         _ = plan(.connected(opened, at: when), &state)
+        _ = recovery.observe(PaneSnapshot(agents: try! panes(Array(state.knownPanes))), state: &state)
         return opened
     }
 
@@ -153,7 +157,9 @@ final class SessionRecoveryTests: XCTestCase {
         let recorded = recovery.observe(PaneSnapshot(agents: try panes(["p1", "p4"])), state: &offline)
         XCTAssertTrue(recorded.isEmpty, "no transport, nothing to subscribe on")
         let opened = recovery.beginInitialAttempt(state: &offline).reconnectAttempt!
-        XCTAssertEqual(plan(.connected(opened, at: Date()), &offline).subscribes, ["p1", "p4"])
+        XCTAssertEqual(plan(.connected(opened, at: Date()), &offline).actions, [.resyncAllPanes])
+        let resub = recovery.observe(PaneSnapshot(agents: try panes(["p1", "p4"])), state: &offline)
+        XCTAssertEqual(resub.subscribes, ["p1", "p4"])
     }
 
     /// AXIS: a callback minted before a State replacement can never be adopted
@@ -258,10 +264,11 @@ final class SessionRecoveryTests: XCTestCase {
 
         // And B's adoption must not be suppressed as a repeat.
         let adoptedB = plan(.connected(attemptB, at: Date()), &state)
-        XCTAssertEqual(adoptedB.actions.first, .resyncAllPanes,
+        XCTAssertEqual(adoptedB.actions, [.resyncAllPanes],
                        "the replayed connectedSince classified B's adoption as a repeat and suppressed it")
-        XCTAssertEqual(adoptedB.subscribes, ["p1", "p9"],
-                       "B must open the full current set, including the pane learned mid-replay")
+        let subscribed = recovery.observe(PaneSnapshot(agents: try panes(["p1", "p9"])), state: &state)
+        XCTAssertEqual(subscribed.subscribes, ["p1", "p9"],
+                       "B subscribes what the authoritative snapshot says, including the pane learned mid-replay")
     }
 
     /// AXIS: a pane forgotten by a snapshot shrink and later rediscovered is
@@ -283,12 +290,54 @@ final class SessionRecoveryTests: XCTestCase {
         XCTAssertTrue(recovery.observe(PaneSnapshot(agents: try panes(["p1", "p2"])), state: &state).isEmpty,
                       "observe re-subscribed a pane this transport already watches")
 
-        // A NEW transport starts from nothing: the full set is re-subscribed.
+        // A NEW transport starts from nothing: the snapshot re-subscribes the set.
         _ = plan(.networkChanged(at: Date()), &state)
         let readopted = recovery.beginInitialAttempt(state: &state).reconnectAttempt
             ?? state.currentAttempt!
-        XCTAssertEqual(plan(.connected(readopted, at: Date()), &state).subscribes, ["p1", "p2"],
-                       "the replacement transport must open the full current set")
+        XCTAssertEqual(plan(.connected(readopted, at: Date()), &state).actions, [.resyncAllPanes])
+        let resub = recovery.observe(PaneSnapshot(agents: try panes(["p1", "p2"])), state: &state)
+        XCTAssertEqual(resub.subscribes, ["p1", "p2"],
+                       "the replacement transport subscribes the authoritative set")
+    }
+
+    /// AXIS: replayed pane knowledge can never subscribe a replacement
+    /// transport to a closed pane.
+    ///
+    /// The reviewer's sixth probe, and the one that finished the decision-input
+    /// inventory: start with p1/p2, save State, paneClosed(p2), networkChanged
+    /// to B, restore the copy, connected(B). Adoption used to subscribe the
+    /// REMEMBERED set — {p1, p2} — seeding the ledger with a pane the server
+    /// had closed, and no later snapshot could retract it (the wire has no
+    /// unsubscribe). Adoption now emits resync only; subscriptions derive from
+    /// the post-adoption authoritative snapshot, so nothing after adoption may
+    /// target p2.
+    func testReplayedKnowledgeCannotSubscribeAClosedPane() throws {
+        var state = try seeded(["p1", "p2"])
+        _ = connect(&state)
+        let saved = state
+
+        _ = plan(.paneClosed("p2"), &state)
+        let changed = plan(.networkChanged(at: Date()), &state)
+        let attemptB = changed.reconnectAttempt!
+
+        state = saved                           // the replay: memory says p2 exists
+
+        let adopted = plan(.connected(attemptB, at: Date()), &state)
+        XCTAssertEqual(adopted.actions, [.resyncAllPanes],
+                       "adoption must not convert remembered panes into subscriptions")
+
+        // The authoritative snapshot — the server knows p2 is gone.
+        let subscribed = recovery.observe(PaneSnapshot(agents: try panes(["p1"])), state: &state)
+        XCTAssertEqual(subscribed.subscribes, ["p1"])
+
+        // Nothing anywhere targeted p2, and the ledger never held it.
+        for action in adopted.actions + subscribed.actions {
+            if case .subscribe(let panes) = action {
+                XCTAssertFalse(panes.contains("p2"), "a closed pane was subscribed onto the fresh transport")
+            }
+        }
+        XCTAssertFalse(state.subscribedPanes.contains("p2"),
+                       "the ledger recorded a subscription to a closed pane — irretractable on this wire")
     }
 
     /// AXIS: a saved foregrounded copy cannot dial after backgrounding.
@@ -445,10 +494,15 @@ final class SessionRecoveryTests: XCTestCase {
 
         let attempt = resumed.reconnectAttempt!
         let connected = plan(.connected(attempt, at: Date().addingTimeInterval(0.3)), &state)
-        XCTAssertEqual(connected.actions, [.resyncAllPanes, .subscribe(["p1", "p2"])],
-                       "resync must precede subscription, and both happen once")
+        XCTAssertEqual(connected.actions, [.resyncAllPanes],
+                       "adoption emits resync ONLY; subscriptions derive from the snapshot it fetches")
 
-        let everything = backgrounded.actions + resumed.actions + connected.actions
+        // The executor's next step: the resync's authoritative snapshot.
+        let snapshot = recovery.observe(PaneSnapshot(agents: try panes(["p1", "p2"])), state: &state)
+        XCTAssertEqual(snapshot.subscribes, ["p1", "p2"],
+                       "the fresh transport subscribes what the server says exists")
+
+        let everything = backgrounded.actions + resumed.actions + connected.actions + snapshot.actions
         XCTAssertEqual(everything.filter { $0 == .resyncAllPanes }.count, 1,
                        "a recovery emitted more than one resync")
         XCTAssertEqual(everything.filter { if case .subscribe = $0 { return true }; return false }.count, 1,
@@ -493,7 +547,10 @@ final class SessionRecoveryTests: XCTestCase {
         XCTAssertEqual(lateA.actions, [.discardConnection], "an abandoned attempt must not be adopted")
 
         let adoptedB = plan(.connected(attemptB, at: Date()), &state)
-        XCTAssertEqual(adoptedB.actions, [.resyncAllPanes, .subscribe(["p1"])])
+        XCTAssertEqual(adoptedB.actions, [.resyncAllPanes],
+                       "adoption resyncs only; subscriptions come from the snapshot")
+        let subscribed = recovery.observe(PaneSnapshot(agents: try panes(["p1"])), state: &state)
+        XCTAssertEqual(subscribed.subscribes, ["p1"])
 
         // ...and then A reports its failure, after B is already in use.
         let failedA = plan(.transportFailed(attemptA, at: Date()), &state)
@@ -501,11 +558,11 @@ final class SessionRecoveryTests: XCTestCase {
         XCTAssertEqual(state.consecutiveFailures, 0, "a stale failure must not count against the backoff")
         XCTAssertNotNil(state.connectedSince, "a stale failure must not tear down the adopted connection")
 
-        let everything = lateA.actions + adoptedB.actions + failedA.actions
+        let everything = lateA.actions + adoptedB.actions + subscribed.actions + failedA.actions
         XCTAssertEqual(everything.filter { $0 == .resyncAllPanes }.count, 1,
                        "exactly one adoption may resync")
         XCTAssertEqual(everything.filter { if case .subscribe = $0 { return true }; return false }.count, 1,
-                       "exactly one adoption may subscribe")
+                       "exactly one snapshot-derived subscribe per recovery")
     }
 
     /// AXIS: no field on `State` can hold a resume position.
@@ -669,8 +726,11 @@ final class SessionRecoveryTests: XCTestCase {
         var state = try seeded(["p1"])
         _ = plan(.paneCreated("p2"), &state)
         let opened = recovery.beginInitialAttempt(state: &state).reconnectAttempt!
-        XCTAssertEqual(plan(.connected(opened, at: Date()), &state).subscribes, ["p1", "p2"],
-                       "a pane discovered mid-session must be re-subscribed, not forgotten")
+        XCTAssertEqual(plan(.connected(opened, at: Date()), &state).actions, [.resyncAllPanes])
+        // The server still has p2, so the authoritative snapshot carries it.
+        let resub = recovery.observe(PaneSnapshot(agents: try panes(["p1", "p2"])), state: &state)
+        XCTAssertEqual(resub.subscribes, ["p1", "p2"],
+                       "a pane discovered mid-session comes back via the snapshot, not memory")
     }
 
     /// AXIS: a closed pane stops being re-subscribed, WITHOUT needing a wholesale
@@ -682,7 +742,9 @@ final class SessionRecoveryTests: XCTestCase {
         var state = try seeded(["p1", "p2"])
         _ = plan(.paneClosed("p2"), &state)
         let opened = recovery.beginInitialAttempt(state: &state).reconnectAttempt!
-        XCTAssertEqual(plan(.connected(opened, at: Date()), &state).subscribes, ["p1"])
+        XCTAssertEqual(plan(.connected(opened, at: Date()), &state).actions, [.resyncAllPanes])
+        let resub = recovery.observe(PaneSnapshot(agents: try panes(["p1"])), state: &state)
+        XCTAssertEqual(resub.subscribes, ["p1"])
     }
 
     /// AXIS: a snapshot replaces the pane set wholesale.

--- a/Tests/HerdrKitTests/SessionRecoveryTests.swift
+++ b/Tests/HerdrKitTests/SessionRecoveryTests.swift
@@ -236,8 +236,11 @@ final class SessionRecoveryTests: XCTestCase {
     /// could not expose this: a copy saved WHILE CONNECTED replayed
     /// connectedSince, so paneCreated subscribed onto the cancelled transport
     /// (isConnected read the replayed date) and connected(B) was classified as
-    /// an already-adopted repeat and suppressed entirely. Connection truth now
-    /// lives in the shared authority, tagged with its attempt.
+    /// an already-adopted repeat and suppressed entirely. Connection and
+    /// subscription state now live in the shared authority, and every
+    /// attempt-changing transition clears them in the same critical section —
+    /// that clearing, not a tag, is the mechanism (an earlier tag was an
+    /// unreachable twin guard and was removed).
     func testACopySavedWhileConnectedCannotPoisonTheReplacementAttempt() throws {
         var state = try seeded(["p1"])
         let attemptA = recovery.beginInitialAttempt(state: &state).reconnectAttempt!
@@ -286,6 +289,49 @@ final class SessionRecoveryTests: XCTestCase {
             ?? state.currentAttempt!
         XCTAssertEqual(plan(.connected(readopted, at: Date()), &state).subscribes, ["p1", "p2"],
                        "the replacement transport must open the full current set")
+    }
+
+    /// AXIS: concurrent discoveries neither lose ledger entries nor emit a
+    /// pane's subscription twice.
+    ///
+    /// The reviewer's probe: 10,000 concurrent paneCreated calls against
+    /// separately-locked get/set accessors retained ~1,400 ledger entries,
+    /// and every lost pane could be subscribed AGAIN on rediscovery. State
+    /// copies share the authority and both types are Sendable, so this is the
+    /// advertised surface. Admission is now one critical section; this drives
+    /// eight State copies of one lineage concurrently and requires exactly-once
+    /// admission with nothing lost.
+    func testConcurrentDiscoveriesAreAdmittedExactlyOnce() throws {
+        var seed = try seeded(["p0"])
+        _ = connect(&seed)
+
+        let paneCount = 1_000
+        let lanes = 8
+        let collected = NSLock()
+        var emitted: [String] = []
+
+        // EVERY lane attempts EVERY pane, deliberately. A first version strided
+        // the panes so each was owned by one lane — under which a mutation that
+        // split the check from the record SURVIVED, because a stale check can
+        // only double-admit when two threads race the SAME pane, and no two
+        // ever did. Contention on the same keys is the property under test.
+        DispatchQueue.concurrentPerform(iterations: lanes) { lane in
+            var copy = seed          // copies share the lineage's authority
+            var generator = SeededGenerator(seed: UInt64(lane) + 1)
+            for index in 0..<paneCount {
+                let plan = recovery.plan(
+                    for: .paneCreated("pane-\(index)"), state: &copy, using: &generator)
+                if let fresh = plan.subscribes, !fresh.isEmpty {
+                    collected.lock(); emitted.append(contentsOf: fresh); collected.unlock()
+                }
+            }
+        }
+
+        XCTAssertEqual(seed.subscribedPanes.count, paneCount + 1,
+                       "the ledger lost entries under concurrency")
+        XCTAssertEqual(emitted.count, paneCount,
+                       "every pane must be subscribed exactly once; \(emitted.count - paneCount) duplicates or losses")
+        XCTAssertEqual(Set(emitted).count, paneCount, "a pane was emitted twice")
     }
 
     /// AXIS: the stability window measures EVENT time, not wall-clock time.

--- a/Tests/HerdrKitTests/SessionRecoveryTests.swift
+++ b/Tests/HerdrKitTests/SessionRecoveryTests.swift
@@ -282,14 +282,15 @@ final class SessionRecoveryTests: XCTestCase {
         XCTAssertEqual(plan(.connected(opened, at: Date()), &state).subscribes, ["p1"])
     }
 
-    /// AXIS: only an authoritative snapshot can replace the pane set.
+    /// AXIS: a snapshot replaces the pane set wholesale.
     ///
-    /// Two earlier signatures failed this. `[String]` replaced wholesale, so a
-    /// filtered listing silently forgot the rest; `[AgentInfo]` was described as
-    /// making that hard and did not — `result.filter { … }` is exactly as easy to
-    /// write as `result`. `PaneSnapshot` cannot be constructed outside the
-    /// module, so provenance is enforced by the type rather than by care.
-    func testOnlyAnAuthoritativeSnapshotCanReplaceThePaneSet() throws {
+    /// Named for what it actually checks. It was called
+    /// `testOnlyAnAuthoritativeSnapshotCanReplaceThePaneSet` and claimed to pin
+    /// provenance — but making `PaneSnapshot.init` public survived it, because
+    /// nothing here inspects who may construct one. That invariant is access
+    /// control, and a behavioural test cannot see access control; it is pinned by
+    /// `PaneSnapshotAccessTests` below instead.
+    func testASnapshotReplacesThePaneSetWholesale() throws {
         var state = try seeded(["p1", "p2", "p3"])
         XCTAssertEqual(state.knownPanes, ["p1", "p2", "p3"])
         recovery.observe(PaneSnapshot(agents: try panes(["p1"])), state: &state)
@@ -361,6 +362,41 @@ final class ResyncInvalidationTests: XCTestCase {
         XCTAssertEqual(
             afterResync["p1"], .fetch,
             "after a gap the pane must be refetched; identical counters are not evidence of no change"
+        )
+    }
+}
+
+
+/// Access control is the provenance guarantee, so it is checked as access
+/// control rather than through behaviour.
+///
+/// A behavioural test cannot observe who is *allowed* to call an initializer —
+/// the previous provenance test passed with `PaneSnapshot.init` made public,
+/// which is precisely the change that reopens the filtered-list path. Reading
+/// the declaration is crude, and it is the only thing here that fails when the
+/// invariant is broken.
+final class PaneSnapshotAccessTests: XCTestCase {
+    func testPaneSnapshotInitialiserIsNotPublic() throws {
+        let source = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()   // HerdrKitTests
+            .deletingLastPathComponent()   // Tests
+            .deletingLastPathComponent()   // repo root
+            .appendingPathComponent("Sources/HerdrKit/SessionRecovery.swift")
+        let text = try String(contentsOf: source, encoding: .utf8)
+
+        guard let declaration = text.range(of: "public struct PaneSnapshot") else {
+            return XCTFail("PaneSnapshot moved; this guard no longer looks where it thinks it does")
+        }
+        let body = text[declaration.lowerBound...]
+        guard let end = body.range(of: "\n}") else {
+            return XCTFail("could not delimit PaneSnapshot")
+        }
+        let snapshot = body[..<end.lowerBound]
+
+        XCTAssertTrue(snapshot.contains("init(agents:"), "the initialiser this guard exists for is gone")
+        XCTAssertFalse(
+            snapshot.contains("public init(agents:"),
+            "PaneSnapshot.init became public — code outside HerdrKit can now build one from a filtered list, which is the exact path observe() exists to close"
         )
     }
 }

--- a/Tests/HerdrKitTests/SessionRecoveryTests.swift
+++ b/Tests/HerdrKitTests/SessionRecoveryTests.swift
@@ -39,7 +39,7 @@ final class SessionRecoveryTests: XCTestCase {
 
     private func seeded(_ ids: [String]) throws -> SessionRecovery.State {
         var state = SessionRecovery.State()
-        recovery.observe(PaneSnapshot(agents: try panes(ids)), state: &state)
+        _ = recovery.observe(PaneSnapshot(agents: try panes(ids)), state: &state)
         return state
     }
 
@@ -51,6 +51,137 @@ final class SessionRecoveryTests: XCTestCase {
         let opened = recovery.beginInitialAttempt(state: &state).reconnectAttempt!
         _ = plan(.connected(opened, at: when), &state)
         return opened
+    }
+
+    /// AXIS: a second `connected` for the SAME adopted attempt is a no-op — no
+    /// duplicate resync/subscribe, and the stability clock keeps the ORIGINAL
+    /// establishment time.
+    ///
+    /// Reachable on real platforms: a connection can go ready -> waiting ->
+    /// ready across a viability blip without failing, so nothing guarantees one
+    /// connected per attempt. Before the fix the repeat re-emitted both actions
+    /// and overwrote connectedSince — observed streak of 3 instead of 1 in the
+    /// sweep's reproduction, because the restarted clock made an 11-second-old
+    /// connection look 2 seconds old.
+    func testRepeatConnectedForTheAdoptedAttemptIsANoOp() throws {
+        var state = try seeded(["p1"])
+        let start = Date()
+        let opened = recovery.beginInitialAttempt(state: &state).reconnectAttempt!
+        _ = plan(.connected(opened, at: start), &state)
+
+        let repeated = plan(.connected(opened, at: start.addingTimeInterval(3)), &state)
+        XCTAssertTrue(repeated.isEmpty, "a repeat ready is news, not a new adoption")
+        XCTAssertEqual(state.connectedSince, start, "the stability clock must keep the original time")
+
+        // The stability consequence, concretely: a failure past the window
+        // still clears the streak, because the clock was not restarted.
+        _ = plan(.transportFailed(opened, at: start.addingTimeInterval(recovery.stabilityInterval + 1)), &state)
+        XCTAssertEqual(state.consecutiveFailures, 1, "the restarted clock would have inherited the streak")
+    }
+
+    /// AXIS: foregrounding cancels whatever transport exists BEFORE dialing.
+    ///
+    /// A foregrounded with a connection still live (the OS never suspended us,
+    /// or no backgrounded was delivered) previously minted a replacement while
+    /// the old transport stayed open and subscribed — and no later plan ever
+    /// closed it: two sockets reading the same panes, forever.
+    func testForegroundingWhileConnectedCancelsTheOldTransportFirst() throws {
+        var state = try seeded(["p1"])
+        let old = connect(&state)
+
+        let resumed = plan(.foregrounded(at: Date()), &state)
+        XCTAssertEqual(resumed.actions.first, .cancelTransport,
+                       "the live transport must be torn down before a new one dials")
+        XCTAssertNotNil(resumed.reconnectAttempt)
+
+        // And the abandoned attempt's late callbacks are stale, both ways.
+        XCTAssertEqual(plan(.connected(old, at: Date()), &state).actions, [.discardConnection])
+        XCTAssertTrue(plan(.transportFailed(old, at: Date()), &state).isEmpty)
+    }
+
+    /// AXIS: beginInitialAttempt is safe to call mid-session — it cancels, and
+    /// the stale connectedSince cannot leak subscribes to an abandoned transport.
+    ///
+    /// The observed composition: begin-while-connected left connectedSince set,
+    /// so paneCreated emitted a subscribe for a transport the policy had just
+    /// walked away from.
+    func testBeginInitialAttemptWhileConnectedCancelsAndClearsAdoption() throws {
+        var state = try seeded(["p1"])
+        _ = connect(&state)
+
+        let restarted = recovery.beginInitialAttempt(state: &state)
+        XCTAssertEqual(restarted.actions.first, .cancelTransport)
+        XCTAssertNil(state.connectedSince, "stale adoption state leaks subscribes to a dead transport")
+        XCTAssertTrue(plan(.paneCreated("p9"), &state).isEmpty,
+                      "no subscribe may target the transport that was just abandoned")
+    }
+
+    /// AXIS: beginInitialAttempt while backgrounded dials nothing, matching
+    /// every other path's refusal to dial while suspended.
+    ///
+    /// This was the ONE mint that ignored backgrounding — which also made it
+    /// the only route by which the since-removed redundant background guards
+    /// were reachable at all.
+    func testBeginInitialAttemptWhileBackgroundedDialsNothing() throws {
+        var state = try seeded(["p1"])
+        _ = plan(.backgrounded(at: Date()), &state)
+        XCTAssertTrue(recovery.beginInitialAttempt(state: &state).isEmpty)
+
+        let resumed = plan(.foregrounded(at: Date()), &state)
+        XCTAssertNotNil(resumed.reconnectAttempt, "foregrounding must still dial")
+    }
+
+    /// AXIS: a pane that first appears in a post-reconnect snapshot gets a
+    /// subscription NOW, not at the next reconnect.
+    ///
+    /// The sweep's reproduction: a pane created during a disconnection gap
+    /// arrives via the snapshot (paneCreated never fires for it — the event
+    /// stream was down). The old Void observe() recorded it, and it sat on the
+    /// "re-subscribe list" unsubscribed for the whole session. Even the
+    /// app-layer workaround was closed: paneCreated for it returned nothing,
+    /// because the pane was already known.
+    func testSnapshotGrowthWhileConnectedSubscribesTheAddedPanes() throws {
+        var state = try seeded(["p1"])
+        _ = connect(&state)
+
+        let grown = recovery.observe(PaneSnapshot(agents: try panes(["p1", "p3"])), state: &state)
+        XCTAssertEqual(grown.subscribes, ["p3"], "exactly the added panes, not the whole set")
+
+        // While disconnected the snapshot only records; the next adoption's
+        // full-set subscribe covers it.
+        var offline = try seeded(["p1"])
+        let recorded = recovery.observe(PaneSnapshot(agents: try panes(["p1", "p4"])), state: &offline)
+        XCTAssertTrue(recorded.isEmpty, "no transport, nothing to subscribe on")
+        let opened = recovery.beginInitialAttempt(state: &offline).reconnectAttempt!
+        XCTAssertEqual(plan(.connected(opened, at: Date()), &offline).subscribes, ["p1", "p4"])
+    }
+
+    /// AXIS: the stability window measures EVENT time, not wall-clock time.
+    ///
+    /// Every prior test used event times near Date(), so `connectedSince =
+    /// Date()` — ignoring the event's own timestamp — survived all of them.
+    /// Replayed or delayed event delivery is exactly when the two diverge.
+    func testStabilityWindowUsesEventTimeNotWallClock() throws {
+        var state = try seeded(["p1"])
+        // A pre-existing streak, because resetting a streak of ZERO is
+        // invisible: the first version of this test started from zero and the
+        // wall-clock mutation survived it — 0-reset-then-increment and
+        // no-reset-then-increment both land on 1.
+        let past = Date().addingTimeInterval(-100)
+        let first = recovery.beginInitialAttempt(state: &state).reconnectAttempt!
+        _ = plan(.connected(first, at: past), &state)
+        let retry = plan(.transportFailed(first, at: past.addingTimeInterval(0.05)), &state)
+        XCTAssertEqual(state.consecutiveFailures, 1, "precondition: a flap on the books")
+
+        // The second connection lasts 15s of EVENT time — past the window, so
+        // the streak resets before the increment. Under the wall-clock bug the
+        // interval computes as negative and the old streak is inherited.
+        let second = retry.reconnectAttempt!
+        _ = plan(.connected(second, at: past.addingTimeInterval(1)), &state)
+        _ = plan(.transportFailed(
+            second, at: past.addingTimeInterval(1 + recovery.stabilityInterval + 5)), &state)
+        XCTAssertEqual(state.consecutiveFailures, 1,
+                       "a connection that lasted past the window in EVENT time must clear the streak; 2 means the clock was wall time")
     }
 
     /// THE AXIS for task 4: a client that missed events resyncs rather than
@@ -70,8 +201,11 @@ final class SessionRecoveryTests: XCTestCase {
         // Short enough that "surely nothing was missed" is tempting — which is
         // exactly the reasoning this must not embody.
         let resumed = plan(.foregrounded(at: Date().addingTimeInterval(0.2)), &state)
-        XCTAssertEqual(resumed.actions.count, 1, "foregrounding has no transport to resync on yet")
+        XCTAssertEqual(resumed.actions.first, .cancelTransport,
+                       "whatever transport may exist is torn down before dialing")
         XCTAssertEqual(resumed.reconnectDelay, 0)
+        XCTAssertFalse(resumed.contains(.resyncAllPanes), "no transport yet to resync on")
+        XCTAssertNil(resumed.subscribes, "no transport yet to subscribe on")
 
         let attempt = resumed.reconnectAttempt!
         let connected = plan(.connected(attempt, at: Date().addingTimeInterval(0.3)), &state)
@@ -85,11 +219,14 @@ final class SessionRecoveryTests: XCTestCase {
                        "subscriptions are persistent; emitting them twice opens each pane twice")
     }
 
-    /// AXIS: a connection completing after backgrounding is discarded, not adopted.
+    /// AXIS: a connection completing after backgrounding is discarded — BY THE
+    /// STALENESS GUARD, which is the one mechanism covering it.
     ///
-    /// Adopting it opens persistent subscriptions on a transport nobody will
-    /// read, on a process about to be suspended.
-    func testConnectionCompletingWhileBackgroundedIsDiscarded() throws {
+    /// Backgrounding clears `currentAttempt`, so the late completion cannot
+    /// match; a separate isForeground guard once sat behind that check and was
+    /// unreachable — the sweep showed this test pinned the staleness path all
+    /// along while its name credited the redundant guard.
+    func testConnectionCompletingWhileBackgroundedIsDiscardedAsStale() throws {
         var state = try seeded(["p1"])
         _ = plan(.backgrounded(at: Date()), &state)
 
@@ -157,6 +294,12 @@ final class SessionRecoveryTests: XCTestCase {
              "isForeground", "knownPanes", "nextAttemptValue"],
             "SessionRecovery.State grew a field; if it can hold a stream position, resumption just became expressible"
         )
+        // One level down too: State stores AttemptID, so a position smuggled
+        // into AttemptID's fields would be invisible to the check above.
+        let attemptFields = Mirror(reflecting: AttemptID(value: 0))
+            .children.compactMap(\.label).sorted()
+        XCTAssertEqual(attemptFields, ["value"],
+                       "AttemptID grew a field; a stream position could hide inside State through it")
     }
 
     /// AXIS: the backoff RANGE grows exponentially until the cap, then stops.
@@ -208,6 +351,14 @@ final class SessionRecoveryTests: XCTestCase {
         }
         XCTAssertGreaterThan(delays.count, 30,
                              "40 clients drew only \(delays.count) distinct delays; they would reconnect in lockstep")
+        // Distinctness alone survives a 1ms jitter band, which is still a
+        // lockstep storm to the server. The draws must SPREAD across the
+        // window: at failure 6 the range is 0..<16s, so 40 draws confined to
+        // less than half of it would mean the generator is not doing what
+        // full jitter is for.
+        let spread = delays.max()! - delays.min()!
+        XCTAssertGreaterThan(spread, 8.0,
+                             "40 draws span only \(spread)s of a 16s window; that is a band, not jitter")
     }
 
     /// AXIS: a connection that drops immediately does not reset the backoff.
@@ -297,12 +448,21 @@ final class SessionRecoveryTests: XCTestCase {
         XCTAssertEqual(state.knownPanes, ["p1"], "an authoritative listing is still authoritative")
     }
 
-    /// AXIS: a backgrounded client schedules no reconnect.
+    /// AXIS: a backgrounded client schedules no reconnect — including when the
+    /// failing attempt was CURRENT until the backgrounding.
+    ///
+    /// The previous version fed a never-minted AttemptID(value: 1), so it only
+    /// ever exercised an arbitrary-stale failure and could not notice if a
+    /// current attempt's failure dialed while suspended.
     func testBackgroundedClientSchedulesNoReconnect() throws {
         var state = try seeded(["p1"])
+        let current = connect(&state)
         _ = plan(.backgrounded(at: Date()), &state)
 
-        XCTAssertNil(plan(.transportFailed(AttemptID(value: 1), at: Date()), &state).reconnectDelay)
+        XCTAssertNil(plan(.transportFailed(current, at: Date()), &state).reconnectDelay,
+                     "the just-backgrounded attempt's failure must not dial")
+        XCTAssertEqual(state.consecutiveFailures, 0,
+                       "backgrounding made that failure stale; it is not a streak")
         XCTAssertNil(plan(.networkChanged(at: Date()), &state).reconnectDelay)
 
         let resumed = plan(.foregrounded(at: Date()), &state)
@@ -396,9 +556,15 @@ final class PaneSnapshotAccessTests: XCTestCase {
         )
         let triple = moduleDir.deletingLastPathComponent().deletingLastPathComponent().lastPathComponent
 
+        // A FRESH directory per run, removed afterwards. The first version wrote
+        // to a persistent per-triple directory and ignored the process exit
+        // status, so a FAILED extraction quietly reused the previous run's graph
+        // and passed — the reviewer reproduced it by breaking the subcommand.
+        // Stale evidence is worse than no evidence: it looks identical to fresh.
         let output = URL(fileURLWithPath: NSTemporaryDirectory())
-            .appendingPathComponent("herdrkit-symbolgraph-\(triple)")
-        try? FileManager.default.createDirectory(at: output, withIntermediateDirectories: true)
+            .appendingPathComponent("herdrkit-symbolgraph-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: output, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: output) }
 
         let swift = ["/opt/swift/usr/bin/swift", "/usr/bin/swift"]
             .first { FileManager.default.isExecutableFile(atPath: $0) }
@@ -412,14 +578,22 @@ final class PaneSnapshotAccessTests: XCTestCase {
             "-I", root.appendingPathComponent("Sources/CSSH").path,
             "-output-dir", output.path, "-minimum-access-level", "package",
         ]
+        let stderrPipe = Pipe()
         process.standardOutput = Pipe()
-        process.standardError = Pipe()
+        process.standardError = stderrPipe
         try process.run()
         process.waitUntilExit()
+        let stderrText = String(
+            data: stderrPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? "<none>"
+        guard process.terminationStatus == 0 else {
+            return XCTFail(
+                "symbolgraph-extract exited \(process.terminationStatus); the access invariant "
+                + "went UNCHECKED. stderr: \(stderrText)")
+        }
 
         let graph = output.appendingPathComponent("HerdrKit.symbols.json")
         guard let data = try? Data(contentsOf: graph) else {
-            return XCTFail("symbolgraph-extract produced no graph; the access invariant went UNCHECKED")
+            return XCTFail("extraction exited 0 but produced no graph; the access invariant went UNCHECKED")
         }
         let decoded = try JSONSerialization.jsonObject(with: data) as? [String: Any]
         let symbols = try XCTUnwrap(decoded?["symbols"] as? [[String: Any]])
@@ -431,12 +605,22 @@ final class PaneSnapshotAccessTests: XCTestCase {
         }
         XCTAssertFalse(snapshotSymbols.isEmpty, "PaneSnapshot is not in the surface at all; wrong module or stale build")
 
-        let initialisers = snapshotSymbols.filter {
-            (($0["kind"] as? [String: Any])?["identifier"] as? String)?.hasPrefix("swift.init") == true
-        }
-        XCTAssertTrue(
-            initialisers.isEmpty,
-            "PaneSnapshot exposes \(initialisers.count) initialiser(s) at package access or above; code outside HerdrKit can now build one from a filtered list, which is the exact path observe() exists to close"
+        // The WHOLE surface, not just initialisers. The init-only version let a
+        // `public static func make(...) -> PaneSnapshot` reopen outside-module
+        // construction without failing anything — construction is what the type
+        // forbids, and a factory constructs. Whitelisting every symbol means any
+        // new member at package access or above must be judged here, out loud.
+        let surface = snapshotSymbols.compactMap { symbol -> String? in
+            guard let kind = (symbol["kind"] as? [String: Any])?["identifier"] as? String,
+                  let path = symbol["pathComponents"] as? [String] else { return nil }
+            return "\(kind) \(path.joined(separator: "."))"
+        }.sorted()
+        XCTAssertEqual(
+            surface,
+            ["swift.func.op PaneSnapshot.!=(_:_:)",
+             "swift.property PaneSnapshot.paneIDs",
+             "swift.struct PaneSnapshot"],
+            "PaneSnapshot's package-visible surface changed; anything that can CONSTRUCT one from caller data reopens the filtered-list path observe() exists to close"
         )
     }
 }

--- a/scripts/mutate.sh
+++ b/scripts/mutate.sh
@@ -1,22 +1,36 @@
 #!/usr/bin/env bash
-# Mutation harness. Every mutation asserts it APPLIED before the result is
-# trusted: three silent no-op mutations this week made green runs look like
-# working guards, because the target string had drifted and sed matched nothing.
+# Mutation harness.
 #
-# Usage: scripts/mutate.sh <name> "<target>" "<replacement>" <test-filter>
-# Exits non-zero if the mutation did not apply, or if the named test still passes
-# with the production code broken.
+# Reports one of four outcomes, because collapsing them is how a mutation run
+# lies:
+#
+#   KILLED   — the mutation compiled, the named tests RAN, and at least one failed
+#   SURVIVED — the mutation compiled, the tests ran, and all passed
+#   INVALID  — the mutation did not compile, or matched no test: it exercised the
+#              compiler or the filter, not the suite
+#   ESCAPED  — the run hung and was killed by the timeout
+#
+# The previous version treated every non-zero `swift test` exit as KILLED. A
+# mutation with a syntax error therefore reported KILLED while proving nothing,
+# and so did a timeout, despite a comment claiming otherwise. Every outcome this
+# harness reports is only as good as its ability to tell those cases apart.
+#
+# Usage: scripts/mutate.sh <name> "<target>" "<replacement>" <test-filter> [file]
 set -uo pipefail
 export PATH=/opt/swift/usr/bin:$PATH
 
 NAME="$1"; TARGET="$2"; REPLACEMENT="$3"; FILTER="$4"
 FILE="${5:-Sources/HerdrKit/SSHTransport.swift}"
 BACKUP="$(mktemp)"
+BUILD_LOG="$(mktemp)"
+RUN_LOG="$(mktemp)"
 cp "$FILE" "$BACKUP"
-restore() { cp "$BACKUP" "$FILE"; rm -f "$BACKUP"; }
+restore() { cp "$BACKUP" "$FILE"; rm -f "$BACKUP" "$BUILD_LOG" "$RUN_LOG"; }
 trap restore EXIT
 
-python3 - "$FILE" "$TARGET" "$REPLACEMENT" <<'PY' || { echo "MUTATION '$NAME' DID NOT APPLY — target absent, result would be meaningless"; exit 2; }
+# The mutation must actually apply. Three silent no-op mutations made green runs
+# look like working guards before this check existed.
+python3 - "$FILE" "$TARGET" "$REPLACEMENT" <<'PY' || { echo "INVALID: mutation '$NAME' DID NOT APPLY — target absent"; exit 2; }
 import sys
 path, target, replacement = sys.argv[1], sys.argv[2], sys.argv[3]
 source = open(path).read()
@@ -25,15 +39,41 @@ if target not in source:
 open(path, "w").write(source.replace(target, replacement, 1))
 PY
 
-echo "--- mutation '$NAME' applied; expecting $FILTER to FAIL ---"
-# Bounded: a mutation that makes the suite hang has not been killed by a test,
-# it has escaped one, and an unbounded run would hide that as a stall.
-if timeout 300 swift test --filter "$FILTER" >/tmp/mutate-$$.log 2>&1; then
-    echo "SURVIVED: $FILTER still passes with '$NAME' broken. The test does not guard it."
-    tail -5 /tmp/mutate-$$.log
-    rm -f /tmp/mutate-$$.log
+# A mutation that does not compile tests the compiler.
+if ! swift build --build-tests >"$BUILD_LOG" 2>&1; then
+    echo "INVALID: mutation '$NAME' does not compile — it proves nothing about the tests"
+    grep -m2 "error:" "$BUILD_LOG"
+    exit 2
+fi
+
+echo "--- mutation '$NAME' applied and compiles; expecting $FILTER to FAIL ---"
+timeout 300 swift test --filter "$FILTER" >"$RUN_LOG" 2>&1
+STATUS=$?
+
+if [ "$STATUS" -eq 124 ]; then
+    echo "ESCAPED: '$NAME' made $FILTER hang. A hang is not a kill."
+    exit 3
+fi
+
+# "Executed 0 tests" means the filter matched nothing, which exits 0 and would
+# otherwise be indistinguishable from a survivor.
+EXECUTED=$(grep -oE "Executed [0-9]+ tests?" "$RUN_LOG" | grep -oE "[0-9]+" | sort -rn | head -1)
+EXECUTED=${EXECUTED:-0}
+if [ "$EXECUTED" -eq 0 ]; then
+    echo "INVALID: filter '$FILTER' matched no tests — nothing was exercised"
+    exit 2
+fi
+
+if [ "$STATUS" -eq 0 ]; then
+    echo "SURVIVED: $FILTER ($EXECUTED tests) still passes with '$NAME' broken. The test does not guard it."
     exit 1
 fi
-echo "KILLED: $FILTER fails when '$NAME' is broken."
-grep -E "error:|XCTAssert|failed" /tmp/mutate-$$.log | head -4
-rm -f /tmp/mutate-$$.log
+
+if ! grep -q "^Test Case .* failed" "$RUN_LOG"; then
+    echo "INVALID: $FILTER exited $STATUS with no test-case failure — the run broke, it did not fail"
+    tail -3 "$RUN_LOG"
+    exit 2
+fi
+
+echo "KILLED: $FILTER ($EXECUTED tests) fails when '$NAME' is broken."
+grep -m3 -E "^/.*error: .*XCTAssert|^Test Case .* failed" "$RUN_LOG"

--- a/scripts/mutate.sh
+++ b/scripts/mutate.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Mutation harness. Every mutation asserts it APPLIED before the result is
+# trusted: three silent no-op mutations this week made green runs look like
+# working guards, because the target string had drifted and sed matched nothing.
+#
+# Usage: scripts/mutate.sh <name> "<target>" "<replacement>" <test-filter>
+# Exits non-zero if the mutation did not apply, or if the named test still passes
+# with the production code broken.
+set -uo pipefail
+export PATH=/opt/swift/usr/bin:$PATH
+
+NAME="$1"; TARGET="$2"; REPLACEMENT="$3"; FILTER="$4"
+FILE="${5:-Sources/HerdrKit/SSHTransport.swift}"
+BACKUP="$(mktemp)"
+cp "$FILE" "$BACKUP"
+restore() { cp "$BACKUP" "$FILE"; rm -f "$BACKUP"; }
+trap restore EXIT
+
+python3 - "$FILE" "$TARGET" "$REPLACEMENT" <<'PY' || { echo "MUTATION '$NAME' DID NOT APPLY — target absent, result would be meaningless"; exit 2; }
+import sys
+path, target, replacement = sys.argv[1], sys.argv[2], sys.argv[3]
+source = open(path).read()
+if target not in source:
+    sys.exit(1)
+open(path, "w").write(source.replace(target, replacement, 1))
+PY
+
+echo "--- mutation '$NAME' applied; expecting $FILTER to FAIL ---"
+# Bounded: a mutation that makes the suite hang has not been killed by a test,
+# it has escaped one, and an unbounded run would hide that as a stall.
+if timeout 300 swift test --filter "$FILTER" >/tmp/mutate-$$.log 2>&1; then
+    echo "SURVIVED: $FILTER still passes with '$NAME' broken. The test does not guard it."
+    tail -5 /tmp/mutate-$$.log
+    rm -f /tmp/mutate-$$.log
+    exit 1
+fi
+echo "KILLED: $FILTER fails when '$NAME' is broken."
+grep -E "error:|XCTAssert|failed" /tmp/mutate-$$.log | head -4
+rm -f /tmp/mutate-$$.log


### PR DESCRIPTION
**WHAT** — `SessionRecovery`, the policy that decides when a client resyncs,
re-subscribes and reconnects. `RefreshCoordinator.invalidateAll()` already
existed; nothing decided when to call it.

**WHY** — herdr's EventHub is a **512-entry ring with no gap signal**. A client
that was away long enough falls off the back and **cannot detect that it did**:
the sequence numbers it sees afterwards are perfectly continuous with the ones it
remembers and simply describe a different stretch of history. So foregrounding
and reconnecting both resync **unconditionally** — a conditional resync would
have to detect the gap, which is exactly the thing that cannot be done.

Nothing here accepts a remembered position, and that absence is the design. A
`resume(from:)` would be used, would pass every test written against a server
that had not wrapped its ring, and would show stale panes only on a phone that
had been in a pocket.

**AXIS** — one sentence each

- `testForegroundingAlwaysResyncsRatherThanTrustingContinuity` — the resync is
  unconditional, including after an absence short enough that "surely nothing was
  missed" is tempting.
- `testNoAPIAcceptsARememberedSequence` — the surface carries no cursor to resume
  from.
- `testBackoffGrowsAndIsCapped` — delays grow and never exceed the ceiling.
- `testBackoffIsJitteredNotFixed` — 40 clients draw >30 distinct delays. Asserting
  only "≤ cap" would pass on a fixed schedule, which is the lockstep reconnect
  storm jitter exists to prevent.
- `testFlappingConnectionDoesNotResetTheBackoff` — a connection that drops inside
  the stability window still counts as a failure.
- `testAHealthyConnectionResetsTheBackoff` — one that outlives it clears the streak.
- `testPaneCreatedSubscribesToThatPane` — new panes get a subscription, and repeats
  do not re-subscribe.
- `testPanesLearnedDuringASessionAreResubscribedAfterReconnect` — a pane discovered
  mid-session is not forgotten across a reconnect.
- `testBackgroundedClientSchedulesNoReconnect` — suspended time is not a failure streak.
- `testNetworkChangeReconnectsImmediately` — a network change is not a failure to
  back off from.
- `testReconnectingResyncs` — a reconnect does not resume from cached generations.
- `testInvalidationForcesAFetchEvenWhenCountersDidNotMove` — the observable
  consequence, asserted against a precondition that the same pane skips when not
  invalidated. Asserting the state was cleared would test the setter.

**RESULTS** — 59 tests, 0 failures, build warning-clean. Six mutations, all
killed, each with the applied-assertion: `foreground-resync`, `backoff-jitter`,
`stability-window`, `background-no-reconnect`, `reconnect-resubscribes`,
`invalidate-clears-lastfetch`.

The stability-window mutation is the one worth noting: replacing "connected long
enough" with "connected at all" is the bug as it is usually written, and the test
counts five flaps rather than asserting a delay, so it fails on the mechanism
rather than on a threshold.

**RISK / open**

- **Policy only — nothing wires it to a transport.** No `NWPathMonitor`, no
  `UIApplication` lifecycle: those are the macOS/iOS half this goal excludes.
  Decisions are tested; delivery of the events that trigger them is not, and a
  caller that never sends `.foregrounded` gets no resync and no warning.
- `stabilityInterval` (10s), `baseDelay` (0.5s) and `maximumDelay` (30s) are
  chosen, not measured. Stated rather than hidden — same criticism as the SSH
  transport's constants.
- The reconnect path does not itself cancel the old transport; it says when to
  reconnect. Whoever wires it must cancel first, since a half-open socket on a
  dead interface fails by timing out rather than erroring.
- `observe(panes:)` replaces the known set wholesale. A caller that calls it with
  a partial listing silently unsubscribes the rest.

HERDR-APP: