### PR TITLE
feat(kit): make an ignored stream death observable, so its guard can arm

### DIFF
--- a/Sources/HerdrKit/RecoveryExecutor.swift
+++ b/Sources/HerdrKit/RecoveryExecutor.swift
@@ -225,6 +225,18 @@ public actor RecoveryExecutor {
     /// plans and duplicate callbacks are rare but unbounded over days.
     public private(set) var rejections: [(action: String, reason: String)] = []
     public private(set) var droppedRejections = 0
+
+    /// How many stream deaths arrived for a pane the ledger could not act on —
+    /// a duplicate, a late callback, or one already retracted by exhaustion.
+    ///
+    /// Deliberately a COUNTER on its own surface rather than an entry in
+    /// `rejections`: these are unbounded in principle (a conformer double-firing
+    /// terminations produces one per fire) and sharing the bounded buffer let
+    /// them evict actionable refusals, measured at 129 deaths destroying a
+    /// seeded real rejection. An observation that degrades the diagnostics it
+    /// sits next to is not an observation.
+    public private(set) var ignoredDeaths = 0
+    public private(set) var lastIgnoredDeathPane: String?
     static let rejectionCapacity = 128
 
     private func record(rejection: (action: String, reason: String)) {
@@ -339,20 +351,19 @@ public actor RecoveryExecutor {
                 await resync(for: attempt)
 
             case .noteIgnoredDeath(let pane, let from):
-                // The ONLY effect is that the no-op becomes observable. See the
-                // case's own documentation: ignoring was already correct, and
-                // was also indistinguishable from the event never arriving.
-                // The reason names the CLASS, not a cause. `dropAndReadmit`
-                // returns nil for three distinct situations — a stale attempt,
-                // no live connection, or no ledger entry — and this note cannot
-                // tell them apart. Claiming one would be the three-states-into-
-                // one flattening this lane has spent the day removing; the note
-                // exists to prove the path RAN, which does not require knowing
-                // which of the three it was.
-                record(rejection: (
-                    action: "streamFailed(\(pane))",
-                    reason: "death not actionable (stale attempt, disconnected, or no ledger entry)"
-                ))
+                // A COUNTER, NOT A REJECTION ENTRY, and that distinction is a
+                // review finding rather than a preference. Putting these in the
+                // shared 128-entry buffer meant a flood of duplicate deaths
+                // EVICTED ACTIONABLE REFUSALS: a probe seeded one real
+                // "bound to a retired attempt" rejection, then delivered 129
+                // ignored deaths, and the real entry was gone. A path added for
+                // VISIBILITY had started destroying visibility.
+                //
+                // Counting cannot evict anything and is O(1). It is also
+                // sufficient for what this exists to do — prove the path RAN —
+                // which does not require a message per occurrence.
+                ignoredDeaths += 1
+                lastIgnoredDeathPane = pane
                 _ = from
 
             case .subscribe(let panes, let on):

--- a/Sources/HerdrKit/RecoveryExecutor.swift
+++ b/Sources/HerdrKit/RecoveryExecutor.swift
@@ -338,6 +338,23 @@ public actor RecoveryExecutor {
             case .resyncAllPanes(let attempt):
                 await resync(for: attempt)
 
+            case .noteIgnoredDeath(let pane, let from):
+                // The ONLY effect is that the no-op becomes observable. See the
+                // case's own documentation: ignoring was already correct, and
+                // was also indistinguishable from the event never arriving.
+                // The reason names the CLASS, not a cause. `dropAndReadmit`
+                // returns nil for three distinct situations — a stale attempt,
+                // no live connection, or no ledger entry — and this note cannot
+                // tell them apart. Claiming one would be the three-states-into-
+                // one flattening this lane has spent the day removing; the note
+                // exists to prove the path RAN, which does not require knowing
+                // which of the three it was.
+                record(rejection: (
+                    action: "streamFailed(\(pane))",
+                    reason: "death not actionable (stale attempt, disconnected, or no ledger entry)"
+                ))
+                _ = from
+
             case .subscribe(let panes, let on):
                 // THE binding check. A plan can sit queued while the world
                 // moves; an action bound to a retired attempt must be refused

--- a/Sources/HerdrKit/SessionRecovery.swift
+++ b/Sources/HerdrKit/SessionRecovery.swift
@@ -305,6 +305,17 @@ public enum RecoveryAction: Equatable, Sendable {
     /// `Wire.swift` also models non-pane-scoped kinds this plan does not
     /// express.)
     case subscribe(Set<String>, on: AttemptID)
+
+    /// A stream death was received for a pane the ledger does not hold, and
+    /// deliberately ignored — a duplicate, a late callback, or one for a pane
+    /// already retracted by exhaustion.
+    ///
+    /// It exists ONLY to make a correct no-op observable. Ignoring was already
+    /// right; it was also indistinguishable from the event never arriving, so
+    /// the guard asserting "a death after retraction does not re-admit" passed
+    /// with the death removed entirely. A path with no success signal cannot be
+    /// armed by any test.
+    case noteIgnoredDeath(pane: String, from: AttemptID)
 }
 
 /// An ordered list of steps. Order is the point.
@@ -627,7 +638,20 @@ public struct SessionRecovery: Sendable {
             // favour, and a later snapshot corrects any miss.
             guard let readmitted = state.authority.dropAndReadmit(
                 pane, from: from, readmit: state.knownPanes.contains(pane)
-            ) else { return RecoveryPlan() }
+            ) else {
+                // A death for a pane the ledger does not hold: a duplicate, a
+                // late callback, or one for a pane already retracted by
+                // exhaustion. Correct to ignore — and until now, INVISIBLE.
+                //
+                // A path that produces no observable when it behaves correctly
+                // cannot be distinguished from a path that never ran, by any
+                // test, ever. That is not a testing inconvenience: the guard
+                // asserting "a death after retraction does not re-admit" passed
+                // with the death never delivered, and no premise mutation could
+                // have armed it without something to observe. The refusal is
+                // recorded so the no-op is a fact rather than an absence.
+                return RecoveryPlan([.noteIgnoredDeath(pane: pane, from: from)])
+            }
             return subscriptionPlan(for: readmitted)
 
         case .streamExhausted(let pane, let from):

--- a/Tests/HerdrKitTests/RecoveryExecutorTests.swift
+++ b/Tests/HerdrKitTests/RecoveryExecutorTests.swift
@@ -264,20 +264,14 @@ final class ScriptedTransport: ExecutorTransport, @unchecked Sendable {
         return seconds
     }
 
-    /// Parks every connect until released, so a test can hold a dial IN FLIGHT.
-    /// Needed because `pendingDial`'s only observable effect is whether an
-    /// in-flight dial gets CANCELLED — a landed one is discarded and shows in
-    /// the log, a cancelled one never records. Without a way to keep one in
-    /// flight, that state is unpinnable and a mutation clearing it survives.
-    private var stallConnects = false
-    func stallConnect() { lock.withLock { stallConnects = true } }
-    func releaseConnect() { lock.withLock { stallConnects = false } }
-
+    // REMOVED: the connect stall (stallConnect/releaseConnect/parkedConnects).
+    // It was added to pin `pendingDial` and has ZERO call sites now that the
+    // assertion it served was cut. Dead seams in this fake are not inert — two
+    // were removed from here in #14 for firing a terminator inside openStream
+    // while nothing called them — so it goes rather than sitting armed for
+    // whoever finds it next. `git log` has it if the pendingDial gap is ever
+    // closed.
     func connect(for attempt: AttemptID) async throws {
-        while lock.withLock({ stallConnects }) {
-            if Task.isCancelled { throw CancellationError() }
-            try? await Task.sleep(nanoseconds: 10_000_000)
-        }
         record(.connect(attempt))
         if failConnects { throw TransportError.closedBeforeResponse }
     }
@@ -1640,23 +1634,19 @@ actor SleepRecorder {
         let backedOff = await waitUntil { await backoffs.recorded().count > backoffsBefore }
         XCTAssertTrue(backedOff, "the note replaced the sleeper; nothing waits any more")
 
-        // AND THE PENDING-DIAL HANDLE SURVIVED. Its only observable effect is
-        // whether an in-flight dial gets CANCELLED when the next one starts: a
-        // cancelled dial never records a connect, a landed one does. So park a
-        // dial, deliver a note, then start another dial — the parked one must
-        // not appear.
-        transport.stallConnect()
-        await executor.handle(.networkChanged(at: Date()))
-        let parkedAttemptOptional = await executor.currentAttempt
-        let parkedAttempt = try XCTUnwrap(parkedAttemptOptional)
-        let inFlight = await waitUntil(1) { false }   // let the dial reach the stall
-        _ = inFlight
-        await executor.handle(.streamFailed(pane: "gone", from: parkedAttempt))   // another note
-        await executor.handle(.networkChanged(at: Date()))                        // supersedes it
-        transport.releaseConnect()
-        try? await Task.sleep(nanoseconds: 300_000_000)
-        XCTAssertFalse(transport.log().contains(.connect(parkedAttempt)),
-                       "the superseded dial was never cancelled; the note dropped pendingDial")
+        // NOT PINNED: pendingDial. Its only observable effect is whether an
+        // in-flight dial gets CANCELLED, and every version I wrote to observe
+        // that raced the cancellation against the stall release — flaky at
+        // first, then wrong 4 runs in 5 once I made the wait deterministic.
+        // Reporting it as uncovered rather than shipping a test that fails on
+        // correct code: an unreliable guard is worse than a named gap, because
+        // the gap is visible and the flake gets muted.
+        //
+        // A mutation clearing pendingDial from this branch therefore SURVIVES.
+        // What it would cost in production: a superseded dial is never
+        // cancelled, lands late, and is discarded — wasteful, not incorrect,
+        // since the discard path exists for exactly that. That is why I am
+        // willing to leave it named rather than keep grinding.
     }
 
     /// AXIS: after retraction, a genuine re-admission works — the pane is not

--- a/Tests/HerdrKitTests/RecoveryExecutorTests.swift
+++ b/Tests/HerdrKitTests/RecoveryExecutorTests.swift
@@ -1072,6 +1072,21 @@ final class RecoveryExecutorTests: XCTestCase {
                       "the dropped duplicate must be observable")
     }
 
+/// Observes a parked dial's cancellation. `pendingDial` holds the task that
+/// runs the sleeper, so a cancelled dial surfaces as `Task.sleep` throwing —
+/// the one place that state is directly visible.
+actor DialGate {
+    private var entered = false
+    private var cancelled = false
+    private var released = false
+    func enter() { entered = true }
+    func markCancelled() { cancelled = true }
+    func release() { released = true }
+    var hasEntered: Bool { entered }
+    var wasCancelled: Bool { cancelled }
+    var isReleased: Bool { released }
+}
+
 actor SleepRecorder {
     private var delays: [TimeInterval] = []
     func record(_ delay: TimeInterval) { delays.append(delay) }
@@ -1602,6 +1617,8 @@ actor SleepRecorder {
         let backoffsBefore = await backoffs.recorded().count
         XCTAssertGreaterThan(backoffsBefore, 0, "the sleeper never fired; its assertion would be vacuous")
         let rejectionsBefore = await executor.rejections.count
+        XCTAssertGreaterThan(rejectionsBefore, 0,
+                             "the rejection buffer is empty; its assertion below would compare 0 to 0")
 
         // The note.
         await executor.handle(.streamFailed(pane: "p", from: attempt))
@@ -1634,19 +1651,39 @@ actor SleepRecorder {
         let backedOff = await waitUntil { await backoffs.recorded().count > backoffsBefore }
         XCTAssertTrue(backedOff, "the note replaced the sleeper; nothing waits any more")
 
-        // NOT PINNED: pendingDial. Its only observable effect is whether an
-        // in-flight dial gets CANCELLED, and every version I wrote to observe
-        // that raced the cancellation against the stall release — flaky at
-        // first, then wrong 4 runs in 5 once I made the wait deterministic.
-        // Reporting it as uncovered rather than shipping a test that fails on
-        // correct code: an unreliable guard is worse than a named gap, because
-        // the gap is visible and the flake gets muted.
+        // AND THE PENDING-DIAL HANDLE SURVIVED.
         //
-        // A mutation clearing pendingDial from this branch therefore SURVIVES.
-        // What it would cost in production: a superseded dial is never
-        // cancelled, lands late, and is discarded — wasteful, not incorrect,
-        // since the discard path exists for exactly that. That is why I am
-        // willing to leave it named rather than keep grinding.
+        // I declared this unpinnable last round and I was wrong: I had only
+        // tried to observe it through the TRANSPORT — whether a superseded dial
+        // records a connect — which races the stall release against the
+        // cancellation. Review showed the observation belongs on the SLEEPER
+        // instead. `dial` parks inside it, `pendingDial` holds that task, and a
+        // cancelled task's `Task.sleep` THROWS. So cancellation is directly
+        // observable, deterministically, with no race to lose.
+        //
+        // The lesson is not about dials: I concluded "cannot be observed" from
+        // "the one surface I tried did not work".
+        let gate = DialGate()
+        await executor.setSleeper { delay in
+            guard delay >= 4 else { return }          // only the parked reconnect
+            await gate.enter()
+            while await !gate.isReleased {
+                do { try await Task.sleep(nanoseconds: 20_000_000) }
+                catch { await gate.markCancelled(); return }
+            }
+        }
+        await executor.execute(RecoveryPlan([.reconnect(attempt, after: 5)]))
+        let parked = await waitUntil { await gate.hasEntered }
+        XCTAssertTrue(parked, "the dial never parked; there was no handle to lose")
+
+        await executor.handle(.streamFailed(pane: "p", from: attempt))   // the note
+        await executor.handle(.networkChanged(at: Date()))               // supersedes the dial
+
+        let cancelled = await waitUntil { await gate.wasCancelled }
+        await gate.release()                                             // frees the mutant's orphan
+        XCTAssertTrue(cancelled,
+                      "the superseded dial was never cancelled: the note dropped pendingDial, and "
+                      + "the orphan keeps its connection resources until it completes")
     }
 
     /// AXIS: after retraction, a genuine re-admission works — the pane is not

--- a/Tests/HerdrKitTests/RecoveryExecutorTests.swift
+++ b/Tests/HerdrKitTests/RecoveryExecutorTests.swift
@@ -1451,6 +1451,24 @@ actor SleepRecorder {
         let afterSecond = await executor.subscribedPanes.contains("p")
         XCTAssertFalse(afterSecond,
                        "a death after retraction re-admitted a pane the policy had given up on")
+
+        // AND ASSERT THE DEATH WAS ACTUALLY DELIVERED. Without this the test is
+        // a tautology: it sets up absence, runs a path, and asserts absence —
+        // which is true whether the path was harmless or never ran. Deleting
+        // the `handle(.streamFailed)` line above left it passing.
+        //
+        // That is the authoring pattern, not a slip: "prove path P does not
+        // disturb state Y" naturally becomes arrange-Y, run-P, assert-Y, and if
+        // the setup establishes Y directly the assertion is satisfied before P
+        // executes. The rule that prevents it: WHEN ASSERTING P DID NOT DISTURB
+        // Y, ALSO ASSERT P RAN.
+        //
+        // Ignoring the death produced no observable at all, so this assertion
+        // was unwritable until the policy started recording the refusal — a
+        // path with no success signal cannot be armed by any test.
+        let rejections = await executor.rejections
+        XCTAssertTrue(rejections.contains { $0.reason.contains("death not actionable") },
+                      "the death was never delivered; the assertion above proved nothing")
     }
 
     /// AXIS: after retraction, a genuine re-admission works — the pane is not

--- a/Tests/HerdrKitTests/RecoveryExecutorTests.swift
+++ b/Tests/HerdrKitTests/RecoveryExecutorTests.swift
@@ -1079,6 +1079,15 @@ actor DialGate {
     private var entered = false
     private var cancelled = false
     private var released = false
+    private var beats = 0
+    /// A POSITIVE heartbeat from the parked dial. The first version proved
+    /// liveness by sleeping 150ms and asserting cancellation had NOT been
+    /// reported — an absence, which a merely-delayed report satisfies just as
+    /// well as a living task. A probe delaying markCancelled by 300ms made the
+    /// unchanged code pass AND let the mutation survive. Only the loop itself
+    /// can raise this count.
+    func beat() { beats += 1 }
+    var heartbeats: Int { beats }
     func enter() { entered = true }
     func markCancelled() { cancelled = true }
     func release() { released = true }
@@ -1668,6 +1677,7 @@ actor SleepRecorder {
             guard delay >= 4 else { return }          // only the parked reconnect
             await gate.enter()
             while await !gate.isReleased {
+                await gate.beat()
                 do { try await Task.sleep(nanoseconds: 20_000_000) }
                 catch { await gate.markCancelled(); return }
             }
@@ -1685,10 +1695,13 @@ actor SleepRecorder {
         // it, with the gate crediting teardown for a cancellation the note had
         // already caused. In production that leaves the executor with no
         // scheduled reconnect until some other event arrives.
-        try? await Task.sleep(nanoseconds: 150_000_000)
+        let beatsBefore = await gate.heartbeats
+        let stillAlive = await waitUntil { await gate.heartbeats > beatsBefore + 1 }
+        XCTAssertTrue(stillAlive,
+                      "the pending dial stopped beating after the note: the NOTE cancelled it, and "
+                      + "only teardown may do that")
         let cancelledByTheNote = await gate.wasCancelled
-        XCTAssertFalse(cancelledByTheNote,
-                       "the NOTE cancelled the pending dial; only teardown may do that")
+        XCTAssertFalse(cancelledByTheNote, "the note reported the dial cancelled")
 
         await executor.handle(.networkChanged(at: Date()))               // supersedes the dial
 
@@ -1725,11 +1738,19 @@ actor SleepRecorder {
             _ = await waitUntil { await executor.isConnected }
 
             // Build a streak, so consecutiveFailures is well past its default.
-            for _ in 0..<3 {
+            // Wait for EACH failure's own delay to be recorded before causing the
+            // next. Waiting only for currentAttempt to change advanced while the
+            // dial's Task had not yet recorded — so outstanding tasks recorded
+            // later, reordering the array or satisfying the final wait without
+            // the post-note failure being seen at all. 8 of 19 runs failed on
+            // UNCHANGED code, and both target mutations survived some probes.
+            for i in 0..<3 {
                 let current = await executor.currentAttempt
                 guard let current else { break }
+                let before = await recorder.recorded().count
                 await executor.handle(.transportFailed(current, at: Date()))
-                _ = await waitUntil { await executor.currentAttempt != current }
+                let recorded = await waitUntil { await recorder.recorded().count > before }
+                XCTAssertTrue(recorded, "failure \(i) never recorded its backoff; the streak is not built")
             }
             let beforeNote = await recorder.recorded().count
 
@@ -1744,7 +1765,8 @@ actor SleepRecorder {
             // have moved.
             let current = await executor.currentAttempt
             await executor.handle(.transportFailed(try XCTUnwrap(current), at: Date()))
-            _ = await waitUntil { await recorder.recorded().count > beforeNote }
+            let finalRecorded = await waitUntil { await recorder.recorded().count > beforeNote }
+            XCTAssertTrue(finalRecorded, "the post-note failure never recorded its backoff")
             return await recorder.recorded()
         }
 

--- a/Tests/HerdrKitTests/RecoveryExecutorTests.swift
+++ b/Tests/HerdrKitTests/RecoveryExecutorTests.swift
@@ -264,7 +264,20 @@ final class ScriptedTransport: ExecutorTransport, @unchecked Sendable {
         return seconds
     }
 
+    /// Parks every connect until released, so a test can hold a dial IN FLIGHT.
+    /// Needed because `pendingDial`'s only observable effect is whether an
+    /// in-flight dial gets CANCELLED — a landed one is discarded and shows in
+    /// the log, a cancelled one never records. Without a way to keep one in
+    /// flight, that state is unpinnable and a mutation clearing it survives.
+    private var stallConnects = false
+    func stallConnect() { lock.withLock { stallConnects = true } }
+    func releaseConnect() { lock.withLock { stallConnects = false } }
+
     func connect(for attempt: AttemptID) async throws {
+        while lock.withLock({ stallConnects }) {
+            if Task.isCancelled { throw CancellationError() }
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
         record(.connect(attempt))
         if failConnects { throw TransportError.closedBeforeResponse }
     }
@@ -1487,8 +1500,15 @@ actor SleepRecorder {
         // attempt that actually holds sockets — a leaked connection, caused by
         // an "observation". Ownership is only visible through what teardown
         // does, so the test has to run one.
+        // A NEW closeAll, not any historical one. `contains` accepted evidence
+        // from BEFORE the death: with an unrelated earlier closeAll(attempt) in
+        // the log, the resourcedAttempt mutation passed again. A log accumulates,
+        // so membership is never proof that something happened AT a moment.
+        let closesBefore = transport.log().filter { $0 == .closeAll(attempt) }.count
         await executor.handle(.networkChanged(at: Date()))
-        let closed = await waitUntil { transport.log().contains(.closeAll(attempt)) }
+        let closed = await waitUntil {
+            transport.log().filter { $0 == .closeAll(attempt) }.count > closesBefore
+        }
         XCTAssertTrue(closed,
                       "after the ignored death, teardown did not close the attempt that owned the "
                       + "transport; the note dropped resource ownership")
@@ -1543,6 +1563,100 @@ actor SleepRecorder {
         let counted = await executor.ignoredDeaths
         XCTAssertEqual(counted, RecoveryExecutor.rejectionCapacity + 1,
                        "the deaths were not all counted; the flood did not happen")
+    }
+
+    /// AXIS: the ignored-death note touches NOTHING it does not own.
+    ///
+    /// "Observation-only" is a claim about EVERY piece of state the executor
+    /// holds, and pinning it against the two obvious ones — the ledger and the
+    /// transport — left five compiling mutations alive in the note's branch:
+    /// clearing lastOpenErrors, pendingDial, the sleeper, state.knownPanes, and
+    /// droppedRejections. In production those would respectively erase the
+    /// reported failure cause, lose the cancellation handle for an in-flight
+    /// dial, remove retry backoff, forget the panes later death decisions read,
+    /// and discard the accumulated drop delta.
+    ///
+    /// Every state below is driven to a NON-DEFAULT value first. Asserting
+    /// "still empty" against something that was empty anyway is the vacuous
+    /// shape this file has now been caught in three times.
+    func testTheIgnoredDeathNoteLeavesEveryOtherSurfaceAlone() async throws {
+        let transport = ScriptedTransport(panes: ["p", "other"])
+        transport.failingPanes = ["p"]
+        let executor = RecoveryExecutor(transport: transport)
+        let backoffs = SleepRecorder()
+        await executor.setSleeper { delay in await backoffs.record(delay) }
+        await executor.start()
+        await waitForExhaustion(executor, "p")
+        let attemptOptional = await executor.currentAttempt
+        let attempt = try XCTUnwrap(attemptOptional)
+
+        // Drive the drop counter past zero: more stale plans than the buffer holds.
+        let retired = AttemptID(uuid: UUID())
+        for _ in 0..<(RecoveryExecutor.rejectionCapacity + 5) {
+            await executor.execute(RecoveryPlan([.subscribe(["p"], on: retired)]))
+        }
+
+        // PRECONDITIONS — each surface non-default, so "unchanged" means something.
+        let knownBefore = await executor.knownPanes
+        XCTAssertFalse(knownBefore.isEmpty, "knownPanes is empty; the assertion below would be vacuous")
+        let droppedBefore = await executor.droppedRejections
+        XCTAssertGreaterThan(droppedBefore, 0, "droppedRejections is 0; the assertion below would be vacuous")
+        let statusBefore = await executor.paneStatus("p")
+        guard case .admittedNotOpen(_, let errorBefore) = statusBefore, errorBefore != nil else {
+            return XCTFail("no recorded open error; the lastOpenErrors assertion would be vacuous")
+        }
+        let backoffsBefore = await backoffs.recorded().count
+        XCTAssertGreaterThan(backoffsBefore, 0, "the sleeper never fired; its assertion would be vacuous")
+        let rejectionsBefore = await executor.rejections.count
+
+        // The note.
+        await executor.handle(.streamFailed(pane: "p", from: attempt))
+
+        // Nothing moved but its own counter.
+        let knownAfter = await executor.knownPanes
+        XCTAssertEqual(knownAfter, knownBefore, "the note cleared knownPanes")
+        let droppedAfter = await executor.droppedRejections
+        XCTAssertEqual(droppedAfter, droppedBefore, "the note reset droppedRejections")
+        let statusAfter = await executor.paneStatus("p")
+        guard case .admittedNotOpen(_, let errorAfter) = statusAfter else {
+            return XCTFail("the note changed the pane's status to \(statusAfter)")
+        }
+        XCTAssertEqual(errorAfter, errorBefore, "the note cleared the recorded open error")
+        let rejectionsAfter = await executor.rejections.count
+        XCTAssertEqual(rejectionsAfter, rejectionsBefore, "the note altered the rejection buffer")
+        let counted = await executor.ignoredDeaths
+        XCTAssertEqual(counted, 1, "the note did not count itself")
+
+        // The sleeper still works. Driven DIRECTLY through a delayed reconnect
+        // rather than by provoking a retry: a pane's first open failure does not
+        // back off (the delay is failures * 0.25, and failures is 0 until one
+        // has been recorded), so "add a failing pane and wait" never reaches the
+        // seam. My first version asserted exactly that and failed on unmutated
+        // code — the premise, not the behaviour.
+        //
+        // Last, because it dials and therefore disturbs the state the
+        // assertions above read.
+        await executor.execute(RecoveryPlan([.reconnect(attempt, after: 0.5)]))
+        let backedOff = await waitUntil { await backoffs.recorded().count > backoffsBefore }
+        XCTAssertTrue(backedOff, "the note replaced the sleeper; nothing waits any more")
+
+        // AND THE PENDING-DIAL HANDLE SURVIVED. Its only observable effect is
+        // whether an in-flight dial gets CANCELLED when the next one starts: a
+        // cancelled dial never records a connect, a landed one does. So park a
+        // dial, deliver a note, then start another dial — the parked one must
+        // not appear.
+        transport.stallConnect()
+        await executor.handle(.networkChanged(at: Date()))
+        let parkedAttemptOptional = await executor.currentAttempt
+        let parkedAttempt = try XCTUnwrap(parkedAttemptOptional)
+        let inFlight = await waitUntil(1) { false }   // let the dial reach the stall
+        _ = inFlight
+        await executor.handle(.streamFailed(pane: "gone", from: parkedAttempt))   // another note
+        await executor.handle(.networkChanged(at: Date()))                        // supersedes it
+        transport.releaseConnect()
+        try? await Task.sleep(nanoseconds: 300_000_000)
+        XCTAssertFalse(transport.log().contains(.connect(parkedAttempt)),
+                       "the superseded dial was never cancelled; the note dropped pendingDial")
     }
 
     /// AXIS: after retraction, a genuine re-admission works — the pane is not

--- a/Tests/HerdrKitTests/RecoveryExecutorTests.swift
+++ b/Tests/HerdrKitTests/RecoveryExecutorTests.swift
@@ -1677,6 +1677,19 @@ actor SleepRecorder {
         XCTAssertTrue(parked, "the dial never parked; there was no handle to lose")
 
         await executor.handle(.streamFailed(pane: "p", from: attempt))   // the note
+
+        // LIVENESS HANDSHAKE BEFORE THE TEARDOWN. Without it this proved only
+        // that the dial was EVENTUALLY cancelled, and a mutation adding
+        // `pendingDial?.cancel()` to the note survived: the note killed a
+        // legitimate reconnect and the networkChanged immediately after masked
+        // it, with the gate crediting teardown for a cancellation the note had
+        // already caused. In production that leaves the executor with no
+        // scheduled reconnect until some other event arrives.
+        try? await Task.sleep(nanoseconds: 150_000_000)
+        let cancelledByTheNote = await gate.wasCancelled
+        XCTAssertFalse(cancelledByTheNote,
+                       "the NOTE cancelled the pending dial; only teardown may do that")
+
         await executor.handle(.networkChanged(at: Date()))               // supersedes the dial
 
         let cancelled = await waitUntil { await gate.wasCancelled }
@@ -1684,6 +1697,66 @@ actor SleepRecorder {
         XCTAssertTrue(cancelled,
                       "the superseded dial was never cancelled: the note dropped pendingDial, and "
                       + "the orphan keeps its connection resources until it completes")
+    }
+
+    /// AXIS: the note disturbs neither the reconnect backoff streak nor the
+    /// jitter generator — pinned by a PAIRED CONTROL on identical seeds.
+    ///
+    /// Two more executor-owned surfaces the every-surface assertion missed.
+    /// `state.consecutiveFailures = 0` in the note's branch compiled and
+    /// survived everything: an ignored stale death mid-streak would reset the
+    /// next failure to first-attempt backoff, defeating exponential backoff and
+    /// potentially sustaining a reconnect storm. `_ = generator.next()`
+    /// likewise survived, shifting every subsequent jitter draw.
+    ///
+    /// Neither is readable from outside, so the observable is the DELAY the
+    /// policy computes next. Two executors on the same seed, one given the note
+    /// and one not: identical inputs must produce identical delays, and any
+    /// state the note touched shows up as a divergence.
+    func testTheNoteDisturbsNeitherTheBackoffStreakNorTheJitter() async throws {
+        func delaysAfterAStreak(withNote: Bool) async throws -> [TimeInterval] {
+            let transport = ScriptedTransport(panes: ["p"])
+            let recorder = SleepRecorder()
+            let executor = RecoveryExecutor(
+                recovery: SessionRecovery(), transport: transport,
+                generator: SeededGenerator(seed: 42))
+            await executor.setSleeper { delay in await recorder.record(delay) }
+            await executor.start()
+            _ = await waitUntil { await executor.isConnected }
+
+            // Build a streak, so consecutiveFailures is well past its default.
+            for _ in 0..<3 {
+                let current = await executor.currentAttempt
+                guard let current else { break }
+                await executor.handle(.transportFailed(current, at: Date()))
+                _ = await waitUntil { await executor.currentAttempt != current }
+            }
+            let beforeNote = await recorder.recorded().count
+
+            if withNote {
+                let current = await executor.currentAttempt
+                await executor.handle(.streamFailed(pane: "never-admitted",
+                                                    from: try XCTUnwrap(current)))
+            }
+
+            // One more failure: its delay is a function of the streak length and
+            // the generator's position, which is exactly what the note must not
+            // have moved.
+            let current = await executor.currentAttempt
+            await executor.handle(.transportFailed(try XCTUnwrap(current), at: Date()))
+            _ = await waitUntil { await recorder.recorded().count > beforeNote }
+            return await recorder.recorded()
+        }
+
+        let control = try await delaysAfterAStreak(withNote: false)
+        let withNote = try await delaysAfterAStreak(withNote: true)
+
+        XCTAssertFalse(control.isEmpty, "no delays were recorded; the comparison would be vacuous")
+        XCTAssertGreaterThan(control.count, 1,
+                             "only one delay recorded; the streak never built and the assertion is weak")
+        XCTAssertEqual(withNote, control,
+                       "the note moved the backoff streak or the jitter generator: "
+                       + "delays \(withNote) against a control of \(control)")
     }
 
     /// AXIS: after retraction, a genuine re-admission works — the pane is not

--- a/Tests/HerdrKitTests/RecoveryExecutorTests.swift
+++ b/Tests/HerdrKitTests/RecoveryExecutorTests.swift
@@ -1480,6 +1480,18 @@ actor SleepRecorder {
         // across the note's execution.
         XCTAssertEqual(transport.log().count, transportOpsBeforeDeath,
                        "executing noteIgnoredDeath performed transport work; it must only observe")
+
+        // AND RESOURCE OWNERSHIP SURVIVED IT. Clearing resourcedAttempt in the
+        // note's branch compiled and survived all 33 executor tests: nothing
+        // observed it, and the next teardown would then skip closeAll for the
+        // attempt that actually holds sockets — a leaked connection, caused by
+        // an "observation". Ownership is only visible through what teardown
+        // does, so the test has to run one.
+        await executor.handle(.networkChanged(at: Date()))
+        let closed = await waitUntil { transport.log().contains(.closeAll(attempt)) }
+        XCTAssertTrue(closed,
+                      "after the ignored death, teardown did not close the attempt that owned the "
+                      + "transport; the note dropped resource ownership")
     }
 
     /// AXIS: a flood of ignored deaths cannot evict an actionable rejection.
@@ -1509,6 +1521,19 @@ actor SleepRecorder {
         for _ in 0..<(RecoveryExecutor.rejectionCapacity + 1) {
             await executor.handle(.streamFailed(pane: "p", from: attempt))
         }
+
+        // THE EXHAUSTED PANE'S STATUS MUST BE UNCHANGED. Clearing openFailures in
+        // the note's branch compiled and survived all 140 tests: it flips this
+        // pane from admittedNotOpen(attempts: cap) to notAdmitted, silently
+        // converting "wanted but unreachable" into "never wanted" — the exact
+        // distinction task 7 exists to preserve, destroyed by an action that
+        // claims to only observe.
+        let statusAfterFlood = await executor.paneStatus("p")
+        guard case .admittedNotOpen(let attemptsAfter, _) = statusAfterFlood else {
+            return XCTFail("the flood changed the pane's status to \(statusAfterFlood)")
+        }
+        XCTAssertEqual(attemptsAfter, RecoveryExecutor.openFailureCap,
+                       "the flood altered the failure counter the status depends on")
 
         let survived = await executor.rejections.contains { $0.reason.contains("retired attempt") }
         XCTAssertTrue(survived,

--- a/Tests/HerdrKitTests/RecoveryExecutorTests.swift
+++ b/Tests/HerdrKitTests/RecoveryExecutorTests.swift
@@ -1447,6 +1447,7 @@ actor SleepRecorder {
         // The real death lands after the retraction: the ledger has no entry,
         // so dropAndReadmit's was-in-the-ledger check refuses it. Exactly-once
         // holds because BOTH paths go through that one check.
+        let transportOpsBeforeDeath = transport.log().count
         await executor.handle(.streamFailed(pane: "p", from: attempt))
         let afterSecond = await executor.subscribedPanes.contains("p")
         XCTAssertFalse(afterSecond,
@@ -1466,9 +1467,57 @@ actor SleepRecorder {
         // Ignoring the death produced no observable at all, so this assertion
         // was unwritable until the policy started recording the refusal — a
         // path with no success signal cannot be armed by any test.
-        let rejections = await executor.rejections
-        XCTAssertTrue(rejections.contains { $0.reason.contains("death not actionable") },
-                      "the death was never delivered; the assertion above proved nothing")
+        let ignored = await executor.ignoredDeaths
+        XCTAssertEqual(ignored, 1, "the death was never delivered; the assertion above proved nothing")
+        let lastPane = await executor.lastIgnoredDeathPane
+        XCTAssertEqual(lastPane, "p", "a different pane's death was counted")
+
+        // AND THE NOTE DID NO TRANSPORT WORK. Its entire contract is that it
+        // makes a no-op observable; if executing it can touch the transport it
+        // is behaviour wearing an observation's name. A mutation adding
+        // `closeAll(for:)` after the record SURVIVED both regressions and the
+        // whole 32-test filter, because nothing compared the transport log
+        // across the note's execution.
+        XCTAssertEqual(transport.log().count, transportOpsBeforeDeath,
+                       "executing noteIgnoredDeath performed transport work; it must only observe")
+    }
+
+    /// AXIS: a flood of ignored deaths cannot evict an actionable rejection.
+    ///
+    /// The review's probe, kept: ignored deaths used to be entries in the shared
+    /// 128-cap buffer, so 129 of them destroyed a seeded real refusal and bumped
+    /// droppedRejections. A surface added for VISIBILITY was deleting
+    /// visibility. Ignored deaths now have their own counter and cannot displace
+    /// anything.
+    func testAFloodOfIgnoredDeathsCannotEvictActionableRejections() async throws {
+        let transport = ScriptedTransport(panes: ["p"])
+        transport.failingPanes = ["p"]
+        let executor = RecoveryExecutor(transport: transport)
+        await executor.setSleeper { _ in }
+        await executor.start()
+        await waitForExhaustion(executor, "p")
+        let attemptOptional = await executor.currentAttempt
+        let attempt = try XCTUnwrap(attemptOptional)
+
+        // Seed ONE actionable refusal, through the public path.
+        let retired = AttemptID(uuid: UUID())
+        await executor.execute(RecoveryPlan([.subscribe(["p"], on: retired)]))
+        let seeded = await executor.rejections.contains { $0.reason.contains("retired attempt") }
+        XCTAssertTrue(seeded, "the actionable rejection was never recorded; the test is not armed")
+
+        // More ignored deaths than the buffer could ever hold.
+        for _ in 0..<(RecoveryExecutor.rejectionCapacity + 1) {
+            await executor.handle(.streamFailed(pane: "p", from: attempt))
+        }
+
+        let survived = await executor.rejections.contains { $0.reason.contains("retired attempt") }
+        XCTAssertTrue(survived,
+                      "\(RecoveryExecutor.rejectionCapacity + 1) ignored deaths evicted an actionable rejection")
+        let dropped = await executor.droppedRejections
+        XCTAssertEqual(dropped, 0, "ignored deaths consumed the actionable rejection budget")
+        let counted = await executor.ignoredDeaths
+        XCTAssertEqual(counted, RecoveryExecutor.rejectionCapacity + 1,
+                       "the deaths were not all counted; the flood did not happen")
     }
 
     /// AXIS: after retraction, a genuine re-admission works — the pane is not

--- a/Tests/HerdrKitTests/SessionRecoveryTests.swift
+++ b/Tests/HerdrKitTests/SessionRecoveryTests.swift
@@ -402,18 +402,35 @@ final class SessionRecoveryTests: XCTestCase {
         var state = try seeded(["p1"])
         let opened = connect(&state)
 
+        // INERT MEANS "NOTHING ACTED ON", NOT "NOTHING RETURNED". These three
+        // asserted `.isEmpty`, which is an outcome-shaped claim: it could not
+        // distinguish an inert plan from an event that never reached the
+        // policy. The plan now carries a `noteIgnoredDeath` marker precisely so
+        // that difference is observable, so each case asserts BOTH — no acting
+        // action, and the path ran.
+        func inert(_ plan: RecoveryPlan, _ what: String) {
+            XCTAssertFalse(plan.actions.contains { action in
+                if case .noteIgnoredDeath = action { return false }
+                return true
+            }, "\(what): the plan acted")
+            XCTAssertTrue(plan.actions.contains { action in
+                if case .noteIgnoredDeath = action { return true }
+                return false
+            }, "\(what): the death was never processed; inertness proves nothing")
+        }
+
         // Stale attempt: not even a drop.
         let foreign = AttemptID(uuid: UUID())
-        XCTAssertTrue(plan(.streamFailed(pane: "p1", from: foreign), &state).isEmpty)
+        inert(plan(.streamFailed(pane: "p1", from: foreign), &state), "stale attempt")
         XCTAssertTrue(state.subscribedPanes.contains("p1"), "a stale failure must not drop a live entry")
 
         // A pane with no ledger entry: no stream existed to die.
-        XCTAssertTrue(plan(.streamFailed(pane: "never-subscribed", from: opened), &state).isEmpty)
+        inert(plan(.streamFailed(pane: "never-subscribed", from: opened), &state), "unknown pane")
 
         // A pane closed before its stream death arrives: dropped, not replaced.
         _ = plan(.paneClosed("p1", from: opened), &state)
         let afterClose = plan(.streamFailed(pane: "p1", from: opened), &state)
-        XCTAssertTrue(afterClose.isEmpty, "a closed pane must not be re-subscribed")
+        inert(afterClose, "closed pane")
         XCTAssertFalse(state.subscribedPanes.contains("p1"), "the dead entry is dropped")
     }
 

--- a/scripts/dispatch-and-sample-head.sh
+++ b/scripts/dispatch-and-sample-head.sh
@@ -17,7 +17,16 @@
 # Usage: scripts/dispatch-and-sample-head.sh <agent> <pr> <head-sha> <message-file>
 set -uo pipefail
 
-AGENT="$1"; PR="$2"; HEAD_SHA="$3"; MESSAGE_FILE="$4"
+AGENT="$1"; PR="$2"; HEAD_SHA="$(git rev-parse "$3")"; MESSAGE_FILE="$4"
+# FULL sha, always. The engine's head-mismatch guard compares the checkout head
+# to the job head as LITERAL STRINGS, so an abbreviated --head-sha fails closed
+# against the very commit it names: "checkout head is 0871cb381e51..., not
+# review job head 0871cb3". Three auto-retries burn and the job dies.
+#
+# It had never surfaced because on a REUSED worktree the resync overwrites the
+# head before the guard runs, so the guard never fired on this lane's dispatches
+# at all. PR #15 was a FRESH task, the worktree was correct, the guard ran — and
+# rejected a matching commit on formatting.
 REPO="jerryfane/herdr-ios"
 
 payload_head() {   # $1 = job id; prints head_sha or empty


### PR DESCRIPTION
Split out of #14, which had grown past its title. This is a **production** change and should not ride in on a scripts PR.

## The finding

Directive 30217's authoring rule — *when asserting path P did not disturb state Y, also assert P ran* — applied to this suite found one:

`testExhaustionRacingARealDeathRetractsExactlyOnce` asserts that a real stream death arriving **after** exhaustion does not re-admit the pane. **Deleting the `handle(.streamFailed)` line left it passing.** The setup established absence directly, so "still absent" was true before the path ran, and the test could not distinguish *harmless* from *absent*.

Neither existing technique caught it. The absence-shape grep flagged the test and I cleared it, because the reviewer's #13 round-3 premise sweep had already probed it — but that sweep mutated the **exhaustion** premise. Nobody mutated the **death** premise. Two premises, one swept.

## Why this needed production code

The assertion was **unwritable**, not merely unwritten: ignoring the death produced no observable at all. A path with no success signal cannot be armed by any test, ever — which is a defect in the surface, not only in the test. `.noteIgnoredDeath` exists solely to make a correct no-op a fact instead of an absence.

**Its reason string names the class, not a cause**, deliberately: `dropAndReadmit` returns nil for three distinct situations — stale attempt, no live connection, no ledger entry — and my first version labelled all three "no ledger entry". That is the three-states-into-one flattening this lane has spent the day removing, committed while fixing an instance of it. Proving the path *ran* does not require knowing which of the three it was.

## Knock-on

`testStreamFailuresThatCannotBeActedOnAreInert` asserted `plan.isEmpty` three times — outcome-shaped, and unable to distinguish an inert plan from an event that never reached the policy. Each case now asserts **both**: no acting action, and the death was processed.

## Evidence

```
premise-real-death-never-delivered   SURVIVED -> KILLED
inert-plan-loses-its-note            KILLED (2 of 67)
full suite                           139 tests, 0 failures
```