### PR TITLE
feat(kit): streamFailed + RecoveryExecutor — the policy meets the wire

### DIFF
--- a/.gitmoot/REVIEW-HEADER.md
+++ b/.gitmoot/REVIEW-HEADER.md
@@ -4,14 +4,41 @@ Prepend verbatim to every review dispatch in this lane.
 
 ## 1. Establish which code you reviewed, and NAME it
 
-**Archive the PR's current head yourself and review that.** Do not trust the
-job's pinned SHA, and do not review the shared worktree
-(`/root/.gitmoot/worktrees/jerryfane--herdr-ios/review-pr-<N>-<id>`) without
-first confirming its HEAD matches the head you intend.
+**Read the commit through local plumbing rather than trusting the working
+tree.** This needs no network and no auth, so it cannot fail closed:
 
-**State in `Tests Run`: the exact head you archived, and the diff range you
-examined.** That line is load-bearing evidence, not a formality — it is
-currently the only channel that reports which code a verdict actually covers.
+```
+git cat-file -t <sha>                              # the gate: object present?
+git diff $(git merge-base <sha> origin/main)..<sha>
+git show <sha>:<path>
+```
+
+Do not review the shared worktree
+(`/root/.gitmoot/worktrees/jerryfane--herdr-ios/review-pr-<N>-<id>`) without
+first confirming its HEAD matches the head you intend. If you *can* reach the
+PR's live head, archive it yourself and review that; if you cannot, review the
+pinned SHA through the plumbing above and say which you did.
+
+**State in `Tests Run` BOTH the SHA you reviewed AND the worktree HEAD you
+found**, even when they agree — especially when they agree.
+
+That pairing is the whole mechanism, and it is why this is a requirement rather
+than advice: it turns an instruction into a **detector**. A reviewer that
+quietly skips the plumbing is caught by the mismatch in its own output, at
+verdict time, instead of by someone diffing afterwards — or never. *An
+instruction that cannot detect its own violation is a hope.* Apply that test to
+any review contract written in this lane, not just this one.
+
+**Two traps that have already fired here:**
+
+- `gitmoot job show`'s verdict summary begins with the **worktree** SHA. Never
+  parse that field for currency; it displays the stale commit by construction.
+- A `policy: read-only` reviewer has no network and no valid auth. A brief
+  demanding verification against the PR's *live* head therefore fails closed
+  forever — six blocked rounds elsewhere proved it. The plumbing path above is
+  the reason this header does not have that failure mode. Do not "fix" it by
+  granting the reviewer network: that expands privilege on the least-privileged
+  party to perform a check the merge gate already does without a race.
 
 **The job record is not evidence.** At execution the job's `head_sha` is
 overwritten from the worktree, so a stale checkout produces a record that agrees
@@ -24,8 +51,18 @@ review task id stable rather than head-derived, so the worktree keyed by it is
 reused and never re-synced. On this repo, five consecutive dispatches recorded a
 head two commits stale while the verdicts were correct. The correctness came
 from *somewhere* — reviewer habit, or an explicitly-passed `--head-sha`; the
-lane's own data cannot distinguish them. A compensating behaviour nobody
-designed as a safeguard is not a safeguard. This header makes it one.
+lane's own data could not distinguish them at the time. A compensating
+behaviour nobody designed as a safeguard is not a safeguard. This header makes
+it one.
+
+That question has since been settled, and the answer removes the more
+comfortable option: a dispatch passing `--head-sha c340f2b` against a reused
+task recorded `e02e40ba`, three rounds stale. **`--head-sha` is not a
+mitigation.** Reviewer habit — this header — is the only thing standing
+between a reused worktree and a confident verdict on the wrong commit. On #11
+that mattered: at the stale head the guard under review still existed, so a
+review of the assigned worktree would have returned clean on a head containing
+a live race.
 
 ## 2. Standing verification clauses
 

--- a/.gitmoot/REVIEW-HEADER.md
+++ b/.gitmoot/REVIEW-HEADER.md
@@ -35,6 +35,28 @@ case — a PR elsewhere merged on exactly such a void verdict. A blob id cannot
 be produced without reading the tree it belongs to, so it is the first
 statement in this header that the coordinator did not supply the answer to.
 
+### Choosing a discriminator (coordinator-side)
+
+**It must sit on the CRITICAL PATH OF THE REASONING, not merely inside the
+diff.** Content a reviewer would read but never have reason to quote —
+comment prose, an identifier cited by line number rather than by name, a hash
+nothing depends on — produces FALSE NEGATIVES: elsewhere this check missed
+three times on a review that had demonstrably read the right head. Prefer an
+exact count the reviewer must verify to reach a verdict, an identifier central
+to the change, or a label with zero occurrences at the parent commit.
+
+**Classify the result in THREE states, never two:**
+
+| | |
+|---|---|
+| ENGAGED | the verdict engages the discriminator → confirmed |
+| INCONCLUSIVE | no engagement, but other head-specific evidence is present — line-number citations, answers to structural questions, findings naming code absent at the parent. **Look closer; do not re-run and do not accuse.** |
+| NO EVIDENCE | no engagement and nothing else head-specific → treat as unverified |
+
+A two-state classifier folds UNCERTAIN into ACCUSATORY, and the remedy for a
+suspected void verdict is another round — so the error lands in the expensive
+direction *and* trains distrust of a reviewer that was correct.
+
 That pairing is the whole mechanism, and it is why this is a requirement rather
 than advice: it turns an instruction into a **detector**. A reviewer that
 quietly skips the plumbing is caught by the mismatch in its own output, at

--- a/.gitmoot/REVIEW-HEADER.md
+++ b/.gitmoot/REVIEW-HEADER.md
@@ -22,6 +22,19 @@ pinned SHA through the plumbing above and say which you did.
 **State in `Tests Run` BOTH the SHA you reviewed AND the worktree HEAD you
 found**, even when they agree — especially when they agree.
 
+**And report the CONTENT DISCRIMINATOR the dispatch asks for.** Each dispatch
+names a file and asks for `git rev-parse <sha>:<path>` — a blob id — plus the
+verbatim text of a specified line. Do not infer these from the dispatch; it
+never contains them.
+
+That requirement exists because naming the SHA is not independent evidence: the
+brief HANDS you the SHA. A reviewer that reads a stale worktree and quotes the
+pinned SHA satisfies every check above without ever touching the code under
+review, and under gitmoot#1415 that is the common case rather than an edge
+case — a PR elsewhere merged on exactly such a void verdict. A blob id cannot
+be produced without reading the tree it belongs to, so it is the first
+statement in this header that the coordinator did not supply the answer to.
+
 That pairing is the whole mechanism, and it is why this is a requirement rather
 than advice: it turns an instruction into a **detector**. A reviewer that
 quietly skips the plumbing is caught by the mismatch in its own output, at

--- a/.gitmoot/REVIEW-HEADER.md
+++ b/.gitmoot/REVIEW-HEADER.md
@@ -1,0 +1,39 @@
+# Standing review header — jerryfane/herdr-ios
+
+Prepend verbatim to every review dispatch in this lane.
+
+## 1. Establish which code you reviewed, and NAME it
+
+**Archive the PR's current head yourself and review that.** Do not trust the
+job's pinned SHA, and do not review the shared worktree
+(`/root/.gitmoot/worktrees/jerryfane--herdr-ios/review-pr-<N>-<id>`) without
+first confirming its HEAD matches the head you intend.
+
+**State in `Tests Run`: the exact head you archived, and the diff range you
+examined.** That line is load-bearing evidence, not a formality — it is
+currently the only channel that reports which code a verdict actually covers.
+
+**Why this is a requirement and not a courtesy:** C1 of gitmoot#1354 made the
+review task id stable rather than head-derived, so the worktree keyed by it is
+reused and never re-synced. On this repo, five consecutive dispatches recorded a
+head two commits stale while the verdicts were correct. The correctness came
+from *somewhere* — reviewer habit, or an explicitly-passed `--head-sha`; the
+lane's own data cannot distinguish them. A compensating behaviour nobody
+designed as a safeguard is not a safeguard. This header makes it one.
+
+## 2. Standing verification clauses
+
+- Mutants must BUILD. A mutation that fails to compile proves nothing about the
+  tests; classify it INVALID, not KILLED.
+- A crash (signal 4) is not a kill. An assertion followed by a force-unwrap
+  turns a real failure into an unclassifiable run — use `XCTUnwrap`.
+- Check the PRECONDITION arms the hazard. A test whose setup never reaches the
+  condition under test passes for reasons unrelated to its name; on this repo
+  that has been the cause more often than a weak assertion.
+- Restore per-file after probing; leave the worktree clean.
+
+## 3. What this lane wants from a review
+
+Disagreement, with a demonstration. Every round on #10 and #11 that found
+something real found it by running a probe, not by reading. A verdict that
+agrees is worth less than one that reproduces.

--- a/.gitmoot/REVIEW-HEADER.md
+++ b/.gitmoot/REVIEW-HEADER.md
@@ -13,6 +13,12 @@ first confirming its HEAD matches the head you intend.
 examined.** That line is load-bearing evidence, not a formality — it is
 currently the only channel that reports which code a verdict actually covers.
 
+**The job record is not evidence.** At execution the job's `head_sha` is
+overwritten from the worktree, so a stale checkout produces a record that agrees
+with it — self-consistent and wrong. Only two surfaces can be trusted: the
+worktree HEAD observed *before* the verdict, and the head you name in your own
+verdict body.
+
 **Why this is a requirement and not a courtesy:** C1 of gitmoot#1354 made the
 review task id stable rather than head-derived, so the worktree keyed by it is
 reused and never re-synced. On this repo, five consecutive dispatches recorded a

--- a/.gitmoot/REVIEW-HEADER.md
+++ b/.gitmoot/REVIEW-HEADER.md
@@ -40,11 +40,20 @@ any review contract written in this lane, not just this one.
   granting the reviewer network: that expands privilege on the least-privileged
   party to perform a check the merge gate already does without a race.
 
-**The job record is not evidence.** At execution the job's `head_sha` is
-overwritten from the worktree, so a stale checkout produces a record that agrees
-with it — self-consistent and wrong. Only two surfaces can be trusted: the
-worktree HEAD observed *before* the verdict, and the head you name in your own
-verdict body.
+**The job record is not evidence, and it is not a second witness.** The value is
+stored correctly when the job is queued and REPLACED FROM THE WORKTREE during
+execution (measured: `queued → 3b04cd0`, `running → e02e40ba`, same job). So a
+stale checkout produces a record that agrees with it — self-consistent and
+wrong.
+
+The trap is subtler than "the record can be stale": *record agrees with
+worktree* looks like corroboration and is not. The record is DERIVED from the
+worktree, so the two agree by construction, including when both are wrong.
+Counting that as two surfaces is reading one fact twice and calling it two
+witnesses — a derived value is never independent evidence of the thing it was
+derived from. **There are two independent surfaces:** (record ≡ worktree), and
+the head the verdict names. Compare both against the PR head; agreement between
+*those* means something.
 
 **Why this is a requirement and not a courtesy:** C1 of gitmoot#1354 made the
 review task id stable rather than head-derived, so the worktree keyed by it is

--- a/Sources/HerdrKit/RecoveryExecutor.swift
+++ b/Sources/HerdrKit/RecoveryExecutor.swift
@@ -412,7 +412,13 @@ public actor RecoveryExecutor {
                 // Back off between consecutive failures for THIS pane on THIS
                 // attempt, through the same seam the dial uses so tests pin it.
                 await sleeper(Double(failures) * 0.25)
-                guard attempt == state.currentAttempt else { return }
+                guard attempt == state.currentAttempt else {
+                    record(rejection: (
+                        action: "openStream(\(pane))",
+                        reason: "attempt retired during retry backoff; retry abandoned"
+                    ))
+                    return
+                }
             }
             do {
                 // The exactly-once termination contract is ENFORCED here, not

--- a/Sources/HerdrKit/RecoveryExecutor.swift
+++ b/Sources/HerdrKit/RecoveryExecutor.swift
@@ -374,18 +374,18 @@ public actor RecoveryExecutor {
 
     private func open(panes: Set<String>, for attempt: AttemptID) async {
         for pane in panes.sorted() {
-            // Re-checked PER PANE, because every openStream await is an actor
-            // suspension point: a retirement can interleave mid-loop, and a
-            // door-only check let the remaining panes open for the retired
-            // attempt AFTER its closeAll had run — orphan streams nothing would
-            // ever close. Reproduced by test before this guard existed.
-            guard attempt == state.currentAttempt else {
-                record(rejection: (
-                    action: "openStream(\(pane))",
-                    reason: "attempt retired mid-subscribe"
-                ))
-                return
-            }
+            // NO pre-await binding check here, deliberately, and this is a
+            // removal rather than an omission: one lived here and was found
+            // UNREACHABLE AS A DECIDER. Actor reentrancy happens only at
+            // suspension points, and between the previous iteration's
+            // post-await reap (which returns) and this position there is none —
+            // so any retirement a pre-check could see was already seen by the
+            // reap. Its mutation survived precisely because the reap covered
+            // every case. Two mechanisms for one property, neither individually
+            // pinnable: the trap this project has now hit four times, and the
+            // fourth was my own fix for the third.
+            //
+            // The single mechanism is the RECHECK-AND-REAP after the open below.
             let failures = openFailures[FailureKey(attempt: attempt, pane: pane)] ?? 0
             guard failures < Self.openFailureCap else {
                 record(rejection: (

--- a/Sources/HerdrKit/RecoveryExecutor.swift
+++ b/Sources/HerdrKit/RecoveryExecutor.swift
@@ -376,9 +376,15 @@ public actor RecoveryExecutor {
         for pane in panes.sorted() {
             // NO pre-await binding check at the top of the iteration. The
             // invariant this loop keeps is stated once and held per site:
-            // EVERY SUSPENSION POINT IN THIS BODY IS FOLLOWED BY ITS OWN
-            // ATTEMPT RECHECK. There are exactly three, and each has a distinct
-            // correction because each leaves the world in a different state:
+            // EVERY SUSPENSION POINT THAT CAN REACH THE TOP OF THE NEXT
+            // ITERATION IS FOLLOWED BY ITS OWN ATTEMPT RECHECK.
+            //
+            // The qualifier is load-bearing. The body contains FOUR awaits; the
+            // fourth is `transport.closeAll` inside the reap below, which is
+            // followed unconditionally by `return`, so its resumption cannot
+            // reach the loop head and it needs no check. Three can, and each has
+            // a distinct correction because each leaves the world in a
+            // different state:
             //   1. the backoff `sleeper` below       -> plain return, nothing built yet
             //   2. `transport.openStream` succeeding  -> RECHECK-AND-REAP; a
             //      registration now exists past the teardown that would have

--- a/Sources/HerdrKit/RecoveryExecutor.swift
+++ b/Sources/HerdrKit/RecoveryExecutor.swift
@@ -374,18 +374,26 @@ public actor RecoveryExecutor {
 
     private func open(panes: Set<String>, for attempt: AttemptID) async {
         for pane in panes.sorted() {
-            // NO pre-await binding check here, deliberately, and this is a
-            // removal rather than an omission: one lived here and was found
-            // UNREACHABLE AS A DECIDER. Actor reentrancy happens only at
-            // suspension points, and between the previous iteration's
-            // post-await reap (which returns) and this position there is none —
-            // so any retirement a pre-check could see was already seen by the
-            // reap. Its mutation survived precisely because the reap covered
-            // every case. Two mechanisms for one property, neither individually
-            // pinnable: the trap this project has now hit four times, and the
-            // fourth was my own fix for the third.
+            // NO pre-await binding check at the top of the iteration. The
+            // invariant this loop keeps is stated once and held per site:
+            // EVERY SUSPENSION POINT IN THIS BODY IS FOLLOWED BY ITS OWN
+            // ATTEMPT RECHECK. There are exactly three, and each has a distinct
+            // correction because each leaves the world in a different state:
+            //   1. the backoff `sleeper` below       -> plain return, nothing built yet
+            //   2. `transport.openStream` succeeding  -> RECHECK-AND-REAP; a
+            //      registration now exists past the teardown that would have
+            //      closed it, so returning without reaping leaks it
+            //   3. `handle(.streamFailed)` in the catch -> plain return; the
+            //      throwing open left no registration to reap
             //
-            // The single mechanism is the RECHECK-AND-REAP after the open below.
+            // A top-of-iteration guard was tried and removed as unreachable,
+            // and that removal was WRONG — round seven built a probe that
+            // walked straight through the hole. The reasoning failed by
+            // enumerating only the success path: the catch path also suspends,
+            // and it did not pass through the reap on its way back to here. The
+            // per-site rule is what makes that enumerable at all; a single
+            // top-of-loop check invites exactly the mistake I made, because it
+            // reads as covering suspensions it never sees.
             let failures = openFailures[FailureKey(attempt: attempt, pane: pane)] ?? 0
             guard failures < Self.openFailureCap else {
                 record(rejection: (
@@ -460,6 +468,25 @@ public actor RecoveryExecutor {
                     lastOpenErrors[FailureKey(attempt: attempt, pane: pane)] = String(describing: error)
                 }
                 await handle(.streamFailed(pane: pane, from: attempt))
+                // Suspension point 3. `handle` re-enters the policy, which
+                // typically dials a REPLACEMENT stream for this pane and
+                // suspends again inside it — a long, reliably-hit window with
+                // this loop parked in the middle of it. A retirement delivered
+                // there is invisible to every other check: the reap above is on
+                // the success path, and the next iteration's backoff guard only
+                // runs for a pane that has already failed once.
+                //
+                // Nothing to reap: `openStream` threw, and the seam's contract
+                // is that a throwing open leaves no live registration. Streams
+                // this attempt opened for EARLIER panes were closed by the
+                // teardown's own closeAll while this await was suspended.
+                guard attempt == state.currentAttempt else {
+                    record(rejection: (
+                        action: "openStream(\(pane))",
+                        reason: "attempt retired while handling an open failure; remaining panes abandoned"
+                    ))
+                    return
+                }
             }
         }
     }

--- a/Sources/HerdrKit/RecoveryExecutor.swift
+++ b/Sources/HerdrKit/RecoveryExecutor.swift
@@ -191,6 +191,18 @@ public actor RecoveryExecutor {
 
     private func open(panes: Set<String>, for attempt: AttemptID) async {
         for pane in panes.sorted() {
+            // Re-checked PER PANE, because every openStream await is an actor
+            // suspension point: a retirement can interleave mid-loop, and a
+            // door-only check let the remaining panes open for the retired
+            // attempt AFTER its closeAll had run — orphan streams nothing would
+            // ever close. Reproduced by test before this guard existed.
+            guard attempt == state.currentAttempt else {
+                rejections.append((
+                    action: "openStream(\(pane))",
+                    reason: "attempt retired mid-subscribe"
+                ))
+                return
+            }
             do {
                 try await transport.openStream(pane: pane, for: attempt) { [weak self] in
                     // One termination, one death event — the exactly-once

--- a/Sources/HerdrKit/RecoveryExecutor.swift
+++ b/Sources/HerdrKit/RecoveryExecutor.swift
@@ -432,14 +432,22 @@ public actor RecoveryExecutor {
                     await transport.closeAll(for: attempt)
                     return
                 }
-                openFailures[FailureKey(attempt: attempt, pane: pane)] = nil
-                lastOpenErrors[FailureKey(attempt: attempt, pane: pane)] = nil
                 // Published only if the stream is still alive: a termination
                 // firing while openStream was suspended already processed the
                 // death, and publishing here anyway reported a dead stream as
                 // .open — after exhaustion, permanently.
+                //
+                // The bookkeeping clears INSIDE the successful branch, not
+                // before the decision: clearing first erased exhausted retry
+                // state, so a pane that had burned every attempt reported
+                // admittedNotOpen(attempts: 0, lastError: nil) — the status
+                // surface telling the truth about openness while lying about
+                // WHY — and a retained orphan callback could then restart
+                // registration past the supposedly exhausted cap.
                 if once.publishIfUnterminated() {
                     openStreams[pane] = OpenRegistration(attempt: attempt, registration: registration)
+                    openFailures[FailureKey(attempt: attempt, pane: pane)] = nil
+                    lastOpenErrors[FailureKey(attempt: attempt, pane: pane)] = nil
                 }
             } catch {
                 // A stream that cannot OPEN is a death the same as one that

--- a/Sources/HerdrKit/RecoveryExecutor.swift
+++ b/Sources/HerdrKit/RecoveryExecutor.swift
@@ -47,15 +47,38 @@ public protocol ExecutorTransport: Sendable {
     func discard(attempt: AttemptID) async
 }
 
-/// One-shot claim for a stream's termination callback.
+/// Lifecycle latch for one stream registration: coordinates the termination
+/// callback with the openStream return, atomically.
+///
+/// Two states short of this were two lies: a termination firing WHILE
+/// openStream was suspended still saw the success path publish the pane as
+/// open afterwards (falsely `.open` after exhaustion), and nothing tied a
+/// termination to the registration it belonged to.
 final class TerminationLatch: @unchecked Sendable {
+    private enum Lifecycle {
+        case fresh
+        case published
+        case terminated
+    }
+
     private let lock = NSLock()
-    private var claimed = false
-    /// True exactly once.
+    private var lifecycle: Lifecycle = .fresh
+
+    /// Termination side: true exactly once, whether or not the open ever
+    /// published — at-most-once is unconditional.
     func claim() -> Bool {
         lock.lock(); defer { lock.unlock() }
-        if claimed { return false }
-        claimed = true
+        if case .terminated = lifecycle { return false }
+        lifecycle = .terminated
+        return true
+    }
+
+    /// Open-return side: true iff the stream is still alive to publish. A
+    /// registration whose termination already fired must NOT surface as open.
+    func publishIfUnterminated() -> Bool {
+        lock.lock(); defer { lock.unlock() }
+        guard case .fresh = lifecycle else { return false }
+        lifecycle = .published
         return true
     }
 }
@@ -103,9 +126,17 @@ public actor RecoveryExecutor {
     }
     private var openFailures: [FailureKey: Int] = [:]
     private var lastOpenErrors: [FailureKey: String] = [:]
-    /// Panes whose stream ACTUALLY opened on the current attempt — the
-    /// executor's observation, distinct from the policy's admission ledger.
-    private var openPanes: Set<String> = []
+    /// Streams ACTUALLY open, keyed by pane and carrying the REGISTRATION that
+    /// opened them — the executor's observation, distinct from the policy's
+    /// admission ledger. Provenance here for the same reason as everywhere
+    /// else in this file: an unprovenanced Set let a retired attempt's delayed
+    /// termination flip a LIVE pane's status to admitted-not-open.
+    private struct OpenRegistration {
+        let attempt: AttemptID
+        let registration: ObjectIdentifier
+    }
+    private var openStreams: [String: OpenRegistration] = [:]
+    private var openPanes: Set<String> { Set(openStreams.keys) }
 
     /// What a caller asking "is this pane watched?" can actually know.
     ///
@@ -213,7 +244,7 @@ public actor RecoveryExecutor {
             case .cancelTransport:
                 pendingDial?.cancel()
                 pendingDial = nil
-                openPanes = []
+                openStreams = [:]
                 retireCounters(keeping: nil)
                 if let owned = resourcedAttempt {
                     await transport.closeAll(for: owned)
@@ -299,7 +330,7 @@ public actor RecoveryExecutor {
         let previous = resourcedAttempt
         resourcedAttempt = attempt
         retireCounters(keeping: attempt)
-        openPanes = []
+        openStreams = [:]
         pendingDial = Task { [transport] in
             if let previous, previous != attempt {
                 await transport.closeAll(for: previous)
@@ -377,12 +408,15 @@ public actor RecoveryExecutor {
                 // cannot dedup this without swallowing real second deaths).
                 // The latch drops duplicates and records them observably.
                 let once = TerminationLatch()
+                let registration = ObjectIdentifier(once)
                 try await transport.openStream(pane: pane, for: attempt) { [weak self] in
                     guard once.claim() else {
                         Task { await self?.recordDuplicateTermination(pane: pane) }
                         return
                     }
-                    Task { await self?.streamDied(pane: pane, from: attempt) }
+                    Task {
+                        await self?.streamDied(pane: pane, from: attempt, registration: registration)
+                    }
                 }
                 // RECHECK-AND-REAP after the await. The pre-await guard cannot
                 // cover the suspension itself: a teardown completing while
@@ -400,7 +434,13 @@ public actor RecoveryExecutor {
                 }
                 openFailures[FailureKey(attempt: attempt, pane: pane)] = nil
                 lastOpenErrors[FailureKey(attempt: attempt, pane: pane)] = nil
-                openPanes.insert(pane)
+                // Published only if the stream is still alive: a termination
+                // firing while openStream was suspended already processed the
+                // death, and publishing here anyway reported a dead stream as
+                // .open — after exhaustion, permanently.
+                if once.publishIfUnterminated() {
+                    openStreams[pane] = OpenRegistration(attempt: attempt, registration: registration)
+                }
             } catch {
                 // A stream that cannot OPEN is a death the same as one that
                 // dies later; the policy decides whether to replace it, and the
@@ -424,10 +464,17 @@ public actor RecoveryExecutor {
         lastOpenErrors = lastOpenErrors.filter { $0.key.attempt == attempt }
     }
 
-    /// A stream's exactly-once death: the pane is no longer open, then the
-    /// policy decides about replacement.
-    private func streamDied(pane: String, from attempt: AttemptID) async {
-        openPanes.remove(pane)
+    /// A stream's exactly-once death: the pane is no longer open — IF this
+    /// death belongs to the registration currently published. A retired
+    /// attempt's delayed termination must not flip a live replacement's status;
+    /// the policy's own provenance gate then decides about the ledger and any
+    /// replacement stream.
+    private func streamDied(
+        pane: String, from attempt: AttemptID, registration: ObjectIdentifier
+    ) async {
+        if let published = openStreams[pane], published.registration == registration {
+            openStreams[pane] = nil
+        }
         await handle(.streamFailed(pane: pane, from: attempt))
     }
 

--- a/Sources/HerdrKit/RecoveryExecutor.swift
+++ b/Sources/HerdrKit/RecoveryExecutor.swift
@@ -1,0 +1,214 @@
+import Foundation
+
+/// What the executor needs from a transport, and nothing more.
+///
+/// A protocol seam so the executor's behaviour — ordering, binding enforcement,
+/// stale rejection — is testable against a scripted fake, which is where every
+/// interesting case lives: the live network cannot be told to deliver a delayed
+/// callback from a retired attempt on cue.
+///
+/// Each call carries the `AttemptID` it serves. The transport does not
+/// interpret it; it hands it back on outcomes so the executor can route them
+/// into the policy with provenance intact.
+public protocol ExecutorTransport: Sendable {
+    /// Establish a connection for this attempt. Throws on failure.
+    func connect(for attempt: AttemptID) async throws
+    /// The complete pane set, from the transport this attempt owns.
+    func fetchSnapshot(for attempt: AttemptID) async throws -> PaneSnapshot
+    /// Open one pane's persistent event stream. `onTermination` fires EXACTLY
+    /// once when the stream dies — this is the executor's contract with the
+    /// policy, which deliberately treats every termination as a real death.
+    func openStream(
+        pane: String, for attempt: AttemptID,
+        onTermination: @escaping @Sendable () -> Void
+    ) async throws
+    /// Tear down everything belonging to this attempt: streams and in-flight
+    /// commands. Idempotent.
+    func closeAll(for attempt: AttemptID) async
+    /// Close a connection that completed but was never wanted (stale or
+    /// backgrounded completion). Must not touch any other attempt's resources.
+    func discard(attempt: AttemptID) async
+}
+
+/// Drives `SessionRecovery`'s plans against a real transport, and turns the
+/// transport's outcomes back into `ClientEvent`s.
+///
+/// This is the integration the policy's sixteen review rounds were preparing
+/// for: every element crossing the boundary carries an `AttemptID`, and this
+/// type is where the carried identity is finally ENFORCED — a subscribe bound
+/// to a retired attempt is rejected here, at execution time, which is the whole
+/// reason the binding exists.
+///
+/// An actor: plan execution mutates one `State` lineage and one set of live
+/// stream registrations, and interleaving those across threads is precisely the
+/// class of bug the policy's authority just spent five rounds closing.
+public actor RecoveryExecutor {
+    private let recovery: SessionRecovery
+    private let transport: ExecutorTransport
+    private var state: SessionRecovery.State
+    private var generator = SystemRandomNumberGenerator()
+    /// The pending dial, so a cancelTransport can stop an attempt that has not
+    /// completed yet rather than letting it land and be discarded later.
+    private var pendingDial: Task<Void, Never>?
+    /// The attempt whose transport resources exist — dialed or connected.
+    ///
+    /// The EXECUTOR tracks this; the policy cannot say it. A cancel-and-
+    /// reconnect plan mints the replacement BEFORE execution, so at execution
+    /// time `state.currentAttempt` is already the new attempt — the first
+    /// version of cancelTransport consulted it and closed the attempt that had
+    /// not dialed yet, while the one actually holding sockets was never closed.
+    /// Caught by the ordering test's operation log on its first run.
+    private var resourcedAttempt: AttemptID?
+
+    /// Retained for tests and diagnostics: every action this executor REFUSED,
+    /// with the reason. Rejections are the point of the bindings, so they are
+    /// observable rather than silent.
+    public private(set) var rejections: [(action: String, reason: String)] = []
+
+    public init(recovery: SessionRecovery = SessionRecovery(), transport: ExecutorTransport) {
+        self.recovery = recovery
+        self.transport = transport
+        self.state = SessionRecovery.State()
+    }
+
+    /// Cold start: mints the first attempt and dials.
+    public func start() async {
+        await execute(recovery.beginInitialAttempt(state: &state))
+    }
+
+    /// Entry point for every transport- or app-originated event.
+    ///
+    /// `.connected` is routed through the discard-aware path whichever door it
+    /// arrives by — the dial callback and this public entry MUST behave
+    /// identically, or a stale completion delivered as an event would be
+    /// policy-discarded but left open at the transport.
+    public func handle(_ event: ClientEvent) async {
+        if case .connected(let attempt, _) = event {
+            await handleConnected(attempt, at: eventDate(of: event) ?? Date())
+            return
+        }
+        await execute(recovery.plan(for: event, state: &state, using: &generator))
+    }
+
+    private func eventDate(of event: ClientEvent) -> Date? {
+        if case .connected(_, let at) = event { return at }
+        return nil
+    }
+
+    /// Post-resync entry: the authoritative snapshot, with the attempt whose
+    /// transport produced it.
+    public func apply(snapshot: PaneSnapshot, from attempt: AttemptID) async {
+        await execute(recovery.observe(snapshot, from: attempt, state: &state))
+    }
+
+    /// Internal, not private: a delayed plan arriving at execution is exactly
+    /// the case the binding rejection exists for, and the test that proves the
+    /// rejection must be able to hand one in.
+    func execute(_ plan: RecoveryPlan) async {
+        for action in plan.actions {
+            switch action {
+            case .cancelTransport:
+                pendingDial?.cancel()
+                pendingDial = nil
+                if let owned = resourcedAttempt {
+                    await transport.closeAll(for: owned)
+                    resourcedAttempt = nil
+                }
+
+            case .discardConnection:
+                // The completing attempt is by definition not current (that is
+                // why it is being discarded), so the transport is told which
+                // one to drop by the event that got us here — but the action
+                // itself carries nothing. The executor closes NOTHING here
+                // beyond what the transport already associates with the stale
+                // completion; see handleConnected for the routing.
+                break
+
+            case .reconnect(let attempt, let after):
+                dial(attempt, after: after)
+
+            case .resyncAllPanes(let attempt):
+                await resync(for: attempt)
+
+            case .subscribe(let panes, let on):
+                // THE binding check. A plan can sit queued while the world
+                // moves; an action bound to a retired attempt must be refused
+                // however it arrives. This is enforcement of the invariant the
+                // policy can only declare.
+                guard on == state.currentAttempt else {
+                    rejections.append((
+                        action: "subscribe(\(panes.sorted().joined(separator: ",")))",
+                        reason: "bound to a retired attempt"
+                    ))
+                    continue
+                }
+                await open(panes: panes, for: on)
+            }
+        }
+    }
+
+    /// Connection outcomes route back through the policy with provenance; a
+    /// completion the policy discards is then discarded AT the transport too.
+    private func handleConnected(_ attempt: AttemptID, at: Date = Date()) async {
+        let plan = recovery.plan(
+            for: .connected(attempt, at: at), state: &state, using: &generator)
+        if plan.actions.contains(.discardConnection) {
+            await transport.discard(attempt: attempt)
+        }
+        await execute(plan)
+    }
+
+    private func dial(_ attempt: AttemptID, after delay: TimeInterval) {
+        pendingDial?.cancel()
+        resourcedAttempt = attempt
+        pendingDial = Task { [transport] in
+            if delay > 0 {
+                try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+            }
+            guard !Task.isCancelled else { return }
+            do {
+                try await transport.connect(for: attempt)
+                await self.handleConnected(attempt)
+            } catch {
+                await self.handle(.transportFailed(attempt, at: Date()))
+            }
+        }
+    }
+
+    /// Resync THEN subscribe, and only through `apply` — the ordering the
+    /// policy documents as load-bearing. Subscriptions on a fresh transport
+    /// exist only downstream of this snapshot; there is no other path that
+    /// opens one, which is what makes the order enforceable by a test that
+    /// fails when it is swapped.
+    private func resync(for attempt: AttemptID) async {
+        do {
+            let snapshot = try await transport.fetchSnapshot(for: attempt)
+            await apply(snapshot: snapshot, from: attempt)
+        } catch {
+            await handle(.transportFailed(attempt, at: Date()))
+        }
+    }
+
+    private func open(panes: Set<String>, for attempt: AttemptID) async {
+        for pane in panes.sorted() {
+            do {
+                try await transport.openStream(pane: pane, for: attempt) { [weak self] in
+                    // One termination, one death event — the exactly-once
+                    // contract the policy's per-death semantics rely on.
+                    Task { await self?.handle(.streamFailed(pane: pane, from: attempt)) }
+                }
+            } catch {
+                // A stream that cannot OPEN is a death the same as one that
+                // dies later; the policy decides whether to replace it.
+                await handle(.streamFailed(pane: pane, from: attempt))
+            }
+        }
+    }
+
+    // MARK: - Read-only state, for tests and the UI layer
+
+    public var currentAttempt: AttemptID? { state.currentAttempt }
+    public var isConnected: Bool { state.isConnected }
+    public var knownPanes: Set<String> { state.knownPanes }
+    public var subscribedPanes: Set<String> { state.subscribedPanes }
+}

--- a/Sources/HerdrKit/RecoveryExecutor.swift
+++ b/Sources/HerdrKit/RecoveryExecutor.swift
@@ -26,13 +26,15 @@ public protocol ExecutorTransport: Sendable {
     /// stream. The executor cannot detect that from outside, so it is a
     /// requirement here rather than a defence there.
     ///
-    /// `onTermination` SHOULD fire
-    /// exactly once when the stream dies; the executor enforces the once with a
-    /// latch regardless, because a double-fire would otherwise become a
-    /// permanent double-subscription — the policy deliberately treats every
-    /// admitted termination as a real death and cannot dedup without
-    /// swallowing real second deaths. A conformer whose stream is torn down by
-    /// `closeAll` should NOT fire termination for that teardown.
+    /// `onTermination` MUST fire for every terminal stream end that is not a
+    /// deliberate `closeAll`/`discard` teardown — at-least-once is the
+    /// conformer's binding obligation, because a missed notification IS the
+    /// silent pane this event exists to remove. The executor's latch supplies
+    /// at-most-once (a double-fire would otherwise become a permanent
+    /// double-subscription, since the policy treats every admitted termination
+    /// as a real death); together they make exactly-once. A stream torn down by
+    /// `closeAll` must NOT fire — that is the executor's own teardown, not a
+    /// death.
     func openStream(
         pane: String, for attempt: AttemptID,
         onTermination: @escaping @Sendable () -> Void
@@ -100,6 +102,38 @@ public actor RecoveryExecutor {
         let pane: String
     }
     private var openFailures: [FailureKey: Int] = [:]
+    private var lastOpenErrors: [FailureKey: String] = [:]
+    /// Panes whose stream ACTUALLY opened on the current attempt — the
+    /// executor's observation, distinct from the policy's admission ledger.
+    private var openPanes: Set<String> = []
+
+    /// What a caller asking "is this pane watched?" can actually know.
+    ///
+    /// Coordinator-mandated: the refusal must be readable from the same surface
+    /// the ledger is read from — not a log line. `admittedNotOpen` is the
+    /// silent-pane condition made visible: the policy admitted the pane, and no
+    /// stream exists. This ADDS an observation of what already happened; it
+    /// does not redefine admission (that boundary is task 7's policy round).
+    public enum PaneWatchStatus: Equatable, Sendable {
+        /// Admitted and a live stream exists.
+        case open
+        /// Admitted, but no stream could be opened: the pane is NOT watched,
+        /// whatever the ledger says. Carries the attempt count and last error.
+        case admittedNotOpen(attempts: Int, lastError: String?)
+        /// Not admitted at all.
+        case notAdmitted
+    }
+
+    /// The same query path as `subscribedPanes`, answering per pane.
+    public func paneStatus(_ pane: String) -> PaneWatchStatus {
+        guard state.subscribedPanes.contains(pane) else { return .notAdmitted }
+        if openPanes.contains(pane) { return .open }
+        let key = state.currentAttempt.map { FailureKey(attempt: $0, pane: pane) }
+        return .admittedNotOpen(
+            attempts: key.flatMap { openFailures[$0] } ?? 0,
+            lastError: key.flatMap { lastOpenErrors[$0] }
+        )
+    }
 
     /// Bounded diagnostics: the most recent refusals, plus how many were
     /// dropped. Append-only was a slow leak on a long-running client — stale
@@ -179,6 +213,8 @@ public actor RecoveryExecutor {
             case .cancelTransport:
                 pendingDial?.cancel()
                 pendingDial = nil
+                openPanes = []
+                retireCounters(keeping: nil)
                 if let owned = resourcedAttempt {
                     await transport.closeAll(for: owned)
                     // Conditional, because the closeAll await is a suspension
@@ -253,8 +289,21 @@ public actor RecoveryExecutor {
 
     private func dial(_ attempt: AttemptID, after delay: TimeInterval) {
         pendingDial?.cancel()
+        // Close the PREVIOUS holder's resources before the claim moves. The
+        // failure paths (connect throw, snapshot throw, external
+        // transportFailed) route through the policy, whose plan is reconnect
+        // ONLY — no cancelTransport — so without this, dialing the replacement
+        // overwrote the claim and the failed attempt's connection and any
+        // opened streams became unreachable forever. Reproduced by a
+        // snapshot-failure probe: B connected with no closeAll(A) anywhere.
+        let previous = resourcedAttempt
         resourcedAttempt = attempt
+        retireCounters(keeping: attempt)
+        openPanes = []
         pendingDial = Task { [transport] in
+            if let previous, previous != attempt {
+                await transport.closeAll(for: previous)
+            }
             if delay > 0 { await self.currentSleeper()(delay) }
             guard !Task.isCancelled else { return }
             do {
@@ -333,7 +382,7 @@ public actor RecoveryExecutor {
                         Task { await self?.recordDuplicateTermination(pane: pane) }
                         return
                     }
-                    Task { await self?.handle(.streamFailed(pane: pane, from: attempt)) }
+                    Task { await self?.streamDied(pane: pane, from: attempt) }
                 }
                 // RECHECK-AND-REAP after the await. The pre-await guard cannot
                 // cover the suspension itself: a teardown completing while
@@ -350,14 +399,36 @@ public actor RecoveryExecutor {
                     return
                 }
                 openFailures[FailureKey(attempt: attempt, pane: pane)] = nil
+                lastOpenErrors[FailureKey(attempt: attempt, pane: pane)] = nil
+                openPanes.insert(pane)
             } catch {
                 // A stream that cannot OPEN is a death the same as one that
                 // dies later; the policy decides whether to replace it, and the
                 // counter above bounds how often that replacement is attempted.
-                openFailures[FailureKey(attempt: attempt, pane: pane), default: 0] += 1
+                // Guarded: a late catch for a RETIRED attempt must not insert a
+                // key the retirement sweep already ran past.
+                if attempt == state.currentAttempt {
+                    openFailures[FailureKey(attempt: attempt, pane: pane), default: 0] += 1
+                    lastOpenErrors[FailureKey(attempt: attempt, pane: pane)] = String(describing: error)
+                }
                 await handle(.streamFailed(pane: pane, from: attempt))
             }
         }
+    }
+
+    /// Drops failure bookkeeping for every attempt except the one kept: the
+    /// counters were retained forever, one more unbounded structure — and a
+    /// late catch after retirement could insert a key for a dead attempt.
+    private func retireCounters(keeping attempt: AttemptID?) {
+        openFailures = openFailures.filter { $0.key.attempt == attempt }
+        lastOpenErrors = lastOpenErrors.filter { $0.key.attempt == attempt }
+    }
+
+    /// A stream's exactly-once death: the pane is no longer open, then the
+    /// policy decides about replacement.
+    private func streamDied(pane: String, from attempt: AttemptID) async {
+        openPanes.remove(pane)
+        await handle(.streamFailed(pane: pane, from: attempt))
     }
 
     private func recordDuplicateTermination(pane: String) {
@@ -365,6 +436,13 @@ public actor RecoveryExecutor {
             action: "termination(\(pane))",
             reason: "duplicate termination dropped by the once-latch"
         ))
+    }
+
+    // Internal observability for the retirement invariant — the mutation
+    // removing retirement survived the whole suite because nothing counted.
+    var openFailureEntryCount: Int { openFailures.count }
+    var openFailureEntryCountForRetiredAttempts: Int {
+        openFailures.keys.filter { $0.attempt != state.currentAttempt }.count
     }
 
     // MARK: - Read-only state, for tests and the UI layer

--- a/Sources/HerdrKit/RecoveryExecutor.swift
+++ b/Sources/HerdrKit/RecoveryExecutor.swift
@@ -8,16 +8,21 @@ import Foundation
 /// callback from a retired attempt on cue.
 ///
 /// Each call carries the `AttemptID` it serves. The transport does not
-/// interpret it; it hands it back on outcomes so the executor can route them
-/// into the policy with provenance intact.
+/// interpret it — and does not hand it back: the executor binds outcomes to
+/// their attempt by closure capture, so a conformer only needs the ID to key
+/// its own resources per attempt (closeAll/discard MUST be attempt-scoped).
 public protocol ExecutorTransport: Sendable {
     /// Establish a connection for this attempt. Throws on failure.
     func connect(for attempt: AttemptID) async throws
     /// The complete pane set, from the transport this attempt owns.
     func fetchSnapshot(for attempt: AttemptID) async throws -> PaneSnapshot
-    /// Open one pane's persistent event stream. `onTermination` fires EXACTLY
-    /// once when the stream dies — this is the executor's contract with the
-    /// policy, which deliberately treats every termination as a real death.
+    /// Open one pane's persistent event stream. `onTermination` SHOULD fire
+    /// exactly once when the stream dies; the executor enforces the once with a
+    /// latch regardless, because a double-fire would otherwise become a
+    /// permanent double-subscription — the policy deliberately treats every
+    /// admitted termination as a real death and cannot dedup without
+    /// swallowing real second deaths. A conformer whose stream is torn down by
+    /// `closeAll` should NOT fire termination for that teardown.
     func openStream(
         pane: String, for attempt: AttemptID,
         onTermination: @escaping @Sendable () -> Void
@@ -28,6 +33,19 @@ public protocol ExecutorTransport: Sendable {
     /// Close a connection that completed but was never wanted (stale or
     /// backgrounded completion). Must not touch any other attempt's resources.
     func discard(attempt: AttemptID) async
+}
+
+/// One-shot claim for a stream's termination callback.
+final class TerminationLatch: @unchecked Sendable {
+    private let lock = NSLock()
+    private var claimed = false
+    /// True exactly once.
+    func claim() -> Bool {
+        lock.lock(); defer { lock.unlock() }
+        if claimed { return false }
+        claimed = true
+        return true
+    }
 }
 
 /// Drives `SessionRecovery`'s plans against a real transport, and turns the
@@ -46,7 +64,14 @@ public actor RecoveryExecutor {
     private let recovery: SessionRecovery
     private let transport: ExecutorTransport
     private var state: SessionRecovery.State
-    private var generator = SystemRandomNumberGenerator()
+    private var generator: any RandomNumberGenerator
+    /// Internal seam replacing Task.sleep in dial, so tests pin the backoff
+    /// deterministically: a mutation deleting the delay SURVIVED 5/5 against
+    /// wall-clock assertions — real time cannot pin "waited long enough"
+    /// without flakes, so the seam records instead.
+    var sleeper: @Sendable (TimeInterval) async -> Void = { delay in
+        try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+    }
     /// The pending dial, so a cancelTransport can stop an attempt that has not
     /// completed yet rather than letting it land and be discarded later.
     private var pendingDial: Task<Void, Never>?
@@ -66,9 +91,19 @@ public actor RecoveryExecutor {
     public private(set) var rejections: [(action: String, reason: String)] = []
 
     public init(recovery: SessionRecovery = SessionRecovery(), transport: ExecutorTransport) {
+        self.init(recovery: recovery, transport: transport, generator: SystemRandomNumberGenerator())
+    }
+
+    /// Internal: a seeded generator makes the policy's jittered delay a known
+    /// number, which is what lets a test assert the executor HONOURED it.
+    init(
+        recovery: SessionRecovery, transport: ExecutorTransport,
+        generator: any RandomNumberGenerator
+    ) {
         self.recovery = recovery
         self.transport = transport
         self.state = SessionRecovery.State()
+        self.generator = generator
     }
 
     /// Cold start: mints the first attempt and dials.
@@ -112,19 +147,37 @@ public actor RecoveryExecutor {
                 pendingDial = nil
                 if let owned = resourcedAttempt {
                     await transport.closeAll(for: owned)
-                    resourcedAttempt = nil
+                    // Conditional, because the closeAll await is a suspension
+                    // point: an interleaved plan may have dialed a replacement
+                    // and installed ITS claim, and the unconditional nil
+                    // destroyed it — after which every later cancelTransport
+                    // closed a resource-less attempt while the current one's
+                    // streams leaked past teardown forever. Reproduced 4/4.
+                    if resourcedAttempt == owned { resourcedAttempt = nil }
                 }
 
             case .discardConnection:
-                // The completing attempt is by definition not current (that is
-                // why it is being discarded), so the transport is told which
-                // one to drop by the event that got us here — but the action
-                // itself carries nothing. The executor closes NOTHING here
-                // beyond what the transport already associates with the stale
-                // completion; see handleConnected for the routing.
+                // Routed where the completing attempt is KNOWN: both production
+                // doors (the dial callback and the public .connected event) go
+                // through handleConnected, which awaits transport.discard for
+                // the stale attempt before executing this plan. Through the
+                // internal execute() door the action is inert by construction —
+                // it carries no attempt, deliberately, so a stale plan replay
+                // cannot aim a discard at anything.
                 break
 
             case .reconnect(let attempt, let after):
+                // The same execution-time binding .subscribe has, and for a
+                // sharper reason: a stale plan's continuation resuming after an
+                // interleaved replacement would not merely dial a retired
+                // attempt — its dial() would CANCEL the current attempt's
+                // pending dial, and the silent cancellation return leaves no
+                // reconnect scheduled at all: a wedged executor. Reproduced 4/4
+                // by the sweep before this guard existed.
+                guard attempt == state.currentAttempt else {
+                    rejections.append((action: "reconnect", reason: "bound to a retired attempt"))
+                    continue
+                }
                 dial(attempt, after: after)
 
             case .resyncAllPanes(let attempt):
@@ -158,13 +211,17 @@ public actor RecoveryExecutor {
         await execute(plan)
     }
 
+    func currentSleeper() -> @Sendable (TimeInterval) async -> Void { sleeper }
+
+    func setSleeper(_ replacement: @escaping @Sendable (TimeInterval) async -> Void) {
+        sleeper = replacement
+    }
+
     private func dial(_ attempt: AttemptID, after delay: TimeInterval) {
         pendingDial?.cancel()
         resourcedAttempt = attempt
         pendingDial = Task { [transport] in
-            if delay > 0 {
-                try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
-            }
+            if delay > 0 { await self.currentSleeper()(delay) }
             guard !Task.isCancelled else { return }
             do {
                 try await transport.connect(for: attempt)
@@ -175,11 +232,12 @@ public actor RecoveryExecutor {
         }
     }
 
-    /// Resync THEN subscribe, and only through `apply` — the ordering the
-    /// policy documents as load-bearing. Subscriptions on a fresh transport
-    /// exist only downstream of this snapshot; there is no other path that
-    /// opens one, which is what makes the order enforceable by a test that
-    /// fails when it is swapped.
+    /// Resync THEN subscribe, through `apply` — the ordering the policy
+    /// documents as load-bearing. Subscriptions on a FRESH transport exist only
+    /// downstream of this snapshot; the incremental paths (`paneCreated`,
+    /// `streamFailed` re-admission) also open streams, but only for panes the
+    /// atomic gate admits on an ALREADY-adopted transport — an earlier comment
+    /// claimed no other path existed, which a probe refuted.
     private func resync(for attempt: AttemptID) async {
         do {
             let snapshot = try await transport.fetchSnapshot(for: attempt)
@@ -204,9 +262,18 @@ public actor RecoveryExecutor {
                 return
             }
             do {
+                // The exactly-once termination contract is ENFORCED here, not
+                // merely asked of conformers: a transport double-firing one
+                // stream's termination produced a permanent double-subscription
+                // (the ledger legitimately re-admits per death, so the policy
+                // cannot dedup this without swallowing real second deaths).
+                // The latch drops duplicates and records them observably.
+                let once = TerminationLatch()
                 try await transport.openStream(pane: pane, for: attempt) { [weak self] in
-                    // One termination, one death event — the exactly-once
-                    // contract the policy's per-death semantics rely on.
+                    guard once.claim() else {
+                        Task { await self?.recordDuplicateTermination(pane: pane) }
+                        return
+                    }
                     Task { await self?.handle(.streamFailed(pane: pane, from: attempt)) }
                 }
             } catch {
@@ -215,6 +282,13 @@ public actor RecoveryExecutor {
                 await handle(.streamFailed(pane: pane, from: attempt))
             }
         }
+    }
+
+    private func recordDuplicateTermination(pane: String) {
+        rejections.append((
+            action: "termination(\(pane))",
+            reason: "duplicate termination dropped by the once-latch"
+        ))
     }
 
     // MARK: - Read-only state, for tests and the UI layer

--- a/Sources/HerdrKit/RecoveryExecutor.swift
+++ b/Sources/HerdrKit/RecoveryExecutor.swift
@@ -16,7 +16,17 @@ public protocol ExecutorTransport: Sendable {
     func connect(for attempt: AttemptID) async throws
     /// The complete pane set, from the transport this attempt owns.
     func fetchSnapshot(for attempt: AttemptID) async throws -> PaneSnapshot
-    /// Open one pane's persistent event stream. `onTermination` SHOULD fire
+    /// Open one pane's persistent event stream.
+    ///
+    /// **Throwing MUST leave no live registration and no future callback.** A
+    /// conformer that installs a callback and then throws creates a resource
+    /// the executor does not know it owns: the catch path starts a replacement
+    /// with its own latch, and a later first fire of the FAILED registration's
+    /// callback retires the replacement's ledger entry and opens a third
+    /// stream. The executor cannot detect that from outside, so it is a
+    /// requirement here rather than a defence there.
+    ///
+    /// `onTermination` SHOULD fire
     /// exactly once when the stream dies; the executor enforces the once with a
     /// latch regardless, because a double-fire would otherwise become a
     /// permanent double-subscription — the policy deliberately treats every
@@ -85,10 +95,34 @@ public actor RecoveryExecutor {
     /// Caught by the ordering test's operation log on its first run.
     private var resourcedAttempt: AttemptID?
 
-    /// Retained for tests and diagnostics: every action this executor REFUSED,
-    /// with the reason. Rejections are the point of the bindings, so they are
-    /// observable rather than silent.
+    struct FailureKey: Hashable {
+        let attempt: AttemptID
+        let pane: String
+    }
+    private var openFailures: [FailureKey: Int] = [:]
+
+    /// Bounded diagnostics: the most recent refusals, plus how many were
+    /// dropped. Append-only was a slow leak on a long-running client — stale
+    /// plans and duplicate callbacks are rare but unbounded over days.
     public private(set) var rejections: [(action: String, reason: String)] = []
+    public private(set) var droppedRejections = 0
+    static let rejectionCapacity = 128
+
+    private func record(rejection: (action: String, reason: String)) {
+        rejections.append(rejection)
+        if rejections.count > Self.rejectionCapacity {
+            rejections.removeFirst(rejections.count - Self.rejectionCapacity)
+            droppedRejections += 1
+        }
+    }
+
+    /// Takes and clears the buffer, for a caller that ships diagnostics.
+    public func drainRejections() -> (entries: [(action: String, reason: String)], dropped: Int) {
+        let taken = (entries: rejections, dropped: droppedRejections)
+        rejections = []
+        droppedRejections = 0
+        return taken
+    }
 
     public init(recovery: SessionRecovery = SessionRecovery(), transport: ExecutorTransport) {
         self.init(recovery: recovery, transport: transport, generator: SystemRandomNumberGenerator())
@@ -175,7 +209,7 @@ public actor RecoveryExecutor {
                 // reconnect scheduled at all: a wedged executor. Reproduced 4/4
                 // by the sweep before this guard existed.
                 guard attempt == state.currentAttempt else {
-                    rejections.append((action: "reconnect", reason: "bound to a retired attempt"))
+                    record(rejection: (action: "reconnect", reason: "bound to a retired attempt"))
                     continue
                 }
                 dial(attempt, after: after)
@@ -189,7 +223,7 @@ public actor RecoveryExecutor {
                 // however it arrives. This is enforcement of the invariant the
                 // policy can only declare.
                 guard on == state.currentAttempt else {
-                    rejections.append((
+                    record(rejection: (
                         action: "subscribe(\(panes.sorted().joined(separator: ",")))",
                         reason: "bound to a retired attempt"
                     ))
@@ -247,6 +281,17 @@ public actor RecoveryExecutor {
         }
     }
 
+    /// Bound on consecutive open failures for one pane on one attempt.
+    ///
+    /// Not a niceness: an open that throws becomes `.streamFailed`, the policy
+    /// re-admits the pane, and the re-admission opens again — a persistently
+    /// failing conformer is an unbounded, delay-free retry loop that saturates
+    /// the actor. The delay grows per consecutive failure and resets when a
+    /// pane opens successfully; past the cap the pane is left unsubscribed with
+    /// the refusal recorded, which is a visibly degraded pane rather than a
+    /// spinning client.
+    static let openFailureCap = 5
+
     private func open(panes: Set<String>, for attempt: AttemptID) async {
         for pane in panes.sorted() {
             // Re-checked PER PANE, because every openStream await is an actor
@@ -255,11 +300,25 @@ public actor RecoveryExecutor {
             // attempt AFTER its closeAll had run — orphan streams nothing would
             // ever close. Reproduced by test before this guard existed.
             guard attempt == state.currentAttempt else {
-                rejections.append((
+                record(rejection: (
                     action: "openStream(\(pane))",
                     reason: "attempt retired mid-subscribe"
                 ))
                 return
+            }
+            let failures = openFailures[FailureKey(attempt: attempt, pane: pane)] ?? 0
+            guard failures < Self.openFailureCap else {
+                record(rejection: (
+                    action: "openStream(\(pane))",
+                    reason: "open failed \(failures) times; pane left unsubscribed"
+                ))
+                continue
+            }
+            if failures > 0 {
+                // Back off between consecutive failures for THIS pane on THIS
+                // attempt, through the same seam the dial uses so tests pin it.
+                await sleeper(Double(failures) * 0.25)
+                guard attempt == state.currentAttempt else { return }
             }
             do {
                 // The exactly-once termination contract is ENFORCED here, not
@@ -276,16 +335,33 @@ public actor RecoveryExecutor {
                     }
                     Task { await self?.handle(.streamFailed(pane: pane, from: attempt)) }
                 }
+                // RECHECK-AND-REAP after the await. The pre-await guard cannot
+                // cover the suspension itself: a teardown completing while
+                // openStream was in flight leaves a stream registered for a
+                // retired attempt — published after its closeAll, so nothing
+                // would ever close it. Reaping is the only correction available
+                // once the registration exists.
+                if attempt != state.currentAttempt {
+                    record(rejection: (
+                        action: "openStream(\(pane))",
+                        reason: "attempt retired during open; stream reaped"
+                    ))
+                    await transport.closeAll(for: attempt)
+                    return
+                }
+                openFailures[FailureKey(attempt: attempt, pane: pane)] = nil
             } catch {
                 // A stream that cannot OPEN is a death the same as one that
-                // dies later; the policy decides whether to replace it.
+                // dies later; the policy decides whether to replace it, and the
+                // counter above bounds how often that replacement is attempted.
+                openFailures[FailureKey(attempt: attempt, pane: pane), default: 0] += 1
                 await handle(.streamFailed(pane: pane, from: attempt))
             }
         }
     }
 
     private func recordDuplicateTermination(pane: String) {
-        rejections.append((
+        record(rejection: (
             action: "termination(\(pane))",
             reason: "duplicate termination dropped by the once-latch"
         ))

--- a/Sources/HerdrKit/SessionRecovery.swift
+++ b/Sources/HerdrKit/SessionRecovery.swift
@@ -180,6 +180,26 @@ final class AttemptAuthority: @unchecked Sendable {
         return Admission(fresh: fresh, attempt: attempt)
     }
 
+    /// Drops a dead stream's ledger entry and re-admits it, ONE section.
+    ///
+    /// The inverse of admission fused with a fresh admission, because as two
+    /// operations the gap between them is the split-section class: a concurrent
+    /// discovery could re-admit the pane between the drop and the re-admission
+    /// and the re-subscribe would then double it. Rules, all decided under the
+    /// one lock: a stale attempt touches nothing; a pane that was NOT in the
+    /// ledger has no stream to have died (a duplicate or late failure) and
+    /// neither drops nor re-admits; `readmit: false` (the pane no longer exists
+    /// in knowledge) drops without re-admitting. Exactly-once re-subscription
+    /// per real stream death falls out of the was-in-the-ledger check.
+    func dropAndReadmit(_ pane: String, from attempt: AttemptID, readmit: Bool) -> Admission? {
+        lock.lock(); defer { lock.unlock() }
+        guard attempt == _current, _connectedSince != nil else { return nil }
+        guard _subscribedPanes.remove(pane) != nil else { return nil }
+        guard readmit else { return nil }
+        _subscribedPanes.insert(pane)
+        return Admission(fresh: [pane], attempt: attempt)
+    }
+
     /// True iff the attempt is current — for gating KNOWLEDGE mutations from
     /// transport-delivered data (snapshots, pane events) the same way
     /// subscriptions are gated. Reading it and acting is two steps for
@@ -230,6 +250,13 @@ public enum ClientEvent: Equatable, Sendable {
     /// event, the only way to remove one is a wholesale replacement, which is
     /// what made partial listings dangerous.
     case paneClosed(String, from: AttemptID)
+    /// ONE pane's event stream died while its connection's other streams live
+    /// on. The wire is N independent per-pane persistent connections, so this
+    /// is a routine cellular event — a server reap, a NAT timeout — and before
+    /// this case existed it was INEXPRESSIBLE: the pane went silent while the
+    /// client believed itself connected, the herdres-class silence. Carries the
+    /// attempt whose transport lost the stream.
+    case streamFailed(pane: String, from: AttemptID)
 }
 
 /// One step of recovery, in the order it must happen.
@@ -575,6 +602,18 @@ public struct SessionRecovery: Sendable {
             guard state.authority.isCurrent(from) else { return RecoveryPlan() }
             state.knownPanes.remove(pane)
             return RecoveryPlan()
+
+        case .streamFailed(let pane, let from):
+            // Drop and conditionally re-admit in one authority section; the
+            // re-subscribe goes through THE emission site, so exactly-once and
+            // attempt-binding cover re-subscription with no separate machinery.
+            // A pane no longer in knowledge is dropped without replacement —
+            // its stream dying and its closure racing is resolved in closure's
+            // favour, and a later snapshot corrects any miss.
+            guard let readmitted = state.authority.dropAndReadmit(
+                pane, from: from, readmit: state.knownPanes.contains(pane)
+            ) else { return RecoveryPlan() }
+            return subscriptionPlan(for: readmitted)
         }
     }
 

--- a/Tests/HerdrKitTests/RecoveryExecutorTests.swift
+++ b/Tests/HerdrKitTests/RecoveryExecutorTests.swift
@@ -52,13 +52,14 @@ final class ScriptedTransport: ExecutorTransport, @unchecked Sendable {
     private var stalledPanes: Set<String> = []
 
     func stall(_ pane: String) { lock.withLock { _ = stalledPanes.insert(pane) } }
-    /// Releases both gates: the shared pane stall and the catch window's own.
-    /// The catch release is LATCHED rather than a removal — a removal can be
-    /// undone by a later insert, which is precisely how the replacement attempt
-    /// re-armed a gate the test had already opened.
-    func release(_ pane: String) {
-        lock.withLock { _ = stalledPanes.remove(pane); _ = catchReleased.insert(pane) }
-    }
+    /// Releases the ORDINARY pane stall, and nothing else.
+    ///
+    /// It used to also latch the catch window open, which coupled two seams
+    /// that exist to be independent: an ordinary stall/release on a pane
+    /// PERMANENTLY pre-released any catch window armed on that pane afterwards,
+    /// so entry 2 sailed through and the window never opened. Reproduced 5/5.
+    /// The catch window has `releaseCatchWindow`.
+    func release(_ pane: String) { lock.withLock { _ = stalledPanes.remove(pane) } }
 
     /// Kill-on-registration: arms a flag so the pane's NEXT registered
     /// terminator fires immediately, INSIDE openStream before it returns —
@@ -99,17 +100,44 @@ final class ScriptedTransport: ExecutorTransport, @unchecked Sendable {
     /// many opens happened" and `registrationCount` for "how many callbacks are
     /// live". Conflating them is what armed this window on a contract
     /// violation for a whole round.
-    private var catchPathWindow: Set<String> = []
-    private var openCounts: [String: Int] = [:]
+    /// Every arm is a fresh GENERATION, and every piece of the window's state is
+    /// keyed to it. Arming twice on one pane, or arming after unrelated traffic
+    /// on that pane, therefore starts clean — the previous version kept a
+    /// pane-keyed phase counter and a pane-keyed release latch, so neither a
+    /// second window nor a window following an ordinary release could be
+    /// represented at all.
+    private var catchArm: [String: Int] = [:]        // current generation
+    private var catchPhase: [String: Int] = [:]      // entries seen since this arm
+    private var catchParkedArm: [String: Int] = [:]  // generation currently parked
+    private var catchReleasedArm: [String: Int] = [:] // generation released
     func armCatchPathWindow(_ pane: String) {
-        lock.withLock { _ = catchPathWindow.insert(pane) }
+        lock.withLock {
+            catchArm[pane] = (catchArm[pane] ?? 0) + 1
+            catchPhase[pane] = 0
+            // No `catchReleasedArm[pane] = nil` here. It was written, its
+            // mutation SURVIVED, and unlike the guard removal that failed
+            // review at round seven this one is exhaustively enumerable rather
+            // than argued: `catchArm` only ever increases, and
+            // `catchReleasedArm` is only ever assigned some value `catchArm`
+            // held at an earlier moment. A stale release is therefore strictly
+            // less than the new generation and can never match it. There is no
+            // suspension point in that argument — it is an invariant on a
+            // monotonic integer, not a claim about interleaving, which is
+            // exactly the distinction round seven's mistake turned on.
+        }
     }
-    /// 0 = not armed for this pane, 1 = the throwing first open, 2+ = a retry.
+    /// Opens the gate for the CURRENT generation only. A release aimed at a
+    /// finished window cannot open the next one.
+    func releaseCatchWindow(_ pane: String) {
+        lock.withLock { catchReleasedArm[pane] = catchArm[pane] }
+    }
+    /// 0 = not armed for this pane, 1 = the throwing first open, 2 = the retry
+    /// that parks, 3+ = pass through.
     private func catchPathPhase(_ pane: String) -> Int {
         lock.withLock {
-            guard catchPathWindow.contains(pane) else { return 0 }
-            openCounts[pane, default: 0] += 1
-            return openCounts[pane] ?? 0
+            guard catchArm[pane] != nil else { return 0 }
+            catchPhase[pane, default: 0] += 1
+            return catchPhase[pane] ?? 0
         }
     }
 
@@ -136,14 +164,7 @@ final class ScriptedTransport: ExecutorTransport, @unchecked Sendable {
     /// nothing had entered yet. The open then parked forever and the test timed
     /// out having proven nothing (1 run in 5). Observing the gate itself cannot
     /// be early by construction.
-    func retryIsParked(_ pane: String) -> Bool { lock.withLock { catchParkedEntry[pane] != nil } }
-
-    /// The catch window's gate, private to it and keyed to one INVOCATION.
-    /// Deliberately not `stalledPanes`: that set is keyed by pane and shared
-    /// with every other stall seam, so a second attempt opening the same pane
-    /// re-armed it under a test that had already released it.
-    private var catchParkedEntry: [String: Int] = [:]
-    private var catchReleased: Set<String> = []
+    func retryIsParked(_ pane: String) -> Bool { lock.withLock { catchParkedArm[pane] != nil } }
 
     /// Drops the registration this call made, so a throwing open leaves none.
     /// Deliberately NOT applied on the `installsThenThrows` path: that one
@@ -285,13 +306,14 @@ final class ScriptedTransport: ExecutorTransport, @unchecked Sendable {
             throw TransportError.closedBeforeResponse
         }
         if phase == 2 {
-            // Keyed to THIS invocation. No other call, on any attempt, can
-            // enter or re-arm it.
-            lock.withLock { catchParkedEntry[pane] = openEntries[pane] }
-            while lock.withLock({ !catchReleased.contains(pane) }) {
+            // Keyed to THIS ARM. No other call, on any attempt, and no release
+            // aimed at any other window, can enter or open it.
+            let arm = lock.withLock { catchArm[pane] }
+            lock.withLock { catchParkedArm[pane] = arm }
+            while lock.withLock({ catchReleasedArm[pane] != arm }) {
                 try? await Task.sleep(nanoseconds: 10_000_000)
             }
-            lock.withLock { catchParkedEntry[pane] = nil }
+            lock.withLock { catchParkedArm[pane] = nil }
         }
         while isStalled(pane) { try? await Task.sleep(nanoseconds: 10_000_000) }
         record(.openAttempt(pane, attempt))
@@ -359,6 +381,14 @@ final class RecoveryExecutorTests: XCTestCase {
         func wait() async {
             while !hasFired { try? await Task.sleep(nanoseconds: 5_000_000) }
         }
+    }
+
+    /// Asserts an async call throws. XCTAssertThrowsError's autoclosure cannot
+    /// carry `await`, which is the same limitation XCTUnwrap has here.
+    private func expectThrow(
+        _ message: String, _ body: () async throws -> Void
+    ) async {
+        do { try await body(); XCTFail(message) } catch { /* expected */ }
     }
 
     private func waitUntil(
@@ -615,7 +645,7 @@ final class RecoveryExecutorTests: XCTestCase {
 
         // The world moves while the loop is parked mid-catch.
         await executor.handle(.networkChanged(at: Date()))
-        transport.release("a-fails")
+        transport.releaseCatchWindow("a-fails")
 
         // Settle on an OUTCOME, not on elapsed time. A fixed sleep let the
         // guard-removal mutant pass 1 run in 9: the negative assertion was
@@ -630,6 +660,68 @@ final class RecoveryExecutorTests: XCTestCase {
         XCTAssertTrue(settled, "neither outcome was reached; the test proved nothing either way")
         XCTAssertFalse(forbidden(),
                        "the loop resumed from its catch and opened a stream for a retired attempt")
+    }
+
+    // MARK: - Seam integrity
+    //
+    // These two pin the FAKE, not the executor, and they earn their place: the
+    // catch-path regression's mutation evidence is only as good as the window
+    // actually arming. Twice now it did not — once because a shared pane-keyed
+    // gate let a second attempt re-arm it, once because an unrelated release
+    // latched it open in advance — and in both cases the executor tests still
+    // reported green. An unarmed window is a test that proves nothing while
+    // looking identical to one that proves something.
+
+    /// AXIS: ordinary stall/release traffic on a pane cannot open a catch
+    /// window that is currently parked on that pane.
+    ///
+    /// The ordering matters and the first version of this test had it wrong.
+    /// Doing the ordinary release BEFORE arming proves nothing under the
+    /// generation-keyed design — no arm exists yet, so a recoupled `release`
+    /// writes a release for generation `nil` and is harmless. Its mutation
+    /// SURVIVED. The discriminating order is ordinary traffic DURING an armed,
+    /// parked window, which is also the stronger invariant.
+    func testOrdinaryReleaseCannotOpenAParkedCatchWindow() async throws {
+        let transport = ScriptedTransport(panes: ["p"])
+        transport.armCatchPathWindow("p")
+
+        // Entry 1 throws (contract: leaves nothing live). Entry 2 must PARK.
+        await expectThrow("entry 1 must throw; the window is armed on it") {
+            try await transport.openStream(pane: "p", for: AttemptID(uuid: UUID())) {}
+        }
+        let second = Task { try await transport.openStream(pane: "p", for: AttemptID(uuid: UUID())) {} }
+        let parked = await waitUntil { transport.retryIsParked("p") }
+        XCTAssertTrue(parked, "the catch window never parked; the test is not armed")
+
+        // Unrelated traffic on the same pane, while the window is held open.
+        transport.stall("p")
+        transport.release("p")
+
+        let escaped = await waitUntil(0.5) { !transport.retryIsParked("p") }
+        XCTAssertFalse(escaped, "an ordinary release opened the catch window it does not own")
+
+        transport.releaseCatchWindow("p")
+        _ = await second.result
+    }
+
+    /// AXIS: two successive catch windows on one pane are each independently
+    /// armable — the second is not consumed by the first's release.
+    func testASecondCatchWindowOnTheSamePaneArmsIndependently() async throws {
+        let transport = ScriptedTransport(panes: ["p"])
+
+        for round in 1...2 {
+            transport.armCatchPathWindow("p")
+            await expectThrow("entry 1 must throw; the window is armed on it") {
+            try await transport.openStream(pane: "p", for: AttemptID(uuid: UUID())) {}
+        }
+            let second = Task { try await transport.openStream(pane: "p", for: AttemptID(uuid: UUID())) {} }
+            let parked = await waitUntil { transport.retryIsParked("p") }
+            XCTAssertTrue(parked, "window \(round) did not park; the previous arm's state leaked into it")
+            transport.releaseCatchWindow("p")
+            _ = await second.result
+            let cleared = await waitUntil { !transport.retryIsParked("p") }
+            XCTAssertTrue(cleared, "window \(round) never cleared its parked state")
+        }
     }
 
     /// AXIS: a retirement landing during a pane's RETRY BACKOFF stops the

--- a/Tests/HerdrKitTests/RecoveryExecutorTests.swift
+++ b/Tests/HerdrKitTests/RecoveryExecutorTests.swift
@@ -61,26 +61,12 @@ final class ScriptedTransport: ExecutorTransport, @unchecked Sendable {
     /// The catch window has `releaseCatchWindow`.
     func release(_ pane: String) { lock.withLock { _ = stalledPanes.remove(pane) } }
 
-    /// Kill-on-registration: arms a flag so the pane's NEXT registered
-    /// terminator fires immediately, INSIDE openStream before it returns —
-    /// the termination-races-the-return interleaving made deterministic.
-    private var killOnRegister: Set<String> = []
-    func releaseAndKill(_ pane: String) {
-        lock.withLock {
-            _ = stalledPanes.remove(pane)
-            _ = killOnRegister.insert(pane)
-        }
-    }
-
-    /// The first open for this pane SUCCEEDS and fires its termination before
-    /// returning; every later one fails (via failingPanes). That is the
-    /// termination-races-the-return window with a deterministic aftermath:
-    /// replacements exhaust, so a false publish by the original call is the
-    /// only way the pane can ever read .open.
-    private var succeedOnceThenKill: Set<String> = []
-    func killDuringFirstSuccessfulOpen(_ pane: String) {
-        lock.withLock { _ = succeedOnceThenKill.insert(pane) }
-    }
+    // REMOVED: releaseAndKill / killDuringFirstSuccessfulOpen and their flags.
+    // Both had ZERO call sites — the tests that used them were rewritten to
+    // observe registrations directly. Dead seams in a fake are not inert: both
+    // fired a terminator INSIDE openStream before it returned, which is the
+    // contract-violating shape three rounds of review have been removing from
+    // this file, sitting armed behind a method nothing called.
     /// The pane's FIRST open throws; its SECOND open parks until released.
     /// Later opens pass through untouched.
     ///
@@ -106,36 +92,48 @@ final class ScriptedTransport: ExecutorTransport, @unchecked Sendable {
     /// pane-keyed phase counter and a pane-keyed release latch, so neither a
     /// second window nor a window following an ordinary release could be
     /// represented at all.
-    private var catchArm: [String: Int] = [:]        // current generation
-    private var catchPhase: [String: Int] = [:]      // entries seen since this arm
-    private var catchParkedArm: [String: Int] = [:]  // generation currently parked
-    private var catchReleasedArm: [String: Int] = [:] // generation released
-    func armCatchPathWindow(_ pane: String) {
-        lock.withLock {
-            catchArm[pane] = (catchArm[pane] ?? 0) + 1
-            catchPhase[pane] = 0
-            // No `catchReleasedArm[pane] = nil` here. It was written, its
-            // mutation SURVIVED, and unlike the guard removal that failed
-            // review at round seven this one is exhaustively enumerable rather
-            // than argued: `catchArm` only ever increases, and
-            // `catchReleasedArm` is only ever assigned some value `catchArm`
-            // held at an earlier moment. A stale release is therefore strictly
-            // less than the new generation and can never match it. There is no
-            // suspension point in that argument — it is an invariant on a
-            // monotonic integer, not a claim about interleaving, which is
-            // exactly the distinction round seven's mistake turned on.
-        }
+    /// One armed window, holding its own gate.
+    ///
+    /// An OBJECT rather than a generation number keyed by pane, and that is the
+    /// second correction to this seam. Generation numbers still went through a
+    /// shared per-pane slot, so `releaseCatchWindow` read
+    /// `catchArm[pane]` AT CALL TIME: a release created for generation 1 but
+    /// delivered once generation 2 was current wrote `2` and opened the wrong
+    /// window. Reproduced 6/6.
+    ///
+    /// I had argued that could not happen — "catchReleasedArm only ever holds a
+    /// value catchArm held earlier" — and the argument was false in the same
+    /// way round seven's was: it enumerated where the value was WRITTEN and not
+    /// where it was READ. Twice now, on this file, reasoning about a shared
+    /// mutable slot has been wrong in a direction no test noticed. So the slot
+    /// is gone: a release names its own window and can reach nothing else. That
+    /// is a property of the shape, not an invariant anyone has to keep true.
+    final class CatchWindow: @unchecked Sendable {
+        private let lock = NSLock()
+        private var released = false
+        private var parked = false
+        var isParked: Bool { lock.withLock { parked } }
+        func release() { lock.withLock { released = true } }
+        fileprivate var isReleased: Bool { lock.withLock { released } }
+        fileprivate func setParked(_ value: Bool) { lock.withLock { parked = value } }
     }
-    /// Opens the gate for the CURRENT generation only. A release aimed at a
-    /// finished window cannot open the next one.
-    func releaseCatchWindow(_ pane: String) {
-        lock.withLock { catchReleasedArm[pane] = catchArm[pane] }
+
+    private var catchWindows: [String: CatchWindow] = [:]   // the CURRENT arm
+    private var catchPhase: [String: Int] = [:]             // entries since this arm
+
+    func armCatchPathWindow(_ pane: String) -> CatchWindow {
+        lock.withLock {
+            let window = CatchWindow()
+            catchWindows[pane] = window
+            catchPhase[pane] = 0
+            return window
+        }
     }
     /// 0 = not armed for this pane, 1 = the throwing first open, 2 = the retry
     /// that parks, 3+ = pass through.
     private func catchPathPhase(_ pane: String) -> Int {
         lock.withLock {
-            guard catchArm[pane] != nil else { return 0 }
+            guard catchWindows[pane] != nil else { return 0 }
             catchPhase[pane, default: 0] += 1
             return catchPhase[pane] ?? 0
         }
@@ -164,7 +162,9 @@ final class ScriptedTransport: ExecutorTransport, @unchecked Sendable {
     /// nothing had entered yet. The open then parked forever and the test timed
     /// out having proven nothing (1 run in 5). Observing the gate itself cannot
     /// be early by construction.
-    func retryIsParked(_ pane: String) -> Bool { lock.withLock { catchParkedArm[pane] != nil } }
+    func retryIsParked(_ pane: String) -> Bool {
+        lock.withLock { catchWindows[pane] }?.isParked ?? false
+    }
 
     /// Drops the registration this call made, so a throwing open leaves none.
     /// Deliberately NOT applied on the `installsThenThrows` path: that one
@@ -306,30 +306,18 @@ final class ScriptedTransport: ExecutorTransport, @unchecked Sendable {
             throw TransportError.closedBeforeResponse
         }
         if phase == 2 {
-            // Keyed to THIS ARM. No other call, on any attempt, and no release
-            // aimed at any other window, can enter or open it.
-            let arm = lock.withLock { catchArm[pane] }
-            lock.withLock { catchParkedArm[pane] = arm }
-            while lock.withLock({ catchReleasedArm[pane] != arm }) {
+            // The parked open holds a REFERENCE to its own window. Nothing
+            // consults per-pane state to decide whether it may proceed, so no
+            // later arm and no delayed release aimed elsewhere can reach it.
+            let window = lock.withLock { catchWindows[pane] }
+            window?.setParked(true)
+            while !(window?.isReleased ?? true) {
                 try? await Task.sleep(nanoseconds: 10_000_000)
             }
-            lock.withLock { catchParkedArm[pane] = nil }
+            window?.setParked(false)
         }
         while isStalled(pane) { try? await Task.sleep(nanoseconds: 10_000_000) }
         record(.openAttempt(pane, attempt))
-        let succeedThisOnce = lock.withLock { succeedOnceThenKill.remove(pane) != nil }
-        if succeedThisOnce {
-            record(.openStream(pane, attempt))
-            // Fires INSIDE the call: the executor's publish runs after this.
-            let terminate = lock.withLock { () -> (@Sendable () -> Void)? in
-                guard var list = terminators[pane], !list.isEmpty else { return nil }
-                let last = list.removeLast()
-                terminators[pane] = list
-                return last
-            }
-            terminate?()
-            return
-        }
         if failOpens || lock.withLock({ failingPanes.contains(pane) }) {
             // The deliberate violation is RETAINING the entry registration, not
             // adding a second one. This used to append the identical closure
@@ -340,18 +328,6 @@ final class ScriptedTransport: ExecutorTransport, @unchecked Sendable {
             throw TransportError.closedBeforeResponse
         }
         record(.openStream(pane, attempt))
-        let fireNow = lock.withLock { killOnRegister.remove(pane) != nil }
-        if fireNow {
-            // Fire BEFORE returning: the executor's success path runs after
-            // this, which is exactly the window under test.
-            let terminate = lock.withLock { () -> (@Sendable () -> Void)? in
-                guard var list = terminators[pane], !list.isEmpty else { return nil }
-                let last = list.removeLast()
-                terminators[pane] = list
-                return last
-            }
-            terminate?()
-        }
     }
 
     func closeAll(for attempt: AttemptID) async {
@@ -613,7 +589,7 @@ final class RecoveryExecutorTests: XCTestCase {
     func testARetirementDuringAFailedOpensHandlingStopsTheRemainingStreams() async throws {
         let transport = ScriptedTransport(panes: ["a-fails", "z-must-not-open"])
         let executor = RecoveryExecutor(transport: transport)
-        transport.armCatchPathWindow("a-fails")   // open 1 throws, open 2 stalls
+        let window = transport.armCatchPathWindow("a-fails")   // open 1 throws, open 2 parks
         await executor.start()
 
         // The window is ENTERED when the replacement open exists: entry 1 is the
@@ -645,7 +621,7 @@ final class RecoveryExecutorTests: XCTestCase {
 
         // The world moves while the loop is parked mid-catch.
         await executor.handle(.networkChanged(at: Date()))
-        transport.releaseCatchWindow("a-fails")
+        window.release()
 
         // Settle on an OUTCOME, not on elapsed time. A fixed sleep let the
         // guard-removal mutant pass 1 run in 9: the negative assertion was
@@ -683,7 +659,7 @@ final class RecoveryExecutorTests: XCTestCase {
     /// parked window, which is also the stronger invariant.
     func testOrdinaryReleaseCannotOpenAParkedCatchWindow() async throws {
         let transport = ScriptedTransport(panes: ["p"])
-        transport.armCatchPathWindow("p")
+        let window = transport.armCatchPathWindow("p")
 
         // Entry 1 throws (contract: leaves nothing live). Entry 2 must PARK.
         await expectThrow("entry 1 must throw; the window is armed on it") {
@@ -700,8 +676,46 @@ final class RecoveryExecutorTests: XCTestCase {
         let escaped = await waitUntil(0.5) { !transport.retryIsParked("p") }
         XCTAssertFalse(escaped, "an ordinary release opened the catch window it does not own")
 
-        transport.releaseCatchWindow("p")
+        window.release()
         _ = await second.result
+    }
+
+    /// AXIS: a release created for an EARLIER window cannot open a later one,
+    /// even when it is delivered while the later window is parked.
+    ///
+    /// This is the defect review found at round eleven, and it existed because
+    /// the release consulted per-pane state when it EXECUTED rather than
+    /// carrying the identity it was created with. My argument that it could not
+    /// happen enumerated where the value was written and not where it was read.
+    /// The regression is kept even though the shared slot is gone, because the
+    /// slot is the kind of thing that comes back.
+    func testAStaleReleaseCannotOpenALaterCatchWindow() async throws {
+        let transport = ScriptedTransport(panes: ["p"])
+        let first = transport.armCatchPathWindow("p")
+        await expectThrow("entry 1 must throw") {
+            try await transport.openStream(pane: "p", for: AttemptID(uuid: UUID())) {}
+        }
+        let firstRetry = Task { try await transport.openStream(pane: "p", for: AttemptID(uuid: UUID())) {} }
+        _ = await waitUntil { transport.retryIsParked("p") }
+        first.release()
+        _ = await firstRetry.result
+
+        // A second window, parked, with the FIRST window's release still in
+        // someone's hand.
+        let second = transport.armCatchPathWindow("p")
+        await expectThrow("entry 1 of the second window must throw") {
+            try await transport.openStream(pane: "p", for: AttemptID(uuid: UUID())) {}
+        }
+        let secondRetry = Task { try await transport.openStream(pane: "p", for: AttemptID(uuid: UUID())) {} }
+        let parked = await waitUntil { transport.retryIsParked("p") }
+        XCTAssertTrue(parked, "the second window never parked; the test is not armed")
+
+        first.release()          // the STALE release, delivered late
+        let escaped = await waitUntil(0.5) { !transport.retryIsParked("p") }
+        XCTAssertFalse(escaped, "a release created for the first window opened the second")
+
+        second.release()
+        _ = await secondRetry.result
     }
 
     /// AXIS: two successive catch windows on one pane are each independently
@@ -710,14 +724,14 @@ final class RecoveryExecutorTests: XCTestCase {
         let transport = ScriptedTransport(panes: ["p"])
 
         for round in 1...2 {
-            transport.armCatchPathWindow("p")
+            let window = transport.armCatchPathWindow("p")
             await expectThrow("entry 1 must throw; the window is armed on it") {
             try await transport.openStream(pane: "p", for: AttemptID(uuid: UUID())) {}
         }
             let second = Task { try await transport.openStream(pane: "p", for: AttemptID(uuid: UUID())) {} }
             let parked = await waitUntil { transport.retryIsParked("p") }
             XCTAssertTrue(parked, "window \(round) did not park; the previous arm's state leaked into it")
-            transport.releaseCatchWindow("p")
+            window.release()
             _ = await second.result
             let cleared = await waitUntil { !transport.retryIsParked("p") }
             XCTAssertTrue(cleared, "window \(round) never cleared its parked state")
@@ -951,9 +965,16 @@ actor SleepRecorder {
         let executor = RecoveryExecutor(transport: transport)
         transport.stall("only")                       // the open suspends
         await executor.start()
-        _ = await waitUntil {
-            transport.log().contains { if case .fetchSnapshot = $0 { return true }; return false }
-        }
+        // Wait for the STREAM'S REGISTRATION, not for fetchSnapshot. The fake
+        // logs the snapshot before returning it and well before openStream
+        // registers, so the old wait could settle with registrationCount 0 —
+        // the attempt then retired before any open was in flight and there was
+        // no late-open window at all. Reproduced 3/3. A baseline or an
+        // unrelated mutant failing for THAT reason corrupts kill attribution,
+        // which is worse than the flake: the harness would report a kill that
+        // had nothing to do with the mutation.
+        let inFlight = await waitUntil { transport.registrationCount("only") > 0 }
+        XCTAssertTrue(inFlight, "no open was in flight; the late-open window never existed")
         let retiredOptional = await executor.currentAttempt
         let retired = try XCTUnwrap(retiredOptional)
 

--- a/Tests/HerdrKitTests/RecoveryExecutorTests.swift
+++ b/Tests/HerdrKitTests/RecoveryExecutorTests.swift
@@ -14,17 +14,30 @@ final class ScriptedTransport: ExecutorTransport, @unchecked Sendable {
         case connect(AttemptID)
         case fetchSnapshot(AttemptID)
         case openStream(String, AttemptID)
+        /// Recorded for EVERY registration attempt, throwing or not — the
+        /// contract-violation test asserted opens == 0 while the fake returned
+        /// before recording failures, so the assertion was vacuous by
+        /// construction.
+        case openAttempt(String, AttemptID)
         case closeAll(AttemptID)
         case discard(AttemptID)
     }
 
     private let lock = NSLock()
     private var operations: [Operation] = []
-    private var terminators: [String: @Sendable () -> Void] = [:]
+    /// Per REGISTRATION, not per pane: overwriting by pane made an older
+    /// registration's closure unselectable, so orphan-callback probes could
+    /// never pick the stale one.
+    private var terminators: [String: [@Sendable () -> Void]] = [:]
     var panesToServe: [String]
     var failConnects = false
     /// Every openStream throws — a persistently broken conformer.
     var failOpens = false
+    /// Every fetchSnapshot throws — establishment fails after connect.
+    var failSnapshots = false
+    /// Panes whose opens always throw, for paired-control tests where one pane
+    /// is healthy and one is not.
+    var failingPanes: Set<String> = []
     /// Installs the callback and THEN throws: the ownership violation the seam
     /// now forbids, kept as a probe of what the executor does when a conformer
     /// breaks the contract anyway.
@@ -46,15 +59,37 @@ final class ScriptedTransport: ExecutorTransport, @unchecked Sendable {
 
     /// Kills a pane's stream from the outside, firing its termination exactly
     /// once — the contract the executor promises the policy.
+    /// Fires the NEWEST registration's termination.
     func killStream(_ pane: String) {
-        let terminate = lock.withLock { terminators.removeValue(forKey: pane) }
+        let terminate = lock.withLock { () -> (@Sendable () -> Void)? in
+            guard var list = terminators[pane], !list.isEmpty else { return nil }
+            let last = list.removeLast()
+            terminators[pane] = list
+            return last
+        }
+        terminate?()
+    }
+
+    /// Fires the OLDEST registration's termination — the orphaned-callback case.
+    func killOldestRegistration(_ pane: String) {
+        let terminate = lock.withLock { () -> (@Sendable () -> Void)? in
+            guard var list = terminators[pane], !list.isEmpty else { return nil }
+            let first = list.removeFirst()
+            terminators[pane] = list
+            return first
+        }
         terminate?()
     }
 
     /// A MISBEHAVING transport: fires the SAME registration's termination
     /// twice, which the executor's once-latch must reduce to one death.
     func killStreamTwice(_ pane: String) {
-        let terminate = lock.withLock { terminators.removeValue(forKey: pane) }
+        let terminate = lock.withLock { () -> (@Sendable () -> Void)? in
+            guard var list = terminators[pane], !list.isEmpty else { return nil }
+            let last = list.removeLast()
+            terminators[pane] = list
+            return last
+        }
         terminate?()
         terminate?()
     }
@@ -83,6 +118,7 @@ final class ScriptedTransport: ExecutorTransport, @unchecked Sendable {
 
     func fetchSnapshot(for attempt: AttemptID) async throws -> PaneSnapshot {
         record(.fetchSnapshot(attempt))
+        if failSnapshots { throw TransportError.closedBeforeResponse }
         let served = lock.withLock { panesToServe }
         return PaneSnapshot(agents: try SessionRecoveryTests.decodePanes(served))
     }
@@ -92,12 +128,15 @@ final class ScriptedTransport: ExecutorTransport, @unchecked Sendable {
         onTermination: @escaping @Sendable () -> Void
     ) async throws {
         while isStalled(pane) { try? await Task.sleep(nanoseconds: 10_000_000) }
-        if failOpens {
-            if installsThenThrows { lock.withLock { terminators[pane] = onTermination } }
+        record(.openAttempt(pane, attempt))
+        if failOpens || lock.withLock({ failingPanes.contains(pane) }) {
+            if installsThenThrows {
+                lock.withLock { terminators[pane, default: []].append(onTermination) }
+            }
             throw TransportError.closedBeforeResponse
         }
         record(.openStream(pane, attempt))
-        lock.withLock { terminators[pane] = onTermination }
+        lock.withLock { terminators[pane, default: []].append(onTermination) }
     }
 
     func closeAll(for attempt: AttemptID) async {
@@ -527,19 +566,24 @@ actor SleepRecorder {
         _ = await waitUntil(8) {
             await executor.rejections.contains { $0.reason.contains("left unsubscribed") }
         }
+        let attemptsAtCap = transport.log().filter {
+            if case .openAttempt = $0 { return true }; return false
+        }.count
+        XCTAssertGreaterThan(attemptsAtCap, 0, "precondition: registrations were attempted")
+        XCTAssertLessThanOrEqual(attemptsAtCap, RecoveryExecutor.openFailureCap + 1,
+                                 "the cap did not bound registration attempts")
 
-        // The orphaned callback from a failed registration fires late.
-        transport.killStream("p1")
-        try? await Task.sleep(nanoseconds: 200_000_000)
+        // The OLDEST registration's orphaned callback fires late.
+        transport.killOldestRegistration("p1")
+        try? await Task.sleep(nanoseconds: 300_000_000)
 
-        // The decisive property: a contract-violating conformer cannot make
-        // the executor STACK streams. No open ever succeeded, so none may be
-        // recorded, whatever the orphaned callback does.
-        let opens = transport.log().filter { if case .openStream = $0 { return true }; return false }.count
-        XCTAssertEqual(opens, 0, "an orphaned callback caused an open; \(opens) recorded")
-        let rejections = await executor.rejections
-        XCTAssertTrue(rejections.contains { $0.reason.contains("left unsubscribed") },
-                      "the cap must still bound a contract-violating conformer")
+        let attemptsAfter = transport.log().filter {
+            if case .openAttempt = $0 { return true }; return false
+        }.count
+        XCTAssertEqual(attemptsAfter, attemptsAtCap,
+                       "an orphaned callback restarted registration attempts past the cap")
+        XCTAssertEqual(transport.log().filter { if case .openStream = $0 { return true }; return false }.count, 0,
+                       "no open ever succeeded, so none may be recorded")
     }
 
     /// AXIS: the diagnostics buffer is bounded and drainable — append-only was
@@ -569,6 +613,87 @@ actor SleepRecorder {
         XCTAssertEqual(drained.entries.count, held)
         let afterDrain = await executor.rejections.count
         XCTAssertEqual(afterDrain, 0, "drain must clear")
+    }
+
+    /// AXIS: failure counters are retired with their attempt — they were one
+    /// more unbounded structure, and the whole-suite mutation removing the
+    /// retirement SURVIVED because nothing observed the count.
+    func testFailureCountersAreRetiredWithTheirAttempt() async throws {
+        let transport = ScriptedTransport(panes: ["bad"])
+        transport.failingPanes = ["bad"]
+        let executor = RecoveryExecutor(transport: transport)
+        await executor.setSleeper { _ in }
+        await executor.start()
+        _ = await waitUntil(8) { await executor.openFailureEntryCount > 0 }
+
+        await executor.handle(.networkChanged(at: Date()))
+        _ = await waitUntil { await executor.isConnected }
+        // The new attempt fails "bad" afresh; only ITS keys may exist.
+        _ = await waitUntil(8) {
+            await executor.rejections.contains { $0.reason.contains("left unsubscribed") }
+        }
+        let staleFree = await executor.openFailureEntryCountForRetiredAttempts == 0
+        XCTAssertTrue(staleFree, "retired attempts' failure counters were retained")
+    }
+
+    /// THE COORDINATOR'S PAIRED CONTROL: a healthy pane reports `.open` AND a
+    /// persistently-failing pane reports `.admittedNotOpen`, through the SAME
+    /// accessor in the same test. One control alone is satisfied by a
+    /// degenerate implementation answering the same thing for everything —
+    /// this is the discriminating-evidence requirement made executable.
+    func testPaneStatusDiscriminatesOpenFromAdmittedNotOpen() async throws {
+        let transport = ScriptedTransport(panes: ["healthy", "broken"])
+        transport.failingPanes = ["broken"]
+        let executor = RecoveryExecutor(transport: transport)
+        await executor.setSleeper { _ in }
+        await executor.start()
+        _ = await waitUntil(8) {
+            await executor.rejections.contains { $0.reason.contains("left unsubscribed") }
+        }
+        let healthySettled = await waitUntil { await executor.paneStatus("healthy") == .open }
+        XCTAssertTrue(healthySettled, "the healthy pane must report open")
+
+        let brokenStatus = await executor.paneStatus("broken")
+        guard case .admittedNotOpen(let attempts, let lastError) = brokenStatus else {
+            return XCTFail("the unwatched pane reads as \(brokenStatus) — the silent-pane lie, unqueryable")
+        }
+        XCTAssertGreaterThan(attempts, 0, "the attempt count must be carried")
+        XCTAssertNotNil(lastError, "the last error must be carried")
+        let unknown = await executor.paneStatus("never-heard-of")
+        XCTAssertEqual(unknown, .notAdmitted)
+    }
+
+    /// AXIS: a failure while establishing (snapshot fetch throws) closes the
+    /// failed attempt's resources BEFORE the replacement's claim installs.
+    ///
+    /// The failure paths route through the policy, whose plan is reconnect
+    /// only — no cancelTransport — so the replacement dial overwrote the claim
+    /// and the failed attempt's connection and any opened streams became
+    /// unreachable forever. The reviewer's probe: B connected with no
+    /// closeAll(A) anywhere in the log.
+    func testAnEstablishmentFailureClosesTheFailedAttemptBeforeReplacement() async throws {
+        let transport = ScriptedTransport(panes: ["p1"])
+        transport.failSnapshots = true
+        let executor = RecoveryExecutor(transport: transport)
+        await executor.setSleeper { _ in }
+        await executor.start()
+
+        let secondConnect = await waitUntil {
+            transport.log().filter { if case .connect = $0 { return true }; return false }.count >= 2
+        }
+        XCTAssertTrue(secondConnect, "the snapshot failure never produced a replacement dial")
+
+        let ops = transport.log()
+        guard case .connect(let attemptA) = ops.first else { return XCTFail("no first dial") }
+        // XCTUnwrap, not `!`: the force-unwrap after a failing NotNil turned a
+        // real kill into signal 4 — the crash-instead-of-fail class, third
+        // instance today, caught by the mutation run reading INVALID.
+        let closeA = try XCTUnwrap(ops.firstIndex(of: .closeAll(attemptA)),
+                                   "the failed attempt's resources were never closed — unreachable forever")
+        let secondDial = try XCTUnwrap(ops.firstIndex { op in
+            if case .connect(let a) = op { return a != attemptA } else { return false }
+        })
+        XCTAssertLessThan(closeA, secondDial, "the close must precede the replacement's dial")
     }
 
     /// A dial that fails schedules the retry through the policy (backoff), and

--- a/Tests/HerdrKitTests/RecoveryExecutorTests.swift
+++ b/Tests/HerdrKitTests/RecoveryExecutorTests.swift
@@ -1,0 +1,307 @@
+import XCTest
+@testable import HerdrKit
+
+/// A scripted transport that records every operation in order and can be told
+/// to fail, stall, or deliver late.
+///
+/// The interesting cases live here and cannot live against the network: a
+/// delayed completion from a retired attempt, a stream that dies on cue, a
+/// snapshot that races a reconnect. The log is the test surface — assertions
+/// read the ORDER of operations, because ordering is what the coordinator made
+/// an acceptance criterion.
+final class ScriptedTransport: ExecutorTransport, @unchecked Sendable {
+    enum Operation: Equatable {
+        case connect(AttemptID)
+        case fetchSnapshot(AttemptID)
+        case openStream(String, AttemptID)
+        case closeAll(AttemptID)
+        case discard(AttemptID)
+    }
+
+    private let lock = NSLock()
+    private var operations: [Operation] = []
+    private var terminators: [String: @Sendable () -> Void] = [:]
+    var panesToServe: [String]
+    var failConnects = false
+
+    init(panes: [String]) { self.panesToServe = panes }
+
+    func log() -> [Operation] { lock.lock(); defer { lock.unlock() }; return operations }
+    private func record(_ op: Operation) { lock.lock(); operations.append(op); lock.unlock() }
+
+    /// Kills a pane's stream from the outside, firing its termination exactly
+    /// once — the contract the executor promises the policy.
+    func killStream(_ pane: String) {
+        lock.lock()
+        let terminate = terminators.removeValue(forKey: pane)
+        lock.unlock()
+        terminate?()
+    }
+
+    func connect(for attempt: AttemptID) async throws {
+        record(.connect(attempt))
+        if failConnects { throw TransportError.closedBeforeResponse }
+    }
+
+    func fetchSnapshot(for attempt: AttemptID) async throws -> PaneSnapshot {
+        record(.fetchSnapshot(attempt))
+        let served = lock.withLock { panesToServe }
+        return PaneSnapshot(agents: try SessionRecoveryTests.decodePanes(served))
+    }
+
+    func openStream(
+        pane: String, for attempt: AttemptID,
+        onTermination: @escaping @Sendable () -> Void
+    ) async throws {
+        record(.openStream(pane, attempt))
+        lock.lock(); terminators[pane] = onTermination; lock.unlock()
+    }
+
+    func closeAll(for attempt: AttemptID) async { record(.closeAll(attempt)) }
+    func discard(attempt: AttemptID) async { record(.discard(attempt)) }
+}
+
+extension NSLock {
+    func withLock<T>(_ body: () -> T) -> T {
+        lock(); defer { unlock() }; return body()
+    }
+}
+
+final class RecoveryExecutorTests: XCTestCase {
+    /// Waits until the executor settles (no fixed sleeps: poll a condition).
+    private func waitUntil(
+        _ timeout: TimeInterval = 5, _ condition: @escaping () async -> Bool
+    ) async -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if await condition() { return true }
+            try? await Task.sleep(nanoseconds: 20_000_000)
+        }
+        return await condition()
+    }
+
+    /// THE HAPPY PATH, asserted on the operation ORDER: dial, resync, then
+    /// streams — and every stream open comes AFTER the snapshot fetch.
+    ///
+    /// CONDITION 4 lives here: resync-before-subscribe is documented as
+    /// load-bearing, so this test must FAIL when the order is swapped. It does
+    /// so structurally — subscriptions exist only downstream of `apply` — and
+    /// the mutation reintroducing memory-derived early subscription is run
+    /// against exactly this assertion.
+    func testColdStartResyncsBeforeAnyStreamOpens() async throws {
+        let transport = ScriptedTransport(panes: ["p1", "p2"])
+        let executor = RecoveryExecutor(transport: transport)
+        await executor.start()
+
+        let settled = await waitUntil { await executor.subscribedPanes == ["p1", "p2"] }
+        XCTAssertTrue(settled, "the cold start never reached full subscription")
+
+        let ops = transport.log()
+        guard case .connect(let attempt) = ops.first else {
+            return XCTFail("the first operation must be the dial, got \(ops)")
+        }
+        XCTAssertEqual(ops[1], .fetchSnapshot(attempt), "resync must be the first post-connect operation")
+        let firstStream = ops.firstIndex { if case .openStream = $0 { return true }; return false }
+        let snapshotIndex = ops.firstIndex(of: .fetchSnapshot(attempt))!
+        XCTAssertNotNil(firstStream)
+        XCTAssertGreaterThan(firstStream!, snapshotIndex,
+                             "a stream opened BEFORE the snapshot: subscribe-from-memory is back")
+        XCTAssertEqual(Set(ops.compactMap { if case .openStream(let p, _) = $0 { return p }; return nil }),
+                       ["p1", "p2"])
+    }
+
+    /// CONDITION 4, armed: a RECONNECT adoption — where memory is non-empty —
+    /// must still fetch the snapshot before any stream opens.
+    ///
+    /// The cold-start version of this assertion let the subscribe-from-memory
+    /// mutation SURVIVE, because a cold start has nothing remembered and the
+    /// wrongly-early subscription opened zero streams. The hazard only arms
+    /// when adoption happens with knowledge aboard; this drives it.
+    func testReconnectAdoptionResyncsBeforeAnyStreamOpensDespiteMemory() async throws {
+        let transport = ScriptedTransport(panes: ["p1", "p2"])
+        let executor = RecoveryExecutor(transport: transport)
+        await executor.start()
+        _ = await waitUntil { await executor.subscribedPanes == ["p1", "p2"] }
+
+        // Memory is now non-empty. Reconnect.
+        await executor.handle(.networkChanged(at: Date()))
+        _ = await waitUntil { await executor.subscribedPanes == ["p1", "p2"] }
+        let attemptB = await executor.currentAttempt!
+
+        let ops = transport.log()
+        let snapshotB = ops.firstIndex(of: .fetchSnapshot(attemptB))
+        let firstStreamB = ops.firstIndex { if case .openStream(_, attemptB) = $0 { return true }; return false }
+        XCTAssertNotNil(snapshotB); XCTAssertNotNil(firstStreamB)
+        XCTAssertGreaterThan(firstStreamB!, snapshotB!,
+                             "a stream opened on B before B's snapshot: memory-derived subscription is back")
+    }
+
+    /// CONDITION 1, half one: a connection completing for a RETIRED attempt is
+    /// discarded at the transport, and no work runs on it.
+    func testADelayedCompletionFromARetiredAttemptIsDiscardedAtTheTransport() async throws {
+        let transport = ScriptedTransport(panes: ["p1"])
+        let executor = RecoveryExecutor(transport: transport)
+        await executor.start()
+        _ = await waitUntil { await executor.isConnected }
+
+        // The network changes; attempt A is retired, B dials.
+        let retired = await executor.currentAttempt!
+        await executor.handle(.networkChanged(at: Date()))
+        _ = await waitUntil { await executor.isConnected }
+
+        // A's completion arrives late, as an event (the second door).
+        await executor.handle(.connected(retired, at: Date()))
+
+        XCTAssertTrue(transport.log().contains(.discard(retired)),
+                      "the stale completion must be discarded AT the transport, not only in policy")
+        let current = await executor.currentAttempt
+        XCTAssertNotEqual(current, retired, "the retired attempt must not have been adopted")
+    }
+
+    /// CONDITION 1, half two: a subscribe bound to a retired attempt is
+    /// REJECTED at execution, observably.
+    func testASubscribeBoundToARetiredAttemptIsRejectedAtExecution() async throws {
+        let transport = ScriptedTransport(panes: ["p1"])
+        let recovery = SessionRecovery()
+        let executor = RecoveryExecutor(recovery: recovery, transport: transport)
+        await executor.start()
+        _ = await waitUntil { await executor.isConnected }
+        let retired = await executor.currentAttempt!
+
+        await executor.handle(.networkChanged(at: Date()))
+        _ = await waitUntil { await executor.isConnected }
+        let streamsBefore = transport.log().filter { if case .openStream = $0 { return true }; return false }.count
+
+        // A's delayed plan arrives: a subscribe bound to the retired attempt.
+        // Constructed directly — the executor cannot know how a stale plan was
+        // produced, only that its binding does not match.
+        await executor.execute(RecoveryPlan([.subscribe(["p1"], on: retired)]))
+
+        let streamsAfter = transport.log().filter { if case .openStream = $0 { return true }; return false }.count
+        XCTAssertEqual(streamsAfter, streamsBefore, "a retired attempt's subscribe opened a stream")
+        let rejections = await executor.rejections
+        XCTAssertEqual(rejections.count, 1, "the rejection must be observable, not silent")
+        XCTAssertTrue(rejections[0].reason.contains("retired"))
+    }
+
+    /// REQUIREMENT ONE end-to-end: one pane's stream dies; exactly that pane is
+    /// re-subscribed, exactly once, on the same attempt; the other pane's
+    /// stream is untouched.
+    func testASingleStreamDeathResubscribesExactlyThatPane() async throws {
+        let transport = ScriptedTransport(panes: ["p1", "p2"])
+        let executor = RecoveryExecutor(transport: transport)
+        await executor.start()
+        _ = await waitUntil { await executor.subscribedPanes == ["p1", "p2"] }
+        let attempt = await executor.currentAttempt!
+        let opensBefore = transport.log().filter { if case .openStream = $0 { return true }; return false }
+
+        transport.killStream("p2")
+
+        let reopened = await waitUntil {
+            transport.log().filter { $0 == .openStream("p2", attempt) }.count == 2
+        }
+        XCTAssertTrue(reopened, "the dead pane was never re-subscribed")
+        let opensAfter = transport.log().filter { if case .openStream = $0 { return true }; return false }
+        XCTAssertEqual(opensAfter.count, opensBefore.count + 1,
+                       "exactly ONE stream open may follow one death — \(opensAfter.count - opensBefore.count) did")
+        XCTAssertEqual(transport.log().filter { $0 == .openStream("p1", attempt) }.count, 1,
+                       "the living pane's stream must be untouched")
+    }
+
+    /// A dial that fails schedules the retry through the policy (backoff), and
+    /// a network change cancels a pending dial rather than racing it.
+    func testAFailedDialRetriesAndACancelledDialDoesNotLand() async throws {
+        let transport = ScriptedTransport(panes: ["p1"])
+        transport.failConnects = true
+        let executor = RecoveryExecutor(transport: transport)
+        await executor.start()
+
+        let retried = await waitUntil(8) {
+            transport.log().filter { if case .connect = $0 { return true }; return false }.count >= 2
+        }
+        XCTAssertTrue(retried, "a failed dial must retry through the policy's backoff")
+
+        transport.failConnects = false
+        await executor.handle(.backgrounded(at: Date()))
+        let connectsAtBackground = transport.log().filter { if case .connect = $0 { return true }; return false }.count
+        try? await Task.sleep(nanoseconds: 500_000_000)
+        let connectsAfter = transport.log().filter { if case .connect = $0 { return true }; return false }.count
+        XCTAssertEqual(connectsAfter, connectsAtBackground,
+                       "a pending dial survived backgrounding: the cancel did not land")
+    }
+}
+
+/// The live half of the verification bar: the executor against the REAL herdr
+/// socket, through a real `HerdrClient`.
+///
+/// Test-local adapter, deliberately: the production SSH adapter belongs to the
+/// app layer and needs credentials this box's suite already exercises
+/// elsewhere; what the LIVE bar proves here is that the executor's contract —
+/// connect, snapshot, per-pane streams — is implementable over the actual
+/// wire, not just the scripted fake.
+final class LiveHerdrTransport: ExecutorTransport, @unchecked Sendable {
+    private let client: HerdrClient
+    private let lock = NSLock()
+    private var streams: [String: Task<Void, Never>] = [:]
+
+    init(client: HerdrClient) { self.client = client }
+
+    func connect(for attempt: AttemptID) async throws {
+        _ = try await client.agentList()   // a real round trip is the connection proof
+    }
+
+    func fetchSnapshot(for attempt: AttemptID) async throws -> PaneSnapshot {
+        try await client.paneSnapshot()
+    }
+
+    func openStream(
+        pane: String, for attempt: AttemptID,
+        onTermination: @escaping @Sendable () -> Void
+    ) async throws {
+        let stream = client.subscribe([Subscription(.paneTurnCompleted, paneID: pane)])
+        let task = Task {
+            do { for try await _ in stream {} } catch {}
+            onTermination()
+        }
+        lock.lock(); streams[pane] = task; lock.unlock()
+    }
+
+    func closeAll(for attempt: AttemptID) async {
+        lock.lock(); let open = streams; streams = [:]; lock.unlock()
+        for task in open.values { task.cancel() }
+    }
+
+    func discard(attempt: AttemptID) async { await closeAll(for: attempt) }
+}
+
+final class LiveRecoveryExecutorTests: XCTestCase {
+    /// The executor cold-starts against the real server: dials, resyncs from
+    /// the real pane set, and opens a real event stream per pane.
+    func testExecutorColdStartsAgainstTheLiveServer() async throws {
+        let path = ProcessInfo.processInfo.environment["HERDR_SOCKET_PATH"]
+            ?? UnixSocketTransport.defaultPath()
+        try XCTSkipIf(!FileManager.default.fileExists(atPath: path), "no live herdr server")
+
+        let client = HerdrClient(transport: UnixSocketTransport(path: path))
+        let transport = LiveHerdrTransport(client: client)
+        let executor = RecoveryExecutor(transport: transport)
+        await executor.start()
+
+        let deadline = Date().addingTimeInterval(10)
+        var subscribed: Set<String> = []
+        while Date() < deadline {
+            subscribed = await executor.subscribedPanes
+            if !subscribed.isEmpty { break }
+            try? await Task.sleep(nanoseconds: 100_000_000)
+        }
+
+        let known = await executor.knownPanes
+        XCTAssertFalse(known.isEmpty, "the live resync must discover the real panes")
+        XCTAssertEqual(subscribed, known, "every discovered pane must carry a live stream")
+        let connected = await executor.isConnected
+        XCTAssertTrue(connected)
+
+        // Teardown so the suite leaves no streams behind on the live server.
+        await executor.handle(.backgrounded(at: Date()))
+    }
+}

--- a/Tests/HerdrKitTests/RecoveryExecutorTests.swift
+++ b/Tests/HerdrKitTests/RecoveryExecutorTests.swift
@@ -47,6 +47,33 @@ final class ScriptedTransport: ExecutorTransport, @unchecked Sendable {
         terminate?()
     }
 
+    /// A MISBEHAVING transport: fires the SAME registration's termination
+    /// twice, which the executor's once-latch must reduce to one death.
+    func killStreamTwice(_ pane: String) {
+        lock.lock()
+        let terminate = terminators.removeValue(forKey: pane)
+        lock.unlock()
+        terminate?()
+        terminate?()
+    }
+
+    /// One-shot, SELF-RELEASING close stall.
+    ///
+    /// Self-releasing because a test-controlled release deadlocks: the test
+    /// awaits the interleaving event, that event parks inside the stalled
+    /// closeAll, and the release never runs because the test is still awaiting.
+    /// My first version did exactly that and hung the suite.
+    private var closeStallSeconds: TimeInterval = 0
+    func stallFirstClose(_ seconds: TimeInterval) {
+        lock.lock(); closeStallSeconds = seconds; lock.unlock()
+    }
+    private func takeCloseStall() -> TimeInterval {
+        lock.lock(); defer { lock.unlock() }
+        let seconds = closeStallSeconds
+        closeStallSeconds = 0
+        return seconds
+    }
+
     func connect(for attempt: AttemptID) async throws {
         record(.connect(attempt))
         if failConnects { throw TransportError.closedBeforeResponse }
@@ -67,7 +94,11 @@ final class ScriptedTransport: ExecutorTransport, @unchecked Sendable {
         lock.lock(); terminators[pane] = onTermination; lock.unlock()
     }
 
-    func closeAll(for attempt: AttemptID) async { record(.closeAll(attempt)) }
+    func closeAll(for attempt: AttemptID) async {
+        let stall = takeCloseStall()
+        if stall > 0 { try? await Task.sleep(nanoseconds: UInt64(stall * 1_000_000_000)) }
+        record(.closeAll(attempt))
+    }
     func discard(attempt: AttemptID) async { record(.discard(attempt)) }
 }
 
@@ -93,11 +124,10 @@ final class RecoveryExecutorTests: XCTestCase {
     /// THE HAPPY PATH, asserted on the operation ORDER: dial, resync, then
     /// streams — and every stream open comes AFTER the snapshot fetch.
     ///
-    /// CONDITION 4 lives here: resync-before-subscribe is documented as
-    /// load-bearing, so this test must FAIL when the order is swapped. It does
-    /// so structurally — subscriptions exist only downstream of `apply` — and
-    /// the mutation reintroducing memory-derived early subscription is run
-    /// against exactly this assertion.
+    /// CONDITION 4's cold-start half. The subscribe-from-memory mutation is
+    /// NOT run against this test — cold-start memory is empty, so it survived
+    /// here vacuously; the reconnect variant below is the armed one the
+    /// mutation kills against. This asserts the happy-path operation order.
     func testColdStartResyncsBeforeAnyStreamOpens() async throws {
         let transport = ScriptedTransport(panes: ["p1", "p2"])
         let executor = RecoveryExecutor(transport: transport)
@@ -166,6 +196,15 @@ final class RecoveryExecutorTests: XCTestCase {
                       "the stale completion must be discarded AT the transport, not only in policy")
         let current = await executor.currentAttempt
         XCTAssertNotEqual(current, retired, "the retired attempt must not have been adopted")
+        // "No work runs on it" is asserted, not narrated: no resync and no
+        // stream may target the discarded attempt after its discard. A mutation
+        // appending a resync for it survived when only the discard was pinned.
+        let ops = transport.log()
+        let discardIndex = ops.firstIndex(of: .discard(retired))!
+        XCTAssertFalse(ops[discardIndex...].contains(.fetchSnapshot(retired)),
+                       "a resync ran on the discarded attempt")
+        XCTAssertFalse(ops[discardIndex...].contains { if case .openStream(_, retired) = $0 { return true }; return false },
+                       "a stream opened on the discarded attempt")
     }
 
     /// CONDITION 1, half two: a subscribe bound to a retired attempt is
@@ -179,7 +218,8 @@ final class RecoveryExecutorTests: XCTestCase {
         let retired = await executor.currentAttempt!
 
         await executor.handle(.networkChanged(at: Date()))
-        _ = await waitUntil { await executor.isConnected }
+        let resettled = await waitUntil { await executor.subscribedPanes == ["p1"] }
+        XCTAssertTrue(resettled, "the replacement never settled; the log below would be mid-flight")
         let streamsBefore = transport.log().filter { if case .openStream = $0 { return true }; return false }.count
 
         // A's delayed plan arrives: a subscribe bound to the retired attempt.
@@ -191,7 +231,10 @@ final class RecoveryExecutorTests: XCTestCase {
         XCTAssertEqual(streamsAfter, streamsBefore, "a retired attempt's subscribe opened a stream")
         let rejections = await executor.rejections
         XCTAssertEqual(rejections.count, 1, "the rejection must be observable, not silent")
-        XCTAssertTrue(rejections[0].reason.contains("retired"))
+        // first?/??, not [0]: when the guard regressed, the empty-array index
+        // trapped with signal 4 and killed the WHOLE suite — a regression must
+        // read as failures the harness can classify, not as a crash.
+        XCTAssertTrue(rejections.first?.reason.contains("retired") ?? false)
     }
 
     /// REQUIREMENT ONE end-to-end: one pane's stream dies; exactly that pane is
@@ -249,6 +292,148 @@ final class RecoveryExecutorTests: XCTestCase {
                        "the loop opened a stream for a retired attempt after its closeAll")
     }
 
+    /// AXIS: a stale plan's reconnect neither dials a retired attempt NOR
+    /// cancels the current attempt's pending dial — the wedge the sweep
+    /// reproduced 4/4: the stale dial's cancel landed on the replacement's
+    /// backoff sleep, the silent cancellation return scheduled nothing, and
+    /// the executor sat wedged with currentAttempt set and no dial in flight.
+    func testAStalePlansReconnectCannotWedgeTheExecutor() async throws {
+        let transport = ScriptedTransport(panes: ["p1"])
+        let executor = RecoveryExecutor(transport: transport)
+        await executor.start()
+        _ = await waitUntil { await executor.isConnected }
+        let retired = await executor.currentAttempt!
+
+        await executor.handle(.networkChanged(at: Date()))
+        _ = await waitUntil { await executor.isConnected }
+        let current = await executor.currentAttempt!
+        let connectsBefore = transport.log().filter { if case .connect = $0 { return true }; return false }.count
+
+        // The stale plan replays, reconnect bound to the retired attempt.
+        await executor.execute(RecoveryPlan([.reconnect(retired, after: 0)]))
+        try? await Task.sleep(nanoseconds: 300_000_000)
+
+        XCTAssertFalse(transport.log().suffix(from: 0).contains { op in
+            if case .connect(let a) = op { return a == retired } else { return false }
+        } && transport.log().filter { $0 == .connect(retired) }.count > 1,
+        "the retired attempt was re-dialed")
+        let connectsAfter = transport.log().filter { if case .connect = $0 { return true }; return false }.count
+        XCTAssertEqual(connectsAfter, connectsBefore, "a stale reconnect dialed something")
+        let stillCurrent = await executor.currentAttempt
+        XCTAssertEqual(stillCurrent, current, "the stale plan disturbed the current attempt")
+        let rejected = await executor.rejections
+        XCTAssertTrue(rejected.contains { $0.action == "reconnect" }, "the refusal must be observable")
+    }
+
+    /// AXIS: an interleaved replacement's resource claim survives the first
+    /// plan's teardown continuation — cancelTransport keeps closing the RIGHT
+    /// attempt afterwards.
+    ///
+    /// The sweep's 4/4 reproduction: two rapid networkChanged; the first plan's
+    /// post-closeAll continuation unconditionally cleared resourcedAttempt,
+    /// destroying the second plan's claim — after which every teardown closed a
+    /// resource-less attempt while the current one's streams leaked forever.
+    func testAnInterleavedClaimSurvivesTheFirstPlansTeardown() async throws {
+        let transport = ScriptedTransport(panes: ["p1"])
+        let executor = RecoveryExecutor(transport: transport)
+        await executor.start()
+        _ = await waitUntil { await executor.subscribedPanes == ["p1"] }
+
+        transport.stallFirstClose(0.3)   // N1's teardown parks inside closeAll
+        Task { await executor.handle(.networkChanged(at: Date())) }   // N1
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        await executor.handle(.networkChanged(at: Date()))            // N2, unstalled
+        let settled = await waitUntil { await executor.isConnected }
+        XCTAssertTrue(settled, "the replacement never connected")
+        let current = await executor.currentAttempt!
+        // N1's continuation resumes after its stall and writes its clear.
+        try? await Task.sleep(nanoseconds: 500_000_000)
+
+        // The decisive probe: a THIRD teardown must close the CURRENT attempt.
+        await executor.handle(.backgrounded(at: Date()))
+        let closed = await waitUntil {
+            transport.log().contains { $0 == .closeAll(current) }
+        }
+        XCTAssertTrue(closed,
+                      "teardown closed a resource-less attempt while the current one's streams leaked")
+    }
+
+    /// AXIS: the executor HONOURS the policy's backoff — the dial waits exactly
+    /// the drawn delay, pinned through the sleeper seam because wall-clock
+    /// assertions let a delete-the-delay mutation survive 5/5.
+    func testTheDialHonoursThePolicysBackoffDelay() async throws {
+        let transport = ScriptedTransport(panes: ["p1"])
+        transport.failConnects = true
+        let recorder = SleepRecorder()
+        let executor = RecoveryExecutor(
+            recovery: SessionRecovery(), transport: transport,
+            generator: SeededGenerator(seed: 42))
+        await executor.setSleeper { delay in await recorder.record(delay) }
+
+        await executor.start()
+        let reachedSleep = await waitUntil { await recorder.recorded().count >= 1 }
+        XCTAssertTrue(reachedSleep, "the failed dial never reached its backoff sleep")
+
+        let delays = await recorder.recorded()
+        // Deterministic: the seeded generator draws the same jitter every run.
+        var reference = SeededGenerator(seed: 42)
+        let expected = SessionRecovery().backoff(failures: 1, using: &reference)
+        // XCTUnwrap, not `!`: with the delay deleted the assertion above fails
+        // AND the force-unwrap trapped with signal 4, which the mutation
+        // harness reads as INVALID rather than KILLED — a real kill misfiled as
+        // a broken run. Same class the sweep found in the rejection test.
+        let slept = try XCTUnwrap(delays.first, "no delay was recorded")
+        XCTAssertEqual(slept, expected, accuracy: 0.0001,
+                       "the executor slept \(slept)s where the policy drew \(expected)s")
+        XCTAssertGreaterThan(expected, 0, "a zero draw would make this assertion vacuous")
+    }
+
+    /// AXIS: teardown actually reaches the transport — a networkChanged closes
+    /// the attempt that held resources. The executor could previously leak
+    /// every stream with the suite green: nothing pinned closeAll at all.
+    func testTeardownClosesTheResourcedAttemptAtTheTransport() async throws {
+        let transport = ScriptedTransport(panes: ["p1"])
+        let executor = RecoveryExecutor(transport: transport)
+        await executor.start()
+        _ = await waitUntil { await executor.subscribedPanes == ["p1"] }
+        let resourced = await executor.currentAttempt!
+
+        await executor.handle(.networkChanged(at: Date()))
+        XCTAssertTrue(transport.log().contains(.closeAll(resourced)),
+                      "the resourced attempt's streams were never closed at the transport")
+    }
+
+    /// AXIS: a transport double-firing one termination produces ONE death — the
+    /// once-latch enforces the contract the seam previously only stated. The
+    /// probe without it: three opens for one real death, a permanent
+    /// double-subscription the policy cannot dedup without swallowing real
+    /// second deaths.
+    func testADoubleFiredTerminationProducesOneDeath() async throws {
+        let transport = ScriptedTransport(panes: ["p1"])
+        let executor = RecoveryExecutor(transport: transport)
+        await executor.start()
+        _ = await waitUntil { await executor.subscribedPanes == ["p1"] }
+        let attempt = await executor.currentAttempt!
+
+        transport.killStreamTwice("p1")
+        _ = await waitUntil {
+            transport.log().filter { $0 == .openStream("p1", attempt) }.count >= 2
+        }
+        try? await Task.sleep(nanoseconds: 200_000_000)
+
+        XCTAssertEqual(transport.log().filter { $0 == .openStream("p1", attempt) }.count, 2,
+                       "one death must produce exactly one replacement open")
+        let rejections = await executor.rejections
+        XCTAssertTrue(rejections.contains { $0.reason.contains("duplicate termination") },
+                      "the dropped duplicate must be observable")
+    }
+
+actor SleepRecorder {
+    private var delays: [TimeInterval] = []
+    func record(_ delay: TimeInterval) { delays.append(delay) }
+    func recorded() -> [TimeInterval] { delays }
+}
+
     /// A dial that fails schedules the retry through the policy (backoff), and
     /// a network change cancels a pending dial rather than racing it.
     func testAFailedDialRetriesAndACancelledDialDoesNotLand() async throws {
@@ -265,7 +450,10 @@ final class RecoveryExecutorTests: XCTestCase {
         transport.failConnects = false
         await executor.handle(.backgrounded(at: Date()))
         let connectsAtBackground = transport.log().filter { if case .connect = $0 { return true }; return false }.count
-        try? await Task.sleep(nanoseconds: 500_000_000)
+        // Short, and NOT the pin: the deterministic pin is the sleeper-based
+        // test above — this residual window only catches a dial that fires
+        // immediately despite the cancel.
+        try? await Task.sleep(nanoseconds: 200_000_000)
         let connectsAfter = transport.log().filter { if case .connect = $0 { return true }; return false }.count
         XCTAssertEqual(connectsAfter, connectsAtBackground,
                        "a pending dial survived backgrounding: the cancel did not land")
@@ -281,9 +469,14 @@ final class RecoveryExecutorTests: XCTestCase {
 /// connect, snapshot, per-pane streams — is implementable over the actual
 /// wire, not just the scripted fake.
 final class LiveHerdrTransport: ExecutorTransport, @unchecked Sendable {
+    private struct Key: Hashable {
+        let attempt: AttemptID
+        let pane: String
+    }
+
     private let client: HerdrClient
     private let lock = NSLock()
-    private var streams: [String: Task<Void, Never>] = [:]
+    private var streams: [Key: Task<Void, Never>] = [:]
 
     init(client: HerdrClient) { self.client = client }
 
@@ -302,14 +495,25 @@ final class LiveHerdrTransport: ExecutorTransport, @unchecked Sendable {
         let stream = client.subscribe([Subscription(.paneTurnCompleted, paneID: pane)])
         let task = Task {
             do { for try await _ in stream {} } catch {}
+            // A teardown-by-closeAll is not a death: the seam requires that a
+            // stream torn down deliberately fires no termination — the first
+            // version fired on cancellation, so every teardown would have
+            // produced a spurious streamFailed per pane.
+            guard !Task.isCancelled else { return }
             onTermination()
         }
-        lock.lock(); streams[pane] = task; lock.unlock()
+        lock.lock(); streams[Key(attempt: attempt, pane: pane)] = task; lock.unlock()
     }
 
+    /// Attempt-SCOPED, as the seam requires. The first version dropped every
+    /// stream regardless of attempt — `attempt` was unused — which violated
+    /// the very requirement this adapter is cited as proving implementable.
     func closeAll(for attempt: AttemptID) async {
-        lock.lock(); let open = streams; streams = [:]; lock.unlock()
-        for task in open.values { task.cancel() }
+        lock.lock()
+        let mine = streams.filter { $0.key.attempt == attempt }
+        for key in mine.keys { streams.removeValue(forKey: key) }
+        lock.unlock()
+        for task in mine.values { task.cancel() }
     }
 
     func discard(attempt: AttemptID) async { await closeAll(for: attempt) }

--- a/Tests/HerdrKitTests/RecoveryExecutorTests.swift
+++ b/Tests/HerdrKitTests/RecoveryExecutorTests.swift
@@ -157,14 +157,20 @@ final class ScriptedTransport: ExecutorTransport, @unchecked Sendable {
         // from outside — that is the reviewer's interleaving: the death is
         // processed while the call is still suspended, and the call then
         // returns and tries to publish.
-        lock.withLock { terminators[pane, default: []].append(onTermination) }
-        while isStalled(pane) { try? await Task.sleep(nanoseconds: 10_000_000) }
-        record(.openAttempt(pane, attempt))
+        // Both the terminator registration AND the first-open claim happen
+        // BEFORE the stall. Claiming after it made the slot stealable: a
+        // replacement triggered by the death reached the check first, became
+        // "the first open", and published legitimately — the test flaked 1 run
+        // in 4 reporting .open for a reason that had nothing to do with the
+        // guard under test.
         let laterOpen = lock.withLock { () -> Bool in
+            terminators[pane, default: []].append(onTermination)
             guard onlyFirstOpenSucceeds else { return false }
             return !opensSeen.insert(pane).inserted
         }
         if laterOpen { throw TransportError.closedBeforeResponse }
+        while isStalled(pane) { try? await Task.sleep(nanoseconds: 10_000_000) }
+        record(.openAttempt(pane, attempt))
         let succeedThisOnce = lock.withLock { succeedOnceThenKill.remove(pane) != nil }
         if succeedThisOnce {
             record(.openStream(pane, attempt))

--- a/Tests/HerdrKitTests/RecoveryExecutorTests.swift
+++ b/Tests/HerdrKitTests/RecoveryExecutorTests.swift
@@ -85,8 +85,17 @@ final class ScriptedTransport: ExecutorTransport, @unchecked Sendable {
 
     /// Kills a pane's stream from the outside, firing its termination exactly
     /// once — the contract the executor promises the policy.
-    /// Fires the NEWEST registration's termination.
-    func killStream(_ pane: String) {
+    /// How many terminators are currently registered for a pane — an
+    /// observable precondition, so a test can wait for the registration to
+    /// EXIST rather than for a proxy that precedes it.
+    func registrationCount(_ pane: String) -> Int {
+        lock.withLock { terminators[pane]?.count ?? 0 }
+    }
+
+    /// Fires the NEWEST registration's termination. Returns whether one fired:
+    /// a silent no-op kill made a death-race test pass by never racing.
+    @discardableResult
+    func killStream(_ pane: String) -> Bool {
         let terminate = lock.withLock { () -> (@Sendable () -> Void)? in
             guard var list = terminators[pane], !list.isEmpty else { return nil }
             let last = list.removeLast()
@@ -94,6 +103,7 @@ final class ScriptedTransport: ExecutorTransport, @unchecked Sendable {
             return last
         }
         terminate?()
+        return terminate != nil
     }
 
     /// Fires the OLDEST registration's termination — the orphaned-callback case.
@@ -742,24 +752,41 @@ actor SleepRecorder {
         transport.onlyFirstOpenSucceeds = true     // one live registration, no replacements
         transport.stall("p1")                      // the open suspends, terminator registered
         await executor.start()
-        _ = await waitUntil {
-            transport.log().contains { if case .fetchSnapshot = $0 { return true }; return false }
-        }
 
-        // The stream dies while its open is STILL SUSPENDED: the death is
-        // processed on the free actor before the call returns.
-        transport.killStream("p1")
+        // Wait for the REGISTRATION, not a proxy: the reviewer showed that
+        // waiting on fetchSnapshot lets killStream be a silent no-op, after
+        // which releasing the stall publishes a legitimately live stream and
+        // the test passes without ever racing anything.
+        let registered = await waitUntil { transport.registrationCount("p1") > 0 }
+        XCTAssertTrue(registered, "no terminator was ever registered; the race could not happen")
+
+        // The stream dies while its open is STILL SUSPENDED.
+        XCTAssertTrue(transport.killStream("p1"), "the death did not fire; the race did not happen")
         try? await Task.sleep(nanoseconds: 150_000_000)
         transport.release("p1")                    // the original call now returns
         try? await Task.sleep(nanoseconds: 400_000_000)
 
-        // UNCONDITIONAL: the registration that terminated must never publish.
-        // The first version asserted only IF status was .open — vacuous
-        // whenever the bug is absent, and the mutation survived it.
+        // UNCONDITIONAL, and on the FULL status: a terminated registration must
+        // neither publish .open nor erase why the pane is unopenable.
         let status = await executor.paneStatus("p1")
-        guard case .admittedNotOpen = status else {
+        guard case .admittedNotOpen(let attempts, let lastError) = status else {
             return XCTFail("a terminated registration published .open (status: \(status))")
         }
+        XCTAssertEqual(attempts, RecoveryExecutor.openFailureCap,
+                       "exhausted retry state was erased: attempts reported \(attempts)")
+        XCTAssertNotNil(lastError, "the last error was erased with the retry state")
+
+        // And a retained orphan callback must not restart attempts past the cap.
+        let attemptsBefore = transport.log().filter {
+            if case .openAttempt = $0 { return true }; return false
+        }.count
+        transport.killOldestRegistration("p1")
+        try? await Task.sleep(nanoseconds: 250_000_000)
+        let attemptsAfter = transport.log().filter {
+            if case .openAttempt = $0 { return true }; return false
+        }.count
+        XCTAssertEqual(attemptsAfter, attemptsBefore,
+                       "an orphan callback restarted registration past the exhausted cap")
     }
 
     /// THE COORDINATOR'S PAIRED CONTROL: a healthy pane reports `.open` AND a

--- a/Tests/HerdrKitTests/RecoveryExecutorTests.swift
+++ b/Tests/HerdrKitTests/RecoveryExecutorTests.swift
@@ -1220,6 +1220,24 @@ actor SleepRecorder {
         XCTAssertEqual(drained.entries.count, held)
         let afterDrain = await executor.rejections.count
         XCTAssertEqual(afterDrain, 0, "drain must clear")
+
+        // The DROPPED COUNT is half of what drain returns and none of it was
+        // asserted: a mutant returning `dropped: 0`, and a separate one leaving
+        // `droppedRejections` un-reset, both compiled and SURVIVED. The buffer's
+        // whole reason for counting overflow is that a caller can tell how much
+        // diagnostic history it lost — a drain that reports zero losses is the
+        // silent-overflow failure this cap exists to prevent, wearing the
+        // counter as decoration.
+        XCTAssertEqual(drained.dropped, dropped,
+                       "drain reported \(drained.dropped) drops against \(dropped) counted")
+        let droppedAfter = await executor.droppedRejections
+        XCTAssertEqual(droppedAfter, 0, "drain must reset the drop counter, not just the entries")
+
+        // A second drain reports nothing, which is what makes the count a
+        // DELTA since the last drain rather than a running total.
+        let second = await executor.drainRejections()
+        XCTAssertEqual(second.entries.count, 0, "a second drain returned entries")
+        XCTAssertEqual(second.dropped, 0, "a second drain re-reported drops already accounted for")
     }
 
     /// AXIS: failure counters are retired with their attempt — they were one

--- a/Tests/HerdrKitTests/RecoveryExecutorTests.swift
+++ b/Tests/HerdrKitTests/RecoveryExecutorTests.swift
@@ -393,6 +393,40 @@ final class RecoveryExecutorTests: XCTestCase {
 
     /// Asserts an async call throws. XCTAssertThrowsError's autoclosure cannot
     /// carry `await`, which is the same limitation XCTUnwrap has here.
+    /// Runs a catch window's phase-1 open, which must THROW promptly.
+    ///
+    /// Bounded and cancellation-backed, and that is the whole point. The plain
+    /// `expectThrow` awaits the call directly, so a mutation that makes entry 1
+    /// PARK instead of throwing — `claimPhase` returning `phase + 1` compiles
+    /// and does exactly this — suspends the test INSIDE the await, where it can
+    /// no longer reach a release or a cancel. The focused test then ran 30
+    /// seconds and was classified ESCAPED. All five catch-window tests shared
+    /// that shape, so it is fixed once here rather than five times.
+    ///
+    /// Third time a mutation escaped into a hang on this file: a test's
+    /// teardown, then the park itself, now the phase-1 expectation. The lesson
+    /// that keeps recurring is that ESCAPED is not KILLED and reads like it.
+    private func expectPhaseOneThrows(
+        _ transport: ScriptedTransport,
+        _ pane: String,
+        _ window: ScriptedTransport.CatchWindow,
+        _ message: String = "entry 1 must throw; the window is armed on it"
+    ) async {
+        let threw = UncheckedBox<Bool?>(nil)
+        let task = Task {
+            do { try await transport.openStream(pane: pane, for: AttemptID(uuid: UUID())) {}
+                 threw.value = false } catch { threw.value = true }
+        }
+        let settled = await waitUntil(2) { threw.value != nil }
+        if !settled {
+            window.release()          // unwedge whatever it parked on
+            task.cancel()
+        }
+        _ = await task.result
+        XCTAssertTrue(settled, "\(message) — it PARKED instead, which would have hung the suite")
+        XCTAssertEqual(threw.value, true, message)
+    }
+
     private func expectThrow(
         _ message: String, _ body: () async throws -> Void
     ) async {
@@ -694,9 +728,7 @@ final class RecoveryExecutorTests: XCTestCase {
         let window = transport.armCatchPathWindow("p")
 
         // Entry 1 throws (contract: leaves nothing live). Entry 2 must PARK.
-        await expectThrow("entry 1 must throw; the window is armed on it") {
-            try await transport.openStream(pane: "p", for: AttemptID(uuid: UUID())) {}
-        }
+        await expectPhaseOneThrows(transport, "p", window)
         let second = Task { try await transport.openStream(pane: "p", for: AttemptID(uuid: UUID())) {} }
         let parked = await waitUntil { transport.retryIsParked("p") }
         XCTAssertTrue(parked, "the catch window never parked; the test is not armed")
@@ -738,9 +770,7 @@ final class RecoveryExecutorTests: XCTestCase {
             replacement.value = transport.armCatchPathWindow("p")   // re-armed mid-flight
         }
 
-        await expectThrow("entry 1 must throw") {
-            try await transport.openStream(pane: "p", for: AttemptID(uuid: UUID())) {}
-        }
+        await expectPhaseOneThrows(transport, "p", first)
         let retry = Task { try await transport.openStream(pane: "p", for: AttemptID(uuid: UUID())) {} }
 
         let parkedItsOwn = await waitUntil { first.isParked }
@@ -777,9 +807,7 @@ final class RecoveryExecutorTests: XCTestCase {
     func testAStaleReleaseCannotOpenALaterCatchWindow() async throws {
         let transport = ScriptedTransport(panes: ["p"])
         let first = transport.armCatchPathWindow("p")
-        await expectThrow("entry 1 must throw") {
-            try await transport.openStream(pane: "p", for: AttemptID(uuid: UUID())) {}
-        }
+        await expectPhaseOneThrows(transport, "p", first)
         let firstRetry = Task { try await transport.openStream(pane: "p", for: AttemptID(uuid: UUID())) {} }
         _ = await waitUntil { transport.retryIsParked("p") }
         first.release()
@@ -791,9 +819,7 @@ final class RecoveryExecutorTests: XCTestCase {
         // A second window, parked, with the FIRST window's release still in
         // someone's hand.
         let second = transport.armCatchPathWindow("p")
-        await expectThrow("entry 1 of the second window must throw") {
-            try await transport.openStream(pane: "p", for: AttemptID(uuid: UUID())) {}
-        }
+        await expectPhaseOneThrows(transport, "p", second, "entry 1 of the second window must throw")
         let secondRetry = Task { try await transport.openStream(pane: "p", for: AttemptID(uuid: UUID())) {} }
         let parked = await waitUntil { transport.retryIsParked("p") }
         XCTAssertTrue(parked, "the second window never parked; the test is not armed")
@@ -816,9 +842,7 @@ final class RecoveryExecutorTests: XCTestCase {
 
         for round in 1...2 {
             let window = transport.armCatchPathWindow("p")
-            await expectThrow("entry 1 must throw; the window is armed on it") {
-            try await transport.openStream(pane: "p", for: AttemptID(uuid: UUID())) {}
-        }
+            await expectPhaseOneThrows(transport, "p", window)
             let second = Task { try await transport.openStream(pane: "p", for: AttemptID(uuid: UUID())) {} }
             let parked = await waitUntil { transport.retryIsParked("p") }
             XCTAssertTrue(parked, "window \(round) did not park; the previous arm's state leaked into it")

--- a/Tests/HerdrKitTests/RecoveryExecutorTests.swift
+++ b/Tests/HerdrKitTests/RecoveryExecutorTests.swift
@@ -23,12 +23,18 @@ final class ScriptedTransport: ExecutorTransport, @unchecked Sendable {
     private var terminators: [String: @Sendable () -> Void] = [:]
     var panesToServe: [String]
     var failConnects = false
+    /// Every openStream throws — a persistently broken conformer.
+    var failOpens = false
+    /// Installs the callback and THEN throws: the ownership violation the seam
+    /// now forbids, kept as a probe of what the executor does when a conformer
+    /// breaks the contract anyway.
+    var installsThenThrows = false
     /// When set, openStream suspends (a REAL actor suspension, not a thread
     /// block) until the flag clears — the door interleavings walk through.
     private var stalledPanes: Set<String> = []
 
-    func stall(_ pane: String) { lock.lock(); stalledPanes.insert(pane); lock.unlock() }
-    func release(_ pane: String) { lock.lock(); stalledPanes.remove(pane); lock.unlock() }
+    func stall(_ pane: String) { lock.withLock { _ = stalledPanes.insert(pane) } }
+    func release(_ pane: String) { lock.withLock { _ = stalledPanes.remove(pane) } }
     private func isStalled(_ pane: String) -> Bool {
         lock.lock(); defer { lock.unlock() }; return stalledPanes.contains(pane)
     }
@@ -36,23 +42,19 @@ final class ScriptedTransport: ExecutorTransport, @unchecked Sendable {
     init(panes: [String]) { self.panesToServe = panes }
 
     func log() -> [Operation] { lock.lock(); defer { lock.unlock() }; return operations }
-    private func record(_ op: Operation) { lock.lock(); operations.append(op); lock.unlock() }
+    private func record(_ op: Operation) { lock.withLock { operations.append(op) } }
 
     /// Kills a pane's stream from the outside, firing its termination exactly
     /// once — the contract the executor promises the policy.
     func killStream(_ pane: String) {
-        lock.lock()
-        let terminate = terminators.removeValue(forKey: pane)
-        lock.unlock()
+        let terminate = lock.withLock { terminators.removeValue(forKey: pane) }
         terminate?()
     }
 
     /// A MISBEHAVING transport: fires the SAME registration's termination
     /// twice, which the executor's once-latch must reduce to one death.
     func killStreamTwice(_ pane: String) {
-        lock.lock()
-        let terminate = terminators.removeValue(forKey: pane)
-        lock.unlock()
+        let terminate = lock.withLock { terminators.removeValue(forKey: pane) }
         terminate?()
         terminate?()
     }
@@ -65,7 +67,7 @@ final class ScriptedTransport: ExecutorTransport, @unchecked Sendable {
     /// My first version did exactly that and hung the suite.
     private var closeStallSeconds: TimeInterval = 0
     func stallFirstClose(_ seconds: TimeInterval) {
-        lock.lock(); closeStallSeconds = seconds; lock.unlock()
+        lock.withLock { closeStallSeconds = seconds }
     }
     private func takeCloseStall() -> TimeInterval {
         lock.lock(); defer { lock.unlock() }
@@ -90,8 +92,12 @@ final class ScriptedTransport: ExecutorTransport, @unchecked Sendable {
         onTermination: @escaping @Sendable () -> Void
     ) async throws {
         while isStalled(pane) { try? await Task.sleep(nanoseconds: 10_000_000) }
+        if failOpens {
+            if installsThenThrows { lock.withLock { terminators[pane] = onTermination } }
+            throw TransportError.closedBeforeResponse
+        }
         record(.openStream(pane, attempt))
-        lock.lock(); terminators[pane] = onTermination; lock.unlock()
+        lock.withLock { terminators[pane] = onTermination }
     }
 
     func closeAll(for attempt: AttemptID) async {
@@ -434,6 +440,137 @@ actor SleepRecorder {
     func recorded() -> [TimeInterval] { delays }
 }
 
+    /// AXIS: a teardown completing WHILE an open is in flight leaves no stream
+    /// registered for the retired attempt — the recheck-and-reap after the
+    /// await, which the pre-await guard structurally cannot cover.
+    ///
+    /// The earlier mid-loop regression missed this: it asserted the SECOND pane
+    /// stayed closed, while the first pane's registration was recorded after
+    /// closeAll and unexamined.
+    func testAnOpenCompletingAfterTeardownIsReaped() async throws {
+        let transport = ScriptedTransport(panes: ["only"])
+        let executor = RecoveryExecutor(transport: transport)
+        transport.stall("only")                       // the open suspends
+        await executor.start()
+        _ = await waitUntil {
+            transport.log().contains { if case .fetchSnapshot = $0 { return true }; return false }
+        }
+        let retired = await executor.currentAttempt!
+
+        await executor.handle(.networkChanged(at: Date()))   // teardown completes
+        transport.release("only")                            // the open lands late
+
+        let reaped = await waitUntil {
+            let ops = transport.log()
+            guard let open = ops.firstIndex(of: .openStream("only", retired)) else { return false }
+            return ops[open...].contains(.closeAll(retired))
+        }
+        XCTAssertTrue(reaped,
+                      "a stream published for the retired attempt after its teardown was never reaped")
+        let rejected = await executor.rejections
+        XCTAssertTrue(rejected.contains { $0.reason.contains("reaped") }, "the reap must be observable")
+    }
+
+    /// AXIS: a persistently failing openStream cannot spin — the failure count
+    /// caps the retries and the pane is left visibly unsubscribed.
+    ///
+    /// Without the cap: an open that throws becomes streamFailed, the policy
+    /// re-admits, the re-admission opens again — an unbounded, delay-free loop
+    /// that saturates the actor. Deterministic here: the transport always
+    /// throws, and the sleeper is recorded rather than slept.
+    func testAPersistentlyFailingOpenCannotSpin() async throws {
+        let transport = ScriptedTransport(panes: ["bad"])
+        transport.failOpens = true
+        let recorder = SleepRecorder()
+        let executor = RecoveryExecutor(transport: transport)
+        await executor.setSleeper { delay in await recorder.record(delay) }
+        await executor.start()
+
+        let capped = await waitUntil(8) {
+            await executor.rejections.contains { $0.reason.contains("left unsubscribed") }
+        }
+        XCTAssertTrue(capped, "the retry loop never hit its cap")
+
+        let backoffs = await recorder.recorded()
+        XCTAssertGreaterThan(backoffs.count, 0, "retries must be delayed, not immediate")
+        XCTAssertTrue(backoffs.allSatisfy { $0 > 0 })
+        XCTAssertLessThanOrEqual(backoffs.count, RecoveryExecutor.openFailureCap,
+                                 "retries exceeded the cap: \(backoffs.count) attempts")
+
+        // KNOWN GAP, asserted so it cannot change silently and ESCALATED rather
+        // than fixed here: the ledger still lists the pane, because admission
+        // happens at observe time and records intent, not an open stream. The
+        // pane therefore reads as subscribed while nothing is watching it —
+        // the silence class this task exists to remove, one level in. Closing
+        // it means the policy distinguishing admitted-from-open, which is a
+        // POLICY change and belongs in its own review round (condition 2).
+        let subscribed = await executor.subscribedPanes
+        XCTAssertTrue(subscribed.contains("bad"),
+                      "documented gap changed: the ledger no longer lists an unopenable pane — if this now fails, the policy gained admitted-vs-open and this test should assert the better behaviour")
+    }
+
+    /// AXIS: a conformer that violates the seam — installing a callback and
+    /// THEN throwing — cannot make the executor open a third stream when that
+    /// orphaned callback finally fires.
+    ///
+    /// The seam now forbids this outright; the test records what happens when a
+    /// conformer breaks the contract anyway, because "requirement on the
+    /// conformer" is only as strong as what the executor does when it is
+    /// violated.
+    func testAnOrphanedCallbackFromAFailedRegistrationCannotStackStreams() async throws {
+        let transport = ScriptedTransport(panes: ["p1"])
+        transport.failOpens = true
+        transport.installsThenThrows = true
+        let executor = RecoveryExecutor(transport: transport)
+        await executor.setSleeper { _ in }
+        await executor.start()
+        _ = await waitUntil(8) {
+            await executor.rejections.contains { $0.reason.contains("left unsubscribed") }
+        }
+
+        // The orphaned callback from a failed registration fires late.
+        transport.killStream("p1")
+        try? await Task.sleep(nanoseconds: 200_000_000)
+
+        // The decisive property: a contract-violating conformer cannot make
+        // the executor STACK streams. No open ever succeeded, so none may be
+        // recorded, whatever the orphaned callback does.
+        let opens = transport.log().filter { if case .openStream = $0 { return true }; return false }.count
+        XCTAssertEqual(opens, 0, "an orphaned callback caused an open; \(opens) recorded")
+        let rejections = await executor.rejections
+        XCTAssertTrue(rejections.contains { $0.reason.contains("left unsubscribed") },
+                      "the cap must still bound a contract-violating conformer")
+    }
+
+    /// AXIS: the diagnostics buffer is bounded and drainable — append-only was
+    /// a slow leak on a long-running client, where stale plans and duplicate
+    /// callbacks are rare but unbounded over days.
+    func testRejectionsAreBoundedAndDrainable() async throws {
+        let transport = ScriptedTransport(panes: ["p1"])
+        let executor = RecoveryExecutor(transport: transport)
+        await executor.start()
+        _ = await waitUntil { await executor.isConnected }
+        let retired = await executor.currentAttempt!
+        await executor.handle(.networkChanged(at: Date()))
+        _ = await waitUntil { await executor.isConnected }
+
+        // More stale plans than the buffer holds.
+        for _ in 0..<(RecoveryExecutor.rejectionCapacity + 20) {
+            await executor.execute(RecoveryPlan([.subscribe(["p1"], on: retired)]))
+        }
+
+        let held = await executor.rejections.count
+        XCTAssertLessThanOrEqual(held, RecoveryExecutor.rejectionCapacity,
+                                 "the buffer grew past its cap: \(held)")
+        let dropped = await executor.droppedRejections
+        XCTAssertGreaterThan(dropped, 0, "overflow must be counted, not silent")
+
+        let drained = await executor.drainRejections()
+        XCTAssertEqual(drained.entries.count, held)
+        let afterDrain = await executor.rejections.count
+        XCTAssertEqual(afterDrain, 0, "drain must clear")
+    }
+
     /// A dial that fails schedules the retry through the policy (backoff), and
     /// a network change cancels a pending dial rather than racing it.
     func testAFailedDialRetriesAndACancelledDialDoesNotLand() async throws {
@@ -477,6 +614,7 @@ final class LiveHerdrTransport: ExecutorTransport, @unchecked Sendable {
     private let client: HerdrClient
     private let lock = NSLock()
     private var streams: [Key: Task<Void, Never>] = [:]
+    private var tornDown: Set<AttemptID> = []
 
     init(client: HerdrClient) { self.client = client }
 
@@ -502,17 +640,28 @@ final class LiveHerdrTransport: ExecutorTransport, @unchecked Sendable {
             guard !Task.isCancelled else { return }
             onTermination()
         }
-        lock.lock(); streams[Key(attempt: attempt, pane: pane)] = task; lock.unlock()
+        // Registered under the lock, and reaped immediately if a teardown for
+        // this attempt already ran — the same register-after-close window the
+        // executor closes on its side; a conformer must not leave one either.
+        let key = Key(attempt: attempt, pane: pane)
+        let stillWanted = lock.withLock { () -> Bool in
+            guard !tornDown.contains(attempt) else { return false }
+            streams[key] = task
+            return true
+        }
+        if !stillWanted { task.cancel() }
     }
 
     /// Attempt-SCOPED, as the seam requires. The first version dropped every
     /// stream regardless of attempt — `attempt` was unused — which violated
     /// the very requirement this adapter is cited as proving implementable.
     func closeAll(for attempt: AttemptID) async {
-        lock.lock()
-        let mine = streams.filter { $0.key.attempt == attempt }
-        for key in mine.keys { streams.removeValue(forKey: key) }
-        lock.unlock()
+        let mine = lock.withLock { () -> [Key: Task<Void, Never>] in
+            tornDown.insert(attempt)
+            let matching = streams.filter { $0.key.attempt == attempt }
+            for key in matching.keys { streams.removeValue(forKey: key) }
+            return matching
+        }
         for task in mine.values { task.cancel() }
     }
 

--- a/Tests/HerdrKitTests/RecoveryExecutorTests.swift
+++ b/Tests/HerdrKitTests/RecoveryExecutorTests.swift
@@ -9,6 +9,18 @@ import XCTest
 /// snapshot that races a reconnect. The log is the test surface — assertions
 /// read the ORDER of operations, because ordering is what the coordinator made
 /// an acceptance criterion.
+/// A lock-guarded mutable cell, so a @Sendable hook can hand a value back to the
+/// test that installed it.
+final class UncheckedBox<T>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var stored: T
+    init(_ value: T) { stored = value }
+    var value: T {
+        get { lock.withLock { stored } }
+        set { lock.withLock { stored = newValue } }
+    }
+}
+
 final class ScriptedTransport: ExecutorTransport, @unchecked Sendable {
     enum Operation: Equatable {
         case connect(AttemptID)
@@ -131,13 +143,33 @@ final class ScriptedTransport: ExecutorTransport, @unchecked Sendable {
     }
     /// 0 = not armed for this pane, 1 = the throwing first open, 2 = the retry
     /// that parks, 3+ = pass through.
-    private func catchPathPhase(_ pane: String) -> Int {
+    /// Classifies the entry AND captures the window it belongs to, under ONE
+    /// lock acquisition.
+    ///
+    /// They were two operations, and that was the last shared-slot race in this
+    /// seam: an invocation could classify as phase 2 against arm N, lose the
+    /// lock, and then look up `catchWindows[pane]` after arm N+1 had replaced
+    /// it — parking the NEW window. `retryIsParked` then answered true for a
+    /// window nothing had legitimately parked, so the seam tests could report
+    /// armed while the parked open belonged to a dead arm. Probe failed 6/6.
+    ///
+    /// Third variant of one mistake on this seam: shared per-pane state read at
+    /// a different moment than it was decided on. Generation numbers fixed the
+    /// value, objects fixed the identity, and this fixes the ATOMICITY — the
+    /// phase decision and the thing it applies to now cannot be separated.
+    private func catchPathStep(_ pane: String) -> (phase: Int, window: CatchWindow?) {
         lock.withLock {
-            guard catchWindows[pane] != nil else { return 0 }
+            guard let window = catchWindows[pane] else { return (0, nil) }
             catchPhase[pane, default: 0] += 1
-            return catchPhase[pane] ?? 0
+            return (catchPhase[pane] ?? 0, window)
         }
     }
+
+    /// Fires between phase classification and the park, so a test can re-arm in
+    /// that gap. Exists only to prove the classification and the window are
+    /// bound atomically — without it, the binding is untestable, because a
+    /// correct implementation has no observable gap to aim at.
+    var afterPhaseClassification: (@Sendable (Int) -> Void)?
 
     /// How many times `openStream` has been ENTERED for this pane, counted
     /// independently of how many terminators are live.
@@ -300,16 +332,18 @@ final class ScriptedTransport: ExecutorTransport, @unchecked Sendable {
         // dead third outcome 1 in 11 — a mutant escaping into a timeout is
         // indistinguishable from a mutant that was killed, so the race
         // corrupted the mutation evidence, not just the test.
-        let phase = catchPathPhase(pane)
+        let step = catchPathStep(pane)
+        afterPhaseClassification?(step.phase)
+        let phase = step.phase
         if phase == 1 {
             dropOwnRegistration(pane)      // the contract: a throwing open leaves nothing live
             throw TransportError.closedBeforeResponse
         }
         if phase == 2 {
-            // The parked open holds a REFERENCE to its own window. Nothing
-            // consults per-pane state to decide whether it may proceed, so no
-            // later arm and no delayed release aimed elsewhere can reach it.
-            let window = lock.withLock { catchWindows[pane] }
+            // The window came back WITH the phase decision, from the same lock
+            // acquisition. Re-reading `catchWindows[pane]` here is the defect
+            // this replaced — by this point a re-arm may have swapped it.
+            let window = step.window
             window?.setParked(true)
             while !(window?.isReleased ?? true) {
                 try? await Task.sleep(nanoseconds: 10_000_000)
@@ -678,6 +712,53 @@ final class RecoveryExecutorTests: XCTestCase {
 
         window.release()
         _ = await second.result
+    }
+
+    /// AXIS: an invocation that classified against one arm parks THAT arm's
+    /// window, even if a replacement is armed before it reaches the park.
+    ///
+    /// The last of three shared-slot defects in this seam, and the one that
+    /// made the other seam tests untrustworthy rather than merely wrong: with
+    /// the classification and the window read separately, an open belonging to
+    /// a dead arm could park the live window, so `retryIsParked` answered true
+    /// for a window nothing had legitimately parked. Every test asserting "a
+    /// window parks" was satisfiable that way.
+    ///
+    /// Needs the `afterPhaseClassification` hook, because a correct
+    /// implementation has no observable gap between the two operations — the
+    /// hook manufactures the only moment at which the question can be asked.
+    func testAnInFlightOpenParksItsOwnArmNotAReplacement() async throws {
+        let transport = ScriptedTransport(panes: ["p"])
+        let first = transport.armCatchPathWindow("p")
+
+        let replacement = UncheckedBox<ScriptedTransport.CatchWindow?>(nil)
+        transport.afterPhaseClassification = { @Sendable phase in
+            guard phase == 2, replacement.value == nil else { return }
+            replacement.value = transport.armCatchPathWindow("p")   // re-armed mid-flight
+        }
+
+        await expectThrow("entry 1 must throw") {
+            try await transport.openStream(pane: "p", for: AttemptID(uuid: UUID())) {}
+        }
+        let retry = Task { try await transport.openStream(pane: "p", for: AttemptID(uuid: UUID())) {} }
+
+        let parkedItsOwn = await waitUntil { first.isParked }
+        XCTAssertTrue(parkedItsOwn, "the in-flight open did not park the arm it classified against")
+        let second = try XCTUnwrap(replacement.value, "the hook never re-armed; the race was not staged")
+        XCTAssertFalse(second.isParked, "the in-flight open parked a window armed after it")
+        XCTAssertFalse(transport.retryIsParked("p"),
+                       "retryIsParked reported the CURRENT window as parked; it is not, and every "
+                       + "seam test asserting 'a window parks' would pass for this wrong reason")
+
+        // Release EVERY window this test armed, not just the one it expects to
+        // be parked. Releasing only `first` made the mutant HANG instead of
+        // fail: with the defect the open parks the replacement, so the awaited
+        // task never returned and the harness reported ESCAPED. A hang is not a
+        // kill — same lesson as a crash not being a kill, one axis over. A test
+        // that stages a race has to be able to tear down either outcome.
+        first.release()
+        replacement.value?.release()
+        _ = await retry.result
     }
 
     /// AXIS: a release created for an EARLIER window cannot open a later one,

--- a/Tests/HerdrKitTests/RecoveryExecutorTests.swift
+++ b/Tests/HerdrKitTests/RecoveryExecutorTests.swift
@@ -23,6 +23,15 @@ final class ScriptedTransport: ExecutorTransport, @unchecked Sendable {
     private var terminators: [String: @Sendable () -> Void] = [:]
     var panesToServe: [String]
     var failConnects = false
+    /// When set, openStream suspends (a REAL actor suspension, not a thread
+    /// block) until the flag clears — the door interleavings walk through.
+    private var stalledPanes: Set<String> = []
+
+    func stall(_ pane: String) { lock.lock(); stalledPanes.insert(pane); lock.unlock() }
+    func release(_ pane: String) { lock.lock(); stalledPanes.remove(pane); lock.unlock() }
+    private func isStalled(_ pane: String) -> Bool {
+        lock.lock(); defer { lock.unlock() }; return stalledPanes.contains(pane)
+    }
 
     init(panes: [String]) { self.panesToServe = panes }
 
@@ -53,6 +62,7 @@ final class ScriptedTransport: ExecutorTransport, @unchecked Sendable {
         pane: String, for attempt: AttemptID,
         onTermination: @escaping @Sendable () -> Void
     ) async throws {
+        while isStalled(pane) { try? await Task.sleep(nanoseconds: 10_000_000) }
         record(.openStream(pane, attempt))
         lock.lock(); terminators[pane] = onTermination; lock.unlock()
     }
@@ -206,6 +216,37 @@ final class RecoveryExecutorTests: XCTestCase {
                        "exactly ONE stream open may follow one death — \(opensAfter.count - opensBefore.count) did")
         XCTAssertEqual(transport.log().filter { $0 == .openStream("p1", attempt) }.count, 1,
                        "the living pane's stream must be untouched")
+    }
+
+    /// AXIS: a retirement interleaving MID-LOOP stops the remaining streams —
+    /// the binding holds per pane, not merely at the loop's door.
+    ///
+    /// The actor suspends at every openStream await. The binding was checked
+    /// once before the loop, so a networkChanged arriving while pane 1's open
+    /// was suspended let pane 2 open for the RETIRED attempt — after closeAll
+    /// had already run for it, so the late stream was an orphan nothing would
+    /// ever close.
+    func testARetirementMidSubscribeLoopStopsTheRemainingStreams() async throws {
+        let transport = ScriptedTransport(panes: ["a-first", "b-second"])
+        let executor = RecoveryExecutor(transport: transport)
+        transport.stall("a-first")             // pane 1 suspends inside its open
+        await executor.start()
+
+        _ = await waitUntil {
+            transport.log().contains { if case .fetchSnapshot = $0 { return true }; return false }
+        }
+        let attemptA = await executor.currentAttempt!
+
+        // While the loop is suspended on pane 1, the world moves.
+        await executor.handle(.networkChanged(at: Date()))
+        transport.release("a-first")
+
+        // Give A's loop every chance to finish; B's own subscribes are for
+        // attempt B and do not confound the assertion.
+        try? await Task.sleep(nanoseconds: 300_000_000)
+
+        XCTAssertFalse(transport.log().contains { $0 == .openStream("b-second", attemptA) },
+                       "the loop opened a stream for a retired attempt after its closeAll")
     }
 
     /// A dial that fails schedules the retry through the policy (backoff), and

--- a/Tests/HerdrKitTests/RecoveryExecutorTests.swift
+++ b/Tests/HerdrKitTests/RecoveryExecutorTests.swift
@@ -99,6 +99,42 @@ final class ScriptedTransport: ExecutorTransport, @unchecked Sendable {
             return openCounts[pane] ?? 0
         }
     }
+
+    /// How many times `openStream` has been ENTERED for this pane, counted
+    /// independently of how many terminators are live.
+    ///
+    /// The two are not the same number and conflating them cost a whole round.
+    /// `registrationCount` was serving as "how many opens have happened", which
+    /// is only true if a throwing open leaves its registration behind — the
+    /// exact thing `ExecutorTransport` forbids. So the precondition was reading
+    /// evidence that existed only because the fake broke the contract under
+    /// test: fix the fake and the count silently drops to 1 and the window
+    /// never arms. Entry count answers the question directly and stays correct
+    /// whether an open throws, stalls, or succeeds.
+    private var openEntries: [String: Int] = [:]
+    func openEntryCount(_ pane: String) -> Int { lock.withLock { openEntries[pane] ?? 0 } }
+
+    /// Whether the pane's open is CURRENTLY parked in the stall.
+    ///
+    /// Stronger than the entry count as a precondition, and the difference is a
+    /// real race rather than a nicety: the entry count is incremented at the top
+    /// of `openStream`, the stall is inserted further down, and a test that
+    /// observed the count could call `release` in between — removing a stall
+    /// that had not been inserted yet. The open then parked forever and the
+    /// test timed out having proven nothing (1 run in 5). Observing the stall
+    /// itself cannot be early by construction.
+    func retryIsParked(_ pane: String) -> Bool { lock.withLock { stalledPanes.contains(pane) } }
+
+    /// Drops the registration this call made, so a throwing open leaves none.
+    /// Deliberately NOT applied on the `installsThenThrows` path: that one
+    /// exists to break the contract on purpose.
+    private func dropOwnRegistration(_ pane: String) {
+        lock.withLock {
+            guard var list = terminators[pane], !list.isEmpty else { return }
+            list.removeLast()
+            terminators[pane] = list
+        }
+    }
     private func isStalled(_ pane: String) -> Bool {
         lock.lock(); defer { lock.unlock() }; return stalledPanes.contains(pane)
     }
@@ -199,17 +235,25 @@ final class ScriptedTransport: ExecutorTransport, @unchecked Sendable {
         // in 4 reporting .open for a reason that had nothing to do with the
         // guard under test.
         let laterOpen = lock.withLock { () -> Bool in
+            openEntries[pane, default: 0] += 1
             terminators[pane, default: []].append(onTermination)
             guard onlyFirstOpenSucceeds else { return false }
             return !opensSeen.insert(pane).inserted
         }
+        // NOT contract-abiding, and deliberately so — like `installsThenThrows`,
+        // `onlyFirstOpenSucceeds` is a probe of what the executor does when a
+        // conformer RETAINS a callback it promised to drop. The orphan IS the
+        // observable in the false-open test; dropping it here made that test's
+        // precondition read 0 registrations and the hazard vanish.
         if laterOpen { throw TransportError.closedBeforeResponse }
         // Armed catch-path window: throw the first time, stall every time
         // after. Both decisions happen AFTER the terminator registration
         // above, so `registrationCount` counts opens ENTERED — which is what
         // lets a test wait for the retry to exist rather than for a proxy.
         switch catchPathPhase(pane) {
-        case 1: throw TransportError.closedBeforeResponse
+        case 1:
+            dropOwnRegistration(pane)      // the contract: a throwing open leaves nothing live
+            throw TransportError.closedBeforeResponse
         case let phase where phase >= 2: lock.withLock { _ = stalledPanes.insert(pane) }
         default: break
         }
@@ -231,6 +275,8 @@ final class ScriptedTransport: ExecutorTransport, @unchecked Sendable {
         if failOpens || lock.withLock({ failingPanes.contains(pane) }) {
             if installsThenThrows {
                 lock.withLock { terminators[pane, default: []].append(onTermination) }
+            } else {
+                dropOwnRegistration(pane)
             }
             throw TransportError.closedBeforeResponse
         }
@@ -301,8 +347,21 @@ final class RecoveryExecutorTests: XCTestCase {
         let executor = RecoveryExecutor(transport: transport)
         await executor.start()
 
-        let settled = await waitUntil { await executor.subscribedPanes == ["p1", "p2"] }
-        XCTAssertTrue(settled, "the cold start never reached full subscription")
+        // Settle on the TRANSPORT LOG, which is what every assertion below
+        // reads, rather than on the ledger. The ledger records a subscription
+        // before the transport finishes opening it, so waiting on
+        // subscribedPanes could return with only p1's openStream logged — the
+        // final set assertion then failed about 1 run in 5. Same shape as the
+        // precondition defects reviewed out of this file: the wait observed
+        // something that PRECEDES what the assertion inspects.
+        let settled = await waitUntil {
+            Set(transport.log().compactMap { if case .openStream(let p, _) = $0 { return p }; return nil })
+                == ["p1", "p2"]
+        }
+        XCTAssertTrue(settled, "the cold start never opened both streams")
+        let ledger = await executor.subscribedPanes
+        XCTAssertEqual(ledger, ["p1", "p2"],
+                       "the ledger disagrees with the streams actually opened")
 
         let ops = transport.log()
         guard case .connect(let attempt) = ops.first else {
@@ -490,14 +549,30 @@ final class RecoveryExecutorTests: XCTestCase {
         transport.armCatchPathWindow("a-fails")   // open 1 throws, open 2 stalls
         await executor.start()
 
-        // The window is ENTERED when the replacement open exists: registration
-        // 1 is the throwing open, 2 is the retry the policy dialed from inside
+        // The window is ENTERED when the replacement open exists: entry 1 is the
+        // throwing open, entry 2 is the retry the policy dialed from inside
         // handle(.streamFailed), and the retry stalls immediately after
-        // registering. Two registrations therefore prove the outer loop is
-        // parked in its catch — the precondition the whole test rests on.
-        let inWindow = await waitUntil { transport.registrationCount("a-fails") >= 2 }
+        // entering. Two ENTRIES therefore prove the outer loop is parked in its
+        // catch — the precondition the whole test rests on.
+        //
+        // Counted as entries, not live registrations. The first version waited
+        // on registrationCount >= 2, which only reached 2 because the fake
+        // registered a terminator and then threw — the one thing
+        // ExecutorTransport forbids a throwing open to do. Making the fake obey
+        // its own contract dropped that count to 1 and the window stopped
+        // arming: the precondition had been reading an artifact of the
+        // violation rather than the retry it named.
+        let inWindow = await waitUntil { transport.retryIsParked("a-fails") }
         XCTAssertTrue(inWindow,
                       "the failed open never produced a replacement; the catch-path window never opened")
+        XCTAssertGreaterThanOrEqual(transport.openEntryCount("a-fails"), 2,
+                                    "parked without a second entry: the stall is not the retry's")
+        // Two entries, exactly ONE live registration: the stalled retry's. The
+        // throwing first open left nothing behind, which is the seam contract
+        // holding — and asserting it here is what stops this precondition from
+        // silently going back to counting orphans.
+        XCTAssertEqual(transport.registrationCount("a-fails"), 1,
+                       "expected only the stalled retry to hold a registration; the throwing open left an orphan")
         let attemptAOptional = await executor.currentAttempt
         let attemptA = try XCTUnwrap(attemptAOptional)
 
@@ -505,9 +580,18 @@ final class RecoveryExecutorTests: XCTestCase {
         await executor.handle(.networkChanged(at: Date()))
         transport.release("a-fails")
 
-        try? await Task.sleep(nanoseconds: 300_000_000)
-
-        XCTAssertFalse(transport.log().contains { $0 == .openAttempt("z-must-not-open", attemptA) },
+        // Settle on an OUTCOME, not on elapsed time. A fixed sleep let the
+        // guard-removal mutant pass 1 run in 9: the negative assertion was
+        // inspected before the faulty outer loop had resumed, so "no forbidden
+        // open yet" and "no forbidden open ever" were indistinguishable. Wait
+        // until one of the two mutually exclusive outcomes is observable.
+        let forbidden: () -> Bool = { transport.log().contains { $0 == .openAttempt("z-must-not-open", attemptA) } }
+        let settled = await waitUntil {
+            if forbidden() { return true }
+            return await executor.rejections.contains { $0.reason.contains("attempt retired while handling an open failure") }
+        }
+        XCTAssertTrue(settled, "neither outcome was reached; the test proved nothing either way")
+        XCTAssertFalse(forbidden(),
                        "the loop resumed from its catch and opened a stream for a retired attempt")
     }
 
@@ -528,17 +612,29 @@ final class RecoveryExecutorTests: XCTestCase {
         let transport = ScriptedTransport(panes: ["p"])
         let executor = RecoveryExecutor(transport: transport)
         transport.failingPanes = ["p"]           // every open throws -> a retry is dialed
-        await executor.start()
 
         // Park the backoff instead of sleeping it: the retry's suspension has
         // to be held open long enough to retire the attempt underneath it, and
         // wall-clock timing cannot pin that without flaking.
+        //
+        // Installed BEFORE start(), and selective on the delay. Installing it
+        // after start() raced the executor's own first backoff, which then ran
+        // on the REAL sleeper and burned a retry before the seam existed — the
+        // test saw 2 opens where it asserted 1, intermittently. Selective
+        // because `dial` shares this seam: parking every call would park the
+        // initial connect and nothing would ever happen. 0.25 is failures(1) *
+        // 0.25, the first pane-retry backoff and the only delay under test.
         let parked = Signal()
         let release = Signal()
-        await executor.setSleeper { _ in
+        await executor.setSleeper { delay in
+            guard delay == 0.25 else {
+                try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                return
+            }
             parked.fire()
             await release.wait()
         }
+        await executor.start()
 
         // Entering the backoff is the precondition, and it is observed rather
         // than assumed: it can only be reached after the first open threw and
@@ -554,10 +650,16 @@ final class RecoveryExecutorTests: XCTestCase {
         await executor.handle(.networkChanged(at: Date()))
         release.fire()
 
-        try? await Task.sleep(nanoseconds: 300_000_000)
-
-        let opensAfter = transport.log().filter { $0 == .openAttempt("p", attemptA) }.count
-        XCTAssertEqual(opensAfter, 1,
+        // Same reasoning as the catch-path regression: settle on whichever
+        // outcome occurs rather than on a fixed duration, so a slow resume
+        // cannot be read as a passing guard.
+        let opensFor: () -> Int = { transport.log().filter { $0 == .openAttempt("p", attemptA) }.count }
+        let settled = await waitUntil {
+            if opensFor() > 1 { return true }
+            return await executor.rejections.contains { $0.reason.contains("attempt retired during retry backoff") }
+        }
+        XCTAssertTrue(settled, "neither outcome was reached; the test proved nothing either way")
+        XCTAssertEqual(opensFor(), 1,
                        "the retry woke from its backoff and opened a channel for a retired attempt")
     }
 

--- a/Tests/HerdrKitTests/RecoveryExecutorTests.swift
+++ b/Tests/HerdrKitTests/RecoveryExecutorTests.swift
@@ -52,7 +52,13 @@ final class ScriptedTransport: ExecutorTransport, @unchecked Sendable {
     private var stalledPanes: Set<String> = []
 
     func stall(_ pane: String) { lock.withLock { _ = stalledPanes.insert(pane) } }
-    func release(_ pane: String) { lock.withLock { _ = stalledPanes.remove(pane) } }
+    /// Releases both gates: the shared pane stall and the catch window's own.
+    /// The catch release is LATCHED rather than a removal — a removal can be
+    /// undone by a later insert, which is precisely how the replacement attempt
+    /// re-armed a gate the test had already opened.
+    func release(_ pane: String) {
+        lock.withLock { _ = stalledPanes.remove(pane); _ = catchReleased.insert(pane) }
+    }
 
     /// Kill-on-registration: arms a flag so the pane's NEXT registered
     /// terminator fires immediately, INSIDE openStream before it returns —
@@ -74,7 +80,8 @@ final class ScriptedTransport: ExecutorTransport, @unchecked Sendable {
     func killDuringFirstSuccessfulOpen(_ pane: String) {
         lock.withLock { _ = succeedOnceThenKill.insert(pane) }
     }
-    /// The pane's FIRST open throws; its SECOND open stalls until released.
+    /// The pane's FIRST open throws; its SECOND open parks until released.
+    /// Later opens pass through untouched.
     ///
     /// That pair IS the catch-path window and nothing else. While the second
     /// open (the policy's replacement, dialed from inside
@@ -83,9 +90,15 @@ final class ScriptedTransport: ExecutorTransport, @unchecked Sendable {
     /// retirement is invisible to both the post-open reap and the backoff
     /// guard. Encoded as a single armed seam rather than composed from
     /// `failingPanes` + `stall`, because composing them cannot express
-    /// "throw, THEN stall" for one pane: the stall precedes the failure check,
+    /// "throw, THEN park" for one pane: the stall precedes the failure check,
     /// so a pre-set stall would park the first open instead of the retry and
     /// the window would never open.
+    ///
+    /// The throwing entry drops its registration, so live registrations and
+    /// entered opens are DIFFERENT counts here — use `openEntryCount` for "how
+    /// many opens happened" and `registrationCount` for "how many callbacks are
+    /// live". Conflating them is what armed this window on a contract
+    /// violation for a whole round.
     private var catchPathWindow: Set<String> = []
     private var openCounts: [String: Int] = [:]
     func armCatchPathWindow(_ pane: String) {
@@ -114,16 +127,23 @@ final class ScriptedTransport: ExecutorTransport, @unchecked Sendable {
     private var openEntries: [String: Int] = [:]
     func openEntryCount(_ pane: String) -> Int { lock.withLock { openEntries[pane] ?? 0 } }
 
-    /// Whether the pane's open is CURRENTLY parked in the stall.
+    /// Whether the pane's catch-window retry is CURRENTLY parked.
     ///
     /// Stronger than the entry count as a precondition, and the difference is a
     /// real race rather than a nicety: the entry count is incremented at the top
-    /// of `openStream`, the stall is inserted further down, and a test that
-    /// observed the count could call `release` in between — removing a stall
-    /// that had not been inserted yet. The open then parked forever and the
-    /// test timed out having proven nothing (1 run in 5). Observing the stall
-    /// itself cannot be early by construction.
-    func retryIsParked(_ pane: String) -> Bool { lock.withLock { stalledPanes.contains(pane) } }
+    /// of `openStream`, the gate is entered further down, and a test that
+    /// observed the count could call `release` in between — releasing a gate
+    /// nothing had entered yet. The open then parked forever and the test timed
+    /// out having proven nothing (1 run in 5). Observing the gate itself cannot
+    /// be early by construction.
+    func retryIsParked(_ pane: String) -> Bool { lock.withLock { catchParkedEntry[pane] != nil } }
+
+    /// The catch window's gate, private to it and keyed to one INVOCATION.
+    /// Deliberately not `stalledPanes`: that set is keyed by pane and shared
+    /// with every other stall seam, so a second attempt opening the same pane
+    /// re-armed it under a test that had already released it.
+    private var catchParkedEntry: [String: Int] = [:]
+    private var catchReleased: Set<String> = []
 
     /// Drops the registration this call made, so a throwing open leaves none.
     /// Deliberately NOT applied on the `installsThenThrows` path: that one
@@ -246,16 +266,32 @@ final class ScriptedTransport: ExecutorTransport, @unchecked Sendable {
         // observable in the false-open test; dropping it here made that test's
         // precondition read 0 registrations and the hazard vanish.
         if laterOpen { throw TransportError.closedBeforeResponse }
-        // Armed catch-path window: throw the first time, stall every time
-        // after. Both decisions happen AFTER the terminator registration
-        // above, so `registrationCount` counts opens ENTERED — which is what
-        // lets a test wait for the retry to exist rather than for a proxy.
-        switch catchPathPhase(pane) {
-        case 1:
+        // Armed catch-path window: entry 1 throws, entry 2 parks. EXACTLY entry
+        // 2 — later entries pass straight through.
+        //
+        // Both the "exactly" and the private gate are corrections, not
+        // tidiness. Stalling every entry >= 2 through the shared, pane-keyed
+        // `stalledPanes` let the REPLACEMENT ATTEMPT re-arm the retired
+        // attempt's gate: once B started, B's own open for the same pane
+        // reinserted it after the test had released A, so both calls parked and
+        // neither outcome ever appeared. The unmutated regression timed out
+        // 1 run in 20, and worse, the guard-removal mutant reached that same
+        // dead third outcome 1 in 11 — a mutant escaping into a timeout is
+        // indistinguishable from a mutant that was killed, so the race
+        // corrupted the mutation evidence, not just the test.
+        let phase = catchPathPhase(pane)
+        if phase == 1 {
             dropOwnRegistration(pane)      // the contract: a throwing open leaves nothing live
             throw TransportError.closedBeforeResponse
-        case let phase where phase >= 2: lock.withLock { _ = stalledPanes.insert(pane) }
-        default: break
+        }
+        if phase == 2 {
+            // Keyed to THIS invocation. No other call, on any attempt, can
+            // enter or re-arm it.
+            lock.withLock { catchParkedEntry[pane] = openEntries[pane] }
+            while lock.withLock({ !catchReleased.contains(pane) }) {
+                try? await Task.sleep(nanoseconds: 10_000_000)
+            }
+            lock.withLock { catchParkedEntry[pane] = nil }
         }
         while isStalled(pane) { try? await Task.sleep(nanoseconds: 10_000_000) }
         record(.openAttempt(pane, attempt))
@@ -273,11 +309,12 @@ final class ScriptedTransport: ExecutorTransport, @unchecked Sendable {
             return
         }
         if failOpens || lock.withLock({ failingPanes.contains(pane) }) {
-            if installsThenThrows {
-                lock.withLock { terminators[pane, default: []].append(onTermination) }
-            } else {
-                dropOwnRegistration(pane)
-            }
+            // The deliberate violation is RETAINING the entry registration, not
+            // adding a second one. This used to append the identical closure
+            // again, so each failed open left TWO retained callbacks while the
+            // test and the doc comment both describe one — the probe was
+            // exercising a hazard twice the size of the one it documents.
+            if !installsThenThrows { dropOwnRegistration(pane) }
             throw TransportError.closedBeforeResponse
         }
         record(.openStream(pane, attempt))

--- a/Tests/HerdrKitTests/RecoveryExecutorTests.swift
+++ b/Tests/HerdrKitTests/RecoveryExecutorTests.swift
@@ -263,9 +263,8 @@ final class RecoveryExecutorTests: XCTestCase {
         }
         XCTAssertEqual(ops[1], .fetchSnapshot(attempt), "resync must be the first post-connect operation")
         let firstStream = ops.firstIndex { if case .openStream = $0 { return true }; return false }
-        let snapshotIndex = ops.firstIndex(of: .fetchSnapshot(attempt))!
-        XCTAssertNotNil(firstStream)
-        XCTAssertGreaterThan(firstStream!, snapshotIndex,
+        let snapshotIndex = try XCTUnwrap(ops.firstIndex(of: .fetchSnapshot(attempt)))
+        XCTAssertGreaterThan(try XCTUnwrap(firstStream), snapshotIndex,
                              "a stream opened BEFORE the snapshot: subscribe-from-memory is back")
         XCTAssertEqual(Set(ops.compactMap { if case .openStream(let p, _) = $0 { return p }; return nil }),
                        ["p1", "p2"])
@@ -287,13 +286,13 @@ final class RecoveryExecutorTests: XCTestCase {
         // Memory is now non-empty. Reconnect.
         await executor.handle(.networkChanged(at: Date()))
         _ = await waitUntil { await executor.subscribedPanes == ["p1", "p2"] }
-        let attemptB = await executor.currentAttempt!
+        let attemptBOptional = await executor.currentAttempt
+        let attemptB = try XCTUnwrap(attemptBOptional)
 
         let ops = transport.log()
         let snapshotB = ops.firstIndex(of: .fetchSnapshot(attemptB))
         let firstStreamB = ops.firstIndex { if case .openStream(_, attemptB) = $0 { return true }; return false }
-        XCTAssertNotNil(snapshotB); XCTAssertNotNil(firstStreamB)
-        XCTAssertGreaterThan(firstStreamB!, snapshotB!,
+        XCTAssertGreaterThan(try XCTUnwrap(firstStreamB), try XCTUnwrap(snapshotB),
                              "a stream opened on B before B's snapshot: memory-derived subscription is back")
     }
 
@@ -306,7 +305,8 @@ final class RecoveryExecutorTests: XCTestCase {
         _ = await waitUntil { await executor.isConnected }
 
         // The network changes; attempt A is retired, B dials.
-        let retired = await executor.currentAttempt!
+        let retiredOptional = await executor.currentAttempt
+        let retired = try XCTUnwrap(retiredOptional)
         await executor.handle(.networkChanged(at: Date()))
         _ = await waitUntil { await executor.isConnected }
 
@@ -321,7 +321,10 @@ final class RecoveryExecutorTests: XCTestCase {
         // stream may target the discarded attempt after its discard. A mutation
         // appending a resync for it survived when only the discard was pinned.
         let ops = transport.log()
-        let discardIndex = ops.firstIndex(of: .discard(retired))!
+        // XCTUnwrap, not `!`: removing transport.discard failed the assertion
+        // above AND then crashed here with signal 4, which the harness reads as
+        // INVALID rather than KILLED — a real kill misfiled as a broken run.
+        let discardIndex = try XCTUnwrap(ops.firstIndex(of: .discard(retired)))
         XCTAssertFalse(ops[discardIndex...].contains(.fetchSnapshot(retired)),
                        "a resync ran on the discarded attempt")
         XCTAssertFalse(ops[discardIndex...].contains { if case .openStream(_, retired) = $0 { return true }; return false },
@@ -336,7 +339,8 @@ final class RecoveryExecutorTests: XCTestCase {
         let executor = RecoveryExecutor(recovery: recovery, transport: transport)
         await executor.start()
         _ = await waitUntil { await executor.isConnected }
-        let retired = await executor.currentAttempt!
+        let retiredOptional = await executor.currentAttempt
+        let retired = try XCTUnwrap(retiredOptional)
 
         await executor.handle(.networkChanged(at: Date()))
         let resettled = await waitUntil { await executor.subscribedPanes == ["p1"] }
@@ -366,7 +370,8 @@ final class RecoveryExecutorTests: XCTestCase {
         let executor = RecoveryExecutor(transport: transport)
         await executor.start()
         _ = await waitUntil { await executor.subscribedPanes == ["p1", "p2"] }
-        let attempt = await executor.currentAttempt!
+        let attemptOptional = await executor.currentAttempt
+        let attempt = try XCTUnwrap(attemptOptional)
         let opensBefore = transport.log().filter { if case .openStream = $0 { return true }; return false }
 
         transport.killStream("p2")
@@ -396,10 +401,16 @@ final class RecoveryExecutorTests: XCTestCase {
         transport.stall("a-first")             // pane 1 suspends inside its open
         await executor.start()
 
-        _ = await waitUntil {
-            transport.log().contains { if case .fetchSnapshot = $0 { return true }; return false }
-        }
-        let attemptA = await executor.currentAttempt!
+        // Wait for the first pane's REGISTRATION, not fetchSnapshot: the fake
+        // logs the snapshot before returning it and before the stalled stream
+        // registers, so waiting on it let networkChanged retire A BEFORE the
+        // loop began — the mutation removing the per-pane guard then built and
+        // passed. Fourth instance in this file of a test observing something
+        // that precedes the window it names.
+        let inWindow = await waitUntil { transport.registrationCount("a-first") > 0 }
+        XCTAssertTrue(inWindow, "the subscribe loop never entered its first open; the window was not exercised")
+        let attemptAOptional = await executor.currentAttempt
+        let attemptA = try XCTUnwrap(attemptAOptional)
 
         // While the loop is suspended on pane 1, the world moves.
         await executor.handle(.networkChanged(at: Date()))
@@ -423,11 +434,13 @@ final class RecoveryExecutorTests: XCTestCase {
         let executor = RecoveryExecutor(transport: transport)
         await executor.start()
         _ = await waitUntil { await executor.isConnected }
-        let retired = await executor.currentAttempt!
+        let retiredOptional = await executor.currentAttempt
+        let retired = try XCTUnwrap(retiredOptional)
 
         await executor.handle(.networkChanged(at: Date()))
         _ = await waitUntil { await executor.isConnected }
-        let current = await executor.currentAttempt!
+        let currentOptional = await executor.currentAttempt
+        let current = try XCTUnwrap(currentOptional)
         let connectsBefore = transport.log().filter { if case .connect = $0 { return true }; return false }.count
 
         // The stale plan replays, reconnect bound to the retired attempt.
@@ -466,7 +479,8 @@ final class RecoveryExecutorTests: XCTestCase {
         await executor.handle(.networkChanged(at: Date()))            // N2, unstalled
         let settled = await waitUntil { await executor.isConnected }
         XCTAssertTrue(settled, "the replacement never connected")
-        let current = await executor.currentAttempt!
+        let currentOptional = await executor.currentAttempt
+        let current = try XCTUnwrap(currentOptional)
         // N1's continuation resumes after its stall and writes its clear.
         try? await Task.sleep(nanoseconds: 500_000_000)
 
@@ -517,7 +531,8 @@ final class RecoveryExecutorTests: XCTestCase {
         let executor = RecoveryExecutor(transport: transport)
         await executor.start()
         _ = await waitUntil { await executor.subscribedPanes == ["p1"] }
-        let resourced = await executor.currentAttempt!
+        let resourcedOptional = await executor.currentAttempt
+        let resourced = try XCTUnwrap(resourcedOptional)
 
         await executor.handle(.networkChanged(at: Date()))
         XCTAssertTrue(transport.log().contains(.closeAll(resourced)),
@@ -534,7 +549,8 @@ final class RecoveryExecutorTests: XCTestCase {
         let executor = RecoveryExecutor(transport: transport)
         await executor.start()
         _ = await waitUntil { await executor.subscribedPanes == ["p1"] }
-        let attempt = await executor.currentAttempt!
+        let attemptOptional = await executor.currentAttempt
+        let attempt = try XCTUnwrap(attemptOptional)
 
         transport.killStreamTwice("p1")
         _ = await waitUntil {
@@ -570,7 +586,8 @@ actor SleepRecorder {
         _ = await waitUntil {
             transport.log().contains { if case .fetchSnapshot = $0 { return true }; return false }
         }
-        let retired = await executor.currentAttempt!
+        let retiredOptional = await executor.currentAttempt
+        let retired = try XCTUnwrap(retiredOptional)
 
         await executor.handle(.networkChanged(at: Date()))   // teardown completes
         transport.release("only")                            // the open lands late
@@ -676,7 +693,8 @@ actor SleepRecorder {
         let executor = RecoveryExecutor(transport: transport)
         await executor.start()
         _ = await waitUntil { await executor.isConnected }
-        let retired = await executor.currentAttempt!
+        let retiredOptional = await executor.currentAttempt
+        let retired = try XCTUnwrap(retiredOptional)
         await executor.handle(.networkChanged(at: Date()))
         _ = await waitUntil { await executor.isConnected }
 

--- a/Tests/HerdrKitTests/RecoveryExecutorTests.swift
+++ b/Tests/HerdrKitTests/RecoveryExecutorTests.swift
@@ -74,6 +74,31 @@ final class ScriptedTransport: ExecutorTransport, @unchecked Sendable {
     func killDuringFirstSuccessfulOpen(_ pane: String) {
         lock.withLock { _ = succeedOnceThenKill.insert(pane) }
     }
+    /// The pane's FIRST open throws; its SECOND open stalls until released.
+    ///
+    /// That pair IS the catch-path window and nothing else. While the second
+    /// open (the policy's replacement, dialed from inside
+    /// `handle(.streamFailed)`) sits suspended, the outer subscribe loop is
+    /// parked in the middle of its catch — the one position from which a
+    /// retirement is invisible to both the post-open reap and the backoff
+    /// guard. Encoded as a single armed seam rather than composed from
+    /// `failingPanes` + `stall`, because composing them cannot express
+    /// "throw, THEN stall" for one pane: the stall precedes the failure check,
+    /// so a pre-set stall would park the first open instead of the retry and
+    /// the window would never open.
+    private var catchPathWindow: Set<String> = []
+    private var openCounts: [String: Int] = [:]
+    func armCatchPathWindow(_ pane: String) {
+        lock.withLock { _ = catchPathWindow.insert(pane) }
+    }
+    /// 0 = not armed for this pane, 1 = the throwing first open, 2+ = a retry.
+    private func catchPathPhase(_ pane: String) -> Int {
+        lock.withLock {
+            guard catchPathWindow.contains(pane) else { return 0 }
+            openCounts[pane, default: 0] += 1
+            return openCounts[pane] ?? 0
+        }
+    }
     private func isStalled(_ pane: String) -> Bool {
         lock.lock(); defer { lock.unlock() }; return stalledPanes.contains(pane)
     }
@@ -179,6 +204,15 @@ final class ScriptedTransport: ExecutorTransport, @unchecked Sendable {
             return !opensSeen.insert(pane).inserted
         }
         if laterOpen { throw TransportError.closedBeforeResponse }
+        // Armed catch-path window: throw the first time, stall every time
+        // after. Both decisions happen AFTER the terminator registration
+        // above, so `registrationCount` counts opens ENTERED — which is what
+        // lets a test wait for the retry to exist rather than for a proxy.
+        switch catchPathPhase(pane) {
+        case 1: throw TransportError.closedBeforeResponse
+        case let phase where phase >= 2: lock.withLock { _ = stalledPanes.insert(pane) }
+        default: break
+        }
         while isStalled(pane) { try? await Task.sleep(nanoseconds: 10_000_000) }
         record(.openAttempt(pane, attempt))
         let succeedThisOnce = lock.withLock { succeedOnceThenKill.remove(pane) != nil }
@@ -231,6 +265,19 @@ extension NSLock {
 
 final class RecoveryExecutorTests: XCTestCase {
     /// Waits until the executor settles (no fixed sleeps: poll a condition).
+    /// A one-shot latch: fires once, and `wait()` suspends until it has. Both
+    /// sides are safe to call in either order, which is the point — a signal
+    /// that only works when fired second is a race dressed as a helper.
+    final class Signal: @unchecked Sendable {
+        private let lock = NSLock()
+        private var fired = false
+        var hasFired: Bool { lock.withLock { fired } }
+        func fire() { lock.withLock { fired = true } }
+        func wait() async {
+            while !hasFired { try? await Task.sleep(nanoseconds: 5_000_000) }
+        }
+    }
+
     private func waitUntil(
         _ timeout: TimeInterval = 5, _ condition: @escaping () async -> Bool
     ) async -> Bool {
@@ -422,6 +469,96 @@ final class RecoveryExecutorTests: XCTestCase {
 
         XCTAssertFalse(transport.log().contains { $0 == .openStream("b-second", attemptA) },
                        "the loop opened a stream for a retired attempt after its closeAll")
+    }
+
+    /// AXIS: a retirement landing while the loop is parked in its CATCH — not
+    /// its open — still stops the remaining panes.
+    ///
+    /// The sibling test above covers the success path, where the post-open reap
+    /// catches the retirement on its way out. This one covers the path the reap
+    /// never sees: the open THREW, so the catch awaits `handle(.streamFailed)`,
+    /// the policy dials a replacement, and that replacement suspends. The outer
+    /// loop is now parked at a suspension point that returns to the TOP OF THE
+    /// NEXT ITERATION rather than through the reap.
+    ///
+    /// This is a review finding, not a hypothesis: round seven built this probe
+    /// against a head where I had removed the guard covering it, and watched
+    /// the loop open the second pane for an attempt that was already dead.
+    func testARetirementDuringAFailedOpensHandlingStopsTheRemainingStreams() async throws {
+        let transport = ScriptedTransport(panes: ["a-fails", "z-must-not-open"])
+        let executor = RecoveryExecutor(transport: transport)
+        transport.armCatchPathWindow("a-fails")   // open 1 throws, open 2 stalls
+        await executor.start()
+
+        // The window is ENTERED when the replacement open exists: registration
+        // 1 is the throwing open, 2 is the retry the policy dialed from inside
+        // handle(.streamFailed), and the retry stalls immediately after
+        // registering. Two registrations therefore prove the outer loop is
+        // parked in its catch — the precondition the whole test rests on.
+        let inWindow = await waitUntil { transport.registrationCount("a-fails") >= 2 }
+        XCTAssertTrue(inWindow,
+                      "the failed open never produced a replacement; the catch-path window never opened")
+        let attemptAOptional = await executor.currentAttempt
+        let attemptA = try XCTUnwrap(attemptAOptional)
+
+        // The world moves while the loop is parked mid-catch.
+        await executor.handle(.networkChanged(at: Date()))
+        transport.release("a-fails")
+
+        try? await Task.sleep(nanoseconds: 300_000_000)
+
+        XCTAssertFalse(transport.log().contains { $0 == .openAttempt("z-must-not-open", attemptA) },
+                       "the loop resumed from its catch and opened a stream for a retired attempt")
+    }
+
+    /// AXIS: a retirement landing during a pane's RETRY BACKOFF stops the
+    /// retry, rather than opening a channel for a dead attempt and reaping it.
+    ///
+    /// The third suspension point in the subscribe loop, and the last one with
+    /// no test of its own. Its mutation SURVIVED when this test did not exist:
+    /// the post-open reap makes deleting the guard harmless to correctness — an
+    /// open bound to a retired attempt is still closed — so the surviving
+    /// difference is one wasted channel open against a connection that is
+    /// already being torn down. That is a real difference and it is observable,
+    /// so it gets pinned rather than argued about. Removing the guard on the
+    /// strength of "the reap covers it" is exactly the reasoning that failed
+    /// review at round seven; the rule this file now follows is that a
+    /// suspension point keeps its own guard AND its own test.
+    func testARetirementDuringARetryBackoffStopsTheRetry() async throws {
+        let transport = ScriptedTransport(panes: ["p"])
+        let executor = RecoveryExecutor(transport: transport)
+        transport.failingPanes = ["p"]           // every open throws -> a retry is dialed
+        await executor.start()
+
+        // Park the backoff instead of sleeping it: the retry's suspension has
+        // to be held open long enough to retire the attempt underneath it, and
+        // wall-clock timing cannot pin that without flaking.
+        let parked = Signal()
+        let release = Signal()
+        await executor.setSleeper { _ in
+            parked.fire()
+            await release.wait()
+        }
+
+        // Entering the backoff is the precondition, and it is observed rather
+        // than assumed: it can only be reached after the first open threw and
+        // the policy dialed a replacement for the same pane on the same
+        // attempt, which is the exact state the guard exists for.
+        let inBackoff = await waitUntil { parked.hasFired }
+        XCTAssertTrue(inBackoff, "the retry never reached its backoff; the window was not exercised")
+        let attemptAOptional = await executor.currentAttempt
+        let attemptA = try XCTUnwrap(attemptAOptional)
+        let opensBefore = transport.log().filter { $0 == .openAttempt("p", attemptA) }.count
+        XCTAssertEqual(opensBefore, 1, "expected exactly the one failed open before the backoff")
+
+        await executor.handle(.networkChanged(at: Date()))
+        release.fire()
+
+        try? await Task.sleep(nanoseconds: 300_000_000)
+
+        let opensAfter = transport.log().filter { $0 == .openAttempt("p", attemptA) }.count
+        XCTAssertEqual(opensAfter, 1,
+                       "the retry woke from its backoff and opened a channel for a retired attempt")
     }
 
     /// AXIS: a stale plan's reconnect neither dials a retired attempt NOR

--- a/Tests/HerdrKitTests/RecoveryExecutorTests.swift
+++ b/Tests/HerdrKitTests/RecoveryExecutorTests.swift
@@ -776,17 +776,21 @@ actor SleepRecorder {
                        "exhausted retry state was erased: attempts reported \(attempts)")
         XCTAssertNotNil(lastError, "the last error was erased with the retry state")
 
-        // And a retained orphan callback must not restart attempts past the cap.
-        let attemptsBefore = transport.log().filter {
-            if case .openAttempt = $0 { return true }; return false
-        }.count
+        // And a retained orphan callback must not restart registrations past the
+        // cap. Observed through registrationCount, NOT the .openAttempt log:
+        // with onlyFirstOpenSucceeds every replacement registers its terminator
+        // and then throws BEFORE .openAttempt is recorded, so the log-equality
+        // form stayed true even when restarts happened — the reviewer isolated
+        // exactly that, seeing registrations grow 4 -> 9 while the shipped
+        // assertion passed. Third time on this test family that the OBSERVABLE,
+        // not the assertion, was what let a mutant through.
+        let registrationsBefore = transport.registrationCount("p1")
+        XCTAssertGreaterThan(registrationsBefore, 0, "precondition: registrations exist to observe")
         transport.killOldestRegistration("p1")
-        try? await Task.sleep(nanoseconds: 250_000_000)
-        let attemptsAfter = transport.log().filter {
-            if case .openAttempt = $0 { return true }; return false
-        }.count
-        XCTAssertEqual(attemptsAfter, attemptsBefore,
-                       "an orphan callback restarted registration past the exhausted cap")
+        try? await Task.sleep(nanoseconds: 300_000_000)
+        let registrationsAfter = transport.registrationCount("p1")
+        XCTAssertEqual(registrationsAfter, registrationsBefore - 1,
+                       "expected exactly the killed callback to be consumed; \(registrationsBefore) -> \(registrationsAfter) means restarts past the exhausted cap")
     }
 
     /// THE COORDINATOR'S PAIRED CONTROL: a healthy pane reports `.open` AND a

--- a/Tests/HerdrKitTests/RecoveryExecutorTests.swift
+++ b/Tests/HerdrKitTests/RecoveryExecutorTests.swift
@@ -38,6 +38,11 @@ final class ScriptedTransport: ExecutorTransport, @unchecked Sendable {
     /// Panes whose opens always throw, for paired-control tests where one pane
     /// is healthy and one is not.
     var failingPanes: Set<String> = []
+    /// Only the FIRST open of each pane succeeds; every later one throws. Lets
+    /// a test have one live registration and no possible replacement, without
+    /// racing a flag against the executor.
+    var onlyFirstOpenSucceeds = false
+    private var opensSeen: Set<String> = []
     /// Installs the callback and THEN throws: the ownership violation the seam
     /// now forbids, kept as a probe of what the executor does when a conformer
     /// breaks the contract anyway.
@@ -48,6 +53,27 @@ final class ScriptedTransport: ExecutorTransport, @unchecked Sendable {
 
     func stall(_ pane: String) { lock.withLock { _ = stalledPanes.insert(pane) } }
     func release(_ pane: String) { lock.withLock { _ = stalledPanes.remove(pane) } }
+
+    /// Kill-on-registration: arms a flag so the pane's NEXT registered
+    /// terminator fires immediately, INSIDE openStream before it returns —
+    /// the termination-races-the-return interleaving made deterministic.
+    private var killOnRegister: Set<String> = []
+    func releaseAndKill(_ pane: String) {
+        lock.withLock {
+            _ = stalledPanes.remove(pane)
+            _ = killOnRegister.insert(pane)
+        }
+    }
+
+    /// The first open for this pane SUCCEEDS and fires its termination before
+    /// returning; every later one fails (via failingPanes). That is the
+    /// termination-races-the-return window with a deterministic aftermath:
+    /// replacements exhaust, so a false publish by the original call is the
+    /// only way the pane can ever read .open.
+    private var succeedOnceThenKill: Set<String> = []
+    func killDuringFirstSuccessfulOpen(_ pane: String) {
+        lock.withLock { _ = succeedOnceThenKill.insert(pane) }
+    }
     private func isStalled(_ pane: String) -> Bool {
         lock.lock(); defer { lock.unlock() }; return stalledPanes.contains(pane)
     }
@@ -127,8 +153,31 @@ final class ScriptedTransport: ExecutorTransport, @unchecked Sendable {
         pane: String, for attempt: AttemptID,
         onTermination: @escaping @Sendable () -> Void
     ) async throws {
+        // Registered BEFORE the stall so a suspended open can be terminated
+        // from outside — that is the reviewer's interleaving: the death is
+        // processed while the call is still suspended, and the call then
+        // returns and tries to publish.
+        lock.withLock { terminators[pane, default: []].append(onTermination) }
         while isStalled(pane) { try? await Task.sleep(nanoseconds: 10_000_000) }
         record(.openAttempt(pane, attempt))
+        let laterOpen = lock.withLock { () -> Bool in
+            guard onlyFirstOpenSucceeds else { return false }
+            return !opensSeen.insert(pane).inserted
+        }
+        if laterOpen { throw TransportError.closedBeforeResponse }
+        let succeedThisOnce = lock.withLock { succeedOnceThenKill.remove(pane) != nil }
+        if succeedThisOnce {
+            record(.openStream(pane, attempt))
+            // Fires INSIDE the call: the executor's publish runs after this.
+            let terminate = lock.withLock { () -> (@Sendable () -> Void)? in
+                guard var list = terminators[pane], !list.isEmpty else { return nil }
+                let last = list.removeLast()
+                terminators[pane] = list
+                return last
+            }
+            terminate?()
+            return
+        }
         if failOpens || lock.withLock({ failingPanes.contains(pane) }) {
             if installsThenThrows {
                 lock.withLock { terminators[pane, default: []].append(onTermination) }
@@ -136,7 +185,18 @@ final class ScriptedTransport: ExecutorTransport, @unchecked Sendable {
             throw TransportError.closedBeforeResponse
         }
         record(.openStream(pane, attempt))
-        lock.withLock { terminators[pane, default: []].append(onTermination) }
+        let fireNow = lock.withLock { killOnRegister.remove(pane) != nil }
+        if fireNow {
+            // Fire BEFORE returning: the executor's success path runs after
+            // this, which is exactly the window under test.
+            let terminate = lock.withLock { () -> (@Sendable () -> Void)? in
+                guard var list = terminators[pane], !list.isEmpty else { return nil }
+                let last = list.removeLast()
+                terminators[pane] = list
+                return last
+            }
+            terminate?()
+        }
     }
 
     func closeAll(for attempt: AttemptID) async {
@@ -533,8 +593,14 @@ actor SleepRecorder {
         let backoffs = await recorder.recorded()
         XCTAssertGreaterThan(backoffs.count, 0, "retries must be delayed, not immediate")
         XCTAssertTrue(backoffs.allSatisfy { $0 > 0 })
-        XCTAssertLessThanOrEqual(backoffs.count, RecoveryExecutor.openFailureCap,
-                                 "retries exceeded the cap: \(backoffs.count) attempts")
+        // EXACT, not <=: the <= form let the failures <= cap off-by-one mutant
+        // survive the whole executor selection. The cap means exactly cap
+        // failed registrations: cap attempts, cap-1 backoffs between them.
+        XCTAssertEqual(backoffs.count, RecoveryExecutor.openFailureCap - 1,
+                       "expected exactly \(RecoveryExecutor.openFailureCap - 1) backoffs, got \(backoffs.count)")
+        let attempts = transport.log().filter { if case .openAttempt = $0 { return true }; return false }.count
+        XCTAssertEqual(attempts, RecoveryExecutor.openFailureCap,
+                       "expected exactly \(RecoveryExecutor.openFailureCap) registration attempts, got \(attempts)")
 
         // KNOWN GAP, asserted so it cannot change silently and ESCALATED rather
         // than fixed here: the ledger still lists the pane, because admission
@@ -570,8 +636,8 @@ actor SleepRecorder {
             if case .openAttempt = $0 { return true }; return false
         }.count
         XCTAssertGreaterThan(attemptsAtCap, 0, "precondition: registrations were attempted")
-        XCTAssertLessThanOrEqual(attemptsAtCap, RecoveryExecutor.openFailureCap + 1,
-                                 "the cap did not bound registration attempts")
+        XCTAssertEqual(attemptsAtCap, RecoveryExecutor.openFailureCap,
+                       "expected exactly \(RecoveryExecutor.openFailureCap) registration attempts, got \(attemptsAtCap)")
 
         // The OLDEST registration's orphaned callback fires late.
         transport.killOldestRegistration("p1")
@@ -634,6 +700,60 @@ actor SleepRecorder {
         }
         let staleFree = await executor.openFailureEntryCountForRetiredAttempts == 0
         XCTAssertTrue(staleFree, "retired attempts' failure counters were retained")
+    }
+
+    /// AXIS: a retired attempt's delayed termination cannot flip a LIVE pane's
+    /// status — the reviewer's probe: p1 open on B, A's stale termination
+    /// arrives, and B's status fell to admittedNotOpen while its stream lived.
+    func testAStaleTerminationCannotFlipALivePanesStatus() async throws {
+        let transport = ScriptedTransport(panes: ["p1"])
+        let executor = RecoveryExecutor(transport: transport)
+        await executor.start()
+        _ = await waitUntil { await executor.paneStatus("p1") == .open }
+
+        // A's registration survives the teardown in the fake's registry (the
+        // stale callback the wire can always deliver late); B re-opens p1.
+        await executor.handle(.networkChanged(at: Date()))
+        _ = await waitUntil { await executor.paneStatus("p1") == .open }
+
+        // The OLDEST registration — A's — fires its termination late.
+        transport.killOldestRegistration("p1")
+        try? await Task.sleep(nanoseconds: 300_000_000)
+
+        let status = await executor.paneStatus("p1")
+        XCTAssertEqual(status, .open,
+                       "a stale termination flipped a live pane to \(status)")
+    }
+
+    /// AXIS: a termination racing the open's suspension cannot yield a false
+    /// .open — the reviewer's probe: replacements exhausted, then the
+    /// terminated ORIGINAL call returned and published, and paneStatus lied
+    /// .open forever after.
+    func testATerminationDuringTheOpenCannotPublishAFalseOpen() async throws {
+        let transport = ScriptedTransport(panes: ["p1"])
+        let executor = RecoveryExecutor(transport: transport)
+        await executor.setSleeper { _ in }
+        transport.onlyFirstOpenSucceeds = true     // one live registration, no replacements
+        transport.stall("p1")                      // the open suspends, terminator registered
+        await executor.start()
+        _ = await waitUntil {
+            transport.log().contains { if case .fetchSnapshot = $0 { return true }; return false }
+        }
+
+        // The stream dies while its open is STILL SUSPENDED: the death is
+        // processed on the free actor before the call returns.
+        transport.killStream("p1")
+        try? await Task.sleep(nanoseconds: 150_000_000)
+        transport.release("p1")                    // the original call now returns
+        try? await Task.sleep(nanoseconds: 400_000_000)
+
+        // UNCONDITIONAL: the registration that terminated must never publish.
+        // The first version asserted only IF status was .open — vacuous
+        // whenever the bug is absent, and the mutation survived it.
+        let status = await executor.paneStatus("p1")
+        guard case .admittedNotOpen = status else {
+            return XCTFail("a terminated registration published .open (status: \(status))")
+        }
     }
 
     /// THE COORDINATOR'S PAIRED CONTROL: a healthy pane reports `.open` AND a

--- a/Tests/HerdrKitTests/RecoveryExecutorTests.swift
+++ b/Tests/HerdrKitTests/RecoveryExecutorTests.swift
@@ -124,47 +124,30 @@ final class ScriptedTransport: ExecutorTransport, @unchecked Sendable {
         private let lock = NSLock()
         private var released = false
         private var parked = false
+        private var phase = 0
         var isParked: Bool { lock.withLock { parked } }
         func release() { lock.withLock { released = true } }
         fileprivate var isReleased: Bool { lock.withLock { released } }
         fileprivate func setParked(_ value: Bool) { lock.withLock { parked = value } }
+        /// The entry counter lives HERE rather than in a pane-keyed dictionary,
+        /// which is the fourth shared per-pane slot removed from this seam. A
+        /// window created after an invocation claimed its phase cannot
+        /// reclassify that invocation, because the invocation is counting
+        /// against an object the new window does not share.
+        fileprivate func claimPhase() -> Int { lock.withLock { phase += 1; return phase } }
     }
 
     private var catchWindows: [String: CatchWindow] = [:]   // the CURRENT arm
-    private var catchPhase: [String: Int] = [:]             // entries since this arm
 
     func armCatchPathWindow(_ pane: String) -> CatchWindow {
         lock.withLock {
             let window = CatchWindow()
             catchWindows[pane] = window
-            catchPhase[pane] = 0
             return window
         }
     }
     /// 0 = not armed for this pane, 1 = the throwing first open, 2 = the retry
     /// that parks, 3+ = pass through.
-    /// Classifies the entry AND captures the window it belongs to, under ONE
-    /// lock acquisition.
-    ///
-    /// They were two operations, and that was the last shared-slot race in this
-    /// seam: an invocation could classify as phase 2 against arm N, lose the
-    /// lock, and then look up `catchWindows[pane]` after arm N+1 had replaced
-    /// it — parking the NEW window. `retryIsParked` then answered true for a
-    /// window nothing had legitimately parked, so the seam tests could report
-    /// armed while the parked open belonged to a dead arm. Probe failed 6/6.
-    ///
-    /// Third variant of one mistake on this seam: shared per-pane state read at
-    /// a different moment than it was decided on. Generation numbers fixed the
-    /// value, objects fixed the identity, and this fixes the ATOMICITY — the
-    /// phase decision and the thing it applies to now cannot be separated.
-    private func catchPathStep(_ pane: String) -> (phase: Int, window: CatchWindow?) {
-        lock.withLock {
-            guard let window = catchWindows[pane] else { return (0, nil) }
-            catchPhase[pane, default: 0] += 1
-            return (catchPhase[pane] ?? 0, window)
-        }
-    }
-
     /// Fires between phase classification and the park, so a test can re-arm in
     /// that gap. Exists only to prove the classification and the window are
     /// bound atomically — without it, the binding is untestable, because a
@@ -307,12 +290,20 @@ final class ScriptedTransport: ExecutorTransport, @unchecked Sendable {
         // "the first open", and published legitimately — the test flaked 1 run
         // in 4 reporting .open for a reason that had nothing to do with the
         // guard under test.
-        let laterOpen = lock.withLock { () -> Bool in
+        // ENTRY AND CLASSIFICATION IN ONE ACQUISITION. They were two, and an
+        // arm installed in the gap could classify an invocation that had
+        // already entered — "entries since this arm" then counted an entry
+        // that predated the arm. Probe reproduced it 6/6. With the claim made
+        // here, "entered" and "classified against a window" are the same
+        // instant and the gap does not exist to be aimed at.
+        let entry = lock.withLock { () -> (laterOpen: Bool, phase: Int, window: CatchWindow?) in
             openEntries[pane, default: 0] += 1
             terminators[pane, default: []].append(onTermination)
-            guard onlyFirstOpenSucceeds else { return false }
-            return !opensSeen.insert(pane).inserted
+            let later = onlyFirstOpenSucceeds ? !opensSeen.insert(pane).inserted : false
+            guard let window = catchWindows[pane] else { return (later, 0, nil) }
+            return (later, window.claimPhase(), window)
         }
+        let laterOpen = entry.laterOpen
         // NOT contract-abiding, and deliberately so — like `installsThenThrows`,
         // `onlyFirstOpenSucceeds` is a probe of what the executor does when a
         // conformer RETAINS a callback it promised to drop. The orphan IS the
@@ -332,9 +323,8 @@ final class ScriptedTransport: ExecutorTransport, @unchecked Sendable {
         // dead third outcome 1 in 11 — a mutant escaping into a timeout is
         // indistinguishable from a mutant that was killed, so the race
         // corrupted the mutation evidence, not just the test.
-        let step = catchPathStep(pane)
-        afterPhaseClassification?(step.phase)
-        let phase = step.phase
+        afterPhaseClassification?(entry.phase)
+        let phase = entry.phase
         if phase == 1 {
             dropOwnRegistration(pane)      // the contract: a throwing open leaves nothing live
             throw TransportError.closedBeforeResponse
@@ -343,12 +333,20 @@ final class ScriptedTransport: ExecutorTransport, @unchecked Sendable {
             // The window came back WITH the phase decision, from the same lock
             // acquisition. Re-reading `catchWindows[pane]` here is the defect
             // this replaced — by this point a re-arm may have swapped it.
-            let window = step.window
+            let window = entry.window
             window?.setParked(true)
+            // CANCELLATION-AWARE. A park that only ends on release turns a
+            // broken release into a HANG: the no-op-release mutant timed out at
+            // 5s and at 20s and was classified ESCAPED, which is not a kill and
+            // reads like one in a summary. A test can now cancel its parked
+            // task as unconditional teardown and get a real assertion failure
+            // instead of a stalled suite.
             while !(window?.isReleased ?? true) {
+                if Task.isCancelled { break }
                 try? await Task.sleep(nanoseconds: 10_000_000)
             }
             window?.setParked(false)
+            if Task.isCancelled { throw CancellationError() }
         }
         while isStalled(pane) { try? await Task.sleep(nanoseconds: 10_000_000) }
         record(.openAttempt(pane, attempt))
@@ -711,6 +709,9 @@ final class RecoveryExecutorTests: XCTestCase {
         XCTAssertFalse(escaped, "an ordinary release opened the catch window it does not own")
 
         window.release()
+        let releaseWorked = await waitUntil { !transport.retryIsParked("p") }
+        XCTAssertTrue(releaseWorked, "release did not unpark the window")
+        second.cancel()                       // teardown, unconditional
         _ = await second.result
     }
 
@@ -758,6 +759,9 @@ final class RecoveryExecutorTests: XCTestCase {
         // that stages a race has to be able to tear down either outcome.
         first.release()
         replacement.value?.release()
+        let releaseWorked = await waitUntil { !first.isParked }
+        XCTAssertTrue(releaseWorked, "release did not unpark the window")
+        retry.cancel()                        // teardown, unconditional
         _ = await retry.result
     }
 
@@ -779,6 +783,9 @@ final class RecoveryExecutorTests: XCTestCase {
         let firstRetry = Task { try await transport.openStream(pane: "p", for: AttemptID(uuid: UUID())) {} }
         _ = await waitUntil { transport.retryIsParked("p") }
         first.release()
+        let firstReleased = await waitUntil { !first.isParked }
+        XCTAssertTrue(firstReleased, "the first window's release did not unpark it")
+        firstRetry.cancel()                   // teardown, unconditional
         _ = await firstRetry.result
 
         // A second window, parked, with the FIRST window's release still in
@@ -796,6 +803,9 @@ final class RecoveryExecutorTests: XCTestCase {
         XCTAssertFalse(escaped, "a release created for the first window opened the second")
 
         second.release()
+        let releaseWorked = await waitUntil { !transport.retryIsParked("p") }
+        XCTAssertTrue(releaseWorked, "release did not unpark the second window")
+        secondRetry.cancel()                  // teardown, unconditional
         _ = await secondRetry.result
     }
 
@@ -813,6 +823,9 @@ final class RecoveryExecutorTests: XCTestCase {
             let parked = await waitUntil { transport.retryIsParked("p") }
             XCTAssertTrue(parked, "window \(round) did not park; the previous arm's state leaked into it")
             window.release()
+            let releaseWorked = await waitUntil { !transport.retryIsParked("p") }
+            XCTAssertTrue(releaseWorked, "window \(round) release did not unpark it")
+            second.cancel()                   // teardown, unconditional
             _ = await second.result
             let cleared = await waitUntil { !transport.retryIsParked("p") }
             XCTAssertTrue(cleared, "window \(round) never cleared its parked state")

--- a/Tests/HerdrKitTests/SessionRecoveryTests.swift
+++ b/Tests/HerdrKitTests/SessionRecoveryTests.swift
@@ -369,6 +369,54 @@ final class SessionRecoveryTests: XCTestCase {
                        "the ledger recorded a subscription to a closed pane — irretractable on this wire")
     }
 
+    /// AXIS: a single pane's stream dying re-subscribes exactly that pane,
+    /// exactly once — and only for the attempt that lost it.
+    ///
+    /// Requirement one of task 6: the wire is N independent per-pane
+    /// connections, and one dying was previously inexpressible — the pane went
+    /// silent while the client believed itself connected.
+    func testAStreamFailureResubscribesThatPaneExactlyOnce() throws {
+        var state = try seeded(["p1", "p2"])
+        let opened = connect(&state)
+
+        let replaced = plan(.streamFailed(pane: "p2", from: opened), &state)
+        XCTAssertEqual(replaced.subscribes, ["p2"], "exactly the dead pane")
+        XCTAssertEqual(replaced.subscribesOn, opened, "bound to the attempt that lost it")
+        XCTAssertTrue(state.subscribedPanes.contains("p2"), "the ledger reflects the replacement")
+
+        // The semantics are once PER DEATH, not once per pane: the ledger
+        // entry now represents the REPLACEMENT stream, so a second failure
+        // event legitimately replaces the replacement. Deduplicating spurious
+        // duplicates for one death is the EXECUTOR's contract — it mints one
+        // streamFailed per stream termination — and the policy must not absorb
+        // that job, or a real second death would be swallowed.
+        let second = plan(.streamFailed(pane: "p2", from: opened), &state)
+        XCTAssertEqual(second.subscribes, ["p2"],
+                       "a second death is a real death; the policy must replace again")
+    }
+
+    /// AXIS: stream-failure events that cannot be acted on emit nothing and
+    /// touch nothing — a stale attempt's, an unsubscribed pane's, and a
+    /// closed pane's.
+    func testStreamFailuresThatCannotBeActedOnAreInert() throws {
+        var state = try seeded(["p1"])
+        let opened = connect(&state)
+
+        // Stale attempt: not even a drop.
+        let foreign = AttemptID(uuid: UUID())
+        XCTAssertTrue(plan(.streamFailed(pane: "p1", from: foreign), &state).isEmpty)
+        XCTAssertTrue(state.subscribedPanes.contains("p1"), "a stale failure must not drop a live entry")
+
+        // A pane with no ledger entry: no stream existed to die.
+        XCTAssertTrue(plan(.streamFailed(pane: "never-subscribed", from: opened), &state).isEmpty)
+
+        // A pane closed before its stream death arrives: dropped, not replaced.
+        _ = plan(.paneClosed("p1", from: opened), &state)
+        let afterClose = plan(.streamFailed(pane: "p1", from: opened), &state)
+        XCTAssertTrue(afterClose.isEmpty, "a closed pane must not be re-subscribed")
+        XCTAssertFalse(state.subscribedPanes.contains("p1"), "the dead entry is dropped")
+    }
+
     /// AXIS: a subscription action is bound to the attempt that admitted it —
     /// A's delayed plan can never be mistaken for B's.
     ///
@@ -1123,9 +1171,15 @@ final class PaneSnapshotAccessTests: XCTestCase {
             }) else { return nil }
             return path.joined(separator: ".")
         }.sorted()
+        // ExecutorTransport.fetchSnapshot RETURNS a snapshot but cannot MINT
+        // one: an outside conformer must obtain the value it returns, and the
+        // only source is HerdrClient.paneSnapshot() — the internal init still
+        // gates construction. RecoveryExecutor.apply consumes. Judged here,
+        // out loud, as this audit requires.
         XCTAssertEqual(
             mentioners,
-            ["HerdrClient.paneSnapshot()", "SessionRecovery.observe(_:from:state:)"],
+            ["ExecutorTransport.fetchSnapshot(for:)", "HerdrClient.paneSnapshot()",
+             "RecoveryExecutor.apply(snapshot:from:)", "SessionRecovery.observe(_:from:state:)"],
             "a new package-visible symbol mentions PaneSnapshot; if it can yield one from caller data it is a construction path, and only HerdrClient.paneSnapshot() may produce"
         )
     }

--- a/Tests/HerdrKitTests/SessionRecoveryTests.swift
+++ b/Tests/HerdrKitTests/SessionRecoveryTests.swift
@@ -11,7 +11,7 @@ private struct ConstantGenerator: RandomNumberGenerator {
 
 /// Deterministic generator, so a jitter test asserts a distribution property
 /// rather than hoping.
-private struct SeededGenerator: RandomNumberGenerator {
+struct SeededGenerator: RandomNumberGenerator {
     private var state: UInt64
     init(seed: UInt64) { self.state = seed &* 6364136223846793005 &+ 1442695040888963407 }
     mutating func next() -> UInt64 {

--- a/scripts/dispatch-and-sample-head.sh
+++ b/scripts/dispatch-and-sample-head.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Dispatch a review AND sample the job payload's head_sha twice: once as close
+# to QUEUE time as the CLI allows, and once after the job reaches a terminal
+# state.
+#
+# Why this exists: gitmoot #1415's model says the job record is re-derived from
+# the (reused, stale) worktree at EXECUTION. A single post-hoc read cannot
+# distinguish that from a stale value written at DISPATCH — both leave the same
+# end state. gitmoot-coc measured one job as correct at queue and stale after
+# running; this lane measured one job as stale, but at an unknown point in its
+# lifecycle, so it could not confirm which write site was responsible.
+#
+# The failure mode being avoided is letting ONE read stand for a value that
+# mutates during its own lifetime. The queue sample is therefore taken in the
+# same command as the dispatch, before anything else runs.
+#
+# Usage: scripts/dispatch-and-sample-head.sh <agent> <pr> <head-sha> <message-file>
+set -uo pipefail
+
+AGENT="$1"; PR="$2"; HEAD_SHA="$3"; MESSAGE_FILE="$4"
+REPO="jerryfane/herdr-ios"
+
+payload_head() {   # $1 = job id; prints head_sha or empty
+  gitmoot job show "$1" --json 2>/dev/null | python3 -c "
+import sys,json
+try:
+    d=json.load(sys.stdin)
+    p=d.get('payload'); p=json.loads(p) if isinstance(p,str) else p
+    print((p or {}).get('head_sha',''))
+except Exception:
+    print('')
+"
+}
+job_state() {
+  gitmoot job show "$1" --json 2>/dev/null | python3 -c "
+import sys,json
+try: print((json.load(sys.stdin).get('job') or {}).get('State',''))
+except Exception: print('')
+"
+}
+
+DISPATCH="$(gitmoot orchestrate "$AGENT" "$(cat "$MESSAGE_FILE")" \
+  --repo "$REPO" --pr "$PR" --head-sha "$HEAD_SHA" --action review 2>&1)"
+JOB="$(printf '%s\n' "$DISPATCH" | grep -o 'local-review-[A-Za-z0-9._-]*' | tail -1)"
+if [ -z "$JOB" ]; then
+  printf 'dispatch produced no job id:\n%s\n' "$DISPATCH" >&2; exit 2
+fi
+
+# SAMPLE 1 — as early as reachable. The state is recorded ALONGSIDE the value:
+# a queue sample that was actually taken after the job started running proves
+# nothing, and recording the state is the only way to know which happened.
+Q_STATE="$(job_state "$JOB")"
+Q_HEAD="$(payload_head "$JOB")"
+
+printf 'job=%s\nrequested=%s\nsample1_state=%s\nsample1_head=%s\n' \
+  "$JOB" "$HEAD_SHA" "${Q_STATE:-unknown}" "${Q_HEAD:-unreadable}"
+
+# SAMPLE 2 — after the job stops moving.
+for _ in $(seq 1 240); do
+  case "$(job_state "$JOB")" in
+    succeeded|failed|cancelled|error|timeout) break ;;
+  esac
+  sleep 15
+done
+T_STATE="$(job_state "$JOB")"
+T_HEAD="$(payload_head "$JOB")"
+printf 'sample2_state=%s\nsample2_head=%s\n' "${T_STATE:-unknown}" "${T_HEAD:-unreadable}"
+
+# The verdict is stated here rather than left to the reader, because the whole
+# point is which WRITE SITE is implicated, not which values appeared.
+if [ "$Q_HEAD" = "$HEAD_SHA" ] && [ "$T_HEAD" != "$HEAD_SHA" ]; then
+  echo "verdict=execution_overwrite (correct at sample 1, stale at sample 2)"
+elif [ "$Q_HEAD" != "$HEAD_SHA" ] && [ "$Q_STATE" = "queued" ]; then
+  echo "verdict=dispatch_write (already stale while still queued: a SECOND write site)"
+elif [ "$Q_HEAD" != "$HEAD_SHA" ]; then
+  echo "verdict=inconclusive (stale at sample 1, but state was '${Q_STATE}', not queued)"
+else
+  echo "verdict=no_overwrite_observed (requested head held at both samples)"
+fi


### PR DESCRIPTION
Task 6, per the coordinator-approved plan and its four binding conditions.

**WHAT**

- **`ClientEvent.streamFailed(pane:from:)`** — requirement one. The wire is N
  independent per-pane persistent connections, so one dying was previously
  *inexpressible*: the pane went silent while the client believed itself
  connected. Handled by `dropAndReadmit` — admission's inverse fused with a
  fresh admission in ONE authority section, so a concurrent discovery cannot
  double the replacement, and re-subscription rides the same atomic gate rather
  than getting its own machinery.
- **`RecoveryExecutor`** (an actor) — maps every provenance-bound action to
  `ExecutorTransport` calls and mints `ClientEvent`s from outcomes. This is
  where the policy's AttemptID bindings are finally **enforced**: a subscribe or
  reconnect bound to a retired attempt is refused at execution, observably.

**THE FOUR CONDITIONS**

1. *Delayed callbacks provably rejected* — a late completion is discarded **at
   the transport** (`testADelayedCompletionFromARetiredAttemptIsDiscardedAtTheTransport`,
   which also asserts no resync and no stream follow it); a stale subscribe
   opens nothing and is recorded (`testASubscribeBoundToARetiredAttemptIsRejectedAtExecution`);
   a stale reconnect neither dials nor disturbs the current attempt
   (`testAStalePlansReconnectCannotWedgeTheExecutor`).
2. *Policy unchanged* beyond the approved `streamFailed` addition. One
   **comment** in `SessionRecovery.swift` was corrected (behaviour untouched):
   it implied duplicate terminations land outside the ledger, which a probe
   refuted. Flagged rather than assumed.
3. *Exclusions honoured* — no UI, Keychain, reachability, or macOS.
4. *Resync-before-subscribe guarded* — `testReconnectAdoptionResyncsBeforeAnyStreamOpensDespiteMemory`.
   Note the cold-start version of this assertion let the mutation survive
   **vacuously** (empty memory subscribes nothing early); the armed version
   drives a reconnect with knowledge aboard, and the mutation kills against it.

**ADVERSARIAL SWEEP BEFORE FIRST REVIEW** — three lenses over the new code, 17
findings, 15 confirmed by independent refutation, all folded. Two HIGHs were the
actor-reentrancy class the policy could not have, each reproduced 4/4:

- **Wedge**: a stale plan's `.reconnect` cancelled the *current* attempt's
  pending dial; the silent cancellation return left nothing scheduled.
- **Leak**: an unconditional `resourcedAttempt` clear after a suspension point
  destroyed an interleaved plan's claim, after which every teardown closed a
  resource-less attempt while the live one's streams leaked forever.

Also folded: the exactly-once termination contract is now **enforced** by a
latch (a double-fire produced three opens for one death); transport teardown,
the backoff delay, and "no work on the discarded attempt" were all unpinned and
now carry killed mutations; `LiveHerdrTransport` violated the seam requirements
it was cited as proving implementable (attempt-blind `closeAll`, termination on
deliberate teardown).

**RESULTS** — 120 tests, 0 failures across repeated full-suite runs; executor
suite 3/3; mutations killed: reconnect-unbound, unconditional-claim-clear,
backoff-ignored, no-closeall, no-once-latch, work-on-discarded, door-only-binding.

**RISK / open**

- **A PRE-EXISTING FLAKE, NOT FROM THIS PR**, reported rather than absorbed:
  `SSHTransportTests.testHostKeyRejectionThroughStreamNeverClosesADescriptorTwice`
  fails roughly 1 run in 10 under full-suite load with `SSH handshake failed
  (-43)` instead of the expected rejection — local `sshd` refusing under 25
  rapid connections plus parallel load. It is merged task-1 code; fixing it
  inside an executor PR is the quiet scope expansion condition 3 warns about, so
  it is escalated separately. Expect it to appear in a review run.
- Two of my own new tests failed honestly during development and are recorded in
  the commit: a deadlocked interleaving regression, and a force-unwrap that
  turned a real mutation kill into signal 4 (harness reads INVALID) — the same
  crash-instead-of-fail class the sweep found elsewhere.
- `rejections` grows unbounded; it is a diagnostics surface bounded by the
  rarity of rejections, and nothing drains it. Stated, not solved.
- The executor exposes event injection points; nothing wires them to
  `NWPathMonitor` or app lifecycle — that is the macOS half, excluded.

HERDR-APP:

---

**Task 7 cross-link (per directive 28002):** the admitted-vs-open policy round is filed as #12. This PR adds the mandated observation surface (`paneStatus`) and does not redefine admission.