### PR TITLE
feat(terminal): fold unwrapped output to phone width losslessly

### DIFF
--- a/Sources/HerdrKit/TerminalWrap.swift
+++ b/Sources/HerdrKit/TerminalWrap.swift
@@ -1,0 +1,153 @@
+import Foundation
+
+/// Folds unwrapped terminal output to a narrow display width.
+///
+/// The pane this text came from is sized for a desktop — commonly 120 columns —
+/// and the phone cannot change that: `pane.resize` grows a pane against its
+/// neighbours in the DESKTOP layout, so there is no "make this pane 40 columns"
+/// without disturbing the machine the user is sitting at. `ReadSource
+/// .recentUnwrapped` is the way out. herdr returns logical lines with no hard
+/// wrapping, and the client folds them to whatever width it actually has.
+///
+/// This is a pure function over strings: no I/O, no UIKit, and fully exercised
+/// by the Linux test suite.
+public enum TerminalWrap {
+
+    /// The result of folding one logical line.
+    public struct Folded: Equatable, Sendable {
+        /// Display lines, in order. Never empty — a blank input line folds to
+        /// one blank output line, because terminal output uses blank lines
+        /// structurally and collapsing them reflows meaning.
+        public let lines: [String]
+        /// True when at least one break was forced mid-token because the token
+        /// could not fit the width. Surfaced rather than hidden: it is the
+        /// signal that the width is too narrow for the content, and a caller
+        /// showing a "content is wider than the screen" affordance needs it.
+        public let hardBroke: Bool
+    }
+
+    /// Folds `lines` to `width` columns.
+    ///
+    /// NON-POSITIVE WIDTH RETURNS THE INPUT UNFOLDED, deliberately. A width of
+    /// zero or less is a caller bug — a layout that has not measured yet, a
+    /// misplaced inset — not a statement about the data. The tempting responses
+    /// are to return `[]` or to trap; both destroy the user's terminal output in
+    /// service of a layout mistake, and the empty case does it silently. An
+    /// unfolded line is visibly wrong and recoverable on the next layout pass.
+    /// Losing output is neither.
+    public static func fold(_ lines: [String], width: Int) -> [Folded] {
+        guard width > 0 else {
+            return lines.map { Folded(lines: [$0], hardBroke: false) }
+        }
+        return lines.map { fold(line: $0, width: width) }
+    }
+
+    static func fold(line: String, width: Int) -> Folded {
+        // A BLANK LINE IS ONE BLANK LINE, not zero. Returning [] here would make
+        // the output shorter than the input and quietly close up the paragraph
+        // breaks that make agent output readable.
+        guard !line.isEmpty else { return Folded(lines: [""], hardBroke: false) }
+
+        var out: [String] = []
+        var current = ""
+        var currentCount = 0
+        var hardBroke = false
+
+        /// Emits `current` and resets. Kept as one operation so no path can
+        /// append without also clearing the counter.
+        ///
+        /// TRAILING WHITESPACE IS TRIMMED HERE AND NOWHERE ELSE. flush() is
+        /// called only at fold points — where the next token did not fit — so
+        /// the space being removed is one the fold created, exactly like the
+        /// leading space dropped from a continuation line. Symmetry matters:
+        /// keeping it produced lines that were visually short of the width by an
+        /// invisible character. The FINAL line does not go through flush(), so a
+        /// line genuinely ending in spaces keeps them; that is content, not an
+        /// artefact, and the two cases must not be conflated.
+        func flush() {
+            while let last = current.last, last.isWhitespace { current.removeLast() }
+            out.append(current)
+            current = ""
+            currentCount = 0
+        }
+
+        for token in tokenise(line) {
+            let tokenCount = token.count
+
+            // A token that cannot fit ANY line must be split, whatever the
+            // current state. Trying to place it whole would either overflow the
+            // width or, if the loop instead flushed and retried, spin forever on
+            // a token that never fits.
+            if tokenCount > width {
+                if currentCount > 0 { flush() }
+                var rest = Substring(token)
+                while !rest.isEmpty {
+                    // TERMINATION. `width` is > 0 here, so `prefix(width)` takes
+                    // at least one Character on every pass and `rest` strictly
+                    // shrinks. There is no input for which this does not finish,
+                    // including width 1 against a multi-scalar grapheme — Swift
+                    // Characters are indivisible, so one is taken and the line
+                    // exceeds the width rather than the loop stalling.
+                    let chunk = rest.prefix(width)
+                    rest = rest.dropFirst(chunk.count)
+                    if rest.isEmpty {
+                        current = String(chunk)
+                        currentCount = chunk.count
+                    } else {
+                        out.append(String(chunk))
+                        hardBroke = true
+                    }
+                }
+                continue
+            }
+
+            if currentCount == 0 {
+                // Leading whitespace on a fresh line is dropped: it is an
+                // artefact of the fold, not content. A run of spaces at the
+                // START of a logical line is preserved by tokenise, which emits
+                // it as part of the first token.
+                if token.allSatisfy(\.isWhitespace) { continue }
+                current = token
+                currentCount = tokenCount
+            } else if currentCount + tokenCount <= width {
+                current += token
+                currentCount += tokenCount
+            } else {
+                flush()
+                if token.allSatisfy(\.isWhitespace) { continue }
+                current = token
+                currentCount = tokenCount
+            }
+        }
+
+        if currentCount > 0 || out.isEmpty { out.append(current) }
+        return Folded(lines: out, hardBroke: hardBroke)
+    }
+
+    /// Splits a line into alternating word and whitespace runs, preserving both.
+    ///
+    /// Whitespace is kept as its own token rather than discarded, so interior
+    /// spacing survives a fold that does not happen to break there. Column
+    /// alignment in terminal output — tables, tree output, diff gutters — is
+    /// made of exactly those runs, and eating them turns aligned output into
+    /// prose.
+    static func tokenise(_ line: String) -> [String] {
+        var tokens: [String] = []
+        var current = ""
+        var currentIsSpace: Bool?
+
+        for ch in line {
+            let isSpace = ch.isWhitespace
+            if currentIsSpace == nil || isSpace == currentIsSpace {
+                current.append(ch)
+                currentIsSpace = isSpace
+            } else {
+                tokens.append(current)
+                current = String(ch)
+                currentIsSpace = isSpace
+            }
+        }
+        if !current.isEmpty { tokens.append(current) }
+        return tokens
+    }
+}

--- a/Sources/HerdrKit/TerminalWrap.swift
+++ b/Sources/HerdrKit/TerminalWrap.swift
@@ -197,9 +197,26 @@ public enum TerminalWrap {
             // line from a continuation the fold created. Only the latter's
             // leading space is an artefact.
             if index == 0 && isWhitespaceToken {
-                current = token
-                currentCols = columns(of: token, startingAt: 0)
                 currentIsLeadingIndent = true
+                if columns(of: token, startingAt: 0) <= width {
+                    current = token
+                    currentCols = columns(of: token, startingAt: 0)
+                } else {
+                    // INDENT WIDER THAN THE SCREEN. The fast path above stored it
+                    // whole and emitted one over-width line — a reviewer probe of
+                    // ten leading spaces at width 6 produced a ten-cell line.
+                    // Whitespace is divisible (unlike a tab), so split it to
+                    // width instead of overflowing, keeping the remainder as the
+                    // still-leading indent the first word will try to join.
+                    var rest = Substring(token)
+                    while columns(of: rest, startingAt: 0) > width {
+                        let chunk = prefixFitting(rest, width: width)
+                        out.append(String(chunk))
+                        rest = rest[chunk.endIndex...]
+                    }
+                    current = String(rest)
+                    currentCols = columns(of: current, startingAt: 0)
+                }
                 continue
             }
 

--- a/Sources/HerdrKit/TerminalWrap.swift
+++ b/Sources/HerdrKit/TerminalWrap.swift
@@ -26,6 +26,90 @@ public enum TerminalWrap {
         public let hardBroke: Bool
     }
 
+    // MARK: - terminal columns
+
+    /// Columns one character occupies in a terminal, at column `col`.
+    ///
+    /// WIDTH IS MEASURED IN TERMINAL CELLS, NOT SWIFT CHARACTERS. The first
+    /// version of this file counted `String.count`, and a reviewer's probe
+    /// folded `界界界` at width 4 into a single SIX-column line. A function whose
+    /// entire purpose is fitting text to a phone's terminal width cannot
+    /// measure in a unit the terminal does not use.
+    ///
+    /// This is an approximation of `wcwidth`, not a port of it — full fidelity
+    /// needs the Unicode East Asian Width table. It covers the ranges that
+    /// actually appear in agent output: CJK, Hangul, fullwidth forms and emoji.
+    /// Stated as an approximation because a caller relying on exactness for,
+    /// say, box-drawing alignment deserves to know it is not guaranteed.
+    static func columns(of ch: Character, at col: Int) -> Int {
+        // A tab advances to the next multiple of 8. It is the only character
+        // whose width depends on where it sits, which is why every width
+        // calculation here threads a starting column rather than summing
+        // per-character widths in isolation.
+        if ch == "\t" { return 8 - (col % 8) }
+
+        guard let scalar = ch.unicodeScalars.first else { return 0 }
+        let v = scalar.value
+
+        // Control characters occupy no cells.
+        if v < 0x20 || (v >= 0x7F && v < 0xA0) { return 0 }
+
+        let wide: [ClosedRange<UInt32>] = [
+            0x1100...0x115F,    // Hangul Jamo
+            0x2E80...0x303E,    // CJK radicals, Kangxi
+            0x3041...0x33FF,    // Hiragana, Katakana, CJK compatibility
+            0x3400...0x4DBF,    // CJK Extension A
+            0x4E00...0x9FFF,    // CJK Unified Ideographs
+            0xA000...0xA4CF,    // Yi
+            0xAC00...0xD7A3,    // Hangul syllables
+            0xF900...0xFAFF,    // CJK compatibility ideographs
+            0xFE30...0xFE6F,    // CJK compatibility forms
+            0xFF00...0xFF60,    // Fullwidth forms
+            0xFFE0...0xFFE6,
+            0x1F300...0x1F64F,  // emoji
+            0x1F900...0x1F9FF,
+            0x20000...0x3FFFD,  // CJK Extension B+
+        ]
+        if wide.contains(where: { $0.contains(v) }) { return 2 }
+
+        // A grapheme built from regional indicators — a flag — renders as one
+        // double-width glyph even though its first scalar is not in the ranges
+        // above.
+        if ch.unicodeScalars.count > 1,
+           ch.unicodeScalars.allSatisfy({ (0x1F1E6...0x1F1FF).contains($0.value) }) {
+            return 2
+        }
+        return 1
+    }
+
+    /// Columns a string occupies, starting from column `start`.
+    static func columns(of s: some StringProtocol, startingAt start: Int = 0) -> Int {
+        var col = start
+        for ch in s { col += columns(of: ch, at: col) }
+        return col - start
+    }
+
+    /// Takes the longest prefix of `s` fitting `width` columns from column 0.
+    ///
+    /// Always takes at least one Character when `s` is non-empty and
+    /// `width > 0`, so a caller looping on the remainder always makes progress —
+    /// including a double-width glyph at width 1, which OVERFLOWS rather than
+    /// stalling. That is the one named exception to the width rule.
+    static func prefixFitting(_ s: Substring, width: Int) -> Substring {
+        var col = 0
+        var end = s.startIndex
+        while end < s.endIndex {
+            let w = columns(of: s[end], at: col)
+            if col + w > width && end != s.startIndex { break }
+            col += w
+            end = s.index(after: end)
+            if col >= width { break }
+        }
+        return s[s.startIndex..<end]
+    }
+
+    // MARK: - folding
+
     /// Folds `lines` to `width` columns.
     ///
     /// NON-POSITIVE WIDTH RETURNS THE INPUT UNFOLDED, deliberately. A width of
@@ -50,49 +134,59 @@ public enum TerminalWrap {
 
         var out: [String] = []
         var current = ""
-        var currentCount = 0
+        var currentCols = 0
         var hardBroke = false
 
-        /// Emits `current` and resets. Kept as one operation so no path can
-        /// append without also clearing the counter.
+        /// Emits `current` and resets.
         ///
         /// TRAILING WHITESPACE IS TRIMMED HERE AND NOWHERE ELSE. flush() is
         /// called only at fold points — where the next token did not fit — so
-        /// the space being removed is one the fold created, exactly like the
-        /// leading space dropped from a continuation line. Symmetry matters:
-        /// keeping it produced lines that were visually short of the width by an
-        /// invisible character. The FINAL line does not go through flush(), so a
-        /// line genuinely ending in spaces keeps them; that is content, not an
-        /// artefact, and the two cases must not be conflated.
+        /// the space removed is one the fold created. The FINAL line does not go
+        /// through flush(), so a line genuinely ending in spaces keeps them;
+        /// that is content, not an artefact, and the two must not be conflated.
         func flush() {
             while let last = current.last, last.isWhitespace { current.removeLast() }
             out.append(current)
             current = ""
-            currentCount = 0
+            currentCols = 0
         }
 
-        for token in tokenise(line) {
-            let tokenCount = token.count
+        for (index, token) in tokenise(line).enumerated() {
+            let isWhitespaceToken = token.allSatisfy(\.isWhitespace)
+
+            // LEADING INDENTATION IS CONTENT AND SURVIVES.
+            //
+            // This branch is the fix for a real defect: the first version
+            // skipped ANY whitespace token found at column zero, so
+            // fold("    child", width: 80) returned "child" — indentation
+            // deleted with no fold even occurring. Code, tree output, YAML and
+            // stack traces are all structured by exactly that indentation, and
+            // the comment sitting here previously claimed tokenise folded it
+            // into the first word, which it never did.
+            //
+            // `index == 0` is what distinguishes the true start of a LOGICAL
+            // line from a continuation the fold created. Only the latter's
+            // leading space is an artefact.
+            if index == 0 && isWhitespaceToken {
+                current = token
+                currentCols = columns(of: token, startingAt: 0)
+                continue
+            }
+
+            let tokenCols = columns(of: token, startingAt: currentCols)
 
             // A token that cannot fit ANY line must be split, whatever the
-            // current state. Trying to place it whole would either overflow the
-            // width or, if the loop instead flushed and retried, spin forever on
-            // a token that never fits.
-            if tokenCount > width {
-                if currentCount > 0 { flush() }
+            // current state. Placing it whole would overflow; flushing and
+            // retrying would spin forever on a token that never fits.
+            if columns(of: token, startingAt: 0) > width {
+                if !current.isEmpty { flush() }
                 var rest = Substring(token)
                 while !rest.isEmpty {
-                    // TERMINATION. `width` is > 0 here, so `prefix(width)` takes
-                    // at least one Character on every pass and `rest` strictly
-                    // shrinks. There is no input for which this does not finish,
-                    // including width 1 against a multi-scalar grapheme — Swift
-                    // Characters are indivisible, so one is taken and the line
-                    // exceeds the width rather than the loop stalling.
-                    let chunk = rest.prefix(width)
-                    rest = rest.dropFirst(chunk.count)
+                    let chunk = prefixFitting(rest, width: width)
+                    rest = rest[chunk.endIndex...]
                     if rest.isEmpty {
                         current = String(chunk)
-                        currentCount = chunk.count
+                        currentCols = columns(of: chunk, startingAt: 0)
                     } else {
                         out.append(String(chunk))
                         hardBroke = true
@@ -101,36 +195,33 @@ public enum TerminalWrap {
                 continue
             }
 
-            if currentCount == 0 {
-                // Leading whitespace on a fresh line is dropped: it is an
-                // artefact of the fold, not content. A run of spaces at the
-                // START of a logical line is preserved by tokenise, which emits
-                // it as part of the first token.
-                if token.allSatisfy(\.isWhitespace) { continue }
+            if current.isEmpty {
+                // Leading whitespace on a CONTINUATION line is dropped: that
+                // one is an artefact of the fold. See index == 0 above.
+                if isWhitespaceToken { continue }
                 current = token
-                currentCount = tokenCount
-            } else if currentCount + tokenCount <= width {
+                currentCols = tokenCols
+            } else if currentCols + tokenCols <= width {
                 current += token
-                currentCount += tokenCount
+                currentCols += tokenCols
             } else {
                 flush()
-                if token.allSatisfy(\.isWhitespace) { continue }
+                if isWhitespaceToken { continue }
                 current = token
-                currentCount = tokenCount
+                currentCols = columns(of: token, startingAt: 0)
             }
         }
 
-        if currentCount > 0 || out.isEmpty { out.append(current) }
+        if !current.isEmpty || out.isEmpty { out.append(current) }
         return Folded(lines: out, hardBroke: hardBroke)
     }
 
     /// Splits a line into alternating word and whitespace runs, preserving both.
     ///
     /// Whitespace is kept as its own token rather than discarded, so interior
-    /// spacing survives a fold that does not happen to break there. Column
-    /// alignment in terminal output — tables, tree output, diff gutters — is
-    /// made of exactly those runs, and eating them turns aligned output into
-    /// prose.
+    /// spacing survives a fold that does not break there. Column alignment in
+    /// terminal output — tables, tree output, diff gutters — is made of exactly
+    /// those runs, and eating them turns aligned output into prose.
     static func tokenise(_ line: String) -> [String] {
         var tokens: [String] = []
         var current = ""

--- a/Sources/HerdrKit/TerminalWrap.swift
+++ b/Sources/HerdrKit/TerminalWrap.swift
@@ -54,6 +54,26 @@ public enum TerminalWrap {
         // Control characters occupy no cells.
         if v < 0x20 || (v >= 0x7F && v < 0xA0) { return 0 }
 
+        // EMOJI PRESENTATION IS ASKED OF THE STDLIB, NOT GUESSED WITH RANGES.
+        // The first version hand-listed 0x1F300+ and missed every double-width
+        // BMP emoji: a reviewer probe measured ✅ (U+2705), ⌚ (U+231A) and the
+        // keycap 1️⃣ as ONE cell. wcwidth reports them as two. Rather than widen
+        // a hand-list — which is the "fixed the instances, not the class" error
+        // I keep making — this defers to Unicode.Scalar.Properties, which IS the
+        // table:
+        //   - a Variation-Selector-16 (U+FE0F) anywhere in the grapheme forces
+        //     emoji (wide) presentation, which is exactly what 1️⃣ = 1 + FE0F +
+        //     20E3 relies on;
+        //   - isEmojiPresentation is true for scalars that default to the wide
+        //     emoji glyph (✅, ⌚) and false for text-default symbols (☀ without
+        //     FE0F), which is the precise distinction wcwidth makes.
+        if ch.unicodeScalars.contains(where: { $0.value == 0xFE0F }) { return 2 }
+        if scalar.properties.isEmojiPresentation { return 2 }
+
+        // East Asian Wide / Fullwidth. The stdlib exposes emoji properties but
+        // NOT East Asian Width, so these ranges remain hand-maintained — they
+        // are stable Unicode blocks, unlike the sprawling emoji assignments the
+        // property query above now covers.
         let wide: [ClosedRange<UInt32>] = [
             0x1100...0x115F,    // Hangul Jamo
             0x2E80...0x303E,    // CJK radicals, Kangxi
@@ -66,15 +86,12 @@ public enum TerminalWrap {
             0xFE30...0xFE6F,    // CJK compatibility forms
             0xFF00...0xFF60,    // Fullwidth forms
             0xFFE0...0xFFE6,
-            0x1F300...0x1F64F,  // emoji
-            0x1F900...0x1F9FF,
             0x20000...0x3FFFD,  // CJK Extension B+
         ]
         if wide.contains(where: { $0.contains(v) }) { return 2 }
 
         // A grapheme built from regional indicators — a flag — renders as one
-        // double-width glyph even though its first scalar is not in the ranges
-        // above.
+        // double-width glyph even though its first scalar is not wide alone.
         if ch.unicodeScalars.count > 1,
            ch.unicodeScalars.allSatisfy({ (0x1F1E6...0x1F1FF).contains($0.value) }) {
             return 2
@@ -136,19 +153,31 @@ public enum TerminalWrap {
         var current = ""
         var currentCols = 0
         var hardBroke = false
+        // True only while `current` holds the ORIGINAL leading indentation of the
+        // logical line and nothing else. That indentation is content; the trailing
+        // whitespace flush() strips at every OTHER fold point is an artefact. The
+        // two look identical (a buffer ending in spaces) and must not be treated
+        // alike — conflating them is exactly the defect below.
+        var currentIsLeadingIndent = false
 
         /// Emits `current` and resets.
         ///
-        /// TRAILING WHITESPACE IS TRIMMED HERE AND NOWHERE ELSE. flush() is
-        /// called only at fold points — where the next token did not fit — so
-        /// the space removed is one the fold created. The FINAL line does not go
-        /// through flush(), so a line genuinely ending in spaces keeps them;
-        /// that is content, not an artefact, and the two must not be conflated.
+        /// TRAILING WHITESPACE IS TRIMMED HERE — EXCEPT when the buffer is the
+        /// logical line's leading indentation. flush() is called at fold points,
+        /// where a trailing space is one the fold created; but a narrow width can
+        /// force a flush while `current` still holds ONLY the leading indent (the
+        /// first word could not join it), and stripping there deleted the
+        /// indentation. fold("    child", width: 6) returned "child": a compiled
+        /// regression the losslessness helper cannot see, because it strips
+        /// whitespace by design. The indent is preserved as its own line instead.
         func flush() {
-            while let last = current.last, last.isWhitespace { current.removeLast() }
+            if !currentIsLeadingIndent {
+                while let last = current.last, last.isWhitespace { current.removeLast() }
+            }
             out.append(current)
             current = ""
             currentCols = 0
+            currentIsLeadingIndent = false
         }
 
         for (index, token) in tokenise(line).enumerated() {
@@ -170,6 +199,7 @@ public enum TerminalWrap {
             if index == 0 && isWhitespaceToken {
                 current = token
                 currentCols = columns(of: token, startingAt: 0)
+                currentIsLeadingIndent = true
                 continue
             }
 
@@ -204,6 +234,11 @@ public enum TerminalWrap {
             } else if currentCols + tokenCols <= width {
                 current += token
                 currentCols += tokenCols
+                // Once anything joins the indent, `current` is no longer pure
+                // leading indentation, so a later flush must resume trimming its
+                // trailing whitespace as an artefact. Without this,
+                // "    a b c" at a narrow width preserves the fold-point space.
+                currentIsLeadingIndent = false
             } else {
                 flush()
                 if isWhitespaceToken { continue }

--- a/Tests/HerdrKitTests/TerminalWrapTests.swift
+++ b/Tests/HerdrKitTests/TerminalWrapTests.swift
@@ -16,6 +16,16 @@ final class TerminalWrapTests: XCTestCase {
     ) {
         let folded = TerminalWrap.fold(line: input, width: width)
         let strip = { (s: String) in s.filter { !$0.isWhitespace } }
+
+        // CANARY. This helper is called from several tests, so if its comparison
+        // were degenerate — both sides normalising to "" — every caller would
+        // pass and the suite would report thorough coverage of nothing. A
+        // reviewer probe confirmed that exact mutation survived. These two lines
+        // make the helper prove it can still tell content apart before it is
+        // trusted to say two things are equal.
+        XCTAssertEqual(strip("a b\tc"), "abc", "the normaliser is not preserving content")
+        XCTAssertNotEqual(strip("abc"), strip("abd"), "the normaliser cannot distinguish content")
+
         XCTAssertEqual(strip(folded.lines.joined()), strip(input),
                        "content changed while folding at width \(width)", file: file, line: line)
     }
@@ -90,10 +100,13 @@ final class TerminalWrapTests: XCTestCase {
     func testNoLineExceedsTheWidthWhenEveryTokenFits() {
         let text = "alpha beta gamma delta epsilon zeta eta theta iota kappa"
         let width = 12
+        XCTAssertFalse(text.isEmpty, "empty text; every assertion below is vacuous")
         XCTAssertTrue(text.split(separator: " ").allSatisfy { $0.count <= width },
                       "a token is wider than the width; an overflow below would not be the folder's fault")
 
         let folded = TerminalWrap.fold(line: text, width: width)
+        XCTAssertGreaterThan(folded.lines.count, 1,
+                             "the text did not fold; a width check over one line proves nothing")
         for line in folded.lines {
             XCTAssertLessThanOrEqual(line.count, width, "line '\(line)' exceeds width \(width)")
         }
@@ -128,12 +141,15 @@ final class TerminalWrapTests: XCTestCase {
     /// recovers on the next layout pass; lost output does not.
     func testANonPositiveWidthReturnsInputUnfoldedRatherThanEmpty() {
         let input = ["first line", "second line"]
+        var widthsChecked = 0
         for width in [0, -1, -80] {
+            widthsChecked += 1
             let folded = TerminalWrap.fold(input, width: width)
             XCTAssertEqual(folded.map(\.lines), [["first line"], ["second line"]],
                            "width \(width) did not return the input unfolded")
             XCTAssertFalse(folded.contains { $0.hardBroke })
         }
+        XCTAssertEqual(widthsChecked, 3, "the width loop did not run; nothing above was asserted")
     }
 
     // MARK: - interior spacing
@@ -145,8 +161,67 @@ final class TerminalWrapTests: XCTestCase {
     /// prose, which is a silent corruption of meaning rather than of characters.
     func testInteriorSpacingIsPreservedWhenTheLineFits() {
         let aligned = "name    status    age"
+        XCTAssertTrue(aligned.contains("  "),
+                      "the fixture has no interior run to preserve; this test is about nothing")
         let folded = TerminalWrap.fold(line: aligned, width: 80)
         XCTAssertEqual(folded.lines, [aligned], "interior spacing was collapsed")
+    }
+
+    // MARK: - the two round-one defects
+
+    /// AXIS: leading indentation is CONTENT and survives a fold that does not
+    /// even happen.
+    ///
+    /// The first version skipped any whitespace token at column zero, so
+    /// `fold("    child", width: 80)` returned `"child"` — indentation deleted
+    /// with no fold occurring. Code, tree output, YAML and stack traces are all
+    /// structured by exactly that indentation. The comment then sitting at the
+    /// defect claimed tokenise folded leading spaces into the first word, which
+    /// it never did: prose describing a behaviour the code did not have.
+    func testLeadingIndentationIsPreserved() {
+        XCTAssertEqual(TerminalWrap.fold(line: "    child", width: 80).lines, ["    child"],
+                       "leading indentation was deleted")
+        XCTAssertEqual(TerminalWrap.fold(line: "\tdeeper", width: 80).lines, ["\tdeeper"],
+                       "a leading tab was deleted")
+
+        // And it must survive a real fold, not just the no-fold case.
+        let folded = TerminalWrap.fold(line: "    alpha beta gamma", width: 12)
+        XCTAssertGreaterThan(folded.lines.count, 1, "the premise: this must actually fold")
+        XCTAssertTrue(folded.lines[0].hasPrefix("    "),
+                      "indentation was lost on a line that folded")
+    }
+
+    /// A continuation line's leading space IS an artefact and is still dropped.
+    /// Without this the fix above would over-correct into padding every folded
+    /// line with the space it broke at.
+    func testContinuationLinesDoNotInheritABreakSpace() {
+        let folded = TerminalWrap.fold(line: "alpha beta gamma", width: 11)
+        XCTAssertEqual(folded.lines, ["alpha beta", "gamma"],
+                       "a continuation line kept the space the fold broke at")
+    }
+
+    /// AXIS: width is counted in TERMINAL CELLS, not Swift Characters.
+    ///
+    /// A reviewer probe folded three double-width CJK glyphs at width 4 and got
+    /// one six-column line, because `String.count` said 3. A function whose
+    /// purpose is fitting text to a terminal width cannot measure in a unit the
+    /// terminal does not use.
+    func testDoubleWidthGlyphsAreCountedAsTwoColumns() {
+        XCTAssertEqual(TerminalWrap.columns(of: "界", at: 0), 2, "a CJK glyph measured as one column")
+        XCTAssertEqual(TerminalWrap.columns(of: "a", at: 0), 1)
+
+        let folded = TerminalWrap.fold(line: "界界界", width: 4)
+        XCTAssertEqual(folded.lines, ["界界", "界"],
+                       "three double-width glyphs did not fold at four columns")
+    }
+
+    /// A tab advances to the next multiple of 8, so its width depends on where
+    /// it sits. Counting it as one character makes every column figure after it
+    /// wrong.
+    func testATabAdvancesToTheNextEightColumnStop() {
+        XCTAssertEqual(TerminalWrap.columns(of: "\t", at: 0), 8)
+        XCTAssertEqual(TerminalWrap.columns(of: "\t", at: 5), 3)
+        XCTAssertEqual(TerminalWrap.columns(of: "\t", at: 8), 8)
     }
 
     func testTokeniseAlternatesWordsAndWhitespaceRuns() {

--- a/Tests/HerdrKitTests/TerminalWrapTests.swift
+++ b/Tests/HerdrKitTests/TerminalWrapTests.swift
@@ -1,0 +1,172 @@
+import XCTest
+@testable import HerdrKit
+
+final class TerminalWrapTests: XCTestCase {
+
+    /// The load-bearing invariant: folding never invents or destroys content.
+    ///
+    /// Compared with whitespace stripped, because a fold legitimately consumes
+    /// the space it breaks at and legitimately drops leading space on a
+    /// continuation line. Everything that is not whitespace must survive, in
+    /// order. This is the property that makes the rest of the wrap safe to
+    /// trust — a wrap that silently eats a character is invisible against a wall
+    /// of log output and corrupts exactly the thing the user came to read.
+    private func assertLossless(
+        _ input: String, width: Int, file: StaticString = #filePath, line: UInt = #line
+    ) {
+        let folded = TerminalWrap.fold(line: input, width: width)
+        let strip = { (s: String) in s.filter { !$0.isWhitespace } }
+        XCTAssertEqual(strip(folded.lines.joined()), strip(input),
+                       "content changed while folding at width \(width)", file: file, line: line)
+    }
+
+    // MARK: - losslessness
+
+    func testFoldingNeverLosesContent() {
+        let cases = [
+            "the quick brown fox jumps over the lazy dog",
+            "/Users/herdrbuild/herdr-ios/Sources/HerdrKit/SessionRecovery.swift:418:29",
+            "Executed 161 tests, with 2 tests skipped and 0 failures (0 unexpected)",
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "short",
+            "a b c d e f g h i j k l m n o p q r s t u v w x y z",
+            "  indented output with a trailing space ",
+            "tabs\tbetween\twords",
+            "mixed 🙂 graphemes é and ﬁ ligatures",
+        ]
+        // COUNT WHAT WAS ACTUALLY EXERCISED. Written as a bare loop, this test
+        // SURVIVED having its case list emptied — zero iterations, zero
+        // assertions, green. A property test that asserts nothing is worse than
+        // no property test, because it reads in the diff as thorough coverage.
+        //
+        // Counting FOLDS rather than iterations is the stronger check: it proves
+        // the inputs were wide enough to make the wrap do work, not merely that
+        // the function was called on strings that already fit.
+        var foldsProducingMultipleLines = 0
+        for input in cases {
+            for width in [1, 2, 3, 7, 12, 40, 200] {
+                assertLossless(input, width: width)
+                if TerminalWrap.fold(line: input, width: width).lines.count > 1 {
+                    foldsProducingMultipleLines += 1
+                }
+            }
+        }
+        XCTAssertGreaterThan(cases.count, 0, "no inputs; every assertion above was skipped")
+        XCTAssertGreaterThan(foldsProducingMultipleLines, 20,
+                             "the inputs barely folded; losslessness was proven mostly against "
+                             + "strings that already fit, which is not the property under test")
+    }
+
+    // MARK: - termination
+
+    /// AXIS: a token far wider than the line cannot spin the loop.
+    ///
+    /// The dangerous shape is "flush the line and retry the token", which makes
+    /// no progress when the token never fits. Width 1 is the sharpest case.
+    func testATokenWiderThanTheLineTerminatesAndBreaks() {
+        let long = String(repeating: "x", count: 500)
+        let folded = TerminalWrap.fold(line: long, width: 1)
+        XCTAssertEqual(folded.lines.count, 500, "width-1 fold did not produce one column per character")
+        XCTAssertTrue(folded.hardBroke, "a mid-token break was not reported")
+        XCTAssertEqual(folded.lines.joined(), long, "characters were lost or reordered")
+    }
+
+    /// Multi-scalar graphemes are indivisible, so at width 1 a line MAY exceed
+    /// the width. That is the one named exception, and it must be a deliberate
+    /// overflow rather than a stall or a dropped character.
+    func testAnIndivisibleGraphemeOverflowsRatherThanStalling() {
+        let flags = "🇬🇧🇯🇵🇮🇹"
+        let folded = TerminalWrap.fold(line: flags, width: 1)
+        XCTAssertEqual(folded.lines.count, 3, "one grapheme per line was not produced")
+        XCTAssertEqual(folded.lines.joined(), flags, "a grapheme was split or lost")
+    }
+
+    // MARK: - width discipline
+
+    /// AXIS: no line exceeds the width, given content that can fit.
+    ///
+    /// The premise matters: every token here is shorter than the width, so any
+    /// overflow is the folder's fault and not an indivisible token.
+    func testNoLineExceedsTheWidthWhenEveryTokenFits() {
+        let text = "alpha beta gamma delta epsilon zeta eta theta iota kappa"
+        let width = 12
+        XCTAssertTrue(text.split(separator: " ").allSatisfy { $0.count <= width },
+                      "a token is wider than the width; an overflow below would not be the folder's fault")
+
+        let folded = TerminalWrap.fold(line: text, width: width)
+        for line in folded.lines {
+            XCTAssertLessThanOrEqual(line.count, width, "line '\(line)' exceeds width \(width)")
+        }
+        XCTAssertFalse(folded.hardBroke, "a mid-token break was reported where every token fits")
+    }
+
+    func testBreaksHappenAtSpacesWhenPossible() {
+        let folded = TerminalWrap.fold(line: "alpha beta gamma", width: 11)
+        XCTAssertEqual(folded.lines, ["alpha beta", "gamma"])
+    }
+
+    // MARK: - blank lines
+
+    /// AXIS: a blank line folds to exactly one blank line.
+    ///
+    /// Returning [] would shorten the output and close up the paragraph breaks
+    /// that make agent output readable.
+    func testABlankLineSurvivesAsOneBlankLine() {
+        XCTAssertEqual(TerminalWrap.fold(line: "", width: 40).lines, [""])
+        let folded = TerminalWrap.fold(["a", "", "b"], width: 40)
+        XCTAssertEqual(folded.map(\.lines), [["a"], [""], ["b"]],
+                       "a blank line between two lines was dropped or merged")
+    }
+
+    // MARK: - the fail-closed width case
+
+    /// AXIS: a non-positive width returns the input UNFOLDED, not empty.
+    ///
+    /// Width 0 is a caller bug — an unmeasured layout — not a statement about
+    /// the data. Returning [] would delete the user's terminal output silently
+    /// in service of a layout mistake. An unfolded line is visibly wrong and
+    /// recovers on the next layout pass; lost output does not.
+    func testANonPositiveWidthReturnsInputUnfoldedRatherThanEmpty() {
+        let input = ["first line", "second line"]
+        for width in [0, -1, -80] {
+            let folded = TerminalWrap.fold(input, width: width)
+            XCTAssertEqual(folded.map(\.lines), [["first line"], ["second line"]],
+                           "width \(width) did not return the input unfolded")
+            XCTAssertFalse(folded.contains { $0.hardBroke })
+        }
+    }
+
+    // MARK: - interior spacing
+
+    /// AXIS: interior whitespace runs survive a fold that does not break there.
+    ///
+    /// Column alignment in terminal output — tables, tree output, diff gutters —
+    /// is made of exactly these runs. Collapsing them turns aligned output into
+    /// prose, which is a silent corruption of meaning rather than of characters.
+    func testInteriorSpacingIsPreservedWhenTheLineFits() {
+        let aligned = "name    status    age"
+        let folded = TerminalWrap.fold(line: aligned, width: 80)
+        XCTAssertEqual(folded.lines, [aligned], "interior spacing was collapsed")
+    }
+
+    func testTokeniseAlternatesWordsAndWhitespaceRuns() {
+        XCTAssertEqual(TerminalWrap.tokenise("ab  cd"), ["ab", "  ", "cd"])
+        XCTAssertEqual(TerminalWrap.tokenise("  lead"), ["  ", "lead"])
+        XCTAssertEqual(TerminalWrap.tokenise(""), [])
+    }
+
+    // MARK: - realistic input
+
+    /// A real herdr pane line at a real phone width, end to end.
+    func testARealLogLineFoldsSensibly() {
+        let line = "Test Case '-[HerdrKitTests.AgentListTests testAnAbsentStatusSurfaces]' passed (0.001 seconds)"
+        let folded = TerminalWrap.fold(line: line, width: 38)
+
+        XCTAssertGreaterThan(folded.lines.count, 1, "the premise: this line must actually need folding")
+        for l in folded.lines where l.count > 38 {
+            XCTAssertTrue(folded.hardBroke, "line '\(l)' overflows but no hard break was reported")
+        }
+        let strip = { (s: String) in s.filter { !$0.isWhitespace } }
+        XCTAssertEqual(strip(folded.lines.joined()), strip(line))
+    }
+}

--- a/Tests/HerdrKitTests/TerminalWrapTests.swift
+++ b/Tests/HerdrKitTests/TerminalWrapTests.swift
@@ -215,13 +215,25 @@ final class TerminalWrapTests: XCTestCase {
     /// Whitespace is divisible, so it must fold like any oversized token — only
     /// an indivisible glyph (a tab) may overflow.
     func testOversizedLeadingIndentIsSplitToWidth() {
-        let folded = TerminalWrap.fold(line: "          child", width: 6)  // 10 spaces
+        let input = "          child"  // 10 spaces
+        let width = 6
+        // PRECONDITION: the leading run must actually exceed width, or the
+        // oversized branch is never taken and this test proves nothing.
+        let leadingRun = input.prefix { $0 == " " }
+        XCTAssertGreaterThan(leadingRun.count, width,
+                             "the fixture's indent does not exceed width; the test is vacuous")
+
+        let folded = TerminalWrap.fold(line: input, width: width)
         for l in folded.lines {
-            XCTAssertLessThanOrEqual(TerminalWrap.columns(of: l, startingAt: 0), 6,
-                                     "line '\(l)' exceeds width 6")
+            XCTAssertLessThanOrEqual(TerminalWrap.columns(of: l, startingAt: 0), width,
+                                     "line '\(l)' exceeds width \(width)")
         }
-        XCTAssertEqual(folded.lines.joined().filter { !$0.isWhitespace }, "child",
-                       "content changed while splitting an oversized indent")
+        // EXACT join, not whitespace-stripped. The earlier version stripped
+        // whitespace before comparing to "child", so deleting the entire indent
+        // — in the fixture OR in production — produced the same observable and
+        // survived. The split lines must rejoin to the original byte-for-byte.
+        XCTAssertEqual(folded.lines.joined(), input,
+                       "joined output does not equal the input exactly; indentation was lost or altered")
     }
 
     /// AXIS: the flag-clear half of the indentation fix is guarded.

--- a/Tests/HerdrKitTests/TerminalWrapTests.swift
+++ b/Tests/HerdrKitTests/TerminalWrapTests.swift
@@ -207,6 +207,34 @@ final class TerminalWrapTests: XCTestCase {
         XCTAssertEqual(folded.lines.joined(), "    child", "content changed")
     }
 
+    /// AXIS: leading indentation WIDER THAN THE SCREEN is split to width, not
+    /// emitted as one over-width line.
+    ///
+    /// The fast path stored the whole indent token and bypassed the oversized
+    /// splitter: ten leading spaces at width 6 produced a ten-cell line.
+    /// Whitespace is divisible, so it must fold like any oversized token — only
+    /// an indivisible glyph (a tab) may overflow.
+    func testOversizedLeadingIndentIsSplitToWidth() {
+        let folded = TerminalWrap.fold(line: "          child", width: 6)  // 10 spaces
+        for l in folded.lines {
+            XCTAssertLessThanOrEqual(TerminalWrap.columns(of: l, startingAt: 0), 6,
+                                     "line '\(l)' exceeds width 6")
+        }
+        XCTAssertEqual(folded.lines.joined().filter { !$0.isWhitespace }, "child",
+                       "content changed while splitting an oversized indent")
+    }
+
+    /// AXIS: the flag-clear half of the indentation fix is guarded.
+    ///
+    /// Deleting `currentIsLeadingIndent = false` (set when a word joins the
+    /// indent) built green against all prior tests — an unguarded fix, exactly
+    /// the revert-mutation I am meant to run on my own work. With it deleted,
+    /// `fold("    a b c", width: 6)` keeps the fold-point space as "    a ".
+    func testFoldPointSpaceIsDroppedAfterIndentJoinsAWord() {
+        XCTAssertEqual(TerminalWrap.fold(line: "    a b c", width: 6).lines, ["    a", "b c"],
+                       "a fold-point space survived after the indent joined a word")
+    }
+
     /// A continuation line's leading space IS an artefact and is still dropped.
     /// Without this the fix above would over-correct into padding every folded
     /// line with the space it broke at.

--- a/Tests/HerdrKitTests/TerminalWrapTests.swift
+++ b/Tests/HerdrKitTests/TerminalWrapTests.swift
@@ -305,6 +305,27 @@ final class TerminalWrapTests: XCTestCase {
         XCTAssertEqual(TerminalWrap.columns(of: "\t", at: 8), 8)
     }
 
+    /// AXIS: whitespace that production PRESERVES is checked exactly, not via the
+    /// whitespace-stripping helper.
+    ///
+    /// The class the reviewer generalised from #23 r4: the losslessness helper
+    /// strips whitespace by design, so any test leaning on it is blind to a lost
+    /// space. Two build-valid mutations passed all prior tests — trimming final
+    /// lines ("child  " -> "child", "   " -> "") and replacing an interior tab
+    /// with a space. These assertions compare exactly and kill both.
+    func testWhitespaceProductionPreservesIsCheckedExactly() {
+        // Final trailing whitespace is content on the last line (flush() only
+        // trims at fold points, never the final line).
+        XCTAssertEqual(TerminalWrap.fold(line: "child  ", width: 40).lines, ["child  "],
+                       "trailing whitespace on the final line was trimmed")
+        // A whitespace-only line is one whitespace line, not empty.
+        XCTAssertEqual(TerminalWrap.fold(line: "   ", width: 40).lines, ["   "],
+                       "a whitespace-only line was emptied")
+        // An interior tab is preserved verbatim, not normalised to a space.
+        XCTAssertEqual(TerminalWrap.fold(line: "a\tb", width: 40).lines, ["a\tb"],
+                       "an interior tab was altered")
+    }
+
     func testTokeniseAlternatesWordsAndWhitespaceRuns() {
         XCTAssertEqual(TerminalWrap.tokenise("ab  cd"), ["ab", "  ", "cd"])
         XCTAssertEqual(TerminalWrap.tokenise("  lead"), ["  ", "lead"])

--- a/Tests/HerdrKitTests/TerminalWrapTests.swift
+++ b/Tests/HerdrKitTests/TerminalWrapTests.swift
@@ -191,6 +191,22 @@ final class TerminalWrapTests: XCTestCase {
                       "indentation was lost on a line that folded")
     }
 
+    /// AXIS: leading indentation survives even when the first word cannot join
+    /// it — the NARROW-WIDTH case the first indentation fix missed.
+    ///
+    /// fold("    child", width: 6) stored the indent, then flushed it alone when
+    /// "child" would not fit beside it, and flush() stripped the indent to an
+    /// empty line. The losslessness helper is blind to this by construction (it
+    /// strips whitespace), so it took a reviewer's compiled probe. This is the
+    /// same class as the original width-80 defect, one width narrower — I fixed
+    /// the instance and not the class the first time.
+    func testLeadingIndentationSurvivesWhenTheFirstWordCannotJoinIt() {
+        let folded = TerminalWrap.fold(line: "    child", width: 6)
+        XCTAssertEqual(folded.lines.first, "    ",
+                       "the leading indent was stripped when flushed alone at a narrow width")
+        XCTAssertEqual(folded.lines.joined(), "    child", "content changed")
+    }
+
     /// A continuation line's leading space IS an artefact and is still dropped.
     /// Without this the fix above would over-correct into padding every folded
     /// line with the space it broke at.
@@ -213,6 +229,31 @@ final class TerminalWrapTests: XCTestCase {
         let folded = TerminalWrap.fold(line: "界界界", width: 4)
         XCTAssertEqual(folded.lines, ["界界", "界"],
                        "three double-width glyphs did not fold at four columns")
+    }
+
+    /// AXIS: double-width EMOJI outside the CJK planes count as two cells.
+    ///
+    /// The first width table hand-listed 0x1F300+ and measured ✅ (U+2705),
+    /// ⌚ (U+231A) and the keycap 1️⃣ as one cell — a reviewer probe folded
+    /// ✅✅✅ into a single line at width 4. Deferring to Unicode.Scalar
+    /// .Properties (isEmojiPresentation, plus the VS16 in a keycap) is the
+    /// "complete table" answer rather than widening a hand-list, which is the
+    /// fix-the-class move I keep failing to make on the first pass.
+    func testBmpEmojiAreCountedAsTwoColumns() {
+        XCTAssertEqual(TerminalWrap.columns(of: "✅", at: 0), 2, "U+2705 measured as one cell")
+        XCTAssertEqual(TerminalWrap.columns(of: "⌚", at: 0), 2, "U+231A measured as one cell")
+        XCTAssertEqual(TerminalWrap.columns(of: "1️⃣", at: 0), 2, "a keycap (VS16) measured as one cell")
+
+        let folded = TerminalWrap.fold(line: "✅✅✅", width: 4)
+        XCTAssertEqual(folded.lines, ["✅✅", "✅"],
+                       "three double-width emoji did not fold at four columns")
+    }
+
+    /// A text-default symbol WITHOUT emoji presentation stays one cell — the
+    /// negative half, so the fix does not just call everything wide.
+    func testTextDefaultSymbolsStayOneColumn() {
+        XCTAssertEqual(TerminalWrap.columns(of: "a", at: 0), 1)
+        XCTAssertEqual(TerminalWrap.columns(of: "±", at: 0), 1, "a plain sign was widened")
     }
 
     /// A tab advances to the next multiple of 8, so its width depends on where


### PR DESCRIPTION
Closes #22.

Screen 3 shows a desktop-sized pane on a ~390pt screen. `pane.resize` can't help — it grows a pane against its neighbours in the *desktop* layout, so there's no "make this pane 40 columns" without disturbing the machine the user is sitting at. `ReadSource.recentUnwrapped` returns logical lines with no hard wrapping; this folds them to the width the phone actually has.

Pure function. No I/O, no UIKit, fully exercised on Linux.

## The load-bearing property

**Losslessness.** Stripping whitespace from the input and from the joined output must give identical strings. A wrap that eats a character is invisible against a wall of log output and corrupts exactly what the user opened the screen to read.

## Three decisions worth arguing with

**A non-positive width returns the input UNFOLDED, not empty.** Width 0 is a caller bug — an unmeasured layout — not a statement about the data. Returning `[]` deletes terminal output silently in service of a layout mistake. Unfolded is visibly wrong and recovers next layout pass; lost output doesn't.

**Termination is argued, not hoped.** A token wider than the line is split by `prefix(width)` with `width > 0`, so ≥1 Character is consumed per pass and the remainder strictly shrinks. Width 1 against a multi-scalar grapheme takes the grapheme and **overflows** rather than stalling — the one named exception to the width rule, tested with flag emoji.

**Trailing whitespace is trimmed at fold points only, never on the final line.** A space removed mid-fold is an artefact the fold created, like the leading space dropped from a continuation. A line that genuinely ends in spaces is content. Conflating them loses data at one end or leaves invisible padding at the other.

Interior whitespace runs survive as their own tokens — column alignment in tables, tree output and diff gutters is made of exactly those runs, and eating them turns aligned output into prose. That's a silent corruption of *meaning*, which is worse than one of characters.

## Evidence

**Production mutations, all KILLED:** `width0-returns-empty`, `blank-line-vanishes`, `no-hardbreak-report`, `drop-interior-space`.

**Premise mutations — and the first caught another vacuous test of mine.** `testFoldingNeverLosesContent` **SURVIVED** having its case list emptied: zero iterations, zero assertions, green, and reading in the diff as thorough coverage. It now counts folds that actually produced multiple lines and requires >20, so it fails both when there are no inputs *and* when the inputs never fold. KILLED both ways.

That's the fifth vacuous test of mine in two days. I predicted the class would recur when dispatching #21, and it recurred on the very first property test I wrote afterwards. Knowing about a defect does not prevent it; probing does.

## What I want challenged

- The trailing-space asymmetry (trim at folds, keep on the final line) is a judgement. If a caller renders these into a fixed-width view, invisible trailing space on the last line may matter.
- Width is counted in Swift `Character`s. A CJK or emoji glyph occupies two terminal columns, so a line of them will render wider than `width` even though the count is right. I have not handled display width, and I'd rather that be a stated limitation than a discovered one.
- Any remaining absence-shaped assertion that survives its premise being broken.

171 tests, 0 failures, `-Xswiftc -warnings-as-errors`.