### PR TITLE
feat(kit): exhaustion retracts the admission, and the reason survives it

### DIFF
--- a/Sources/HerdrKit/RecoveryExecutor.swift
+++ b/Sources/HerdrKit/RecoveryExecutor.swift
@@ -124,6 +124,22 @@ public actor RecoveryExecutor {
         let attempt: AttemptID
         let pane: String
     }
+    /// LOAD-BEARING, NOT INCIDENTAL — read this before changing when it clears.
+    ///
+    /// It bounds retries, and since task 7 it is also the ONLY thing that
+    /// distinguishes a never-wanted pane from a wanted-but-unreachable one.
+    /// Exhaustion RETRACTS the ledger admission, so `paneStatus` can no longer
+    /// learn that from ledger membership; at cap this counter is what makes an
+    /// absent pane report `.admittedNotOpen` instead of `.notAdmitted`.
+    ///
+    /// Two properties are therefore contractual rather than convenient:
+    ///   - NO LEDGER OPERATION MAY TOUCH IT. It has to survive the retraction
+    ///     that removes the entry, or the distinction dies with the entry.
+    ///   - IT IS KEYED BY (attempt, pane) AND RETIRES WITH ITS ATTEMPT, so a
+    ///     pane exhausted on one connection gets a genuine fresh chance on the
+    ///     next and does not report unreachable before it has been tried.
+    /// Clearing it earlier, or keying it by pane alone, silently breaks a
+    /// reported status rather than a retry bound.
     private var openFailures: [FailureKey: Int] = [:]
     private var lastOpenErrors: [FailureKey: String] = [:]
     /// Streams ACTUALLY open, keyed by pane and carrying the REGISTRATION that
@@ -157,11 +173,31 @@ public actor RecoveryExecutor {
 
     /// The same query path as `subscribedPanes`, answering per pane.
     public func paneStatus(_ pane: String) -> PaneWatchStatus {
-        guard state.subscribedPanes.contains(pane) else { return .notAdmitted }
-        if openPanes.contains(pane) { return .open }
         let key = state.currentAttempt.map { FailureKey(attempt: $0, pane: pane) }
+        let failures = key.flatMap { openFailures[$0] } ?? 0
+        guard state.subscribedPanes.contains(pane) else {
+            // ABSENCE IS NOT ONE FACT. Since exhaustion RETRACTS the admission,
+            // an absent pane is either never-wanted or wanted-but-unreachable,
+            // and reporting `.notAdmitted` for both would delete the very
+            // distinction this accessor exists to make.
+            //
+            // The failure counter is the discriminator, and no second store was
+            // needed for it: it is keyed by (attempt, pane) and NO ledger
+            // operation touches it, so it survives the retraction that removed
+            // the ledger entry. At cap it means "admitted, could not be opened,
+            // and will be retried on the next attempt".
+            //
+            // A pane exhausted on attempt N has NO failures on attempt N+1, so
+            // after a reconnect it reports `.notAdmitted` until resync
+            // re-admits it. That is correct — a new connection is a genuine
+            // fresh chance and the pane has not failed on it — and it is
+            // correct BY THE KEYING, which is why it is tested explicitly.
+            guard failures >= Self.openFailureCap else { return .notAdmitted }
+            return .admittedNotOpen(attempts: failures, lastError: key.flatMap { lastOpenErrors[$0] })
+        }
+        if openPanes.contains(pane) { return .open }
         return .admittedNotOpen(
-            attempts: key.flatMap { openFailures[$0] } ?? 0,
+            attempts: failures,
             lastError: key.flatMap { lastOpenErrors[$0] }
         )
     }
@@ -406,6 +442,22 @@ public actor RecoveryExecutor {
                     action: "openStream(\(pane))",
                     reason: "open failed \(failures) times; pane left unsubscribed"
                 ))
+                // RETRACT THE ADMISSION. Before this, the pane stayed in the
+                // ledger with nothing watching it — subscribed in name, silent
+                // in fact. The policy owns the ledger, so exhaustion is an
+                // EVENT, not a reach-in.
+                //
+                // Suspension point: `handle` re-enters the policy. It is
+                // followed by its own attempt recheck, per this loop's
+                // invariant — see the enumeration at the top of the body.
+                await handle(.streamExhausted(pane: pane, from: attempt))
+                guard attempt == state.currentAttempt else {
+                    record(rejection: (
+                        action: "openStream(\(pane))",
+                        reason: "attempt retired while retracting an exhausted pane; remaining panes abandoned"
+                    ))
+                    return
+                }
                 continue
             }
             if failures > 0 {

--- a/Sources/HerdrKit/RecoveryExecutor.swift
+++ b/Sources/HerdrKit/RecoveryExecutor.swift
@@ -156,18 +156,36 @@ public actor RecoveryExecutor {
 
     /// What a caller asking "is this pane watched?" can actually know.
     ///
-    /// Coordinator-mandated: the refusal must be readable from the same surface
-    /// the ledger is read from — not a log line. `admittedNotOpen` is the
-    /// silent-pane condition made visible: the policy admitted the pane, and no
-    /// stream exists. This ADDS an observation of what already happened; it
-    /// does not redefine admission (that boundary is task 7's policy round).
+    /// **The answer is about WATCHING, not about ledger membership**, and since
+    /// task 7 those are genuinely different questions. #11 introduced this
+    /// surface as an observation that explicitly did NOT redefine admission —
+    /// that sentence stood here and is now wrong, because task 7's policy round
+    /// made exhaustion RETRACT the admission. A caller can no longer infer
+    /// ledger membership from a case, and should not try to: ask
+    /// `subscribedPanes` for membership and this for whether anything is
+    /// actually watching.
+    ///
+    /// The three answers partition WATCHED / WANTED-BUT-UNWATCHED /
+    /// NOT-WANTED, which is what a caller needs and what ledger membership
+    /// alone can no longer express.
     public enum PaneWatchStatus: Equatable, Sendable {
-        /// Admitted and a live stream exists.
+        /// A live stream exists. Necessarily admitted.
         case open
-        /// Admitted, but no stream could be opened: the pane is NOT watched,
-        /// whatever the ledger says. Carries the attempt count and last error.
+
+        /// The pane is WANTED and NOT WATCHED — no stream exists.
+        ///
+        /// Two situations reach it and callers are not expected to
+        /// distinguish them, because the actionable fact is the same:
+        ///   - still in the ledger, opening or between retries;
+        ///   - RETRACTED after exhausting its attempts on this connection —
+        ///     absent from the ledger, but retained here because the intent
+        ///     survives the retraction and a new connection will retry it.
+        /// `attempts` at `openFailureCap` identifies the second.
         case admittedNotOpen(attempts: Int, lastError: String?)
-        /// Not admitted at all.
+
+        /// Not wanted: no admission and no exhausted attempt on this
+        /// connection. NOT the same as "absent from the ledger" — an exhausted
+        /// pane is also absent and reports `admittedNotOpen`.
         case notAdmitted
     }
 

--- a/Sources/HerdrKit/SessionRecovery.swift
+++ b/Sources/HerdrKit/SessionRecovery.swift
@@ -257,6 +257,21 @@ public enum ClientEvent: Equatable, Sendable {
     /// client believed itself connected, the herdres-class silence. Carries the
     /// attempt whose transport lost the stream.
     case streamFailed(pane: String, from: AttemptID)
+
+    /// ONE pane's stream could not be opened at all, after every permitted
+    /// attempt. Distinct from `streamFailed`, which is a stream that EXISTED
+    /// and died: this one never existed, and the executor has stopped trying on
+    /// this attempt.
+    ///
+    /// Before this case, admission recorded INTENT and nothing retracted it, so
+    /// an unopenable pane stayed listed while nothing watched it — the pane
+    /// read as subscribed with no stream behind it. That is the herdres-class
+    /// silence one level further in, and it is why issue #12 exists.
+    ///
+    /// Exhaustion IS a death that happened before the stream existed, which is
+    /// why it retracts through the SAME authority section as a real death
+    /// rather than a mechanism of its own.
+    case streamExhausted(pane: String, from: AttemptID)
 }
 
 /// One step of recovery, in the order it must happen.
@@ -614,6 +629,27 @@ public struct SessionRecovery: Sendable {
                 pane, from: from, readmit: state.knownPanes.contains(pane)
             ) else { return RecoveryPlan() }
             return subscriptionPlan(for: readmitted)
+
+        case .streamExhausted(let pane, let from):
+            // RETRACT, and do not re-admit. The same authority section as a real
+            // death, with `readmit: false` — the primitive already expresses
+            // exactly this and is already reviewed, which is why exhaustion
+            // needs no machinery of its own.
+            //
+            // Re-admitting here would be a spin: the executor's failure counter
+            // is keyed by (attempt, pane) and is NOT cleared by any ledger
+            // operation, so a re-admitted pane on the SAME attempt hits the cap
+            // guard again and is refused without a transport call. Correct, but
+            // it would churn a plan per resync for a pane already known
+            // hopeless on this connection.
+            //
+            // The pane is NOT abandoned. A new attempt retires the counters and
+            // adoption's `.resyncAllPanes` re-admits everything from a fresh
+            // snapshot, so a new connection is a genuine fresh chance. That is
+            // the whole recovery schedule and it is deliberately global — there
+            // is no per-pane retry queue and this case does not add one.
+            _ = state.authority.dropAndReadmit(pane, from: from, readmit: false)
+            return RecoveryPlan()
         }
     }
 

--- a/Tests/HerdrKitTests/RecoveryExecutorTests.swift
+++ b/Tests/HerdrKitTests/RecoveryExecutorTests.swift
@@ -1361,6 +1361,34 @@ actor SleepRecorder {
     // correct across the transitions that now depend on it. A signal promoted
     // without a matching rise in its guards is how a class gets reopened later.
 
+    /// Waits for POSITIVE evidence that a pane exhausted its attempts, and
+    /// asserts it.
+    ///
+    /// `!subscribedPanes.contains(pane)` is NOT that evidence, and both
+    /// transition tests were armed on it: absence is true immediately at
+    /// start, before the first connection and snapshot have admitted anything,
+    /// so the wait returned instantly and the tests ran with no exhaustion
+    /// having occurred. A compiling no-op replacing the whole retraction
+    /// SURVIVED both. Seventh instance in this file of a precondition
+    /// observing something that PRECEDES the window it names — and the first
+    /// where the observable was the very state the window is supposed to
+    /// produce, which is what made it look right.
+    ///
+    /// Exhaustion at the cap is positive and cannot be true early.
+    private func waitForExhaustion(
+        _ executor: RecoveryExecutor, _ pane: String
+    ) async {
+        let exhausted = await waitUntil {
+            if case .admittedNotOpen(let attempts, _) = await executor.paneStatus(pane) {
+                return attempts >= RecoveryExecutor.openFailureCap
+            }
+            return false
+        }
+        XCTAssertTrue(exhausted,
+                      "\(pane) never reached the failure cap; the test is not armed and any "
+                      + "assertion about retraction below is vacuous")
+    }
+
     /// AXIS: exhaustion arriving DURING adoption cannot retract from the new
     /// attempt's ledger — the retraction is bound to the attempt that exhausted.
     func testExhaustionDuringAdoptionCannotRetractTheNewAttemptsAdmission() async throws {
@@ -1371,10 +1399,11 @@ actor SleepRecorder {
         await executor.start()
         let oldOptional = await executor.currentAttempt
         let old = try XCTUnwrap(oldOptional)
-        // Wait for the first attempt to have exhausted and retracted, so the
-        // late event below is genuinely a RETIRED attempt's exhaustion.
-        let firstRetracted = await waitUntil { await !executor.subscribedPanes.contains("bad") }
-        XCTAssertTrue(firstRetracted, "the first attempt never exhausted; the test is not armed")
+        // POSITIVE evidence of exhaustion first, then absence — so the late
+        // event below is genuinely a RETIRED attempt's exhaustion.
+        await waitForExhaustion(executor, "bad")
+        let firstRetracted = await !executor.subscribedPanes.contains("bad")
+        XCTAssertTrue(firstRetracted, "exhaustion did not retract the first attempt's admission")
 
         // A new attempt adopts and re-admits from a fresh snapshot. The pane
         // is STALLED rather than failing now, so the new attempt holds a live
@@ -1432,8 +1461,9 @@ actor SleepRecorder {
         let executor = RecoveryExecutor(transport: transport)
         await executor.setSleeper { _ in }
         await executor.start()
-        let retracted = await waitUntil { await !executor.subscribedPanes.contains("p") }
-        XCTAssertTrue(retracted, "the pane was never retracted; the test is not armed")
+        await waitForExhaustion(executor, "p")
+        let retracted = await !executor.subscribedPanes.contains("p")
+        XCTAssertTrue(retracted, "exhaustion did not retract the admission")
 
         // A new connection is a genuine fresh chance: counters retire with the
         // attempt and adoption re-admits from the snapshot.

--- a/Tests/HerdrKitTests/RecoveryExecutorTests.swift
+++ b/Tests/HerdrKitTests/RecoveryExecutorTests.swift
@@ -1142,16 +1142,28 @@ actor SleepRecorder {
         XCTAssertEqual(attempts, RecoveryExecutor.openFailureCap,
                        "expected exactly \(RecoveryExecutor.openFailureCap) registration attempts, got \(attempts)")
 
-        // KNOWN GAP, asserted so it cannot change silently and ESCALATED rather
-        // than fixed here: the ledger still lists the pane, because admission
-        // happens at observe time and records intent, not an open stream. The
-        // pane therefore reads as subscribed while nothing is watching it —
-        // the silence class this task exists to remove, one level in. Closing
-        // it means the policy distinguishing admitted-from-open, which is a
-        // POLICY change and belongs in its own review round (condition 2).
+        // THE GAP IS CLOSED, and this assertion is the inversion of the one
+        // that stood here. #11 asserted the ledger STILL listed an unopenable
+        // pane, with a failure message telling whoever broke it to assert the
+        // better behaviour instead. Task 7 broke it deliberately; this is that
+        // instruction being followed.
+        //
+        // Exhaustion now retracts the admission, so the pane is no longer
+        // listed as subscribed — nothing claims to be watching it.
         let subscribed = await executor.subscribedPanes
-        XCTAssertTrue(subscribed.contains("bad"),
-                      "documented gap changed: the ledger no longer lists an unopenable pane — if this now fails, the policy gained admitted-vs-open and this test should assert the better behaviour")
+        XCTAssertFalse(subscribed.contains("bad"),
+                       "an unopenable pane is still listed as subscribed with nothing watching it")
+
+        // AND THE RETRACTION DID NOT DELETE THE REASON. Absence alone would say
+        // never-wanted; the status must still distinguish it, which is the
+        // whole point of retracting through a surface rather than silently.
+        let status = await executor.paneStatus("bad")
+        guard case .admittedNotOpen(let attempts, let lastError) = status else {
+            return XCTFail("a retracted-because-unopenable pane reports \(status), not admittedNotOpen")
+        }
+        XCTAssertEqual(attempts, RecoveryExecutor.openFailureCap,
+                       "the exhaustion count was lost with the ledger entry")
+        XCTAssertNotNil(lastError, "the last error was lost with the ledger entry")
     }
 
     /// AXIS: a conformer that violates the seam — installing a callback and
@@ -1341,6 +1353,147 @@ actor SleepRecorder {
     /// accessor in the same test. One control alone is satisfied by a
     /// degenerate implementation answering the same thing for everything —
     /// this is the discriminating-evidence requirement made executable.
+    // MARK: - Task 7: admitted-vs-open under transition
+    //
+    // The coordinator's condition for landing B: promoting `paneStatus` from a
+    // diagnostic to a load-bearing signal raises its guard requirements. The
+    // paired control proves the surface DISCRIMINATES; these prove it stays
+    // correct across the transitions that now depend on it. A signal promoted
+    // without a matching rise in its guards is how a class gets reopened later.
+
+    /// AXIS: exhaustion arriving DURING adoption cannot retract from the new
+    /// attempt's ledger — the retraction is bound to the attempt that exhausted.
+    func testExhaustionDuringAdoptionCannotRetractTheNewAttemptsAdmission() async throws {
+        let transport = ScriptedTransport(panes: ["bad"])
+        transport.failingPanes = ["bad"]
+        let executor = RecoveryExecutor(transport: transport)
+        await executor.setSleeper { _ in }
+        await executor.start()
+        let oldOptional = await executor.currentAttempt
+        let old = try XCTUnwrap(oldOptional)
+        // Wait for the first attempt to have exhausted and retracted, so the
+        // late event below is genuinely a RETIRED attempt's exhaustion.
+        let firstRetracted = await waitUntil { await !executor.subscribedPanes.contains("bad") }
+        XCTAssertTrue(firstRetracted, "the first attempt never exhausted; the test is not armed")
+
+        // A new attempt adopts and re-admits from a fresh snapshot. The pane
+        // is STALLED rather than failing now, so the new attempt holds a live
+        // admission for it — otherwise it exhausts again and there is nothing
+        // for the late event to retract wrongly.
+        transport.failingPanes = []
+        transport.stall("bad")
+        await executor.handle(.networkChanged(at: Date()))
+        _ = await waitUntil { await executor.isConnected }
+        let freshOptional = await executor.currentAttempt
+        let fresh = try XCTUnwrap(freshOptional)
+        XCTAssertNotEqual(fresh, old, "the attempt did not roll over; the test is not armed")
+        let readmitted = await waitUntil { await executor.subscribedPanes.contains("bad") }
+        XCTAssertTrue(readmitted, "adoption did not re-admit the pane; nothing to retract wrongly")
+
+        // The OLD attempt's exhaustion, arriving late.
+        await executor.handle(.streamExhausted(pane: "bad", from: old))
+
+        let stillAdmitted = await executor.subscribedPanes
+        XCTAssertTrue(stillAdmitted.contains("bad"),
+                      "a retired attempt's exhaustion retracted the live attempt's admission")
+        transport.release("bad")
+    }
+
+    /// AXIS: exhaustion racing a real stream death does not double-retract, and
+    /// the death's re-admission is not silently undone by the late exhaustion.
+    func testExhaustionRacingARealDeathRetractsExactlyOnce() async throws {
+        let transport = ScriptedTransport(panes: ["p"])
+        let executor = RecoveryExecutor(transport: transport)
+        await executor.setSleeper { _ in }
+        await executor.start()
+        _ = await waitUntil { await executor.paneStatus("p") == .open }
+        let attemptOptional = await executor.currentAttempt
+        let attempt = try XCTUnwrap(attemptOptional)
+
+        // Both arrive for the same pane on the same attempt.
+        await executor.handle(.streamExhausted(pane: "p", from: attempt))
+        let afterFirst = await executor.subscribedPanes.contains("p")
+        XCTAssertFalse(afterFirst, "exhaustion did not retract")
+
+        // The real death lands after the retraction: the ledger has no entry,
+        // so dropAndReadmit's was-in-the-ledger check refuses it. Exactly-once
+        // holds because BOTH paths go through that one check.
+        await executor.handle(.streamFailed(pane: "p", from: attempt))
+        let afterSecond = await executor.subscribedPanes.contains("p")
+        XCTAssertFalse(afterSecond,
+                       "a death after retraction re-admitted a pane the policy had given up on")
+    }
+
+    /// AXIS: after retraction, a genuine re-admission works — the pane is not
+    /// permanently barred by having been exhausted once.
+    func testAPaneCanBeReadmittedAfterExhaustion() async throws {
+        let transport = ScriptedTransport(panes: ["p"])
+        transport.failingPanes = ["p"]
+        let executor = RecoveryExecutor(transport: transport)
+        await executor.setSleeper { _ in }
+        await executor.start()
+        let retracted = await waitUntil { await !executor.subscribedPanes.contains("p") }
+        XCTAssertTrue(retracted, "the pane was never retracted; the test is not armed")
+
+        // A new connection is a genuine fresh chance: counters retire with the
+        // attempt and adoption re-admits from the snapshot.
+        transport.failingPanes = []
+        await executor.handle(.networkChanged(at: Date()))
+        _ = await waitUntil { await executor.isConnected }
+        let reopened = await waitUntil { await executor.paneStatus("p") == .open }
+        XCTAssertTrue(reopened, "an exhausted pane was barred from recovering on a new connection")
+    }
+
+    /// AXIS: a pane exhausted on attempt N reports `.notAdmitted` on attempt
+    /// N+1 BEFORE it has been tried — not `.admittedNotOpen`.
+    ///
+    /// Correct behaviour, and correct BY THE KEYING rather than by a check:
+    /// the counter is keyed by (attempt, pane) and retires with its attempt, so
+    /// the new attempt has no failures to report. That is exactly the kind of
+    /// property that breaks silently when someone re-keys the counter, which is
+    /// why the coordinator asked for it explicitly.
+    func testAnExhaustedPaneDoesNotReportUnreachableOnAFreshAttempt() async throws {
+        let transport = ScriptedTransport(panes: ["p"])
+        transport.failingPanes = ["p"]
+        let executor = RecoveryExecutor(transport: transport)
+        await executor.setSleeper { _ in }
+        await executor.start()
+        let exhausted = await waitUntil {
+            if case .admittedNotOpen = await executor.paneStatus("p") { return true }
+            return false
+        }
+        XCTAssertTrue(exhausted, "the pane never reached exhaustion; the test is not armed")
+
+        // Roll the attempt with the pane STALLED rather than failing, so on the
+        // new connection it is admitted and not yet open — the state in which
+        // an inherited count would be visible.
+        transport.failingPanes = []
+        transport.stall("p")
+        await executor.handle(.networkChanged(at: Date()))
+        _ = await waitUntil { await executor.isConnected }
+        let readmitted = await waitUntil { await executor.subscribedPanes.contains("p") }
+        XCTAssertTrue(readmitted, "adoption did not re-admit; the fresh-attempt state is not armed")
+
+        // It reports admitted-not-open — true, it IS admitted and not yet open —
+        // but with ZERO attempts. The count is the whole point: inheriting the
+        // previous connection's exhaustion would report this pane as having
+        // burned its chances on a connection it has not been tried on.
+        let status = await executor.paneStatus("p")
+        guard case .admittedNotOpen(let attempts, let lastError) = status else {
+            return XCTFail("a re-admitted pane reports \(status) on a fresh attempt")
+        }
+        XCTAssertEqual(attempts, 0,
+                       "the fresh attempt inherited \(attempts) failures from the previous one; "
+                       + "the counter is no longer retiring with its attempt")
+        XCTAssertNil(lastError, "the fresh attempt inherited the previous connection's error")
+
+        // The paired half: a pane with no admission AND no failures is the
+        // never-wanted case, and must not be dressed up as unreachable.
+        let unknown = await executor.paneStatus("never-heard-of")
+        XCTAssertEqual(unknown, .notAdmitted, "an unknown pane reported \(unknown)")
+        transport.release("p")
+    }
+
     func testPaneStatusDiscriminatesOpenFromAdmittedNotOpen() async throws {
         let transport = ScriptedTransport(panes: ["healthy", "broken"])
         transport.failingPanes = ["broken"]

--- a/Tests/HerdrKitTests/RecoveryExecutorTests.swift
+++ b/Tests/HerdrKitTests/RecoveryExecutorTests.swift
@@ -1488,11 +1488,20 @@ actor SleepRecorder {
         let executor = RecoveryExecutor(transport: transport)
         await executor.setSleeper { _ in }
         await executor.start()
-        let exhausted = await waitUntil {
-            if case .admittedNotOpen = await executor.paneStatus("p") { return true }
-            return false
-        }
-        XCTAssertTrue(exhausted, "the pane never reached exhaustion; the test is not armed")
+        // Through the helper, NOT a bare `.admittedNotOpen` match. The bare
+        // match accepted `attempts: 0` — the state of a pane admitted a
+        // moment ago and not yet opened — so this test asserted that counters
+        // retire across attempts without ever requiring a counter to exist. A
+        // premise mutation replacing the failing pane with a stalled one, so
+        // nothing ever failed, left it passing.
+        //
+        // Same class as round one's two, and the third time: the wait matched a
+        // state that is ALSO reachable before the window opens. There the
+        // early value was an empty set; here it is a zero count inside an
+        // otherwise-correct case, which is harder to see and no different.
+        await waitForExhaustion(executor, "p")
+        let retracted = await !executor.subscribedPanes.contains("p")
+        XCTAssertTrue(retracted, "exhaustion did not retract before the attempt rolled")
 
         // Roll the attempt with the pane STALLED rather than failing, so on the
         // new connection it is admitted and not yet open — the state in which


### PR DESCRIPTION
Task 7. Closes #12, under coordinator ruling 29761 (option B).

## The gap

The ledger recorded **admission** — intent, at observe time — and nothing retracted it. A pane whose stream could not be opened after 5 attempts stayed listed while nothing watched it: subscribed in name, silent in fact. #11 could only *report* that; this closes it.

## What changed

**Exhaustion is a transition.** `.streamExhausted(pane:from:)` retracts through `dropAndReadmit(readmit: false)` — the same authority section a real death uses, already reviewed, because exhaustion is a death that happened before the stream existed. No new mechanism, and **the ledger gains no intermediate state**, which is why this did not reopen #10's exactly-once invariants.

**It does not re-admit.** The failure counter is keyed by `(attempt, pane)` and no ledger operation clears it, so re-admitting on the same attempt would hit the cap guard again — correct, but a plan churned per resync for a pane already hopeless on this connection. The pane is not abandoned: a new attempt retires the counters and adoption's `resyncAllPanes` re-admits from a fresh snapshot. That global re-admission **is** the recovery schedule; there is no per-pane retry queue and this does not add one.

**Absence is no longer one fact**, so `paneStatus` stopped deriving `.notAdmitted` from bare ledger membership:

```
absent + failures >= cap  ->  .admittedNotOpen(attempts:lastError:)
absent + no failures      ->  .notAdmitted
```

The discriminator is `openFailures`, which needed **no second store** because `paneStatus` already read it, and which survives the retraction precisely because no ledger operation touches it. It is documented at its declaration as load-bearing, with the two properties that are now contractual rather than convenient.

## Guards rose with the promotion

The paired control proves the surface *discriminates*; these prove it survives the transitions that now depend on it. All four were required by the ruling:

| case | property |
|---|---|
| exhaustion during adoption | a retired attempt's exhaustion cannot retract the live one |
| exhaustion racing a real death | retracts exactly once — both paths go through the same was-in-the-ledger check |
| re-admission after exhaustion | a new connection is a genuine fresh chance |
| attempt rollover | a pane exhausted on attempt N reports 0 attempts on N+1, not the inherited count |

The rollover case is correct *by the keying* rather than by a check, which is exactly why it is tested explicitly — it would break silently if someone re-keyed the counter.

#11's documented-gap assertion was **inverted rather than deleted**: it asserted the ledger still listed an unopenable pane, with a failure message telling whoever broke it to assert the better behaviour. This is that instruction being followed.

## Evidence

```
exhaustion-does-not-retract     KILLED
exhaustion-readmits             KILLED
absent-always-notadmitted       KILLED
counters-survive-retirement     KILLED
executor suite  0 failures / 8 runs, 32 tests
full suite      139 tests, 0 failures
```

## Known, deliberately not closed

Immediately after a reconnect the counters retire and adoption seeds an empty ledger, so every pane reads `.notAdmitted` until resync re-admits it. Pre-existing and not widened here; reported to the coordinator before implementing rather than discovered afterwards. Closing it is separate work I did not fold in silently.