### PR TITLE
feat(list): agent list model with fail-open-visible unknown statuses

### DIFF
--- a/Sources/HerdrKit/AgentList.swift
+++ b/Sources/HerdrKit/AgentList.swift
@@ -7,8 +7,9 @@ import Foundation
 /// ways of not knowing, and the whole value of this type is refusing to merge
 /// them:
 ///
-///   - `.absent`      the field was not sent. Not an agent pane, or an older
-///                    server that predates the field.
+///   - `.absent`      the field was not sent. `agent.list` only ever returns
+///                    agent terminals, so this means an older server or a gap
+///                    — NOT "this is not an agent".
 ///   - `.indefinite`  the server sent `"unknown"`. It looked and could not tell.
 ///   - `.unrecognised` the server sent something this client has never heard of.
 ///
@@ -135,8 +136,15 @@ public struct AgentRow: Equatable, Sendable, Identifiable {
         // client is out of date", which are different problems with different
         // fixes — but they group identically, because the user's situation is
         // the same either way.
-        case .indefinite, .unrecognised: return .unrecognised
-        case .absent: return .idle
+        // ALL THREE NOT-KNOWINGS SURFACE. `.absent` was grouped as `.idle`
+        // here, on the reasoning that a missing status means "not an agent
+        // pane". That reasoning was wrong, and the reviewer checked the server
+        // rather than argue it: `agent_info` returns None unless
+        // `terminal.is_agent_terminal()` (herdr src/app/agents.rs:368), so
+        // every row in `agent.list` IS an agent. An absent status means an
+        // older server or a gap — never a non-agent — and calling it definite
+        // idle collapsed the exact case this file exists to surface.
+        case .indefinite, .unrecognised, .absent: return .unrecognised
         }
     }
 }
@@ -152,7 +160,11 @@ public struct AgentList: Equatable, Sendable {
     /// What the top of the screen says. Counts only positively-blocked agents —
     /// an unrecognised status is surfaced by its own section, and inflating this
     /// number with maybes would make the one number on the screen untrustworthy.
-    public var needsYouCount: Int { rows.filter { $0.status.isBlocked }.count }
+    /// Counts the GROUP, not the retained status. Reading `status.isBlocked`
+    /// directly meant a blocked agent whose pane had since vanished sorted into
+    /// `.stopped` and made `isQuiet` true while still reporting 1 here — the
+    /// screen simultaneously claiming all-clear and one-waiting.
+    public var needsYouCount: Int { rows.filter { $0.group == .needsYou }.count }
 
     /// True when nothing is blocked AND nothing is unrecognised. The quiet state
     /// has to mean "I checked everything", so an uninterpretable agent must

--- a/Sources/HerdrKit/AgentList.swift
+++ b/Sources/HerdrKit/AgentList.swift
@@ -1,0 +1,192 @@
+import Foundation
+
+/// What an agent is doing, as the client is willing to act on it.
+///
+/// herdr serialises its own `AgentStatus` as `idle | working | blocked | done |
+/// unknown`, and the field is optional. That gives the client THREE distinct
+/// ways of not knowing, and the whole value of this type is refusing to merge
+/// them:
+///
+///   - `.absent`      the field was not sent. Not an agent pane, or an older
+///                    server that predates the field.
+///   - `.indefinite`  the server sent `"unknown"`. It looked and could not tell.
+///   - `.unrecognised` the server sent something this client has never heard of.
+///
+/// The third is the one that matters. A future herdr adding, say,
+/// `"waiting_approval"` would — under a `default: .idle` mapping — sort an agent
+/// that is blocked on a human into the quietest group on the screen, and nothing
+/// would ever report it. The bug would be invisible, permanent, and would look
+/// exactly like the feature working.
+///
+/// So the raw string is CARRIED, not discarded. It costs one associated value
+/// and it is the difference between a client that degrades and one that lies.
+public enum AgentStatus: Equatable, Sendable {
+    case idle
+    case working
+    case blocked
+    case done
+    /// The server sent `"unknown"` — it looked and could not determine a state.
+    case indefinite
+    /// A value this build does not know. The payload is retained verbatim so it
+    /// can be surfaced and diagnosed rather than guessed at.
+    case unrecognised(String)
+    /// No `agent_status` field at all.
+    case absent
+
+    /// Maps the wire value. Deliberately has no `default:` collapsing arm — an
+    /// unmatched string becomes `.unrecognised(raw)`, never a real state.
+    public init(wire: String?) {
+        guard let wire else { self = .absent; return }
+        switch wire {
+        case "idle": self = .idle
+        case "working": self = .working
+        case "blocked": self = .blocked
+        case "done": self = .done
+        case "unknown": self = .indefinite
+        default: self = .unrecognised(wire)
+        }
+    }
+
+    /// True only when herdr positively reports the agent is waiting on a human.
+    ///
+    /// NOT true for the unknown cases. Claiming an agent needs you when you do
+    /// not know is a different lie from claiming it does not — this property
+    /// answers exactly one question and the grouping below handles the rest.
+    public var isBlocked: Bool { self == .blocked }
+}
+
+/// Which section of the list an agent belongs to.
+///
+/// Order is the screen's entire argument: the list exists to answer "does
+/// anything need me?", so the answer sorts first and everything quiet sorts
+/// last. `RawValue` is the sort key.
+public enum AgentGroup: Int, Equatable, Sendable, CaseIterable, Comparable {
+    /// herdr says this agent is waiting on a human.
+    case needsYou = 0
+    /// The pane is gone or the process exited.
+    case stopped = 1
+    /// THE FAIL-CLOSED PLACEMENT, and the reason this type exists.
+    ///
+    /// A status this build cannot interpret sorts ABOVE working and idle, not
+    /// below them. "I do not know what this agent is doing" is nearer to *needs
+    /// attention* than to *nothing to do*, and burying it is what would make a
+    /// new upstream state permanently unobservable. Being wrong here is cheap —
+    /// a stale row shown too prominently. Being wrong the other way is silent.
+    case unrecognised = 2
+    case working = 3
+    case idle = 4
+
+    public static func < (a: AgentGroup, b: AgentGroup) -> Bool {
+        a.rawValue < b.rawValue
+    }
+
+    public var label: String {
+        switch self {
+        case .needsYou: return "needs you"
+        case .stopped: return "stopped"
+        case .unrecognised: return "unrecognised"
+        case .working: return "working"
+        case .idle: return "idle"
+        }
+    }
+
+    /// Whether the section starts collapsed. Only the quiet tail does — a
+    /// collapsed group must never be able to hide something wanting attention,
+    /// which is why `.unrecognised` is not in here.
+    public var startsCollapsed: Bool { self == .idle }
+}
+
+/// One row of the list, and the grouping decision for it.
+public struct AgentRow: Equatable, Sendable, Identifiable {
+    public let info: AgentInfo
+    public let status: AgentStatus
+    public let group: AgentGroup
+
+    public var id: String { info.paneID }
+    public var title: String { info.displayName }
+
+    /// Whether the pane still exists. A row for a pane herdr no longer lists is
+    /// `stopped` regardless of the last status it reported.
+    public let isLive: Bool
+
+    public init(info: AgentInfo, isLive: Bool = true) {
+        self.info = info
+        self.isLive = isLive
+        let status = AgentStatus(wire: info.agentStatus)
+        self.status = status
+        self.group = AgentRow.group(for: status, isLive: isLive)
+    }
+
+    /// EXHAUSTIVE OVER `AgentStatus` ON PURPOSE — no `default:` arm.
+    ///
+    /// Adding a case to `AgentStatus` must fail to compile here rather than fall
+    /// through to a guess. That compile error is the guard; a `default:` would
+    /// silently swallow exactly the class of change this whole file exists to
+    /// catch.
+    static func group(for status: AgentStatus, isLive: Bool) -> AgentGroup {
+        guard isLive else { return .stopped }
+        switch status {
+        case .blocked: return .needsYou
+        case .working: return .working
+        case .idle, .done: return .idle
+        // Both of these mean "this build cannot say what is happening", and
+        // both surface rather than sink. They stay SEPARATE cases in the status
+        // type so a diagnostic can tell "the server could not tell" from "this
+        // client is out of date", which are different problems with different
+        // fixes — but they group identically, because the user's situation is
+        // the same either way.
+        case .indefinite, .unrecognised: return .unrecognised
+        case .absent: return .idle
+        }
+    }
+}
+
+/// The whole list screen's state, derived from one `agent.list` response.
+public struct AgentList: Equatable, Sendable {
+    public let rows: [AgentRow]
+
+    /// Sections in fixed group order, each holding its rows. Empty groups are
+    /// omitted; the screen renders no heading for a section with nothing in it.
+    public let sections: [(group: AgentGroup, rows: [AgentRow])]
+
+    /// What the top of the screen says. Counts only positively-blocked agents —
+    /// an unrecognised status is surfaced by its own section, and inflating this
+    /// number with maybes would make the one number on the screen untrustworthy.
+    public var needsYouCount: Int { rows.filter { $0.status.isBlocked }.count }
+
+    /// True when nothing is blocked AND nothing is unrecognised. The quiet state
+    /// has to mean "I checked everything", so an uninterpretable agent must
+    /// prevent it — otherwise the screen says all-clear while holding a row it
+    /// could not read.
+    public var isQuiet: Bool {
+        !rows.contains { $0.group == .needsYou || $0.group == .unrecognised }
+    }
+
+    public static func == (a: AgentList, b: AgentList) -> Bool { a.rows == b.rows }
+
+    /// Builds the list from an `agent.list` response.
+    ///
+    /// `livePaneIDs`, when supplied, is the set of panes herdr still reports;
+    /// anything absent from it is `stopped`. Passing `nil` means "no pane
+    /// census available", and every row is treated as live — the ONLY safe
+    /// reading, since inferring death from missing evidence would mark every
+    /// agent stopped the moment a census failed to arrive.
+    public init(agents: [AgentInfo], livePaneIDs: Set<String>? = nil) {
+        let rows = agents.map { info in
+            AgentRow(info: info, isLive: livePaneIDs.map { $0.contains(info.paneID) } ?? true)
+        }
+        // STABLE WITHIN A GROUP. Sorting by group alone leaves ties resolved by
+        // whatever order the server happened to answer in, so a list could
+        // reshuffle under the user's thumb between two refreshes that changed
+        // nothing. paneID is the tiebreak because it is the one field that is
+        // unique and does not change as the agent works.
+        let ordered = rows.sorted {
+            $0.group == $1.group ? $0.info.paneID < $1.info.paneID : $0.group < $1.group
+        }
+        self.rows = ordered
+        self.sections = AgentGroup.allCases.compactMap { group in
+            let inGroup = ordered.filter { $0.group == group }
+            return inGroup.isEmpty ? nil : (group, inGroup)
+        }
+    }
+}

--- a/Tests/HerdrKitTests/AgentListTests.swift
+++ b/Tests/HerdrKitTests/AgentListTests.swift
@@ -1,0 +1,217 @@
+import XCTest
+@testable import HerdrKit
+
+final class AgentListTests: XCTestCase {
+
+    // MARK: - fixtures
+
+    /// Builds an AgentInfo through the decoder, so these tests exercise the same
+    /// path the wire does. Constructing it in memory would let a test pass while
+    /// the JSON key was wrong.
+    private func agent(
+        pane: String, status: String?, name: String? = nil
+    ) throws -> AgentInfo {
+        var obj: [String: Any] = ["pane_id": pane]
+        if let status { obj["agent_status"] = status }
+        if let name { obj["name"] = name }
+        let data = try JSONSerialization.data(withJSONObject: obj)
+        return try JSONDecoder().decode(AgentInfo.self, from: data)
+    }
+
+    // MARK: - the three ways of not knowing
+
+    /// AXIS: absent, indefinite and unrecognised are three different situations
+    /// and the type refuses to merge them.
+    ///
+    /// Asserting only "none of them is .blocked" would pass against a mapping
+    /// that collapsed all three into one case, which is the defect. Each is
+    /// therefore pinned to its own value AND checked to differ from the others.
+    func testTheThreeUnknownsAreDistinct() {
+        let absent = AgentStatus(wire: nil)
+        let indefinite = AgentStatus(wire: "unknown")
+        let unrecognised = AgentStatus(wire: "waiting_approval")
+
+        XCTAssertEqual(absent, .absent)
+        XCTAssertEqual(indefinite, .indefinite)
+        XCTAssertEqual(unrecognised, .unrecognised("waiting_approval"))
+
+        XCTAssertNotEqual(absent, indefinite, "absent and indefinite collapsed into one case")
+        XCTAssertNotEqual(indefinite, unrecognised, "indefinite and unrecognised collapsed into one case")
+        XCTAssertNotEqual(absent, unrecognised, "absent and unrecognised collapsed into one case")
+    }
+
+    /// The unrecognised payload is carried verbatim, not normalised or dropped.
+    /// Without this, `.unrecognised("")` would satisfy the test above and the
+    /// diagnostic value — knowing WHICH unknown state arrived — would be gone.
+    func testUnrecognisedCarriesTheRawStringVerbatim() {
+        guard case .unrecognised(let raw) = AgentStatus(wire: "Waiting_Approval") else {
+            return XCTFail("a novel status did not become .unrecognised")
+        }
+        XCTAssertEqual(raw, "Waiting_Approval",
+                       "the raw value was normalised or replaced; a diagnostic cannot name what arrived")
+    }
+
+    /// Every documented wire value maps to its own case. This is the premise for
+    /// the novel-status test below: if "blocked" did not map, that test would be
+    /// comparing two unrecognised values and proving nothing.
+    func testEveryKnownWireValueMaps() {
+        XCTAssertEqual(AgentStatus(wire: "idle"), .idle)
+        XCTAssertEqual(AgentStatus(wire: "working"), .working)
+        XCTAssertEqual(AgentStatus(wire: "blocked"), .blocked)
+        XCTAssertEqual(AgentStatus(wire: "done"), .done)
+    }
+
+    // MARK: - the regression this issue exists for
+
+    /// AXIS: a status from a NEWER herdr must not be sorted into the quiet group.
+    ///
+    /// This is the defect the whole file guards. A `default: .idle` mapping would
+    /// place an agent that is blocked on a human into the one section that starts
+    /// collapsed, and nothing anywhere would report it.
+    ///
+    /// The assertion is deliberately NOT "is not idle" — that would also pass if
+    /// the row were sorted into `.stopped`, which is a different wrong answer.
+    /// It pins the exact group AND its position relative to the quiet ones.
+    func testANovelStatusSortsAboveWorkingAndIdleNotIntoThem() throws {
+        let list = AgentList(agents: [
+            try agent(pane: "p1", status: "idle"),
+            try agent(pane: "p2", status: "waiting_approval"),
+            try agent(pane: "p3", status: "working"),
+        ])
+
+        let novel = try XCTUnwrap(list.rows.first { $0.info.paneID == "p2" })
+        XCTAssertEqual(novel.group, .unrecognised,
+                       "a status this build does not know was given a definite meaning")
+        XCTAssertLessThan(novel.group, .working,
+                          "an uninterpretable agent sorted below working; a new blocked-like state "
+                          + "would be buried where nobody looks")
+        XCTAssertLessThan(novel.group, .idle,
+                          "an uninterpretable agent sorted into or below the collapsed group")
+
+        // And it must actually reach the user: the quiet state cannot hold one.
+        XCTAssertFalse(list.isQuiet,
+                       "the screen would say all-clear while holding a row it could not read")
+    }
+
+    /// The unrecognised group must never start collapsed — sorting it high is
+    /// pointless if the section is shut by default.
+    func testOnlyTheIdleGroupStartsCollapsed() {
+        for group in AgentGroup.allCases {
+            XCTAssertEqual(group.startsCollapsed, group == .idle,
+                           "\(group.label) has the wrong collapse default; a collapsed group must "
+                           + "not be able to hide something wanting attention")
+        }
+    }
+
+    // MARK: - grouping and order
+
+    func testGroupsSortNeedsYouFirstAndIdleLast() throws {
+        let list = AgentList(agents: [
+            try agent(pane: "p1", status: "idle"),
+            try agent(pane: "p2", status: "working"),
+            try agent(pane: "p3", status: "blocked"),
+        ])
+        XCTAssertEqual(list.sections.map(\.group), [.needsYou, .working, .idle])
+        XCTAssertEqual(list.rows.first?.info.paneID, "p3", "a blocked agent was not first")
+    }
+
+    /// Empty sections are omitted rather than rendered as bare headings.
+    func testEmptyGroupsAreOmitted() throws {
+        let list = AgentList(agents: [try agent(pane: "p1", status: "idle")])
+        XCTAssertEqual(list.sections.map(\.group), [.idle])
+    }
+
+    /// AXIS: the order within a group does not depend on the order the server
+    /// answered in.
+    ///
+    /// Without a tiebreak, two refreshes returning the same agents in a
+    /// different order would reshuffle the list under the user's thumb. The two
+    /// inputs here are REVERSES of each other, so a sort that preserved input
+    /// order would produce different output and fail.
+    func testOrderWithinAGroupIsStableAgainstServerOrder() throws {
+        // THE INPUT ORDERS ARE BUILT FROM THESE ARRAYS so that the premise is
+        // assertable. Written with the two lists inline, this test SURVIVED its
+        // premise mutation: making both inputs identical left it green, because
+        // both sides then trivially matched the expected order and nothing had
+        // exercised a differing server order at all. Measured, not theorised.
+        let firstOrder = ["a", "b", "c"]
+        let secondOrder = ["c", "b", "a"]
+        XCTAssertNotEqual(firstOrder, secondOrder,
+                          "the two server orders are identical; this test cannot detect "
+                          + "order-dependence and is not about what it claims")
+
+        let first = AgentList(agents: try firstOrder.map { try agent(pane: $0, status: "working") })
+        let second = AgentList(agents: try secondOrder.map { try agent(pane: $0, status: "working") })
+
+        XCTAssertEqual(first.rows.map(\.info.paneID), ["a", "b", "c"])
+        XCTAssertEqual(second.rows.map(\.info.paneID), first.rows.map(\.info.paneID),
+                       "list order followed the server's response order; it will churn between refreshes")
+    }
+
+    // MARK: - liveness
+
+    /// A pane missing from the census is stopped, whatever it last reported.
+    func testAPaneAbsentFromTheCensusIsStopped() throws {
+        let list = AgentList(
+            agents: [try agent(pane: "gone", status: "working")],
+            livePaneIDs: ["still-here"]
+        )
+        let row = try XCTUnwrap(list.rows.first)
+        XCTAssertEqual(row.group, .stopped,
+                       "a pane herdr no longer lists was grouped by its stale status")
+        XCTAssertEqual(row.status, .working,
+                       "the last reported status was discarded; the detail view has nothing to show")
+    }
+
+    /// AXIS: no census means "unknown liveness", NOT "everything died".
+    ///
+    /// Inferring death from missing evidence would mark every agent stopped the
+    /// instant a census call failed — turning a transient error into a screen
+    /// that says all your work crashed.
+    func testNoCensusTreatsEveryAgentAsLive() throws {
+        let list = AgentList(agents: [
+            try agent(pane: "p1", status: "working"),
+            try agent(pane: "p2", status: "blocked"),
+        ], livePaneIDs: nil)
+        XCTAssertFalse(list.rows.contains { $0.group == .stopped },
+                       "a missing census was read as evidence of death")
+    }
+
+    // MARK: - the count and the quiet state
+
+    /// The headline number counts only positively-blocked agents. Inflating it
+    /// with maybes would make the one number on the screen untrustworthy.
+    func testNeedsYouCountsOnlyPositivelyBlockedAgents() throws {
+        let list = AgentList(agents: [
+            try agent(pane: "p1", status: "blocked"),
+            try agent(pane: "p2", status: "waiting_approval"),
+            try agent(pane: "p3", status: "unknown"),
+            try agent(pane: "p4", status: nil),
+        ])
+        XCTAssertEqual(list.needsYouCount, 1,
+                       "the headline count included an agent whose state is not known to be blocking")
+        // But the uninterpretable ones must still be visible somewhere.
+        XCTAssertTrue(list.sections.contains { $0.group == .unrecognised },
+                      "agents with uninterpretable status vanished from the screen entirely")
+    }
+
+    func testQuietRequiresNothingBlockedAndNothingUnrecognised() throws {
+        let quiet = AgentList(agents: [
+            try agent(pane: "p1", status: "idle"),
+            try agent(pane: "p2", status: "done"),
+        ])
+        XCTAssertTrue(quiet.isQuiet)
+        XCTAssertEqual(quiet.needsYouCount, 0)
+
+        let notQuiet = AgentList(agents: [try agent(pane: "p1", status: "unknown")])
+        XCTAssertFalse(notQuiet.isQuiet,
+                       "an agent the server could not read still allowed an all-clear")
+    }
+
+    func testAnEmptyListIsQuiet() {
+        let list = AgentList(agents: [])
+        XCTAssertTrue(list.isQuiet)
+        XCTAssertEqual(list.needsYouCount, 0)
+        XCTAssertTrue(list.sections.isEmpty)
+    }
+}

--- a/Tests/HerdrKitTests/AgentListTests.swift
+++ b/Tests/HerdrKitTests/AgentListTests.swift
@@ -93,6 +93,52 @@ final class AgentListTests: XCTestCase {
                        "the screen would say all-clear while holding a row it could not read")
     }
 
+    /// AXIS: an agent whose status field is ABSENT surfaces like any other
+    /// not-knowing.
+    ///
+    /// This was wrong at first review and the fix was unguarded until this test
+    /// existed: reverting `.absent` to group as `.idle` left the whole suite
+    /// green. `agent.list` returns only agent terminals — herdr's `agent_info`
+    /// bails unless `terminal.is_agent_terminal()` — so an absent status is an
+    /// older server or a gap, never "not an agent", and must not be read as a
+    /// definite idle.
+    func testAnAbsentStatusSurfacesRatherThanReadingAsIdle() throws {
+        let list = AgentList(agents: [
+            try agent(pane: "old-server", status: nil),
+            try agent(pane: "p2", status: "idle"),
+        ])
+        let row = try XCTUnwrap(list.rows.first { $0.info.paneID == "old-server" })
+
+        XCTAssertEqual(row.status, .absent, "the premise: this row's status field is missing")
+        XCTAssertEqual(row.group, .unrecognised,
+                       "an agent with no status was given the definite meaning 'idle'")
+        XCTAssertLessThan(row.group, .idle, "it sorted into or below the collapsed group")
+        XCTAssertFalse(list.isQuiet,
+                       "the screen claimed all-clear while holding an agent it could not read")
+    }
+
+    /// AXIS: the headline count follows the GROUP, not the retained status.
+    ///
+    /// A blocked agent whose pane has since vanished belongs in `.stopped`. It
+    /// kept its blocked status for the detail view, and the count read that
+    /// status directly — so the screen said "nothing needs you" and "1 needs
+    /// you" at the same time. Reverting the fix left the suite green until this
+    /// test existed.
+    func testAStoppedAgentDoesNotCountEvenIfItsLastStatusWasBlocked() throws {
+        let list = AgentList(
+            agents: [try agent(pane: "gone", status: "blocked")],
+            livePaneIDs: ["someone-else"]
+        )
+        let row = try XCTUnwrap(list.rows.first)
+        XCTAssertEqual(row.status, .blocked, "the premise: the row retains its blocked status")
+        XCTAssertEqual(row.group, .stopped, "the premise: the pane is absent from the census")
+
+        XCTAssertEqual(list.needsYouCount, 0,
+                       "the count read the stale status; the screen reports both all-clear and "
+                       + "one-waiting at once")
+        XCTAssertTrue(list.isQuiet)
+    }
+
     /// The unrecognised group must never start collapsed — sorting it high is
     /// pointless if the section is shut by default.
     func testOnlyTheIdleGroupStartsCollapsed() {
@@ -173,6 +219,11 @@ final class AgentListTests: XCTestCase {
             try agent(pane: "p1", status: "working"),
             try agent(pane: "p2", status: "blocked"),
         ], livePaneIDs: nil)
+        // THE ROWS MUST EXIST FIRST. Asserting "none is stopped" is trivially
+        // true of an empty list, and this test passed with every agent removed
+        // — an absence assertion with nothing establishing the presence it is
+        // about.
+        XCTAssertEqual(list.rows.count, 2, "no rows were built; the assertion below is vacuous")
         XCTAssertFalse(list.rows.contains { $0.group == .stopped },
                        "a missing census was read as evidence of death")
     }
@@ -200,6 +251,11 @@ final class AgentListTests: XCTestCase {
             try agent(pane: "p1", status: "idle"),
             try agent(pane: "p2", status: "done"),
         ])
+        // Same trap: `isQuiet` is true of an empty list, and this passed with
+        // the fixture removed entirely. Pin that the quiet rows are actually
+        // present and actually quiet-by-status before concluding anything.
+        XCTAssertEqual(quiet.rows.map(\.status), [.idle, .done],
+                       "the quiet fixture is not present; isQuiet below proves nothing")
         XCTAssertTrue(quiet.isQuiet)
         XCTAssertEqual(quiet.needsYouCount, 0)
 


### PR DESCRIPTION
Closes #20.

Screen 2 is the home screen and the app's whole argument — *does anything need me?* Nothing modelled it: `AgentInfo.agentStatus` was a raw `String?` whose only consumer was `isWorking: Bool { agentStatus == "working" }`.

**Not rebuilt, because it already existed:** `InputRouter`/`InputPlan` already cover the reply path *and* the key row; `PaneRead` covers terminal reading. I had offered to build both — checking first avoided duplicating them.

## The design point: three ways of not knowing

herdr sends `idle|working|blocked|done|unknown`, and the field is optional. So a client can fail to know in three distinct ways, and merging them is the defect:

| case | means |
|---|---|
| `.absent` | no field — not an agent pane, or an older server |
| `.indefinite` | server sent `"unknown"` — it looked and couldn't tell |
| `.unrecognised(String)` | a value this build has never heard of |

The third is why this exists. Under a `default: .idle` mapping, a future herdr adding a blocked-like state would sort an agent **waiting on a human** into the one section that starts collapsed — invisible, permanent, and indistinguishable from the feature working.

So unrecognised **sorts above working and idle**, never starts collapsed, and blocks the all-clear. Wrong that way costs a stale row shown too prominently; wrong the other way is silent.

`group(for:isLive:)` is exhaustive with **no `default:` arm** — adding an `AgentStatus` case fails to compile rather than falling through to a guess. The compile error is the guard.

Also fail-closed: a `nil` pane census means *liveness unknown*, not *everything died*. Inferring death from missing evidence would turn one failed call into a screen claiming all your work crashed.

## Evidence

**7 production mutations, all KILLED:** `novel-status-becomes-idle`, `unrecognised-groups-as-idle`, `collapse-unknown-into-absent`, `drop-stable-tiebreak`, `no-census-means-dead`, `quiet-ignores-unrecognised`, `unrecognised-starts-collapsed`.

**3 premise mutations — and one found a vacuous test of mine.** `testOrderWithinAGroupIsStableAgainstServerOrder` **SURVIVED** having its two inputs made identical: both sides then trivially matched the expected order, so it had never exercised a differing server order at all. Rewritten to build both lists from named arrays with an assertion that the arrays differ — now KILLED in both directions.

I wrote a vacuous test while guarding against vacuous tests. That is the argument for running premise mutation rather than trusting the author, and I'd rather it be in the record than quietly fixed.

## What I want challenged

- Is `.unrecognised` sorting *above* `working` right, or is it alarmist? I argued the asymmetry (silent failure vs. a prominent stale row), but it is a judgement call.
- `.absent` groups as `.idle` while `.indefinite` groups as `.unrecognised`. Defensible — an absent field usually means "not an agent pane" — but it is the one place I merge a not-knowing into a definite group.
- Anything else in the 13 tests that would survive its premise being broken.

159 tests, 0 failures, `-Xswiftc -warnings-as-errors`. Linux only; the buildbox now watches `main`.