### PR TITLE
fix(kit): attribute descriptor audits, and make the host-key test detect anything

### DIFF
--- a/Sources/HerdrKit/SSHTransport.swift
+++ b/Sources/HerdrKit/SSHTransport.swift
@@ -176,7 +176,7 @@ public struct SSHTransport: HerdrTransport {
     /// Every channel it opens inherits this token, so a test can ask what THIS
     /// transport did without reading a process-wide tally that every other
     /// test also writes to.
-    final class AuditToken {}
+    final class AuditToken: Sendable {}
     let auditToken = AuditToken()
 
     /// Shared, bounded pool for blocking libssh2 work. Bounded because a thread
@@ -552,7 +552,7 @@ public struct SSHTransport: HerdrTransport {
             // Published before the first call that can block on it, so an
             // interrupt arriving mid-connect has a real descriptor to shut down.
             guard live?.adopt(rawSocket: fd) ?? true else {
-                _ = Glibc_close(fd)
+                DescriptorAudit.close(fd, owner: auditToken)
                 throw CancellationError()
             }
             do {
@@ -568,7 +568,7 @@ public struct SSHTransport: HerdrTransport {
                 // published number before closing it — otherwise `close()` closes
                 // it a second time, by which point it may name another socket.
                 live?.release()
-                _ = Glibc_close(fd)
+                DescriptorAudit.close(fd, owner: auditToken)
                 guard case SSHError.connectFailed(_, _, let failure) = error else {
                     // A deadline or an interrupt ends the attempt outright: both
                     // are global, and trying the next address cannot help.

--- a/Sources/HerdrKit/SSHTransport.swift
+++ b/Sources/HerdrKit/SSHTransport.swift
@@ -176,7 +176,30 @@ public struct SSHTransport: HerdrTransport {
     /// Every channel it opens inherits this token, so a test can ask what THIS
     /// transport did without reading a process-wide tally that every other
     /// test also writes to.
-    final class AuditToken: Sendable {}
+    /// Carries its own audit state, so nothing is keyed by an ADDRESS.
+    ///
+    /// The counters and the injectable closer used to live in
+    /// `[ObjectIdentifier: ...]` maps, which are keyed by a pointer value that
+    /// the allocator reuses: review released a token WITHOUT calling forget(),
+    /// obtained a replacement at the same address, and watched the retired
+    /// token's closer run for it. Manual cleanup is not a lifetime; holding the
+    /// state on the object IS one, and it deletes the whole class of hazard
+    /// rather than adding a rule people must remember.
+    final class AuditToken: @unchecked Sendable {
+        private let lock = NSLock()
+        private var _closer: @Sendable (Int32) -> Int32 = { DescriptorAudit.realClose($0) }
+        private var _doubleCloses = 0
+        private var _rejections = 0
+
+        var closer: @Sendable (Int32) -> Int32 {
+            get { lock.withLock { _closer } }
+            set { lock.withLock { _closer = newValue } }
+        }
+        var doubleCloses: Int { lock.withLock { _doubleCloses } }
+        var adoptionRejections: Int { lock.withLock { _rejections } }
+        fileprivate func recordDoubleClose() { lock.withLock { _doubleCloses += 1 } }
+        fileprivate func recordRejection() { lock.withLock { _rejections += 1 } }
+    }
     let auditToken = AuditToken()
 
     /// Internal seam: fires once a descriptor exists and BEFORE it is offered to
@@ -303,7 +326,7 @@ public struct SSHTransport: HerdrTransport {
         let sock: Int32
         let handle: OpaquePointer
         /// Who a double close here is attributed to. See DescriptorAudit.
-        var auditOwner: AnyObject?
+        var auditOwner: SSHTransport.AuditToken?
 
         init(sock: Int32, handle: OpaquePointer) {
             self.sock = sock
@@ -978,7 +1001,7 @@ final class LiveChannel: @unchecked Sendable {
     /// and never held by a caller, so attributing to `self` gives a test
     /// nothing it can ask about; the TRANSPORT outlives every channel it makes
     /// and is what a test actually holds.
-    var auditOwner: AnyObject?
+    var auditOwner: SSHTransport.AuditToken?
     private let lock = NSLock()
     private var session: SSHTransport.Session?
     private var channel: OpaquePointer?
@@ -1113,7 +1136,7 @@ final class LiveChannel: @unchecked Sendable {
         if let session {
             session.closeSocket()
         } else if raw >= 0 {
-            DescriptorAudit.close(raw, owner: auditOwner ?? self)
+            DescriptorAudit.close(raw, owner: auditOwner)
         }
     }
 }
@@ -1128,148 +1151,53 @@ final class LiveChannel: @unchecked Sendable {
 enum DescriptorAudit {
     private static let lock = NSLock()
     private static var doubleCloseCount = 0
-    private static var byOwner: [ObjectIdentifier: Int] = [:]
+    private static var generations: [Int32: Int] = [:]
 
-    /// Closes, and records the close of a descriptor that was not open.
-    ///
-    /// `owner` attributes the double close to the object whose teardown caused
-    /// it. Without it the tally was PROCESS-WIDE, and the only test reading it
-    /// bracketed a window with a baseline — which is safe only if nothing else
-    /// in the process closes a descriptor during that window. Other tests'
-    /// async teardown does exactly that, so the assertion failed roughly one
-    /// run in ten under full-suite load and never in isolation. The comment
-    /// here used to say the baseline handled sharing a process; it handled
-    /// SEQUENTIAL sharing, not concurrent.
-    static func close(_ fd: Int32, owner: AnyObject? = nil) {
-        guard Glibc_close(fd) != 0, errno == EBADF else { return }
-        lock.lock()
-        doubleCloseCount += 1
-        if let owner { byOwner[ObjectIdentifier(owner), default: 0] += 1 }
-        lock.unlock()
+    static func realClose(_ fd: Int32) -> Int32 { Glibc_close(fd) }
+
+    /// Closes, and records a double close against the token that owned it.
+    static func close(_ fd: Int32, owner: SSHTransport.AuditToken?) {
+        guard (owner?.closer ?? realClose)(fd) != 0, errno == EBADF else { return }
+        lock.lock(); doubleCloseCount += 1; lock.unlock()
+        owner?.recordDoubleClose()
     }
 
-    /// Process-wide tally. Kept for diagnostics; NOT sound for a test
-    /// assertion, because any concurrent teardown lands inside the window.
+    /// Process-wide tally. NOT sound for a test assertion — any concurrent
+    /// teardown lands inside the window. Ask a token instead.
     static var doubleCloses: Int {
         lock.lock(); defer { lock.unlock() }
         return doubleCloseCount
     }
 
-    /// Double closes attributable to ONE object — the only form a test can
-    /// assert on without depending on what the rest of the process is doing.
-    static func doubleCloses(by owner: AnyObject) -> Int {
-        lock.lock(); defer { lock.unlock() }
-        return byOwner[ObjectIdentifier(owner)] ?? 0
-    }
-
-    /// Adoption rejections, attributed. The rejection branch closes its
-    /// descriptor and throws — and BOTH of those are indistinguishable from what
-    /// the ordinary cleanup does one level down, so a test could not tell the
-    /// branch had run at all. Bypassing it entirely compiled and left its own
-    /// regression green. A path with no success signal cannot be armed by any
-    /// test; this is that signal.
-    private static var rejectionsByOwner: [ObjectIdentifier: Int] = [:]
-    /// Closes a descriptor whose adoption was refused, and records the rejection
-    /// ONLY BECAUSE the close happened.
-    ///
-    /// ONE operation, because two independent ones diverge. Recording and
-    /// closing were separate calls, so deleting the close compiled and left the
-    /// counter incrementing: the test saw "one rejection, zero double closes"
-    /// and passed, while the descriptor LEAKED. A positive observable that does
-    /// not originate from the act it witnesses is just a second claim.
-    /// Records that a descriptor number has just been opened, and returns the
-    /// GENERATION that identifies this particular use of it.
-    ///
-    /// Descriptor numbers are recycled: close 7, open a socket, and the kernel
-    /// hands back 7. `EBADF` therefore distinguishes only the NUMBER'S current
-    /// state, never which opening it belonged to — a probe closed a descriptor,
-    /// opened another that reused the number, and the audit reported the second
-    /// one's close as the first one's success. A generation is the only thing
-    /// that can tell those apart.
-    /// The close used for an owner's descriptors — real by default, injectable
-    /// so a test can witness that a site invoked it.
-    private static var closers: [ObjectIdentifier: @Sendable (Int32) -> Int32] = [:]
-    static func setCloser(_ closer: @escaping @Sendable (Int32) -> Int32, for owner: AnyObject) {
-        lock.lock(); closers[ObjectIdentifier(owner)] = closer; lock.unlock()
-    }
-    static func realClose(_ fd: Int32) -> Int32 { Glibc_close(fd) }
-    private static func closer(for owner: AnyObject?) -> @Sendable (Int32) -> Int32 {
-        guard let owner else { return { Glibc_close($0) } }
-        lock.lock(); defer { lock.unlock() }
-        return closers[ObjectIdentifier(owner)] ?? { Glibc_close($0) }
-    }
-
+    /// Records that a descriptor NUMBER has just been opened, returning the
+    /// generation that identifies this particular use of it. Numbers recycle,
+    /// so EBADF alone can never say which opening a close belonged to.
     static func opened(_ fd: Int32) -> Int {
         lock.lock(); defer { lock.unlock() }
         generations[fd, default: 0] += 1
         return generations[fd] ?? 0
     }
-    private static var generations: [Int32: Int] = [:]
 
-    /// Closes the descriptor an adoption refused, and records the rejection only
-    /// on PROOF that THIS generation of THAT descriptor is now gone.
+    /// Closes the descriptor an adoption refused, and records the rejection
+    /// only because the close ran.
     ///
-    /// Two things are verified rather than assumed, because both were exploited:
-    ///   - the GENERATION still matches, so a recycled number cannot be closed
-    ///     in place of the one the caller meant;
-    ///   - the close goes through an INJECTABLE, owner-scoped closer, so a test
-    ///     can prove this site actually invoked it. That replaces an earlier
-    ///     post-close `fcntl(F_GETFD)` check which was itself racy — once close
-    ///     returns the number is free, another thread can reuse it, and a
-    ///     healthy rejection then went unrecorded under load.
+    /// Verified rather than assumed: the GENERATION still matches, so a
+    /// recycled number cannot be closed in the original's place; and the close
+    /// goes through the token's injectable closer, so a test can witness that
+    /// this site invoked it. An earlier version probed the descriptor with
+    /// fcntl AFTER closing — racy, because by then the number may belong to
+    /// someone else, and it failed under load on unchanged code.
     ///
-    /// The seam is what makes "did this site close anything?" answerable without
-    /// inspecting a number that no longer belongs to us. I had accepted that gap
-    /// as unclosable; review built the construction that closes it.
-    static func closeRejectedAdoption(_ fd: Int32, generation: Int, owner: AnyObject?) {
+    /// Both a success-shaped substitute for the call and deleting it outright
+    /// leave the injected closer uninvoked, so both are caught.
+    static func closeRejectedAdoption(
+        _ fd: Int32, generation: Int, owner: SSHTransport.AuditToken?
+    ) {
         let current = lock.withLock { generations[fd] ?? 0 }
         guard current == generation else { return }   // recycled: not ours to close
-        // NO POST-CLOSE PROBE. A previous version closed and then verified with
-        // fcntl(fd, F_GETFD) that the descriptor was gone. That check is
-        // ITSELF RACY: once close returns, the number is free and another
-        // thread can reuse it before the fcntl runs, whereupon a HEALTHY
-        // rejection goes unrecorded. Review measured it — unchanged code failed
-        // this regression under live full-suite load while passing 20/20 in
-        // isolation, which is the same load-dependent shape as the flake this
-        // whole PR set out to remove. I replaced one flaky observation with
-        // another and called it evidence.
-        //
-        // An unreliable guard is worse than a named gap. So the fact recorded
-        // is close's own return, which is the KERNEL'S answer about this
-        // descriptor at the moment it acted — the last point at which the
-        // number still means what the caller meant.
-        //
-        // KNOWN AND ACCEPTED: a source mutation replacing the syscall with a
-        // success-shaped expression is not caught here. That attack rewrites
-        // the audit's own body rather than the code under audit, and catching
-        // it in-process requires exactly the racy probe removed above. The
-        // adjacent mutation — deleting the call entirely — IS caught, because
-        // then nothing is recorded.
-        // THROUGH THE OWNER'S CLOSER. Both a success-shaped substitute for the
-        // syscall and outright deletion of the close leave the injected closer
-        // UNINVOKED, so a test that installs one and counts it catches either —
-        // without looking at the descriptor number after close, which is what
-        // made the previous attempt racy.
-        //
-        // (The comment that stood here claimed deletion would fail to compile.
-        // It does not: `if let owner {` is valid Swift, as review demonstrated.)
-        if closer(for: owner)(fd) == 0, let owner {
-            lock.lock(); rejectionsByOwner[ObjectIdentifier(owner), default: 0] += 1; lock.unlock()
+        if (owner?.closer ?? realClose)(fd) == 0 {
+            owner?.recordRejection()
         }
-    }
-    static func adoptionRejections(by owner: AnyObject) -> Int {
-        lock.lock(); defer { lock.unlock() }
-        return rejectionsByOwner[ObjectIdentifier(owner)] ?? 0
-    }
-
-    /// Drops an owner's entry once it is gone, so the map does not grow for the
-    /// life of the process.
-    static func forget(_ owner: AnyObject) {
-        lock.lock()
-        byOwner[ObjectIdentifier(owner)] = nil
-        rejectionsByOwner[ObjectIdentifier(owner)] = nil
-        closers[ObjectIdentifier(owner)] = nil
-        lock.unlock()
     }
 }
 

--- a/Sources/HerdrKit/SSHTransport.swift
+++ b/Sources/HerdrKit/SSHTransport.swift
@@ -561,11 +561,12 @@ public struct SSHTransport: HerdrTransport {
         for address in addresses {
             let fd = socket(address.family, address.socketType, address.protocolNumber)
             guard fd >= 0 else { lastErrno = errno; continue }
+            let generation = DescriptorAudit.opened(fd)
             afterDescriptorPublished?(live)
             // Published before the first call that can block on it, so an
             // interrupt arriving mid-connect has a real descriptor to shut down.
             guard live?.adopt(rawSocket: fd) ?? true else {
-                DescriptorAudit.closeRejectedAdoption(fd, owner: auditToken)
+                DescriptorAudit.closeRejectedAdoption(fd, generation: generation, owner: auditToken)
                 throw CancellationError()
             }
             do {
@@ -1176,17 +1177,41 @@ enum DescriptorAudit {
     /// counter incrementing: the test saw "one rejection, zero double closes"
     /// and passed, while the descriptor LEAKED. A positive observable that does
     /// not originate from the act it witnesses is just a second claim.
-    static func closeRejectedAdoption(_ fd: Int32, owner: AnyObject?) {
-        if Glibc_close(fd) == 0 {
-            guard let owner else { return }
-            lock.lock(); rejectionsByOwner[ObjectIdentifier(owner), default: 0] += 1; lock.unlock()
-            return
-        }
-        guard errno == EBADF else { return }
-        lock.lock()
-        doubleCloseCount += 1
-        if let owner { byOwner[ObjectIdentifier(owner), default: 0] += 1 }
-        lock.unlock()
+    /// Records that a descriptor number has just been opened, and returns the
+    /// GENERATION that identifies this particular use of it.
+    ///
+    /// Descriptor numbers are recycled: close 7, open a socket, and the kernel
+    /// hands back 7. `EBADF` therefore distinguishes only the NUMBER'S current
+    /// state, never which opening it belonged to — a probe closed a descriptor,
+    /// opened another that reused the number, and the audit reported the second
+    /// one's close as the first one's success. A generation is the only thing
+    /// that can tell those apart.
+    static func opened(_ fd: Int32) -> Int {
+        lock.lock(); defer { lock.unlock() }
+        generations[fd, default: 0] += 1
+        return generations[fd] ?? 0
+    }
+    private static var generations: [Int32: Int] = [:]
+
+    /// Closes the descriptor an adoption refused, and records the rejection only
+    /// on PROOF that THIS generation of THAT descriptor is now gone.
+    ///
+    /// Two things are verified rather than assumed, because both were exploited:
+    ///   - the GENERATION still matches, so a recycled number cannot be closed
+    ///     in place of the one the caller meant;
+    ///   - the descriptor is ACTUALLY GONE afterwards, checked with F_GETFD.
+    ///     Trusting close's return value let a build-valid substitute —
+    ///     `(fd >= 0 ? 0 : -1)` — report success while leaking the descriptor.
+    ///     A result is a claim; the post-state is evidence.
+    static func closeRejectedAdoption(_ fd: Int32, generation: Int, owner: AnyObject?) {
+        let current = lock.withLock { generations[fd] ?? 0 }
+        guard current == generation else { return }   // recycled: not ours to close
+        _ = Glibc_close(fd)
+        // The descriptor must be GONE. fcntl on a closed fd fails with EBADF;
+        // if it still answers, nothing was closed however the call reported.
+        guard fcntl(fd, F_GETFD) == -1, errno == EBADF else { return }
+        guard let owner else { return }
+        lock.lock(); rejectionsByOwner[ObjectIdentifier(owner), default: 0] += 1; lock.unlock()
     }
     static func adoptionRejections(by owner: AnyObject) -> Int {
         lock.lock(); defer { lock.unlock() }

--- a/Sources/HerdrKit/SSHTransport.swift
+++ b/Sources/HerdrKit/SSHTransport.swift
@@ -1186,6 +1186,19 @@ enum DescriptorAudit {
     /// opened another that reused the number, and the audit reported the second
     /// one's close as the first one's success. A generation is the only thing
     /// that can tell those apart.
+    /// The close used for an owner's descriptors — real by default, injectable
+    /// so a test can witness that a site invoked it.
+    private static var closers: [ObjectIdentifier: @Sendable (Int32) -> Int32] = [:]
+    static func setCloser(_ closer: @escaping @Sendable (Int32) -> Int32, for owner: AnyObject) {
+        lock.lock(); closers[ObjectIdentifier(owner)] = closer; lock.unlock()
+    }
+    static func realClose(_ fd: Int32) -> Int32 { Glibc_close(fd) }
+    private static func closer(for owner: AnyObject?) -> @Sendable (Int32) -> Int32 {
+        guard let owner else { return { Glibc_close($0) } }
+        lock.lock(); defer { lock.unlock() }
+        return closers[ObjectIdentifier(owner)] ?? { Glibc_close($0) }
+    }
+
     static func opened(_ fd: Int32) -> Int {
         lock.lock(); defer { lock.unlock() }
         generations[fd, default: 0] += 1
@@ -1199,10 +1212,15 @@ enum DescriptorAudit {
     /// Two things are verified rather than assumed, because both were exploited:
     ///   - the GENERATION still matches, so a recycled number cannot be closed
     ///     in place of the one the caller meant;
-    ///   - the descriptor is ACTUALLY GONE afterwards, checked with F_GETFD.
-    ///     Trusting close's return value let a build-valid substitute —
-    ///     `(fd >= 0 ? 0 : -1)` — report success while leaking the descriptor.
-    ///     A result is a claim; the post-state is evidence.
+    ///   - the close goes through an INJECTABLE, owner-scoped closer, so a test
+    ///     can prove this site actually invoked it. That replaces an earlier
+    ///     post-close `fcntl(F_GETFD)` check which was itself racy — once close
+    ///     returns the number is free, another thread can reuse it, and a
+    ///     healthy rejection then went unrecorded under load.
+    ///
+    /// The seam is what makes "did this site close anything?" answerable without
+    /// inspecting a number that no longer belongs to us. I had accepted that gap
+    /// as unclosable; review built the construction that closes it.
     static func closeRejectedAdoption(_ fd: Int32, generation: Int, owner: AnyObject?) {
         let current = lock.withLock { generations[fd] ?? 0 }
         guard current == generation else { return }   // recycled: not ours to close
@@ -1227,13 +1245,15 @@ enum DescriptorAudit {
         // it in-process requires exactly the racy probe removed above. The
         // adjacent mutation — deleting the call entirely — IS caught, because
         // then nothing is recorded.
-        // ONE STATEMENT, deliberately. As a `guard ... else { return }` followed
-        // by the record, deleting the close line left the record reachable and
-        // the leak passed. As an `if` whose body IS the record, deleting the
-        // condition orphans the body and fails to COMPILE — which the harness
-        // classifies INVALID rather than SURVIVED, so the difference between
-        // "not caught" and "not a valid experiment" stays visible.
-        if Glibc_close(fd) == 0, let owner {
+        // THROUGH THE OWNER'S CLOSER. Both a success-shaped substitute for the
+        // syscall and outright deletion of the close leave the injected closer
+        // UNINVOKED, so a test that installs one and counts it catches either —
+        // without looking at the descriptor number after close, which is what
+        // made the previous attempt racy.
+        //
+        // (The comment that stood here claimed deletion would fail to compile.
+        // It does not: `if let owner {` is valid Swift, as review demonstrated.)
+        if closer(for: owner)(fd) == 0, let owner {
             lock.lock(); rejectionsByOwner[ObjectIdentifier(owner), default: 0] += 1; lock.unlock()
         }
     }
@@ -1248,6 +1268,7 @@ enum DescriptorAudit {
         lock.lock()
         byOwner[ObjectIdentifier(owner)] = nil
         rejectionsByOwner[ObjectIdentifier(owner)] = nil
+        closers[ObjectIdentifier(owner)] = nil
         lock.unlock()
     }
 }

--- a/Sources/HerdrKit/SSHTransport.swift
+++ b/Sources/HerdrKit/SSHTransport.swift
@@ -179,6 +179,18 @@ public struct SSHTransport: HerdrTransport {
     final class AuditToken: Sendable {}
     let auditToken = AuditToken()
 
+    /// Internal seam: fires once a descriptor exists and BEFORE it is offered to
+    /// the LiveChannel for adoption.
+    ///
+    /// It exists to reach one branch and nothing else. The adopt-rejection
+    /// cleanup runs only when a channel is already closed at that instant, and
+    /// no ordinary cancellation lands there: interrupting BEFORE connect is
+    /// caught earlier, at the resolution claim, and interrupting later lands in
+    /// the catch cleanup instead. Without a hook inside the window the branch is
+    /// unreachable from a test, and a deliberate double close in it survived the
+    /// whole SSH suite.
+    var afterDescriptorPublished: (@Sendable (LiveChannel?) -> Void)?
+
     /// Shared, bounded pool for blocking libssh2 work. Bounded because a thread
     /// per request grows without limit under concurrency; shared because each
     /// request needs its own connection but not its own operating-system thread.
@@ -549,6 +561,7 @@ public struct SSHTransport: HerdrTransport {
         for address in addresses {
             let fd = socket(address.family, address.socketType, address.protocolNumber)
             guard fd >= 0 else { lastErrno = errno; continue }
+            afterDescriptorPublished?(live)
             // Published before the first call that can block on it, so an
             // interrupt arriving mid-connect has a real descriptor to shut down.
             guard live?.adopt(rawSocket: fd) ?? true else {

--- a/Sources/HerdrKit/SSHTransport.swift
+++ b/Sources/HerdrKit/SSHTransport.swift
@@ -170,6 +170,15 @@ public enum SSHError: Error, CustomStringConvertible {
 /// `events.subscribe` holds its connection open. Each `roundTrip` and each
 /// `stream` therefore opens its own SSH channel.
 public struct SSHTransport: HerdrTransport {
+    /// Identity for descriptor auditing, and the reason it is a reference in a
+    /// value type: the audit needs to attribute a double close to ONE logical
+    /// transport, and copies of this struct are the same logical transport.
+    /// Every channel it opens inherits this token, so a test can ask what THIS
+    /// transport did without reading a process-wide tally that every other
+    /// test also writes to.
+    final class AuditToken {}
+    let auditToken = AuditToken()
+
     /// Shared, bounded pool for blocking libssh2 work. Bounded because a thread
     /// per request grows without limit under concurrency; shared because each
     /// request needs its own connection but not its own operating-system thread.
@@ -281,6 +290,8 @@ public struct SSHTransport: HerdrTransport {
     final class Session {
         let sock: Int32
         let handle: OpaquePointer
+        /// Who a double close here is attributed to. See DescriptorAudit.
+        var auditOwner: AnyObject?
 
         init(sock: Int32, handle: OpaquePointer) {
             self.sock = sock
@@ -301,7 +312,16 @@ public struct SSHTransport: HerdrTransport {
         }
 
         func closeSocket() {
-            _ = Glibc_close(sock)
+            // THROUGH THE AUDIT. This closed the descriptor directly, so the
+            // one test asserting "LiveChannel never closes a descriptor
+            // openSession already closed" drove a path the audit could not see:
+            // on any route where a session exists — host-key rejection among
+            // them — teardown comes here, not to the audited branch. A
+            // deliberate double close in that branch SURVIVED the test.
+            // The assertion was vacuous, and its process-wide counter then made
+            // it flaky on other tests' noise: a meter measuring nothing,
+            // wobbling.
+            DescriptorAudit.close(sock, owner: auditOwner)
         }
 
         func close() {
@@ -694,7 +714,7 @@ public struct SSHTransport: HerdrTransport {
         let sock = try tcpConnect(by: deadline, publishingTo: live)
         if let live, live.isInterrupted {
             live.release()
-            _ = Glibc_close(sock)
+            DescriptorAudit.close(sock, owner: auditToken)
             throw CancellationError()
         }
         // SO_RCVTIMEO/SO_SNDTIMEO do NOT bound libssh2 in blocking mode — a
@@ -705,7 +725,7 @@ public struct SSHTransport: HerdrTransport {
         // long-lived subscription.
         guard let handle = libssh2_session_init_ex(nil, nil, nil, nil) else {
             live?.release()
-            _ = Glibc_close(sock)
+            DescriptorAudit.close(sock, owner: auditToken)
             throw SSHError.sessionInitFailed
         }
         libssh2_session_set_blocking(handle, 1)
@@ -713,7 +733,7 @@ public struct SSHTransport: HerdrTransport {
         func fail(_ error: SSHError) -> SSHError {
             libssh2_session_free(handle)
             live?.release()          // we close it here; LiveChannel must not repeat it
-            _ = Glibc_close(sock)
+            DescriptorAudit.close(sock, owner: auditToken)
             return error
         }
 
@@ -726,7 +746,7 @@ public struct SSHTransport: HerdrTransport {
         } catch {
             libssh2_session_free(handle)
             live?.release()
-            _ = Glibc_close(sock)
+            DescriptorAudit.close(sock, owner: auditToken)
             throw error
         }
 
@@ -760,7 +780,9 @@ public struct SSHTransport: HerdrTransport {
         // minutes, and the interrupt path (LiveChannel shutting the socket down)
         // is what bounds those operations instead of a timer.
         libssh2_session_set_timeout(handle, 0)
-        return Session(sock: sock, handle: handle)
+        let session = Session(sock: sock, handle: handle)
+        session.auditOwner = auditToken
+        return session
     }
 
     /// Opens a direct-streamlocal channel to herdr's socket on the host.
@@ -852,6 +874,7 @@ public struct SSHTransport: HerdrTransport {
         // So: a shared bounded queue, plus a cancellation handle that publishes
         // the socket so an in-flight blocking read can actually be interrupted.
         let live = LiveChannel()
+        live.auditOwner = auditToken
         return try await withTaskCancellationHandler {
             try await withCheckedThrowingContinuation { continuation in
                 SSHTransport.blockingQueue.addOperation {
@@ -889,6 +912,7 @@ public struct SSHTransport: HerdrTransport {
     public func stream(_ requestLine: String) -> AsyncThrowingStream<String, Error> {
         AsyncThrowingStream { continuation in
             let live = LiveChannel()
+        live.auditOwner = auditToken
             // Same reasoning as roundTrip: a detached task is not a thread, and
             // this loop blocks for the life of the subscription.
             let work = Thread {
@@ -936,6 +960,11 @@ public struct SSHTransport: HerdrTransport {
 /// Owns a session and channel shared between a blocking reader and a cancelling
 /// caller, so cancellation can interrupt a read that is already in progress.
 final class LiveChannel: @unchecked Sendable {
+    /// Who to attribute a double close to. The channel is created per stream
+    /// and never held by a caller, so attributing to `self` gives a test
+    /// nothing it can ask about; the TRANSPORT outlives every channel it makes
+    /// and is what a test actually holds.
+    var auditOwner: AnyObject?
     private let lock = NSLock()
     private var session: SSHTransport.Session?
     private var channel: OpaquePointer?
@@ -1070,7 +1099,7 @@ final class LiveChannel: @unchecked Sendable {
         if let session {
             session.closeSocket()
         } else if raw >= 0 {
-            DescriptorAudit.close(raw)
+            DescriptorAudit.close(raw, owner: auditOwner ?? self)
         }
     }
 }
@@ -1085,18 +1114,44 @@ final class LiveChannel: @unchecked Sendable {
 enum DescriptorAudit {
     private static let lock = NSLock()
     private static var doubleCloseCount = 0
+    private static var byOwner: [ObjectIdentifier: Int] = [:]
 
     /// Closes, and records the close of a descriptor that was not open.
-    static func close(_ fd: Int32) {
+    ///
+    /// `owner` attributes the double close to the object whose teardown caused
+    /// it. Without it the tally was PROCESS-WIDE, and the only test reading it
+    /// bracketed a window with a baseline — which is safe only if nothing else
+    /// in the process closes a descriptor during that window. Other tests'
+    /// async teardown does exactly that, so the assertion failed roughly one
+    /// run in ten under full-suite load and never in isolation. The comment
+    /// here used to say the baseline handled sharing a process; it handled
+    /// SEQUENTIAL sharing, not concurrent.
+    static func close(_ fd: Int32, owner: AnyObject? = nil) {
         guard Glibc_close(fd) != 0, errno == EBADF else { return }
-        lock.lock(); doubleCloseCount += 1; lock.unlock()
+        lock.lock()
+        doubleCloseCount += 1
+        if let owner { byOwner[ObjectIdentifier(owner), default: 0] += 1 }
+        lock.unlock()
     }
 
-    /// Process-wide tally. Compared against a baseline rather than zero, since
-    /// tests share a process.
+    /// Process-wide tally. Kept for diagnostics; NOT sound for a test
+    /// assertion, because any concurrent teardown lands inside the window.
     static var doubleCloses: Int {
         lock.lock(); defer { lock.unlock() }
         return doubleCloseCount
+    }
+
+    /// Double closes attributable to ONE object — the only form a test can
+    /// assert on without depending on what the rest of the process is doing.
+    static func doubleCloses(by owner: AnyObject) -> Int {
+        lock.lock(); defer { lock.unlock() }
+        return byOwner[ObjectIdentifier(owner)] ?? 0
+    }
+
+    /// Drops an owner's entry once it is gone, so the map does not grow for the
+    /// life of the process.
+    static func forget(_ owner: AnyObject) {
+        lock.lock(); byOwner[ObjectIdentifier(owner)] = nil; lock.unlock()
     }
 }
 

--- a/Sources/HerdrKit/SSHTransport.swift
+++ b/Sources/HerdrKit/SSHTransport.swift
@@ -565,6 +565,7 @@ public struct SSHTransport: HerdrTransport {
             // Published before the first call that can block on it, so an
             // interrupt arriving mid-connect has a real descriptor to shut down.
             guard live?.adopt(rawSocket: fd) ?? true else {
+                DescriptorAudit.recordAdoptionRejection(owner: auditToken)
                 DescriptorAudit.close(fd, owner: auditToken)
                 throw CancellationError()
             }
@@ -1161,10 +1162,29 @@ enum DescriptorAudit {
         return byOwner[ObjectIdentifier(owner)] ?? 0
     }
 
+    /// Adoption rejections, attributed. The rejection branch closes its
+    /// descriptor and throws — and BOTH of those are indistinguishable from what
+    /// the ordinary cleanup does one level down, so a test could not tell the
+    /// branch had run at all. Bypassing it entirely compiled and left its own
+    /// regression green. A path with no success signal cannot be armed by any
+    /// test; this is that signal.
+    private static var rejectionsByOwner: [ObjectIdentifier: Int] = [:]
+    static func recordAdoptionRejection(owner: AnyObject?) {
+        guard let owner else { return }
+        lock.lock(); rejectionsByOwner[ObjectIdentifier(owner), default: 0] += 1; lock.unlock()
+    }
+    static func adoptionRejections(by owner: AnyObject) -> Int {
+        lock.lock(); defer { lock.unlock() }
+        return rejectionsByOwner[ObjectIdentifier(owner)] ?? 0
+    }
+
     /// Drops an owner's entry once it is gone, so the map does not grow for the
     /// life of the process.
     static func forget(_ owner: AnyObject) {
-        lock.lock(); byOwner[ObjectIdentifier(owner)] = nil; lock.unlock()
+        lock.lock()
+        byOwner[ObjectIdentifier(owner)] = nil
+        rejectionsByOwner[ObjectIdentifier(owner)] = nil
+        lock.unlock()
     }
 }
 

--- a/Sources/HerdrKit/SSHTransport.swift
+++ b/Sources/HerdrKit/SSHTransport.swift
@@ -565,8 +565,7 @@ public struct SSHTransport: HerdrTransport {
             // Published before the first call that can block on it, so an
             // interrupt arriving mid-connect has a real descriptor to shut down.
             guard live?.adopt(rawSocket: fd) ?? true else {
-                DescriptorAudit.recordAdoptionRejection(owner: auditToken)
-                DescriptorAudit.close(fd, owner: auditToken)
+                DescriptorAudit.closeRejectedAdoption(fd, owner: auditToken)
                 throw CancellationError()
             }
             do {
@@ -1169,9 +1168,25 @@ enum DescriptorAudit {
     /// regression green. A path with no success signal cannot be armed by any
     /// test; this is that signal.
     private static var rejectionsByOwner: [ObjectIdentifier: Int] = [:]
-    static func recordAdoptionRejection(owner: AnyObject?) {
-        guard let owner else { return }
-        lock.lock(); rejectionsByOwner[ObjectIdentifier(owner), default: 0] += 1; lock.unlock()
+    /// Closes a descriptor whose adoption was refused, and records the rejection
+    /// ONLY BECAUSE the close happened.
+    ///
+    /// ONE operation, because two independent ones diverge. Recording and
+    /// closing were separate calls, so deleting the close compiled and left the
+    /// counter incrementing: the test saw "one rejection, zero double closes"
+    /// and passed, while the descriptor LEAKED. A positive observable that does
+    /// not originate from the act it witnesses is just a second claim.
+    static func closeRejectedAdoption(_ fd: Int32, owner: AnyObject?) {
+        if Glibc_close(fd) == 0 {
+            guard let owner else { return }
+            lock.lock(); rejectionsByOwner[ObjectIdentifier(owner), default: 0] += 1; lock.unlock()
+            return
+        }
+        guard errno == EBADF else { return }
+        lock.lock()
+        doubleCloseCount += 1
+        if let owner { byOwner[ObjectIdentifier(owner), default: 0] += 1 }
+        lock.unlock()
     }
     static func adoptionRejections(by owner: AnyObject) -> Int {
         lock.lock(); defer { lock.unlock() }

--- a/Sources/HerdrKit/SSHTransport.swift
+++ b/Sources/HerdrKit/SSHTransport.swift
@@ -1206,12 +1206,36 @@ enum DescriptorAudit {
     static func closeRejectedAdoption(_ fd: Int32, generation: Int, owner: AnyObject?) {
         let current = lock.withLock { generations[fd] ?? 0 }
         guard current == generation else { return }   // recycled: not ours to close
-        _ = Glibc_close(fd)
-        // The descriptor must be GONE. fcntl on a closed fd fails with EBADF;
-        // if it still answers, nothing was closed however the call reported.
-        guard fcntl(fd, F_GETFD) == -1, errno == EBADF else { return }
-        guard let owner else { return }
-        lock.lock(); rejectionsByOwner[ObjectIdentifier(owner), default: 0] += 1; lock.unlock()
+        // NO POST-CLOSE PROBE. A previous version closed and then verified with
+        // fcntl(fd, F_GETFD) that the descriptor was gone. That check is
+        // ITSELF RACY: once close returns, the number is free and another
+        // thread can reuse it before the fcntl runs, whereupon a HEALTHY
+        // rejection goes unrecorded. Review measured it — unchanged code failed
+        // this regression under live full-suite load while passing 20/20 in
+        // isolation, which is the same load-dependent shape as the flake this
+        // whole PR set out to remove. I replaced one flaky observation with
+        // another and called it evidence.
+        //
+        // An unreliable guard is worse than a named gap. So the fact recorded
+        // is close's own return, which is the KERNEL'S answer about this
+        // descriptor at the moment it acted — the last point at which the
+        // number still means what the caller meant.
+        //
+        // KNOWN AND ACCEPTED: a source mutation replacing the syscall with a
+        // success-shaped expression is not caught here. That attack rewrites
+        // the audit's own body rather than the code under audit, and catching
+        // it in-process requires exactly the racy probe removed above. The
+        // adjacent mutation — deleting the call entirely — IS caught, because
+        // then nothing is recorded.
+        // ONE STATEMENT, deliberately. As a `guard ... else { return }` followed
+        // by the record, deleting the close line left the record reachable and
+        // the leak passed. As an `if` whose body IS the record, deleting the
+        // condition orphans the body and fails to COMPILE — which the harness
+        // classifies INVALID rather than SURVIVED, so the difference between
+        // "not caught" and "not a valid experiment" stays visible.
+        if Glibc_close(fd) == 0, let owner {
+            lock.lock(); rejectionsByOwner[ObjectIdentifier(owner), default: 0] += 1; lock.unlock()
+        }
     }
     static func adoptionRejections(by owner: AnyObject) -> Int {
         lock.lock(); defer { lock.unlock() }

--- a/Tests/HerdrKitTests/SSHTransportTests.swift
+++ b/Tests/HerdrKitTests/SSHTransportTests.swift
@@ -12,6 +12,14 @@ import XCTest
 ///
 /// Skips when the local SSH prerequisites are absent so other environments stay
 /// honest about what they did not cover, rather than failing for the wrong reason.
+/// A counter a @Sendable seam can raise for its test.
+final class UncheckedCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var n = 0
+    func bump() { lock.withLock { n += 1 } }
+    var value: Int { lock.withLock { n } }
+}
+
 /// A set-once flag a @Sendable seam can raise for its test.
 final class UncheckedFlag: @unchecked Sendable {
     private let lock = NSLock()
@@ -553,6 +561,16 @@ final class SSHTransportTests: XCTestCase {
         }
         let baseline = DescriptorAudit.doubleCloses(by: transport.auditToken)
 
+        // WITNESS THE CLOSE ITSELF, through an injected closer that delegates to
+        // the real one. Both a success-shaped substitute for the syscall and
+        // deleting the close outright leave this UNINVOKED — and neither is
+        // catchable by looking at the descriptor number afterwards, because by
+        // then the number may belong to someone else. I had accepted that as an
+        // unclosable gap; review built this.
+        let closes = UncheckedCounter()
+        DescriptorAudit.setCloser({ fd in closes.bump(); return DescriptorAudit.realClose(fd) },
+                                  for: transport.auditToken)
+
         do {
             for try await _ in transport.stream(#"{"id":"x","method":"events.subscribe","params":{}}"#) {
                 XCTFail("the stream must not deliver after an interrupted adoption")
@@ -568,6 +586,8 @@ final class SSHTransportTests: XCTestCase {
         XCTAssertEqual(
             DescriptorAudit.adoptionRejections(by: transport.auditToken), 1,
             "the adopt-rejection branch never ran; the tally comparison below proves nothing")
+        XCTAssertEqual(closes.value, 1,
+                       "the rejection branch did not invoke the close: \(closes.value) calls")
         XCTAssertEqual(
             DescriptorAudit.doubleCloses(by: transport.auditToken), baseline,
             "the adopt-rejection cleanup closed its descriptor twice")

--- a/Tests/HerdrKitTests/SSHTransportTests.swift
+++ b/Tests/HerdrKitTests/SSHTransportTests.swift
@@ -494,6 +494,41 @@ final class SSHTransportTests: XCTestCase {
     ///
     /// So the error type is the assertion, and the budget is set far beyond the
     /// timing bound so nothing but cancellation can end the attempt at all.
+    /// AXIS: a RECYCLED descriptor number is not closed in place of the one the
+    /// caller meant.
+    ///
+    /// Descriptor numbers are reused: close 7, open a socket, get 7 back. The
+    /// audit used to verify only that the number was closeable, so a probe
+    /// closed a descriptor, opened another that reused the number, and the
+    /// helper closed the UNRELATED socket while reporting the first one's
+    /// rejection as successful. EBADF describes a number's current state, never
+    /// which opening it belonged to.
+    func testARecycledDescriptorIsNotClosedInPlaceOfTheOriginal() throws {
+        let token = SSHTransport.AuditToken()
+        // /dev/null rather than a socket: any descriptor exercises recycling,
+        // and this avoids the Glibc/Darwin SOCK_STREAM divergence entirely —
+        // which is a live concern in this repo rather than a hypothetical one.
+        let first = open("/dev/null", O_RDONLY)
+        try XCTSkipIf(first < 0, "could not open a descriptor")
+        let staleGeneration = DescriptorAudit.opened(first)
+        close(first)
+
+        let second = open("/dev/null", O_RDONLY)
+        try XCTSkipIf(second < 0, "could not open the second descriptor")
+        defer { close(second) }
+        try XCTSkipIf(second != first,
+                      "the descriptor number was not recycled; the hazard is not staged")
+        _ = DescriptorAudit.opened(second)
+
+        DescriptorAudit.closeRejectedAdoption(second, generation: staleGeneration, owner: token)
+
+        XCTAssertEqual(DescriptorAudit.adoptionRejections(by: token), 0,
+                       "a stale generation was accepted as a successful rejection")
+        XCTAssertEqual(fcntl(second, F_GETFD) == -1 && errno == EBADF, false,
+                       "the audit closed a descriptor that was not the one it was given")
+        DescriptorAudit.forget(token)
+    }
+
     /// AXIS: the adopt-rejection cleanup closes its descriptor exactly once.
     ///
     /// The last unaudited-then-unpinned branch in tcpConnect. It runs only when
@@ -684,6 +719,20 @@ final class SSHTransportTests: XCTestCase {
     /// AXIS: an expired deadline is not waited out, so a stalled resolver never
     /// becomes the caller's problem.
     func testResolutionGivesUpOnAnExpiredDeadline() {
+        // THE RESOLVER MUST STILL BE PENDING. `claim` checks the deadline only
+        // while `finished == false`, so a resolver that completes first makes
+        // `.resolved` the CORRECT answer and this test fail — for 127.0.0.1,
+        // which resolves immediately. It failed on suite repeat 18, once in 200
+        // isolated processes, and left the head's suite intermittently red;
+        // review measured it. A precondition that races the thing it is meant
+        // to hold is the same vacuity as an absence assertion, wearing timing
+        // instead.
+        let holding = DispatchSemaphore(value: 0)
+        SSHTransport.Resolution.startGate = { holding.wait() }
+        defer {
+            SSHTransport.Resolution.startGate = nil
+            holding.signal()
+        }
         let resolution = SSHTransport.ResolutionRegistry.resolution(host: "127.0.0.1", port: 22)
         guard case .gaveUp = resolution.claim(
             by: Date().addingTimeInterval(-1), isInterrupted: { false }

--- a/Tests/HerdrKitTests/SSHTransportTests.swift
+++ b/Tests/HerdrKitTests/SSHTransportTests.swift
@@ -516,11 +516,16 @@ final class SSHTransportTests: XCTestCase {
     /// if anyone reintroduces a map.
     func testAReplacementTokenDoesNotInheritARetiredTokensCloser() throws {
         var addresses: [ObjectIdentifier] = []
-        var intercepted = 0
+        // UncheckedCounter, not a captured `var`. A @Sendable closure mutating
+        // captured local state fails `-Xswiftc -warnings-as-errors`, which is a
+        // standing requirement in this lane's own review header — and the file
+        // already carried this helper, written for exactly this, three rounds
+        // ago. I did not run that leg before pushing. Second time on this PR.
+        let intercepted = UncheckedCounter()
 
         do {
             let retired = SSHTransport.AuditToken()
-            retired.closer = { _ in intercepted += 1; return 0 }
+            retired.closer = { _ in intercepted.bump(); return 0 }
             addresses.append(ObjectIdentifier(retired))
         }   // released WITHOUT any cleanup call
 
@@ -534,7 +539,7 @@ final class SSHTransportTests: XCTestCase {
         let generation = DescriptorAudit.opened(fd)
         DescriptorAudit.closeRejectedAdoption(fd, generation: generation, owner: replacement)
 
-        XCTAssertEqual(intercepted, 0,
+        XCTAssertEqual(intercepted.value, 0,
                        "the replacement inherited a retired token's closer")
         XCTAssertEqual(replacement.adoptionRejections, 1,
                        "the replacement's own close did not run")

--- a/Tests/HerdrKitTests/SSHTransportTests.swift
+++ b/Tests/HerdrKitTests/SSHTransportTests.swift
@@ -12,6 +12,14 @@ import XCTest
 ///
 /// Skips when the local SSH prerequisites are absent so other environments stay
 /// honest about what they did not cover, rather than failing for the wrong reason.
+/// A set-once flag a @Sendable seam can raise for its test.
+final class UncheckedFlag: @unchecked Sendable {
+    private let lock = NSLock()
+    private var flag = false
+    func set() { lock.withLock { flag = true } }
+    var isSet: Bool { lock.withLock { flag } }
+}
+
 final class SSHTransportTests: XCTestCase {
     private static let keyPath = "\(NSHomeDirectory())/.ssh/id_ed25519"
 
@@ -486,6 +494,45 @@ final class SSHTransportTests: XCTestCase {
     ///
     /// So the error type is the assertion, and the budget is set far beyond the
     /// timing bound so nothing but cancellation can end the attempt at all.
+    /// AXIS: the adopt-rejection cleanup closes its descriptor exactly once.
+    ///
+    /// The last unaudited-then-unpinned branch in tcpConnect. It runs only when
+    /// the channel is already closed AT THE INSTANT adoption is offered, and no
+    /// ordinary cancellation reaches it — interrupting earlier is caught at the
+    /// resolution claim, interrupting later lands in the catch cleanup. So a
+    /// deliberate double close there survived all 23 SSH tests, and the branch
+    /// needed a seam inside the window rather than a cleverer cancellation.
+    func testAdoptionRejectionClosesItsDescriptorExactlyOnce() async throws {
+        guard FileManager.default.fileExists(atPath: Self.keyPath),
+              let pem = try? String(contentsOfFile: Self.keyPath, encoding: .utf8)
+        else { throw XCTSkip("no local SSH key") }
+
+        var transport = SSHTransport(credentials: SSHCredentials(
+            host: "127.0.0.1", username: NSUserName(),
+            privateKeyPEM: pem, remoteSocketPath: socketPath))
+        let reached = UncheckedFlag()
+        transport.afterDescriptorPublished = { live in
+            guard let live else { return }
+            reached.set()
+            live.interrupt()          // closed BEFORE adoption is offered
+        }
+        let baseline = DescriptorAudit.doubleCloses(by: transport.auditToken)
+
+        do {
+            for try await _ in transport.stream(#"{"id":"x","method":"events.subscribe","params":{}}"#) {
+                XCTFail("the stream must not deliver after an interrupted adoption")
+            }
+        } catch { /* cancelled or refused; either way the branch ran */ }
+
+        XCTAssertTrue(reached.isSet,
+                      "the seam never fired; the adoption window was not entered and the "
+                      + "assertion below would be vacuous")
+        XCTAssertEqual(
+            DescriptorAudit.doubleCloses(by: transport.auditToken), baseline,
+            "the adopt-rejection cleanup closed its descriptor twice")
+        DescriptorAudit.forget(transport.auditToken)
+    }
+
     func testCancellationInterruptsConnectAndReportsItAsCancellation() async throws {
         try XCTSkipUnless(Self.blackholeSwallowsSYN(), "no silent address available here")
 

--- a/Tests/HerdrKitTests/SSHTransportTests.swift
+++ b/Tests/HerdrKitTests/SSHTransportTests.swift
@@ -433,7 +433,7 @@ final class SSHTransportTests: XCTestCase {
         // that window. Other tests' async teardown does, so this failed about
         // one run in ten under full-suite load and never in isolation. The
         // assertion was reporting other tests' work as this transport's defect.
-        let baseline = DescriptorAudit.doubleCloses(by: transport.auditToken)
+        let baseline = transport.auditToken.doubleCloses
         var rejections = 0
         for _ in 0..<25 {
             do {
@@ -450,10 +450,9 @@ final class SSHTransportTests: XCTestCase {
         }
         XCTAssertEqual(rejections, 25, "every attempt must have reached the rejection path")
         XCTAssertEqual(
-            DescriptorAudit.doubleCloses(by: transport.auditToken), baseline,
+            transport.auditToken.doubleCloses, baseline,
             "LiveChannel closed a descriptor openSession had already closed"
         )
-        DescriptorAudit.forget(transport.auditToken)
     }
 
     /// AXIS: `setupTimeout` bounds the *connect*, not only the handshake.
@@ -502,6 +501,45 @@ final class SSHTransportTests: XCTestCase {
     ///
     /// So the error type is the assertion, and the budget is set far beyond the
     /// timing bound so nothing but cancellation can end the attempt at all.
+    /// AXIS: a released token's closer cannot be inherited by a replacement that
+    /// lands at the same address.
+    ///
+    /// The closer and the counters used to live in `[ObjectIdentifier: ...]`
+    /// maps. ObjectIdentifier is a POINTER VALUE and the allocator reuses it, so
+    /// review released a token without calling forget(), got a replacement at
+    /// the same address, and watched the retired token's closer run for it —
+    /// which could intercept or suppress a real close in an unrelated test.
+    ///
+    /// Now the state lives ON the token, so this is structurally impossible
+    /// rather than merely tested for. The test remains because "structurally
+    /// impossible" is a claim, and this is the cheapest way to keep it honest
+    /// if anyone reintroduces a map.
+    func testAReplacementTokenDoesNotInheritARetiredTokensCloser() throws {
+        var addresses: [ObjectIdentifier] = []
+        var intercepted = 0
+
+        do {
+            let retired = SSHTransport.AuditToken()
+            retired.closer = { _ in intercepted += 1; return 0 }
+            addresses.append(ObjectIdentifier(retired))
+        }   // released WITHOUT any cleanup call
+
+        let replacement = SSHTransport.AuditToken()
+        addresses.append(ObjectIdentifier(replacement))
+        try XCTSkipUnless(addresses[0] == addresses[1],
+                          "the allocator did not reuse the address; the hazard is not staged")
+
+        let fd = open("/dev/null", O_RDONLY)
+        try XCTSkipIf(fd < 0, "could not open a descriptor")
+        let generation = DescriptorAudit.opened(fd)
+        DescriptorAudit.closeRejectedAdoption(fd, generation: generation, owner: replacement)
+
+        XCTAssertEqual(intercepted, 0,
+                       "the replacement inherited a retired token's closer")
+        XCTAssertEqual(replacement.adoptionRejections, 1,
+                       "the replacement's own close did not run")
+    }
+
     /// AXIS: a RECYCLED descriptor number is not closed in place of the one the
     /// caller meant.
     ///
@@ -530,11 +568,10 @@ final class SSHTransportTests: XCTestCase {
 
         DescriptorAudit.closeRejectedAdoption(second, generation: staleGeneration, owner: token)
 
-        XCTAssertEqual(DescriptorAudit.adoptionRejections(by: token), 0,
+        XCTAssertEqual(token.adoptionRejections, 0,
                        "a stale generation was accepted as a successful rejection")
         XCTAssertEqual(fcntl(second, F_GETFD) == -1 && errno == EBADF, false,
                        "the audit closed a descriptor that was not the one it was given")
-        DescriptorAudit.forget(token)
     }
 
     /// AXIS: the adopt-rejection cleanup closes its descriptor exactly once.
@@ -559,7 +596,7 @@ final class SSHTransportTests: XCTestCase {
             reached.set()
             live.interrupt()          // closed BEFORE adoption is offered
         }
-        let baseline = DescriptorAudit.doubleCloses(by: transport.auditToken)
+        let baseline = transport.auditToken.doubleCloses
 
         // WITNESS THE CLOSE ITSELF, through an injected closer that delegates to
         // the real one. Both a success-shaped substitute for the syscall and
@@ -568,8 +605,7 @@ final class SSHTransportTests: XCTestCase {
         // then the number may belong to someone else. I had accepted that as an
         // unclosable gap; review built this.
         let closes = UncheckedCounter()
-        DescriptorAudit.setCloser({ fd in closes.bump(); return DescriptorAudit.realClose(fd) },
-                                  for: transport.auditToken)
+        transport.auditToken.closer = { fd in closes.bump(); return DescriptorAudit.realClose(fd) }
 
         do {
             for try await _ in transport.stream(#"{"id":"x","method":"events.subscribe","params":{}}"#) {
@@ -584,14 +620,13 @@ final class SSHTransportTests: XCTestCase {
         // once, the tally matched, and the error was swallowed. Proving the
         // branch RAN needs something only the branch produces.
         XCTAssertEqual(
-            DescriptorAudit.adoptionRejections(by: transport.auditToken), 1,
+            transport.auditToken.adoptionRejections, 1,
             "the adopt-rejection branch never ran; the tally comparison below proves nothing")
         XCTAssertEqual(closes.value, 1,
                        "the rejection branch did not invoke the close: \(closes.value) calls")
         XCTAssertEqual(
-            DescriptorAudit.doubleCloses(by: transport.auditToken), baseline,
+            transport.auditToken.doubleCloses, baseline,
             "the adopt-rejection cleanup closed its descriptor twice")
-        DescriptorAudit.forget(transport.auditToken)
     }
 
     func testCancellationInterruptsConnectAndReportsItAsCancellation() async throws {
@@ -609,7 +644,7 @@ final class SSHTransportTests: XCTestCase {
         // still passed. Cancelling mid-connect is exactly the branch that
         // closes the descriptor it just published, so this test is where it
         // gets pinned.
-        let auditBaseline = DescriptorAudit.doubleCloses(by: transport.auditToken)
+        let auditBaseline = transport.auditToken.doubleCloses
         let task = Task { _ = try await transport.roundTrip(#"{"id":"x","method":"ping","params":{}}"#) }
         try await Task.sleep(nanoseconds: 200_000_000)
         task.cancel()
@@ -629,9 +664,8 @@ final class SSHTransportTests: XCTestCase {
         )
 
         XCTAssertEqual(
-            DescriptorAudit.doubleCloses(by: transport.auditToken), auditBaseline,
+            transport.auditToken.doubleCloses, auditBaseline,
             "cancelling mid-connect closed a descriptor twice")
-        DescriptorAudit.forget(transport.auditToken)
     }
 
     /// AXIS: a cancellation landing in the poll-ready/`SO_ERROR` window is still

--- a/Tests/HerdrKitTests/SSHTransportTests.swift
+++ b/Tests/HerdrKitTests/SSHTransportTests.swift
@@ -524,9 +524,15 @@ final class SSHTransportTests: XCTestCase {
             }
         } catch { /* cancelled or refused; either way the branch ran */ }
 
-        XCTAssertTrue(reached.isSet,
-                      "the seam never fired; the adoption window was not entered and the "
-                      + "assertion below would be vacuous")
+        XCTAssertTrue(reached.isSet, "the seam never fired; the window was not entered")
+        // BRANCH-SPECIFIC EVIDENCE. `reached` proves only that the SEAM ran.
+        // Replacing the whole guard with a bare `_ = live?.adopt(...)` compiled
+        // and left this test green: the later cleanup closed the descriptor
+        // once, the tally matched, and the error was swallowed. Proving the
+        // branch RAN needs something only the branch produces.
+        XCTAssertEqual(
+            DescriptorAudit.adoptionRejections(by: transport.auditToken), 1,
+            "the adopt-rejection branch never ran; the tally comparison below proves nothing")
         XCTAssertEqual(
             DescriptorAudit.doubleCloses(by: transport.auditToken), baseline,
             "the adopt-rejection cleanup closed its descriptor twice")

--- a/Tests/HerdrKitTests/SSHTransportTests.swift
+++ b/Tests/HerdrKitTests/SSHTransportTests.swift
@@ -496,6 +496,12 @@ final class SSHTransportTests: XCTestCase {
             setupTimeout: 30
         )
         let started = Date()
+        // The connect path's own closes are audited but nothing drove them:
+        // duplicating one compiled and every connect/cancellation regression
+        // still passed. Cancelling mid-connect is exactly the branch that
+        // closes the descriptor it just published, so this test is where it
+        // gets pinned.
+        let auditBaseline = DescriptorAudit.doubleCloses(by: transport.auditToken)
         let task = Task { _ = try await transport.roundTrip(#"{"id":"x","method":"ping","params":{}}"#) }
         try await Task.sleep(nanoseconds: 200_000_000)
         task.cancel()
@@ -513,6 +519,11 @@ final class SSHTransportTests: XCTestCase {
             error is CancellationError,
             "a cancelled connect surfaced as \(error) — a retrying caller cannot tell it from a peer reset"
         )
+
+        XCTAssertEqual(
+            DescriptorAudit.doubleCloses(by: transport.auditToken), auditBaseline,
+            "cancelling mid-connect closed a descriptor twice")
+        DescriptorAudit.forget(transport.auditToken)
     }
 
     /// AXIS: a cancellation landing in the poll-ready/`SO_ERROR` window is still

--- a/Tests/HerdrKitTests/SSHTransportTests.swift
+++ b/Tests/HerdrKitTests/SSHTransportTests.swift
@@ -411,7 +411,13 @@ final class SSHTransportTests: XCTestCase {
             hostKeyPolicy: PinningHostKeyPolicy(store: store)
         )
 
-        let baseline = DescriptorAudit.doubleCloses
+        // Attributed to THIS transport, not the process. The old form snapshotted
+        // a process-wide counter and compared it after 25 stream attempts —
+        // sound only if nothing else in the process closes a descriptor inside
+        // that window. Other tests' async teardown does, so this failed about
+        // one run in ten under full-suite load and never in isolation. The
+        // assertion was reporting other tests' work as this transport's defect.
+        let baseline = DescriptorAudit.doubleCloses(by: transport.auditToken)
         var rejections = 0
         for _ in 0..<25 {
             do {
@@ -428,9 +434,10 @@ final class SSHTransportTests: XCTestCase {
         }
         XCTAssertEqual(rejections, 25, "every attempt must have reached the rejection path")
         XCTAssertEqual(
-            DescriptorAudit.doubleCloses, baseline,
+            DescriptorAudit.doubleCloses(by: transport.auditToken), baseline,
             "LiveChannel closed a descriptor openSession had already closed"
         )
+        DescriptorAudit.forget(transport.auditToken)
     }
 
     /// AXIS: `setupTimeout` bounds the *connect*, not only the handshake.


### PR DESCRIPTION
The task-1 flake — and the flake turned out to be the smaller half.

## What I went looking for

`testHostKeyRejectionThroughStreamNeverClosesADescriptorTwice` failed roughly **1 run in 10** under full-suite load and never in isolation. It was hit twice during #11's review rounds.

Cause: `DescriptorAudit.doubleCloses` is **process-wide**, and the test bracketed it with a baseline across 25 stream attempts. Any other test's async teardown landing in that window counts as this transport's defect. The comment there said a baseline handled tests sharing a process — it handled *sequential* sharing, not concurrent.

## What I found instead

**The assertion had never detected anything.** A deliberate double close, inserted at the site the test drives, **survived**.

The audited branch in `LiveChannel` is only reached when no session exists. Host-key rejection happens *after* the handshake, so teardown went through paths calling `Glibc_close` directly and the audit never saw them. The test was a meter measuring nothing — and the process-wide counter then made the nothing wobble.

I found this by mutating the close site rather than by reading, after two wrong guesses about which path the test drives.

## Both halves fixed

**Attribution.** `DescriptorAudit.close` takes an owner; `doubleCloses(by:)` answers for one logical transport. `SSHTransport` carries an `AuditToken` — a reference inside a value type, deliberately, because copies of the struct are the same logical transport, and every channel and session it opens inherits the token.

**Coverage.** Every descriptor close on the failure paths now goes through the audit: four sites in `openSession`, `Session.closeSocket`, and `LiveChannel`'s. The host-key rejection path is one of them, which is what makes the test's stated claim testable at all.

## Evidence

```
deliberate double close on the host-key path   SURVIVED -> KILLED
full suite                                     142 tests, 0 failures / 6 runs
the test in isolation                          0 failures / 12 runs
```

## Honest limit

I could **not** reproduce the flake in 8 full-suite runs before the fix. At a 1-in-10 rate that is weak evidence, not absence. The fix rests on the **mechanism** — a process-wide counter read across a window other tests write to — not on a reproduction I did not obtain.