### PR TITLE
fix(build): make the package build on macOS

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,6 +8,19 @@ import PackageDescription
 // consumes it unchanged.
 let package = Package(
     name: "HerdrKit",
+    // REQUIRED, and its absence was invisible from Linux. With no `platforms`,
+    // SwiftPM assumes macOS 10.10 and every modern-concurrency symbol this
+    // package is built on becomes unavailable — Task, AsyncThrowingStream,
+    // CancellationError, withTaskCancellationHandler, and the rest. Linux does
+    // no availability checking at all, so the package compiled there while
+    // being unbuildable on any Apple platform.
+    //
+    // The floors are chosen, not defaults: macOS 13 for the toolchain that runs
+    // the tests, iOS 17 because that is the floor the app target will inherit
+    // and it decides which SwiftUI is available to the UI work. `platforms`
+    // constrains Apple platforms only, so the "builds on Linux too" property
+    // above is untouched.
+    platforms: [.macOS(.v13), .iOS(.v17)],
     products: [
         .library(name: "HerdrKit", targets: ["HerdrKit"])
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,14 @@ let package = Package(
         .library(name: "HerdrKit", targets: ["HerdrKit"])
     ],
     targets: [
-        .systemLibrary(name: "CSSH", path: "Sources/CSSH"),
+        // pkgConfig, not a hardcoded header path: libssh2 lives at
+        // /usr/include on Debian, /opt/homebrew/include on Apple Silicon and
+        // /usr/local/include on Intel macs. providers only advise on how to
+        // install it; pkgConfig is what actually supplies the flags.
+        .systemLibrary(
+            name: "CSSH", path: "Sources/CSSH",
+            pkgConfig: "libssh2",
+            providers: [.brew(["libssh2"]), .apt(["libssh2-1-dev"])]),
         .target(name: "HerdrKit", dependencies: ["CSSH"]),
         // CSSH so tests can build a real Session to drive LiveChannel's
         // ownership handoff directly, rather than only through a live server.

--- a/README.md
+++ b/README.md
@@ -8,15 +8,32 @@ exposes both, so panes become real UI objects instead of pixels.
 
 ## Status
 
-Pre-alpha. Only `HerdrKit` — the transport and protocol layer — exists so far.
+Pre-alpha. Only `HerdrKit` — the transport and protocol layer — exists so far; there is no app target yet.
 
 `HerdrKit` contains no UIKit or SwiftUI, so it builds and tests on Linux and can be exercised
 against a real herdr server. The iOS target will consume it unchanged.
+
+### Prerequisites
+
+`HerdrKit` links **libssh2** through pkg-config, so the development package must be present
+before `swift build` will work on a clean machine:
+
+```bash
+# Debian / Ubuntu
+sudo apt-get install -y libssh2-1-dev pkg-config
+
+# macOS
+brew install libssh2 pkg-config
+```
 
 ```bash
 swift build
 swift test          # live tests run when a herdr socket is present, skip otherwise
 ```
+
+Builds and tests on **Linux and macOS** (macOS 13+, iOS 17+ floors are declared in
+`Package.swift`). The header path comes from `pkg-config --cflags libssh2` rather than a
+hardcoded location, because Debian and Homebrew put it in different places.
 
 ## Measured protocol facts
 
@@ -37,10 +54,18 @@ and they shape the transport design:
 
 ```
 Sources/HerdrKit/
-  Transport.swift    HerdrTransport protocol + AF_UNIX implementation
-  Wire.swift         request/response envelopes, models, subscription types
-  HerdrClient.swift  typed API: agentList, read, prompt, sendKeys, subscribe
+  Transport.swift        HerdrTransport protocol + AF_UNIX implementation
+  SSHTransport.swift     libssh2 direct-streamlocal tunnel to a remote herdr socket
+  SessionRecovery.swift  reconnect/resync policy: attempt identity, the subscription ledger
+  RecoveryExecutor.swift drives that policy against a real transport
+  PlatformSocket.swift   the C symbols whose Swift spelling differs on Glibc vs Darwin
+  Wire.swift             request/response envelopes, models, subscription types
+  HerdrClient.swift      typed API: agentList, read, prompt, sendKeys, subscribe
+Sources/CSSH/            libssh2 system-library target (shim.h + module map)
 ```
 
-Planned: SSH transport (`direct-streamlocal@openssh.com` — note that plain `direct-tcpip`
-cannot reach a remote unix socket), terminal rendering, and the gesture layer.
+**Done**: the SSH transport (`direct-streamlocal@openssh.com` — plain `direct-tcpip` cannot
+reach a remote unix socket), connection measurement, the pool design, and reconnect/resync
+including how an unopenable pane is distinguished from an unwanted one.
+
+**Planned**: the iOS app target, terminal rendering, and the gesture layer.

--- a/README.md
+++ b/README.md
@@ -54,14 +54,16 @@ and they shape the transport design:
 
 ```
 Sources/HerdrKit/
-  Transport.swift        HerdrTransport protocol + AF_UNIX implementation
-  SSHTransport.swift     libssh2 direct-streamlocal tunnel to a remote herdr socket
-  SessionRecovery.swift  reconnect/resync policy: attempt identity, the subscription ledger
-  RecoveryExecutor.swift drives that policy against a real transport
-  PlatformSocket.swift   the C symbols whose Swift spelling differs on Glibc vs Darwin
-  Wire.swift             request/response envelopes, models, subscription types
-  HerdrClient.swift      typed API: agentList, read, prompt, sendKeys, subscribe
-Sources/CSSH/            libssh2 system-library target (shim.h + module map)
+  HerdrClient.swift       typed API: agentList, read, prompt, sendKeys, subscribe
+  InputIntent.swift       keystroke/gesture intent, decoupled from any UI framework
+  PlatformSocket.swift    the C symbols whose Swift spelling differs on Glibc vs Darwin
+  RecoveryExecutor.swift  drives that policy against a real transport
+  RefreshPolicy.swift     when cached agent state is stale enough to refetch
+  SSHTransport.swift      libssh2 direct-streamlocal tunnel to a remote herdr socket
+  SessionRecovery.swift   reconnect/resync policy: attempt identity, the subscription ledger
+  Transport.swift         HerdrTransport protocol + AF_UNIX implementation
+  Wire.swift              request/response envelopes, models, subscription types
+Sources/CSSH/             libssh2 system-library target (shim.h + module map)
 ```
 
 **Done**: the SSH transport (`direct-streamlocal@openssh.com` — plain `direct-tcpip` cannot

--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ and they shape the transport design:
 
 ## Layout
 
+A guide to the main files, **not an exhaustive inventory** — `swift package describe`
+is authoritative. Everything named here must exist; not everything that exists is named.
+
 ```
 Sources/HerdrKit/
   HerdrClient.swift       typed API: agentList, read, prompt, sendKeys, subscribe

--- a/Sources/CSSH/module.modulemap
+++ b/Sources/CSSH/module.modulemap
@@ -1,5 +1,5 @@
 module CSSH [system] {
-    header "/usr/include/libssh2.h"
+    header "shim.h"
     link "ssh2"
     export *
 }

--- a/Sources/CSSH/shim.h
+++ b/Sources/CSSH/shim.h
@@ -1,0 +1,10 @@
+/* Include libssh2 by NAME, not by path.
+ *
+ * The module map used to name /usr/include/libssh2.h directly, which is where
+ * Debian's libssh2-1-dev puts it and nowhere else: Homebrew installs to
+ * /opt/homebrew/include on Apple Silicon and /usr/local/include on Intel, so
+ * every macOS build failed while parsing the module map — before compiling a
+ * line. A relative shim plus pkg-config lets the toolchain supply the search
+ * path per platform.
+ */
+#include <libssh2.h>

--- a/Sources/HerdrKit/PlatformSocket.swift
+++ b/Sources/HerdrKit/PlatformSocket.swift
@@ -1,0 +1,18 @@
+#if canImport(Glibc)
+import Glibc
+#else
+import Darwin
+#endif
+
+/// `SOCK_STREAM`, as an `Int32`, on both platforms.
+///
+/// Glibc models it as an enum case, so it needs `.rawValue`; Darwin already
+/// declares it as `Int32`, where `.rawValue` does not exist. Written inline as
+/// `Int32(SOCK_STREAM.rawValue)` it compiled on Linux and failed on macOS —
+/// one of three defects in this package that Linux could not see, so it lives
+/// in one place rather than being spelled at each call site.
+#if canImport(Darwin)
+let sockStream = SOCK_STREAM
+#else
+let sockStream = Int32(SOCK_STREAM.rawValue)
+#endif

--- a/Sources/HerdrKit/PlatformSocket.swift
+++ b/Sources/HerdrKit/PlatformSocket.swift
@@ -12,7 +12,23 @@ import Darwin
 /// one of three defects in this package that Linux could not see, so it lives
 /// in one place rather than being spelled at each call site.
 #if canImport(Darwin)
-let sockStream = SOCK_STREAM
+public let sockStream = SOCK_STREAM
 #else
-let sockStream = Int32(SOCK_STREAM.rawValue)
+public let sockStream = Int32(SOCK_STREAM.rawValue)
 #endif
+
+/// `bind(2)`, reached unambiguously.
+///
+/// On Darwin, `XCTestCase` exposes an instance method named `bind`, so a bare
+/// `bind(fd, ...)` inside a test resolves to it and fails to compile. Naming the
+/// module explicitly is the fix, and it lives here beside `sockStream` because
+/// it is the same problem: a C symbol whose spelling differs by platform.
+public func platformBind(
+    _ fd: Int32, _ addr: UnsafePointer<sockaddr>, _ len: socklen_t
+) -> Int32 {
+#if canImport(Darwin)
+    return Darwin.bind(fd, addr, len)
+#else
+    return Glibc.bind(fd, addr, len)
+#endif
+}

--- a/Sources/HerdrKit/SSHTransport.swift
+++ b/Sources/HerdrKit/SSHTransport.swift
@@ -394,7 +394,7 @@ public struct SSHTransport: HerdrTransport {
                 gate?()
                 var hints = addrinfo()
                 hints.ai_family = AF_UNSPEC
-                hints.ai_socktype = Int32(SOCK_STREAM.rawValue)
+                hints.ai_socktype = sockStream
                 var info: UnsafeMutablePointer<addrinfo>?
                 let rc = getaddrinfo(host, String(port), &hints, &info)
 

--- a/Sources/HerdrKit/Transport.swift
+++ b/Sources/HerdrKit/Transport.swift
@@ -66,7 +66,7 @@ public struct UnixSocketTransport: HerdrTransport {
     }
 
     private func connectFD() throws -> Int32 {
-        let fd = socket(AF_UNIX, Int32(SOCK_STREAM.rawValue), 0)
+        let fd = socket(AF_UNIX, sockStream, 0)
         guard fd >= 0 else { throw TransportError.socketCreationFailed(errno: errno) }
 
         var addr = sockaddr_un()

--- a/Tests/HerdrKitTests/HerdrKitTests.swift
+++ b/Tests/HerdrKitTests/HerdrKitTests.swift
@@ -150,7 +150,7 @@ final class LiveServerTests: XCTestCase {
         try XCTSkipIf(socketPath == nil, "no live herdr server")
         let path = try XCTUnwrap(socketPath)
 
-        let fd = socket(AF_UNIX, Int32(SOCK_STREAM.rawValue), 0)
+        let fd = socket(AF_UNIX, sockStream, 0)
         XCTAssertGreaterThanOrEqual(fd, 0)
         defer { close(fd) }
 

--- a/Tests/HerdrKitTests/ReadmeLayoutTests.swift
+++ b/Tests/HerdrKitTests/ReadmeLayoutTests.swift
@@ -12,8 +12,14 @@ import XCTest
 /// in the repository at all.
 ///
 /// A guard that lives in someone's terminal history is not a guard. This one
-/// runs with `swift test`, so a file added without a README entry fails the
-/// suite rather than silently narrowing an inventory that reads as exhaustive.
+/// runs with `swift test`.
+///
+/// It checks ONE DIRECTION ONLY: every path the README names must exist. Adding
+/// a source file without a README entry does NOT fail — that completeness claim
+/// was dropped deliberately, because enforcing it meant maintaining a second,
+/// worse copy of the package manifest and would have false-failed the iOS app
+/// target. This sentence previously said the opposite, which is the fourth time
+/// tonight a comment outlived the guard it described.
 final class ReadmeLayoutTests: XCTestCase {
     private func repoRoot() -> URL {
         URL(fileURLWithPath: #filePath)

--- a/Tests/HerdrKitTests/ReadmeLayoutTests.swift
+++ b/Tests/HerdrKitTests/ReadmeLayoutTests.swift
@@ -47,28 +47,40 @@ final class ReadmeLayoutTests: XCTestCase {
         else { return XCTFail("no layout block found in README.md") }
         let block = String(readme[open.lowerBound..<close.lowerBound])
 
-        // UNRECOGNISED ROWS FAIL; they do not vanish. The previous parser skipped
-        // anything whose first token it did not understand, so wrapping a name
-        // in backticks silently removed it from the guard — the file could then
-        // name something nonexistent and pass. A parser that ignores what it
-        // cannot read is a filter, not a check, and the thing it filters out is
-        // exactly the thing nobody looked at.
+        // A STRICT GRAMMAR, AND NO NORMALISATION AT ALL.
         //
-        // I named this risk in my own review dispatch and shipped without
-        // closing it. Twice, on this file.
+        // The previous version stripped a set of decoration characters before
+        // matching. `trimmingCharacters(in:)` removes each listed character
+        // INDEPENDENTLY from both ends rather than recognising balanced
+        // formatting, so `HerdrClient.swift*` — a path that does not exist —
+        // had its stray `*` stripped and silently checked the real file
+        // instead. Failing closed on rows it cannot read was right; being
+        // generous about what it CAN read reintroduced the same defect
+        // pointing the other way, and I named that exact risk in a review
+        // dispatch before shipping it.
+        //
+        // The block is a bare code fence, so decoration is not expected and
+        // rejecting it is correct. Two shapes are legal and nothing else is:
+        //     <name>.swift        a file under Sources/HerdrKit
+        //     Sources/<name>/     a source directory
         var named: [String] = []
         var unparsed: [String] = []
         for line in block.split(separator: "\n") {
             let text = line.trimmingCharacters(in: .whitespaces)
             guard !text.isEmpty else { continue }
             let token = String(text.split(separator: " ").first ?? "")
-                .trimmingCharacters(in: CharacterSet(charactersIn: "`*-+•│├└─"))
-            if token.hasSuffix(".swift") { named.append("Sources/HerdrKit/" + token) }
-            else if token.hasPrefix("Sources/"), token.hasSuffix("/") { named.append(String(token.dropLast())) }
+            let isFile = token.hasSuffix(".swift")
+                && token.dropLast(6).allSatisfy { $0.isLetter || $0.isNumber || $0 == "_" }
+                && !token.dropLast(6).isEmpty
+            let isDir = token.hasPrefix("Sources/") && token.hasSuffix("/")
+                && token.dropFirst(8).dropLast().allSatisfy { $0.isLetter || $0.isNumber || $0 == "_" }
+                && !token.dropFirst(8).dropLast().isEmpty
+            if isFile { named.append("Sources/HerdrKit/" + token) }
+            else if isDir { named.append(String(token.dropLast())) }
             else { unparsed.append(text) }
         }
         XCTAssertTrue(unparsed.isEmpty,
-                      "layout rows the guard cannot read, so it cannot check them: "
+                      "layout rows that do not match the grammar, so the guard cannot check them: "
                       + unparsed.joined(separator: " | "))
         XCTAssertFalse(named.isEmpty, "no entries parsed from the layout; the check is vacuous")
 

--- a/Tests/HerdrKitTests/ReadmeLayoutTests.swift
+++ b/Tests/HerdrKitTests/ReadmeLayoutTests.swift
@@ -20,35 +20,24 @@ final class ReadmeLayoutTests: XCTestCase {
             .deletingLastPathComponent()   // repo
     }
 
-    /// Rows are PARSED and compared as sets, and EVERY entry under Sources/ is
-    /// checked — not just HerdrKit's.
+    /// Every file the README NAMES must exist. It does not claim the reverse.
     ///
-    /// Both corrections come from probes against my previous version:
-    ///   - `block.contains(name)` searched the whole block, so deleting
-    ///     Wire.swift's row passed as long as some OTHER row's description
-    ///     mentioned "Wire.swift". A substring search cannot tell an inventory
-    ///     entry from prose.
-    ///   - the guard hardcoded Sources/HerdrKit, so replacing the Sources/CSSH
-    ///     row with a nonexistent directory passed, and so did adding a whole
-    ///     new target the layout never mentioned.
+    /// THIS IS A DELIBERATE REVERSAL, and worth explaining because the previous
+    /// direction cost four review rounds. I had the layout assert COMPLETENESS —
+    /// every source file must appear — which meant the guard had to model
+    /// SwiftPM's source graph to be correct: nested sources, targets with custom
+    /// paths, and more than one Swift target. It could not, and each round found
+    /// another way it was wrong. Worse, it would have FALSE-FAILED the moment
+    /// the iOS app target lands, which is the next piece of work.
     ///
-    /// I named that second gap in two consecutive review dispatches before
-    /// closing it. Naming a gap is not closing it; it just makes the omission
-    /// deliberate.
-    func testTheReadmeLayoutMatchesTheRepositoryExactly() throws {
+    /// Review offered this option in round four and I took the harder path. The
+    /// README is a guide, not an inventory; making it claim exhaustiveness meant
+    /// maintaining a second, worse copy of the package manifest. So the claim is
+    /// dropped and the block says so, leaving the one property that is cheap,
+    /// true, and useful: A NAME IN THE DOCS POINTS AT SOMETHING REAL. That is
+    /// what actually rots — files get renamed and the prose does not follow.
+    func testEveryFileTheReadmeNamesExists() throws {
         let root = repoRoot()
-        let fm = FileManager.default
-
-        let sourcesDir = root.appendingPathComponent("Sources")
-        let dirsOnDisk = Set(try fm.contentsOfDirectory(atPath: sourcesDir.path)
-            .filter { name in
-                var isDir: ObjCBool = false
-                _ = fm.fileExists(atPath: sourcesDir.appendingPathComponent(name).path,
-                                  isDirectory: &isDir)
-                return isDir.boolValue
-            })
-        XCTAssertFalse(dirsOnDisk.isEmpty, "no source directories found; the comparison is vacuous")
-
         let readme = try String(
             contentsOf: root.appendingPathComponent("README.md"), encoding: .utf8)
         guard let open = readme.range(of: "Sources/"),
@@ -56,31 +45,17 @@ final class ReadmeLayoutTests: XCTestCase {
         else { return XCTFail("no layout block found in README.md") }
         let block = String(readme[open.lowerBound..<close.lowerBound])
 
-        // A row is its FIRST token. Anything after it is prose and is ignored,
-        // which is the whole point of parsing rather than substring-searching.
-        var dirsListed = Set<String>()
-        var filesListed = Set<String>()
+        var named: [String] = []
         for line in block.split(separator: "\n") {
             guard let token = line.split(separator: " ").first.map(String.init) else { continue }
-            if token.hasPrefix("Sources/"), token.hasSuffix("/") {
-                dirsListed.insert(String(token.dropFirst("Sources/".count).dropLast()))
-            } else if token.hasSuffix(".swift") {
-                filesListed.insert(token)
-            }
+            if token.hasSuffix(".swift") { named.append("Sources/HerdrKit/" + token) }
+            else if token.hasPrefix("Sources/"), token.hasSuffix("/") { named.append(String(token.dropLast())) }
         }
+        XCTAssertFalse(named.isEmpty, "no entries parsed from the layout; the check is vacuous")
 
-        XCTAssertEqual(dirsListed, dirsOnDisk,
-                       "the layout's source directories do not match the repository: "
-                       + "listed \(dirsListed.sorted()), on disk \(dirsOnDisk.sorted())")
-
-        for dir in dirsOnDisk {
-            let swift = Set(try fm.contentsOfDirectory(
-                atPath: sourcesDir.appendingPathComponent(dir).path)
-                .filter { $0.hasSuffix(".swift") })
-            guard !swift.isEmpty else { continue }   // CSSH carries no Swift
-            XCTAssertEqual(filesListed, swift,
-                           "the layout's \(dir) files do not match the repository: "
-                           + "listed \(filesListed.sorted()), on disk \(swift.sorted())")
-        }
+        let missing = named.filter { !FileManager.default.fileExists(
+            atPath: root.appendingPathComponent($0).path) }
+        XCTAssertTrue(missing.isEmpty,
+                      "the README names paths that do not exist: \(missing.joined(separator: ", "))")
     }
 }

--- a/Tests/HerdrKitTests/ReadmeLayoutTests.swift
+++ b/Tests/HerdrKitTests/ReadmeLayoutTests.swift
@@ -1,0 +1,56 @@
+import XCTest
+
+/// The README's layout block must list every source file, and only real ones.
+///
+/// WHY THIS IS A TEST AND NOT A SCRIPT: I described that block as "generated
+/// from `ls`, and the generator fails if a file has no description" — and then
+/// committed only its OUTPUT. The generator existed for one invocation in a
+/// shell. Review added an undescribed source file, the warnings-as-errors build
+/// compiled it, and nothing noticed: the safeguard I had claimed did not exist
+/// in the repository at all.
+///
+/// A guard that lives in someone's terminal history is not a guard. This one
+/// runs with `swift test`, so a file added without a README entry fails the
+/// suite rather than silently narrowing an inventory that reads as exhaustive.
+final class ReadmeLayoutTests: XCTestCase {
+    private func repoRoot() -> URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()   // HerdrKitTests
+            .deletingLastPathComponent()   // Tests
+            .deletingLastPathComponent()   // repo
+    }
+
+    func testTheReadmeLayoutListsEverySourceFile() throws {
+        let root = repoRoot()
+        let sources = root.appendingPathComponent("Sources/HerdrKit")
+        let onDisk = try FileManager.default
+            .contentsOfDirectory(atPath: sources.path)
+            .filter { $0.hasSuffix(".swift") }
+            .sorted()
+        XCTAssertFalse(onDisk.isEmpty, "no sources found; the comparison would be vacuous")
+
+        let readme = try String(
+            contentsOf: root.appendingPathComponent("README.md"), encoding: .utf8)
+        guard let start = readme.range(of: "Sources/HerdrKit/"),
+              let end = readme.range(of: "```", range: start.upperBound..<readme.endIndex)
+        else { return XCTFail("no layout block found in README.md") }
+        let block = String(readme[start.upperBound..<end.lowerBound])
+
+        let missing = onDisk.filter { !block.contains($0) }
+        XCTAssertTrue(missing.isEmpty,
+                      "README layout omits \(missing.joined(separator: ", ")) — it reads as an "
+                      + "inventory, so a silent omission is a false claim about the repository")
+
+        // The other direction: a name in the README that no longer exists is the
+        // same defect pointing backwards, and it is how a layout goes stale
+        // without anyone deleting anything.
+        let listed = block.split(separator: "\n").compactMap { line -> String? in
+            let t = line.trimmingCharacters(in: .whitespaces)
+            guard let name = t.split(separator: " ").first, name.hasSuffix(".swift") else { return nil }
+            return String(name)
+        }
+        let vanished = listed.filter { !onDisk.contains($0) }
+        XCTAssertTrue(vanished.isEmpty,
+                      "README layout lists files that do not exist: \(vanished.joined(separator: ", "))")
+    }
+}

--- a/Tests/HerdrKitTests/ReadmeLayoutTests.swift
+++ b/Tests/HerdrKitTests/ReadmeLayoutTests.swift
@@ -20,37 +20,67 @@ final class ReadmeLayoutTests: XCTestCase {
             .deletingLastPathComponent()   // repo
     }
 
-    func testTheReadmeLayoutListsEverySourceFile() throws {
+    /// Rows are PARSED and compared as sets, and EVERY entry under Sources/ is
+    /// checked — not just HerdrKit's.
+    ///
+    /// Both corrections come from probes against my previous version:
+    ///   - `block.contains(name)` searched the whole block, so deleting
+    ///     Wire.swift's row passed as long as some OTHER row's description
+    ///     mentioned "Wire.swift". A substring search cannot tell an inventory
+    ///     entry from prose.
+    ///   - the guard hardcoded Sources/HerdrKit, so replacing the Sources/CSSH
+    ///     row with a nonexistent directory passed, and so did adding a whole
+    ///     new target the layout never mentioned.
+    ///
+    /// I named that second gap in two consecutive review dispatches before
+    /// closing it. Naming a gap is not closing it; it just makes the omission
+    /// deliberate.
+    func testTheReadmeLayoutMatchesTheRepositoryExactly() throws {
         let root = repoRoot()
-        let sources = root.appendingPathComponent("Sources/HerdrKit")
-        let onDisk = try FileManager.default
-            .contentsOfDirectory(atPath: sources.path)
-            .filter { $0.hasSuffix(".swift") }
-            .sorted()
-        XCTAssertFalse(onDisk.isEmpty, "no sources found; the comparison would be vacuous")
+        let fm = FileManager.default
+
+        let sourcesDir = root.appendingPathComponent("Sources")
+        let dirsOnDisk = Set(try fm.contentsOfDirectory(atPath: sourcesDir.path)
+            .filter { name in
+                var isDir: ObjCBool = false
+                _ = fm.fileExists(atPath: sourcesDir.appendingPathComponent(name).path,
+                                  isDirectory: &isDir)
+                return isDir.boolValue
+            })
+        XCTAssertFalse(dirsOnDisk.isEmpty, "no source directories found; the comparison is vacuous")
 
         let readme = try String(
             contentsOf: root.appendingPathComponent("README.md"), encoding: .utf8)
-        guard let start = readme.range(of: "Sources/HerdrKit/"),
-              let end = readme.range(of: "```", range: start.upperBound..<readme.endIndex)
+        guard let open = readme.range(of: "Sources/"),
+              let close = readme.range(of: "```", range: open.lowerBound..<readme.endIndex)
         else { return XCTFail("no layout block found in README.md") }
-        let block = String(readme[start.upperBound..<end.lowerBound])
+        let block = String(readme[open.lowerBound..<close.lowerBound])
 
-        let missing = onDisk.filter { !block.contains($0) }
-        XCTAssertTrue(missing.isEmpty,
-                      "README layout omits \(missing.joined(separator: ", ")) — it reads as an "
-                      + "inventory, so a silent omission is a false claim about the repository")
-
-        // The other direction: a name in the README that no longer exists is the
-        // same defect pointing backwards, and it is how a layout goes stale
-        // without anyone deleting anything.
-        let listed = block.split(separator: "\n").compactMap { line -> String? in
-            let t = line.trimmingCharacters(in: .whitespaces)
-            guard let name = t.split(separator: " ").first, name.hasSuffix(".swift") else { return nil }
-            return String(name)
+        // A row is its FIRST token. Anything after it is prose and is ignored,
+        // which is the whole point of parsing rather than substring-searching.
+        var dirsListed = Set<String>()
+        var filesListed = Set<String>()
+        for line in block.split(separator: "\n") {
+            guard let token = line.split(separator: " ").first.map(String.init) else { continue }
+            if token.hasPrefix("Sources/"), token.hasSuffix("/") {
+                dirsListed.insert(String(token.dropFirst("Sources/".count).dropLast()))
+            } else if token.hasSuffix(".swift") {
+                filesListed.insert(token)
+            }
         }
-        let vanished = listed.filter { !onDisk.contains($0) }
-        XCTAssertTrue(vanished.isEmpty,
-                      "README layout lists files that do not exist: \(vanished.joined(separator: ", "))")
+
+        XCTAssertEqual(dirsListed, dirsOnDisk,
+                       "the layout's source directories do not match the repository: "
+                       + "listed \(dirsListed.sorted()), on disk \(dirsOnDisk.sorted())")
+
+        for dir in dirsOnDisk {
+            let swift = Set(try fm.contentsOfDirectory(
+                atPath: sourcesDir.appendingPathComponent(dir).path)
+                .filter { $0.hasSuffix(".swift") })
+            guard !swift.isEmpty else { continue }   // CSSH carries no Swift
+            XCTAssertEqual(filesListed, swift,
+                           "the layout's \(dir) files do not match the repository: "
+                           + "listed \(filesListed.sorted()), on disk \(swift.sorted())")
+        }
     }
 }

--- a/Tests/HerdrKitTests/ReadmeLayoutTests.swift
+++ b/Tests/HerdrKitTests/ReadmeLayoutTests.swift
@@ -1,6 +1,8 @@
 import XCTest
 
-/// The README's layout block must list every source file, and only real ones.
+/// Every path the README's layout NAMES must exist. It deliberately does not
+/// check the reverse — see the test's own comment for why that claim was
+/// dropped after four rounds of trying to make it correct.
 ///
 /// WHY THIS IS A TEST AND NOT A SCRIPT: I described that block as "generated
 /// from `ls`, and the generator fails if a file has no description" — and then
@@ -45,12 +47,29 @@ final class ReadmeLayoutTests: XCTestCase {
         else { return XCTFail("no layout block found in README.md") }
         let block = String(readme[open.lowerBound..<close.lowerBound])
 
+        // UNRECOGNISED ROWS FAIL; they do not vanish. The previous parser skipped
+        // anything whose first token it did not understand, so wrapping a name
+        // in backticks silently removed it from the guard — the file could then
+        // name something nonexistent and pass. A parser that ignores what it
+        // cannot read is a filter, not a check, and the thing it filters out is
+        // exactly the thing nobody looked at.
+        //
+        // I named this risk in my own review dispatch and shipped without
+        // closing it. Twice, on this file.
         var named: [String] = []
+        var unparsed: [String] = []
         for line in block.split(separator: "\n") {
-            guard let token = line.split(separator: " ").first.map(String.init) else { continue }
+            let text = line.trimmingCharacters(in: .whitespaces)
+            guard !text.isEmpty else { continue }
+            let token = String(text.split(separator: " ").first ?? "")
+                .trimmingCharacters(in: CharacterSet(charactersIn: "`*-+•│├└─"))
             if token.hasSuffix(".swift") { named.append("Sources/HerdrKit/" + token) }
             else if token.hasPrefix("Sources/"), token.hasSuffix("/") { named.append(String(token.dropLast())) }
+            else { unparsed.append(text) }
         }
+        XCTAssertTrue(unparsed.isEmpty,
+                      "layout rows the guard cannot read, so it cannot check them: "
+                      + unparsed.joined(separator: " | "))
         XCTAssertFalse(named.isEmpty, "no entries parsed from the layout; the check is vacuous")
 
         let missing = named.filter { !FileManager.default.fileExists(

--- a/Tests/HerdrKitTests/SSHTransportTests.swift
+++ b/Tests/HerdrKitTests/SSHTransportTests.swift
@@ -526,6 +526,15 @@ final class SSHTransportTests: XCTestCase {
         do {
             let retired = SSHTransport.AuditToken()
             retired.closer = { _ in intercepted.bump(); return 0 }
+            // PROVE THE CLOSER IS INSTALLED before releasing the token. Without
+            // this, replacing the assignment with `_ = retired` left the test
+            // GREEN: address reuse still happened, so nothing skipped, but the
+            // hazard was never armed and "the replacement did not inherit it"
+            // was true because there was nothing to inherit.
+            _ = retired.closer(-1)
+            XCTAssertEqual(intercepted.value, 1,
+                           "the retired token's closer was never installed; the inheritance "
+                           + "check below would be vacuous")
             addresses.append(ObjectIdentifier(retired))
         }   // released WITHOUT any cleanup call
 
@@ -539,8 +548,9 @@ final class SSHTransportTests: XCTestCase {
         let generation = DescriptorAudit.opened(fd)
         DescriptorAudit.closeRejectedAdoption(fd, generation: generation, owner: replacement)
 
-        XCTAssertEqual(intercepted.value, 0,
-                       "the replacement inherited a retired token's closer")
+        XCTAssertEqual(intercepted.value, 1,
+                       "the replacement inherited a retired token's closer: the count rose past "
+                       + "the one invocation that armed it")
         XCTAssertEqual(replacement.adoptionRejections, 1,
                        "the replacement's own close did not run")
     }

--- a/Tests/HerdrKitTests/SSHTransportTests.swift
+++ b/Tests/HerdrKitTests/SSHTransportTests.swift
@@ -317,7 +317,7 @@ final class SSHTransportTests: XCTestCase {
     /// lands.
     func testReleasedDescriptorIsNotClosedOntoARecycledNumber() throws {
         let live = LiveChannel()
-        let published = socket(AF_UNIX, Int32(SOCK_STREAM.rawValue), 0)
+        let published = socket(AF_UNIX, sockStream, 0)
         try XCTSkipIf(published < 0, "could not open a descriptor")
         XCTAssertTrue(live.adopt(rawSocket: published))
 
@@ -326,7 +326,7 @@ final class SSHTransportTests: XCTestCase {
         XCTAssertEqual(close(published), 0)
         live.release()
 
-        let canary = socket(AF_UNIX, Int32(SOCK_STREAM.rawValue), 0)
+        let canary = socket(AF_UNIX, sockStream, 0)
         try XCTSkipIf(
             canary != published,
             "another thread took the freed descriptor; the canary would prove nothing"
@@ -353,7 +353,7 @@ final class SSHTransportTests: XCTestCase {
     func testRejectedSessionAdoptionStopsPublishingTheDescriptor() throws {
         try SSHRuntime.ensureStarted()
         let live = LiveChannel()
-        let published = socket(AF_UNIX, Int32(SOCK_STREAM.rawValue), 0)
+        let published = socket(AF_UNIX, sockStream, 0)
         try XCTSkipIf(published < 0, "could not open a descriptor")
         XCTAssertTrue(live.adopt(rawSocket: published))
 
@@ -370,7 +370,7 @@ final class SSHTransportTests: XCTestCase {
         // the descriptor.
         session.close()
 
-        let canary = socket(AF_UNIX, Int32(SOCK_STREAM.rawValue), 0)
+        let canary = socket(AF_UNIX, sockStream, 0)
         try XCTSkipIf(
             canary != published,
             "another thread took the freed descriptor; the canary would prove nothing"
@@ -562,7 +562,7 @@ final class SSHTransportTests: XCTestCase {
     /// goes EINPROGRESS and then fails for real, which is the one thing a
     /// blackhole cannot provide.
     static func boundButNotListening() throws -> (Int32, UInt16) {
-        let fd = socket(AF_INET, Int32(SOCK_STREAM.rawValue), 0)
+        let fd = socket(AF_INET, sockStream, 0)
         guard fd >= 0 else { throw XCTSkip("could not open a socket") }
         var addr = sockaddr_in()
         addr.sin_family = sa_family_t(AF_INET)
@@ -570,7 +570,7 @@ final class SSHTransportTests: XCTestCase {
         addr.sin_port = 0
         _ = withUnsafePointer(to: &addr) { p in
             p.withMemoryRebound(to: sockaddr.self, capacity: 1) {
-                bind(fd, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
+                platformBind(fd, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
             }
         }
         var bound = sockaddr_in()
@@ -832,7 +832,7 @@ final class SSHTransportTests: XCTestCase {
     /// Container networks often answer ENETUNREACH at once, which would turn
     /// every bound assertion below into a test of nothing.
     static func blackholeSwallowsSYN() -> Bool {
-        let fd = socket(AF_INET, Int32(SOCK_STREAM.rawValue), 0)
+        let fd = socket(AF_INET, sockStream, 0)
         guard fd >= 0 else { return false }
         defer { _ = close(fd) }
         let flags = fcntl(fd, F_GETFL, 0)
@@ -929,7 +929,7 @@ final class SilentPeer: @unchecked Sendable {
     private var held: [Int32] = []
 
     func start() throws {
-        fd = socket(AF_INET, Int32(SOCK_STREAM.rawValue), 0)
+        fd = socket(AF_INET, sockStream, 0)
         var on: Int32 = 1
         setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &on, socklen_t(MemoryLayout<Int32>.size))
         var addr = sockaddr_in()
@@ -938,7 +938,7 @@ final class SilentPeer: @unchecked Sendable {
         addr.sin_port = 0
         _ = withUnsafePointer(to: &addr) { p in
             p.withMemoryRebound(to: sockaddr.self, capacity: 1) {
-                bind(fd, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
+                platformBind(fd, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
             }
         }
         var bound = sockaddr_in()
@@ -1010,7 +1010,7 @@ final class PausableRelay: @unchecked Sendable {
     private func notePark(_ id: Int) { lock.lock(); parked.insert(id); lock.unlock() }
 
     func start() throws {
-        listenFD = socket(AF_INET, Int32(SOCK_STREAM.rawValue), 0)
+        listenFD = socket(AF_INET, sockStream, 0)
         guard listenFD >= 0 else { throw XCTSkip("relay socket unavailable") }
         var on: Int32 = 1
         setsockopt(listenFD, SOL_SOCKET, SO_REUSEADDR, &on, socklen_t(MemoryLayout<Int32>.size))
@@ -1020,7 +1020,7 @@ final class PausableRelay: @unchecked Sendable {
         addr.sin_port = 0
         _ = withUnsafePointer(to: &addr) { p in
             p.withMemoryRebound(to: sockaddr.self, capacity: 1) {
-                bind(listenFD, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
+                platformBind(listenFD, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
             }
         }
         var bound = sockaddr_in()
@@ -1046,7 +1046,7 @@ final class PausableRelay: @unchecked Sendable {
     }
 
     private func connectUpstream() -> Int32? {
-        let fd = socket(AF_INET, Int32(SOCK_STREAM.rawValue), 0)
+        let fd = socket(AF_INET, sockStream, 0)
         guard fd >= 0 else { return nil }
         var addr = sockaddr_in()
         addr.sin_family = sa_family_t(AF_INET)

--- a/Tests/HerdrKitTests/SessionRecoveryTests.swift
+++ b/Tests/HerdrKitTests/SessionRecoveryTests.swift
@@ -179,7 +179,15 @@ final class SessionRecoveryTests: XCTestCase {
         // discovery has no other path: snapshots only arrive over transports.
         var offline = try seeded(["p1"])
         let stale = recovery.beginInitialAttempt(state: &offline).reconnectAttempt!
+        // CONNECT IT FIRST. Without this the attempt is current-but-unconnected,
+        // which rejects snapshots for a DIFFERENT reason — so deleting the
+        // networkChanged below left the test green and it pinned the connection
+        // gate rather than abandonment.
+        XCTAssertEqual(plan(.connected(stale, at: Date()), &offline).actions,
+                       [.resyncAllPanes(stale)],
+                       "the attempt never adopted; the abandonment below is not the gate under test")
         _ = plan(.networkChanged(at: Date()), &offline)   // stale is abandoned
+        XCTAssertNotEqual(offline.currentAttempt, stale, "the attempt was not abandoned")
         let ignored = recovery.observe(PaneSnapshot(agents: try panes(["p1", "p4"])), from: stale, state: &offline)
         XCTAssertTrue(ignored.isEmpty, "an abandoned attempt's snapshot must admit nothing")
         XCTAssertEqual(offline.knownPanes, ["p1"], "nor may it mutate knowledge")
@@ -203,7 +211,14 @@ final class SessionRecoveryTests: XCTestCase {
         var state = try seeded(["p1"])
         let preReplacement = recovery.beginInitialAttempt(state: &state).reconnectAttempt!
 
-        state = try seeded(["p1"])   // the caller rebuilds their state
+        // A MARKER THAT CROSSES THE ASSIGNMENT. Deleting the rebuild left this
+        // green: both attempts are minted from the same lineage either way and
+        // the identities still differ, so "not equal" proved nothing about
+        // replacement. knownPanes is value-stored, so it travels with the
+        // rebuilt State and distinguishes it from the original.
+        state = try seeded(["p1", "replacement-marker"])   // the caller rebuilds their state
+        XCTAssertTrue(state.knownPanes.contains("replacement-marker"),
+                      "the state was never replaced; every assertion below is about the original")
         let postReplacement = recovery.beginInitialAttempt(state: &state).reconnectAttempt!
         XCTAssertNotEqual(preReplacement, postReplacement,
                           "a rebuilt State reminted an identical attempt identity")
@@ -224,9 +239,18 @@ final class SessionRecoveryTests: XCTestCase {
     func testMintingAfterASavedCopyRestoreCannotReproduceAnIdentity() throws {
         var state = try seeded(["p1"])
         let saved = state
+        // MARK THE LIVE STATE so the restore below is observable. Deleting
+        // `state = saved` left these tests green: the authority is shared by
+        // reference, so the assertions held whether or not the value copy was
+        // ever restored — they pinned the reference behaviour and said nothing
+        // about replay, which is the entire subject. knownPanes is
+        // value-stored, so it travels with the copy and distinguishes them.
+        state.knownPanes.insert("live-marker-1")
         let minted = recovery.beginInitialAttempt(state: &state).reconnectAttempt!
 
         state = saved   // the replay
+        XCTAssertFalse(state.knownPanes.contains("live-marker-1"),
+                       "the saved copy was never restored; this test is not about replay")
         let reminted = recovery.beginInitialAttempt(state: &state).reconnectAttempt!
         XCTAssertNotEqual(minted, reminted,
                           "a saved-copy restore reproduced a previously minted identity")
@@ -250,11 +274,20 @@ final class SessionRecoveryTests: XCTestCase {
         var state = try seeded(["p1"])
         let attemptA = recovery.beginInitialAttempt(state: &state).reconnectAttempt!
         let saved = state                      // A is current in this copy
+        // MARK THE LIVE STATE so the restore below is observable. Deleting
+        // `state = saved` left these tests green: the authority is shared by
+        // reference, so the assertions held whether or not the value copy was
+        // ever restored — they pinned the reference behaviour and said nothing
+        // about replay, which is the entire subject. knownPanes is
+        // value-stored, so it travels with the copy and distinguishes them.
+        state.knownPanes.insert("live-marker-2")
 
         let changed = plan(.networkChanged(at: Date()), &state)   // cancels A, mints B
         let attemptB = changed.reconnectAttempt!
 
         state = saved                          // the replay
+        XCTAssertFalse(state.knownPanes.contains("live-marker-2"),
+                       "the saved copy was never restored; this test is not about replay")
         let lateA = plan(.connected(attemptA, at: Date()), &state)
         XCTAssertEqual(lateA.actions, [.discardConnection],
                        "a cancelled attempt was reauthorized by value restoration")
@@ -281,11 +314,20 @@ final class SessionRecoveryTests: XCTestCase {
         let attemptA = recovery.beginInitialAttempt(state: &state).reconnectAttempt!
         _ = plan(.connected(attemptA, at: Date()), &state)
         let saved = state                       // connected bookkeeping aboard
+        // MARK THE LIVE STATE so the restore below is observable. Deleting
+        // `state = saved` left these tests green: the authority is shared by
+        // reference, so the assertions held whether or not the value copy was
+        // ever restored — they pinned the reference behaviour and said nothing
+        // about replay, which is the entire subject. knownPanes is
+        // value-stored, so it travels with the copy and distinguishes them.
+        state.knownPanes.insert("live-marker-3")
 
         let changed = plan(.networkChanged(at: Date()), &state)   // cancels A, mints B
         let attemptB = changed.reconnectAttempt!
 
         state = saved                           // the replay
+        XCTAssertFalse(state.knownPanes.contains("live-marker-3"),
+                       "the saved copy was never restored; this test is not about replay")
 
         // No incremental subscribe may target the cancelled transport.
         XCTAssertTrue(plan(.paneCreated("p9", from: state.currentAttempt ?? AttemptID(uuid: UUID())), &state).isEmpty,
@@ -353,14 +395,32 @@ final class SessionRecoveryTests: XCTestCase {
     /// target p2.
     func testReplayedKnowledgeCannotSubscribeAClosedPane() throws {
         var state = try seeded(["p1", "p2"])
-        _ = connect(&state)
+        let opened = connect(&state)
+        // p2 MUST BE IN THE SAVED COPY, or "replayed knowledge cannot subscribe
+        // it" is true because there was nothing to replay. The test passed both
+        // with the close deleted AND with p2 never present: the authoritative
+        // ["p1"] snapshot at the end supplies the closed-pane state on its own.
+        XCTAssertTrue(state.knownPanes.contains("p2"),
+                      "p2 is not in the state being saved; the replay has nothing to carry")
         let saved = state
+        // MARK THE LIVE STATE so the restore below is observable. Deleting
+        // `state = saved` left these tests green: the authority is shared by
+        // reference, so the assertions held whether or not the value copy was
+        // ever restored — they pinned the reference behaviour and said nothing
+        // about replay, which is the entire subject. knownPanes is
+        // value-stored, so it travels with the copy and distinguishes them.
+        state.knownPanes.insert("live-marker-4")
 
-        _ = plan(.paneClosed("p2", from: state.currentAttempt ?? AttemptID(uuid: UUID())), &state)
+        _ = plan(.paneClosed("p2", from: opened), &state)
+        XCTAssertFalse(state.knownPanes.contains("p2"),
+                       "the close did not take effect; the replay below carries a pane the "
+                       + "live state never dropped, so nothing distinguishes replay from truth")
         let changed = plan(.networkChanged(at: Date()), &state)
         let attemptB = changed.reconnectAttempt!
 
         state = saved                           // the replay: memory says p2 exists
+        XCTAssertFalse(state.knownPanes.contains("live-marker-4"),
+                       "the saved copy was never restored; this test is not about replay")
 
         let adopted = plan(.connected(attemptB, at: Date()), &state)
         XCTAssertEqual(adopted.actions, [.resyncAllPanes(attemptB)],
@@ -578,9 +638,18 @@ final class SessionRecoveryTests: XCTestCase {
     func testASavedForegroundedCopyCannotDialAfterBackgrounding() throws {
         var state = try seeded(["p1"])
         let saved = state                       // foregrounded copy
+        // MARK THE LIVE STATE so the restore below is observable. Deleting
+        // `state = saved` left these tests green: the authority is shared by
+        // reference, so the assertions held whether or not the value copy was
+        // ever restored — they pinned the reference behaviour and said nothing
+        // about replay, which is the entire subject. knownPanes is
+        // value-stored, so it travels with the copy and distinguishes them.
+        state.knownPanes.insert("live-marker-5")
 
         _ = plan(.backgrounded(at: Date()), &state)
         state = saved                           // the replay
+        XCTAssertFalse(state.knownPanes.contains("live-marker-5"),
+                       "the saved copy was never restored; this test is not about replay")
 
         XCTAssertTrue(recovery.beginInitialAttempt(state: &state).isEmpty,
                       "a replayed foreground bit let a backgrounded client dial")

--- a/Tests/HerdrKitTests/SessionRecoveryTests.swift
+++ b/Tests/HerdrKitTests/SessionRecoveryTests.swift
@@ -1081,6 +1081,35 @@ final class ResyncInvalidationTests: XCTestCase {
 /// module, so formatting, access-level spelling and additional initialisers are
 /// all covered by construction rather than by enumeration.
 final class PaneSnapshotAccessTests: XCTestCase {
+    /// libssh2's header search path, from pkg-config.
+    ///
+    /// SwiftPM hands the CSSH target these flags automatically — but this test
+    /// spawns symbolgraph-extract ITSELF, so it inherits nothing. On Debian that
+    /// was invisible because /usr/include is a default search path; on macOS,
+    /// Homebrew's prefix is not, so the shim's `#include <libssh2.h>` failed and
+    /// the whole module could not be built for extraction.
+    ///
+    /// That is a defect the pkg-config fix CREATED: moving from a hardcoded path
+    /// to a resolved one fixed the build and broke every hand-rolled tool
+    /// invocation that had been relying on the hardcoded assumption.
+    static func libssh2ClangFlags() -> [String] {
+        let p = Process()
+        p.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        p.arguments = ["pkg-config", "--cflags-only-I", "libssh2"]
+        let out = Pipe()
+        p.standardOutput = out
+        p.standardError = Pipe()
+        guard (try? p.run()) != nil else { return [] }
+        p.waitUntilExit()
+        let text = String(
+            data: out.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        return text.split(separator: " ").compactMap { flag -> [String]? in
+            let f = flag.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard f.hasPrefix("-I"), f.count > 2 else { return nil }
+            return ["-Xcc", f]
+        }.flatMap { $0 }
+    }
+
     func testPaneSnapshotExposesNoInitialiserOutsideTheModule() throws {
         let root = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent()
@@ -1139,6 +1168,7 @@ final class PaneSnapshotAccessTests: XCTestCase {
             "-include-spi-symbols",
             "-I", moduleDir.path,
             "-I", root.appendingPathComponent("Sources/CSSH").path,
+        ] + Self.libssh2ClangFlags() + [
             "-output-dir", output.path, "-minimum-access-level", "package",
         ]
         let stderrPipe = Pipe()

--- a/Tests/HerdrKitTests/SessionRecoveryTests.swift
+++ b/Tests/HerdrKitTests/SessionRecoveryTests.swift
@@ -313,6 +313,17 @@ final class SessionRecoveryTests: XCTestCase {
         // The snapshot forgets p2; its subscription on this transport stays open.
         XCTAssertTrue(recovery.observe(PaneSnapshot(agents: try panes(["p1"])), from: opened, state: &state).isEmpty)
 
+        // THE SHRINK MUST HAVE HAPPENED. Without this the test passed with the
+        // shrink deleted entirely: p2 begins subscribed, so both rediscovery
+        // operations below return empty whether or not it ever left. The
+        // divergence between the two sets IS the state under test — forgotten
+        // in knowledge, still subscribed on the wire — and asserting it is what
+        // makes the emptiness below mean "not re-subscribed" rather than
+        // "nothing changed".
+        XCTAssertFalse(state.knownPanes.contains("p2"), "the snapshot did not shrink")
+        XCTAssertTrue(state.subscribedPanes.contains("p2"),
+                      "the shrink dropped the subscription; there is no unsubscribe verb")
+
         // p2 reappears — via event and via snapshot. Neither may re-subscribe.
         XCTAssertTrue(plan(.paneCreated("p2", from: opened), &state).isEmpty,
                       "paneCreated re-subscribed a pane this transport already watches")
@@ -948,6 +959,15 @@ final class SessionRecoveryTests: XCTestCase {
         var state = try seeded(["p1"])
         let first = connect(&state)
         _ = plan(.paneCreated("p2", from: first), &state)   // learned mid-session
+
+        // THE LEARNING MUST HAVE HAPPENED, and it is the whole subject of this
+        // test's name. Without it the test passed with the paneCreated deleted:
+        // the authoritative snapshot after reconnect supplies p2 independently,
+        // so the final assertion held for a reason unrelated to learning
+        // anything mid-session.
+        XCTAssertTrue(state.knownPanes.contains("p2"), "the mid-session pane was never learned")
+        XCTAssertTrue(state.subscribedPanes.contains("p2"),
+                      "the mid-session pane was learned but never subscribed")
 
         _ = plan(.networkChanged(at: Date()), &state)
         let second = recovery.beginInitialAttempt(state: &state).reconnectAttempt!

--- a/Tests/HerdrKitTests/SessionRecoveryTests.swift
+++ b/Tests/HerdrKitTests/SessionRecoveryTests.swift
@@ -964,10 +964,30 @@ final class SessionRecoveryTests: XCTestCase {
     /// Removal used to require passing a fresh full listing, which is what made
     /// partial listings dangerous — there was no other way to drop one.
     func testClosedPanesAreDroppedIncrementally() throws {
+        // CONNECT FIRST, so paneClosed arrives from the CURRENT attempt.
+        //
+        // This seeded knownPanes with no current attempt and sent paneClosed
+        // with a fresh random AttemptID, which production correctly REJECTS at
+        // the provenance gate. The drop never happened — the authoritative
+        // snapshot below removed p2 wholesale, producing the same final state,
+        // and the assertion could not tell the two apart. Replacing the
+        // paneClosed call with `_ = state` left the test green.
+        //
+        // Ninth instance today of an assertion expecting an absence with
+        // nothing establishing the presence was reachable. Found by applying
+        // the rule from the previous round to a test this PR never touched.
         var state = try seeded(["p1", "p2"])
-        _ = plan(.paneClosed("p2", from: state.currentAttempt ?? AttemptID(uuid: UUID())), &state)
         let opened = recovery.beginInitialAttempt(state: &state).reconnectAttempt!
         XCTAssertEqual(plan(.connected(opened, at: Date()), &state).actions, [.resyncAllPanes(opened)])
+        XCTAssertTrue(state.knownPanes.contains("p2"), "p2 was never present; the drop is vacuous")
+
+        _ = plan(.paneClosed("p2", from: opened), &state)
+
+        // Asserted BEFORE any snapshot, which would otherwise mask the result by
+        // producing the same absence for an unrelated reason.
+        XCTAssertFalse(state.knownPanes.contains("p2"),
+                       "the incremental close did not drop the pane")
+
         let resub = recovery.observe(PaneSnapshot(agents: try panes(["p1"])), from: opened, state: &state)
         XCTAssertEqual(resub.subscribes, ["p1"])
     }

--- a/Tests/HerdrKitTests/SessionRecoveryTests.swift
+++ b/Tests/HerdrKitTests/SessionRecoveryTests.swift
@@ -1081,6 +1081,32 @@ final class ResyncInvalidationTests: XCTestCase {
 /// module, so formatting, access-level spelling and additional initialisers are
 /// all covered by construction rather than by enumeration.
 final class PaneSnapshotAccessTests: XCTestCase {
+    /// The SDK path, on Apple platforms only.
+    ///
+    /// Without it symbolgraph-extract cannot find the standard library at all —
+    /// "missing required modules: 'Swift', '_Concurrency', ..." — because on
+    /// Darwin the stdlib lives inside the SDK rather than beside the compiler.
+    /// Linux needs nothing here, which is why the invocation worked for months
+    /// without it.
+    static func sdkFlags() -> [String] {
+        #if canImport(Darwin)
+        let p = Process()
+        p.executableURL = URL(fileURLWithPath: "/usr/bin/xcrun")
+        p.arguments = ["--show-sdk-path"]
+        let out = Pipe()
+        p.standardOutput = out
+        p.standardError = Pipe()
+        guard (try? p.run()) != nil else { return [] }
+        p.waitUntilExit()
+        let path = String(
+            data: out.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return path.isEmpty ? [] : ["-sdk", path]
+        #else
+        return []
+        #endif
+    }
+
     /// libssh2's header search path, from pkg-config.
     ///
     /// SwiftPM hands the CSSH target these flags automatically — but this test
@@ -1168,7 +1194,7 @@ final class PaneSnapshotAccessTests: XCTestCase {
             "-include-spi-symbols",
             "-I", moduleDir.path,
             "-I", root.appendingPathComponent("Sources/CSSH").path,
-        ] + Self.libssh2ClangFlags() + [
+        ] + Self.libssh2ClangFlags() + Self.sdkFlags() + [
             "-output-dir", output.path, "-minimum-access-level", "package",
         ]
         let stderrPipe = Pipe()

--- a/Tests/HerdrKitTests/SessionRecoveryTests.swift
+++ b/Tests/HerdrKitTests/SessionRecoveryTests.swift
@@ -1094,7 +1094,24 @@ final class PaneSnapshotAccessTests: XCTestCase {
         let moduleDir = try XCTUnwrap(
             modules, "no built HerdrKit.swiftmodule; the access invariant went UNCHECKED"
         )
-        let triple = moduleDir.deletingLastPathComponent().deletingLastPathComponent().lastPathComponent
+        let buildTriple = moduleDir.deletingLastPathComponent()
+            .deletingLastPathComponent().lastPathComponent
+        // APPLE TRIPLES NEED THE DEPLOYMENT VERSION. SwiftPM names the build
+        // directory with an UNVERSIONED triple ("arm64-apple-macosx"), and
+        // symbolgraph-extract then defaults to macOS 10.4 — older than the
+        // module's floor, so it refuses to load it and the invariant goes
+        // unchecked. Invisible on Linux, which has no deployment-target concept.
+        //
+        // The running OS version is used rather than mirroring Package.swift's
+        // floor: it is >= the floor by construction (the module could not have
+        // been built otherwise), so it cannot drift out of step with the
+        // manifest the way a duplicated constant would.
+        let triple: String = {
+            guard buildTriple.contains("apple"),
+                  buildTriple.last.map({ !$0.isNumber }) ?? true else { return buildTriple }
+            let v = ProcessInfo.processInfo.operatingSystemVersion
+            return "\(buildTriple)\(v.majorVersion).\(v.minorVersion)"
+        }()
 
         // A FRESH directory per run, removed afterwards. The first version wrote
         // to a persistent per-triple directory and ignored the process exit

--- a/goals/v1b-transport.md
+++ b/goals/v1b-transport.md
@@ -24,10 +24,19 @@ speculatively.
 - Lint gate before every push: `swift build` must be warning-clean.
 - A live herdr server runs at `~/.config/herdr/herdr.sock`, so live tests
   execute rather than skip. `HERDR_SOCKET_PATH` overrides the path.
-- `CSSH` is already declared as a `systemLibrary` target in `Package.swift`,
-  with `Sources/CSSH/module.modulemap` mapping `/usr/include/libssh2.h` and
-  linking `ssh2`. Verified working: libssh2 1.11.0,
-  `libssh2_channel_direct_streamlocal_ex` resolves from Swift.
+- `CSSH` is declared as a `systemLibrary` target in `Package.swift` with
+  `pkgConfig: "libssh2"`. `Sources/CSSH/module.modulemap` names a RELATIVE
+  `shim.h`, which includes `<libssh2.h>` BY NAME; pkg-config supplies the
+  platform's header path. Verified working: libssh2 1.11.0 on Linux,
+  1.11.1 under Homebrew on macOS, `libssh2_channel_direct_streamlocal_ex`
+  resolves from Swift on both.
+
+  This paragraph previously said the module map mapped `/usr/include/libssh2.h`
+  directly. That was true when written and became false when the package moved
+  to pkg-config — and it is exactly the kind of stale repo fact a later task
+  reads as current and reintroduces. A goal file describing the build is a
+  REPRESENTATION of the build's assumptions, no different from a comment or a
+  recipe, and it needs sweeping when those assumptions change.
 
 ## Core Rules
 

--- a/scripts/readiness-experiment.swift
+++ b/scripts/readiness-experiment.swift
@@ -32,7 +32,19 @@
 //     block the decision in the analyzer.
 // It is a measurement harness, not production code: no cancellation.
 //
-// Build:  swiftc -I Sources/CSSH -lssh2 -O -o /tmp/readiness scripts/readiness-experiment.swift
+// Build:  swiftc -I Sources/CSSH $(pkg-config --cflags --libs libssh2) \
+//              -O -o /tmp/readiness scripts/readiness-experiment.swift
+//
+// THE pkg-config CALL IS NOT OPTIONAL. This recipe hardcoded `-lssh2` and no
+// include path, which works only where libssh2 sits in the compiler's default
+// search paths — Debian. Under Homebrew, or any staged prefix, it fails at
+// shim.h with "libssh2.h file not found", exactly as the package itself did
+// before CSSH moved to pkg-config.
+//
+// This is the SECOND hand-rolled libssh2 invocation in the repo, and I told a
+// reviewer there was only one: I had grepped Swift source for Process and
+// executableURL, which cannot see a build command written in a comment. The
+// class was not closed; it was closed in the places I knew how to look.
 // Run:    /tmp/readiness [trials-per-arm] [output.csv]
 
 import CSSH


### PR DESCRIPTION
Closes #17.

The owner's Mac buildbox found that **this package did not build on macOS at all** — in **seven layers**, each hidden behind the last, none visible from Linux. `eb30c71` is the first green macOS build in this project's history.

| # | defect | why Linux couldn't see it |
|---|---|---|
| 1 | `libssh2.h` by hardcoded `/usr/include` path | Debian's location; Homebrew uses `/opt/homebrew` |
| 2 | no `platforms:` → assumed macOS 10.4, every concurrency symbol unavailable | Linux does **no availability checking** |
| 3 | `SOCK_STREAM.rawValue` in Sources | enum on Glibc, `Int32` on Darwin |
| 4 | same at **10 more sites** in tests, plus `bind` resolving to `XCTestCase.bind` | same, plus a Darwin-only name collision |
| 5 | `symbolgraph-extract` targeting macOS 10.4 | unversioned triple; no deployment-target concept on Linux |
| 6 | `symbolgraph-extract` missing libssh2's include path | `/usr/include` is a default search path on Debian |
| 7 | `symbolgraph-extract` missing the SDK | on Darwin the stdlib lives inside the SDK |

Layers 5–7 are consequences of fixing 1 and 2: a deployment floor and a resolved include path each invalidated a hand-rolled tool invocation that had been relying on the old assumptions.

## What I'd do differently

Layers 3 and 4 were **one defect**. Issue #17 named two `SOCK_STREAM.rawValue` sites; I fixed exactly those two and pushed — there were ten more in the test files. That cost a full cycle. Every push after it applied a **grep-the-class-before-pushing** rule, which is why 5, 6 and 7 each took one push instead of two.

## Verification

- **`eb30c71` — status 0 on macOS.** The only proof that matters for this PR; Linux green is precisely what missed all seven.
- Linux: 142 tests, 0 failures, from a wiped `.build` (the change under test is the manifest, so an incremental build can keep succeeding against the old one).
- `grep` returns zero unqualified `SOCK_STREAM.rawValue` or bare `bind(` across `Sources` and `Tests`.

`"screenshot": null` is expected — swiftpm mode, no app target yet.