### PR TITLE
tests: sweep the two attempt fallbacks, and fix what they were hiding

### DIFF
--- a/Tests/HerdrKitTests/SessionRecoveryTests.swift
+++ b/Tests/HerdrKitTests/SessionRecoveryTests.swift
@@ -172,13 +172,12 @@ final class SessionRecoveryTests: XCTestCase {
         // Deleting the adoption below leaves no subscribe: KILLED, so this
         // control is armed and adoption is its premise.
         //
-        // What it does NOT fix, measured after adding it rather than assumed:
-        // substituting a stranger AttemptID for `minted` in the assertion ABOVE
-        // still SURVIVES. Provenance rejects a stranger to the identical
-        // observable, and the control below reads `minted` independently, so
-        // nothing binds the two lines to one attempt. The negative line is
-        // therefore not attempt-discriminating; attempt discrimination is
-        // pinned by testALatePaneEventFromAnAbandonedAttemptActsOnNothing.
+        // ATTEMPT DISCRIMINATION comes from the shared `probe` value, not from
+        // this control. While the two deliveries were constructed separately, a
+        // stranger AttemptID substituted into the negative line alone SURVIVED
+        // — provenance rejects a stranger to the identical observable. Sharing
+        // one immutable event makes that substitution reach here too, where the
+        // subscribe then fails to appear: KILLED.
         _ = plan(.connected(minted, at: Date()), &state)
         XCTAssertEqual(plan(probe, &state).subscribes, ["p9"],
                        "the same event still admits nothing after adoption; the emptiness above was "
@@ -386,17 +385,13 @@ final class SessionRecoveryTests: XCTestCase {
         let probe = ClientEvent.paneCreated("adoption-probe", from: attemptB)
         XCTAssertTrue(plan(probe, &state).isEmpty,
                       "an event from B before B's adoption is processed admits nothing")
-        // MEASURED LIMITATION, stated rather than implied: substituting a
-        // stranger AttemptID for `attemptB` here leaves this assertion true
-        // (SURVIVED), because provenance rejects a stranger to the same
-        // observable. So this line pins "nothing leaks before adoption" and
-        // does NOT discriminate which attempt was refused. A positive control
-        // of the kind used in
-        // testBeginInitialAttemptWhileConnectedCancelsAndClearsAdoption does
-        // not fit here without consuming p9's freshness and gutting the
-        // mid-replay-learning assertion at the end of this test, which is the
-        // stronger check. Attempt discrimination is pinned by
-        // testALatePaneEventFromAnAbandonedAttemptActsOnNothing.
+        // ORDERING IS LOAD-BEARING HERE and is pinned: moving this delivery
+        // after the adoption below KILLS (it subscribes instead of staying
+        // empty), and moving the post-adoption delivery before it KILLS (no
+        // subscription appears). The post-adoption delivery and the snapshot
+        // below ARE interchangeable — both follow adoption and touch distinct
+        // panes — which is independence, not redundancy: the stranger mutation
+        // pins the probe and the p9 collision pins the snapshot.
 
         // And B's adoption must not be suppressed as a repeat.
         let adoptedB = plan(.connected(attemptB, at: Date()), &state)

--- a/Tests/HerdrKitTests/SessionRecoveryTests.swift
+++ b/Tests/HerdrKitTests/SessionRecoveryTests.swift
@@ -147,7 +147,15 @@ final class SessionRecoveryTests: XCTestCase {
         let minted = try XCTUnwrap(restarted.reconnectAttempt)
         XCTAssertEqual(state.currentAttempt, minted,
                        "the restart did not become current; the event below is not from the attempt under test")
-        XCTAssertTrue(plan(.paneCreated("p9", from: minted), &state).isEmpty,
+        // ONE EVENT VALUE, DELIVERED TWICE — the reviewer's construction, and the
+        // thing that makes the negative line attempt-discriminating. Built
+        // separately, the before and after events shared nothing, so swapping a
+        // stranger into the negative line alone left it empty (provenance
+        // rejects a stranger to the identical observable) and SURVIVED. Sharing
+        // the value means a stranger substituted here must also be a stranger
+        // below, where the post-adoption subscribe then fails to appear.
+        let probe = ClientEvent.paneCreated("p9", from: minted)
+        XCTAssertTrue(plan(probe, &state).isEmpty,
                       "an event from the CURRENT attempt, before its adoption is processed, admits nothing "
                       + "— it needs nothing, because the post-adoption snapshot covers it via observe. "
                       + "(This does NOT pin the abandoned-attempt path: `minted` IS current here, so "
@@ -172,7 +180,7 @@ final class SessionRecoveryTests: XCTestCase {
         // therefore not attempt-discriminating; attempt discrimination is
         // pinned by testALatePaneEventFromAnAbandonedAttemptActsOnNothing.
         _ = plan(.connected(minted, at: Date()), &state)
-        XCTAssertEqual(plan(.paneCreated("p9", from: minted), &state).subscribes, ["p9"],
+        XCTAssertEqual(plan(probe, &state).subscribes, ["p9"],
                        "the same event still admits nothing after adoption; the emptiness above was "
                        + "never attributable to the cleared adoption")
     }
@@ -371,7 +379,12 @@ final class SessionRecoveryTests: XCTestCase {
         // onto a cancelled transport: neither half is reachable by this route.
         XCTAssertEqual(state.currentAttempt, attemptB,
                        "the restore retargeted currentAttempt; the event below is not from B")
-        XCTAssertTrue(plan(.paneCreated("p9", from: attemptB), &state).isEmpty,
+        // THE SAME SHARED-VALUE CONSTRUCTION as site 1. I judged it did not fit
+        // here without consuming p9's freshness and gutting the mid-replay
+        // snapshot assertion below; the reviewer showed a distinct pane carries
+        // it with p9 left untouched, so the stronger check survives intact.
+        let probe = ClientEvent.paneCreated("adoption-probe", from: attemptB)
+        XCTAssertTrue(plan(probe, &state).isEmpty,
                       "an event from B before B's adoption is processed admits nothing")
         // MEASURED LIMITATION, stated rather than implied: substituting a
         // stranger AttemptID for `attemptB` here leaves this assertion true
@@ -389,6 +402,13 @@ final class SessionRecoveryTests: XCTestCase {
         let adoptedB = plan(.connected(attemptB, at: Date()), &state)
         XCTAssertEqual(adoptedB.actions, [.resyncAllPanes(attemptB)],
                        "the replayed connectedSince classified B's adoption as a repeat and suppressed it")
+        // The other half of the shared-value pair: the SAME event, once B is
+        // adopted, does admit. A stranger substituted into `probe` above is
+        // killed here.
+        XCTAssertEqual(plan(probe, &state).subscribes, ["adoption-probe"],
+                       "the same event still admits nothing after B's adoption; the emptiness above "
+                       + "was never attributable to B being unadopted")
+
         let subscribed = recovery.observe(PaneSnapshot(agents: try panes(["p1", "p9"])), from: attemptB, state: &state)
         XCTAssertEqual(subscribed.subscribes, ["p1", "p9"],
                        "B subscribes what the authoritative snapshot says, including the pane learned mid-replay")

--- a/Tests/HerdrKitTests/SessionRecoveryTests.swift
+++ b/Tests/HerdrKitTests/SessionRecoveryTests.swift
@@ -139,8 +139,42 @@ final class SessionRecoveryTests: XCTestCase {
         let restarted = recovery.beginInitialAttempt(state: &state)
         XCTAssertEqual(restarted.actions.first, .cancelTransport)
         XCTAssertNil(state.connectedSince, "stale adoption state leaks subscribes to a dead transport")
-        XCTAssertTrue(plan(.paneCreated("p9", from: state.currentAttempt ?? AttemptID(uuid: UUID())), &state).isEmpty,
-                      "no subscribe may target the transport that was just abandoned")
+
+        // FROM THE MINTED ATTEMPT, NAMED — not read back out of the state.
+        // `state.currentAttempt` forwards to `authority.current`, so reading it
+        // here silently retargets the test to whatever the transition left
+        // current. Binding it makes the premise a claim that can fail.
+        let minted = try XCTUnwrap(restarted.reconnectAttempt)
+        XCTAssertEqual(state.currentAttempt, minted,
+                       "the restart did not become current; the event below is not from the attempt under test")
+        XCTAssertTrue(plan(.paneCreated("p9", from: minted), &state).isEmpty,
+                      "an event from the CURRENT attempt, before its adoption is processed, admits nothing "
+                      + "— it needs nothing, because the post-adoption snapshot covers it via observe. "
+                      + "(This does NOT pin the abandoned-attempt path: `minted` IS current here, so "
+                      + "provenance passes and the cleared connectedSince is what rejects. The stale-attempt "
+                      + "path is pinned by testALatePaneEventFromAnAbandonedAttemptActsOnNothing.)")
+
+        // POSITIVE CONTROL. It establishes CAUSATION and nothing more, and the
+        // difference matters enough to write down.
+        //
+        // What it fixes: `.isEmpty` on its own is consistent with the event
+        // being inert for any reason at all. Adopting `minted` supplies the one
+        // missing condition and nothing else, so a subscribe appearing here
+        // proves the emptiness above was caused by the cleared adoption.
+        // Deleting the adoption below leaves no subscribe: KILLED, so this
+        // control is armed and adoption is its premise.
+        //
+        // What it does NOT fix, measured after adding it rather than assumed:
+        // substituting a stranger AttemptID for `minted` in the assertion ABOVE
+        // still SURVIVES. Provenance rejects a stranger to the identical
+        // observable, and the control below reads `minted` independently, so
+        // nothing binds the two lines to one attempt. The negative line is
+        // therefore not attempt-discriminating; attempt discrimination is
+        // pinned by testALatePaneEventFromAnAbandonedAttemptActsOnNothing.
+        _ = plan(.connected(minted, at: Date()), &state)
+        XCTAssertEqual(plan(.paneCreated("p9", from: minted), &state).subscribes, ["p9"],
+                       "the same event still admits nothing after adoption; the emptiness above was "
+                       + "never attributable to the cleared adoption")
     }
 
     /// AXIS: beginInitialAttempt while backgrounded dials nothing, matching
@@ -329,9 +363,27 @@ final class SessionRecoveryTests: XCTestCase {
         XCTAssertFalse(state.knownPanes.contains("live-marker-3"),
                        "the saved copy was never restored; this test is not about replay")
 
-        // No incremental subscribe may target the cancelled transport.
-        XCTAssertTrue(plan(.paneCreated("p9", from: state.currentAttempt ?? AttemptID(uuid: UUID())), &state).isEmpty,
-                      "a replayed connectedSince let paneCreated subscribe onto a cancelled transport")
+        // NOT the cancelled transport — B, which is current but NOT YET ADOPTED.
+        // connectedSince is not value-stored (State.connectedSince forwards to
+        // authority.connectedSince), so `state = saved` cannot replay it into
+        // the gate at all, and currentAttempt likewise resolves to B, not A.
+        // The old message here claimed a replayed connectedSince subscribing
+        // onto a cancelled transport: neither half is reachable by this route.
+        XCTAssertEqual(state.currentAttempt, attemptB,
+                       "the restore retargeted currentAttempt; the event below is not from B")
+        XCTAssertTrue(plan(.paneCreated("p9", from: attemptB), &state).isEmpty,
+                      "an event from B before B's adoption is processed admits nothing")
+        // MEASURED LIMITATION, stated rather than implied: substituting a
+        // stranger AttemptID for `attemptB` here leaves this assertion true
+        // (SURVIVED), because provenance rejects a stranger to the same
+        // observable. So this line pins "nothing leaks before adoption" and
+        // does NOT discriminate which attempt was refused. A positive control
+        // of the kind used in
+        // testBeginInitialAttemptWhileConnectedCancelsAndClearsAdoption does
+        // not fit here without consuming p9's freshness and gutting the
+        // mid-replay-learning assertion at the end of this test, which is the
+        // stronger check. Attempt discrimination is pinned by
+        // testALatePaneEventFromAnAbandonedAttemptActsOnNothing.
 
         // And B's adoption must not be suppressed as a repeat.
         let adoptedB = plan(.connected(attemptB, at: Date()), &state)


### PR DESCRIPTION
Follow-up to #18, directed by JARVIS in directive 33095: sweep the two remaining test-only `state.currentAttempt ?? AttemptID(uuid: UUID())` fallbacks as a separate PR rather than widening #18.

## The sweep is small; what it uncovered is not

Both become `try XCTUnwrap(...)` and both tests still pass — the `??` branch was dead in both, so the round-15 reviewer's reading was correct.

Removing the mask made the sites readable, and both were **mislabelled**:

- `State.connectedSince` and `State.currentAttempt` are **not value-stored** — both forward to the shared authority (`SessionRecovery.swift:474,485`). `state = saved` cannot replay either into the gate.
- Both assertions therefore send from the **new, current, not-yet-adopted** attempt and are rejected by the *connection* check. Neither pins the abandoned-transport path its message claimed.

## Established by distribution, not by argument

Mutating `admitWhileConnected`'s two sub-checks against the whole suite partitions it cleanly:

| mutation | killed by |
|---|---|
| drop-provenance | `testADelayedSnapshotFromAnAbandonedAttemptAdmitsNothing`, `testALatePaneEventFromAnAbandonedAttemptActsOnNothing` |
| drop-connection | `testACopySavedWhileConnectedCannotPoisonTheReplacementAttempt`, `testBeginInitialAttemptWhileConnectedCancelsAndClearsAdoption` |

No test straddles. **The stale-attempt path was never uncovered** — it is pinned by tests that say so in their names. This is a labelling defect, not a coverage hole, and I am not claiming otherwise.

## Changes

- Both sites send from a **named** attempt (`minted`, `attemptB`) rather than reading `currentAttempt` back out of the state, plus an assertion that it is the expected one. Reading it back lets a transition silently retarget the test.
- Messages corrected to the invariant actually pinned.
- A **positive control** at the first site: adopt, re-send the same event, require the subscribe. Deleting the adoption KILLS it — armed, with adoption as its premise.

## Residual, measured and not papered over

Substituting a stranger `AttemptID` into either negative assertion still **SURVIVES**: provenance rejects a stranger to the identical observable, and the control reads its attempt independently, so nothing binds the two lines to one attempt. The negative lines are not attempt-discriminating.

I wrote a comment claiming the control fixed that, measured that it did not, and rewrote the comment. Both limitations are stated at the sites.

**If a construction binds them, I have not found it — that is the thing I most want challenged.**

## Evidence

146 tests, 0 failures, `-Xswiftc -warnings-as-errors`. Skips were 2 this run vs 3 previously; the SSH gates are descriptor/fixture-availability dependent and vary run to run, not from this change. Linux only — the macOS buildbox verdict follows the push.