### PR TITLE
Design pass: agent-list screen to the Claude Design kit

### DIFF
--- a/App/DesignSystem.swift
+++ b/App/DesignSystem.swift
@@ -47,53 +47,29 @@ enum Typography {
     static let microLabel = Font.system(size: 11, weight: .semibold, design: .monospaced)
 }
 
-/// The four agent states the design distinguishes — by SHAPE and colour, so they
-/// survive a sideways glance or colour-blindness (brief §9.2).
-enum AgentState: Int, Comparable {
-    case needsYou   // amber, "!" — blocked on a question
-    case stopped    // red, "✕" — exited / died
-    case working    // blue, elapsed time
-    case done       // green, "✓"
-    case idle       // dim
-
-    static func < (l: AgentState, r: AgentState) -> Bool { l.rawValue < r.rawValue }
-
-    /// Best-effort mapping from the API's `agent_status` string.
-    static func from(_ status: String?) -> AgentState {
-        switch (status ?? "").lowercased() {
-        case let s where s.contains("wait") || s.contains("input") || s.contains("pending") || s.contains("ask") || s.contains("block"):
-            return .needsYou
-        case let s where s.contains("exit") || s.contains("dead") || s.contains("stop") || s.contains("error") || s.contains("crash") || s.contains("fail"):
-            return .stopped
-        case let s where s.contains("work") || s.contains("run"):
-            return .working
-        case let s where s.contains("done") || s.contains("complete") || s.contains("finish"):
-            return .done
-        default:
-            return .idle
-        }
-    }
-
+/// The VISUAL half of the status story. The CLASSIFICATION — which agent belongs
+/// in which section, fail-closed, stopped-from-liveness, unknowns surfaced — is
+/// HerdrKit's `AgentGroup` (Sources/HerdrKit/AgentList.swift), which is unit
+/// tested on Linux. This is only the colour + heading each group renders as, so
+/// the meaning and its picture cannot drift out of one file.
+///
+/// Colour = meaning (brief): amber = wants a look (blocked OR uninterpretable),
+/// red = the pane is gone, blue = working, faint = idle. `.unrecognised` is amber
+/// on purpose — "this build cannot read it" is nearer to needs-attention than to
+/// nothing-to-do, the same reasoning that sorts it high.
+extension AgentGroup {
     var color: Color {
         switch self {
         case .needsYou: return Palette.waiting
         case .stopped: return Palette.died
+        case .unrecognised: return Palette.waiting
         case .working: return Palette.working
-        case .done: return Palette.done
         case .idle: return Palette.textFaint
         }
     }
 
-    /// Uppercase section header for a group of this state.
-    var sectionTitle: String {
-        switch self {
-        case .needsYou: return "NEEDS YOU"
-        case .stopped: return "STOPPED"
-        case .working: return "WORKING"
-        case .done: return "DONE"
-        case .idle: return "IDLE"
-        }
-    }
+    /// Uppercase micro-label heading, from the model's own label.
+    var sectionTitle: String { label.uppercased() }
 }
 
 /// A subtle gradient carrying agent identity — the one place colour is allowed to

--- a/App/DesignSystem.swift
+++ b/App/DesignSystem.swift
@@ -92,7 +92,10 @@ enum AgentIdentity {
     /// The marks echo each vendor: Claude's spoked asterisk, a plain C for codex.
     static func glyph(for agent: String?) -> String {
         switch (agent ?? "").lowercased() {
-        case let s where s.contains("claude"): return "\u{2733}"   // ✳ eight-spoked asterisk
+        // U+2731 HEAVY ASTERISK, NOT U+2733: the eight-spoked asterisk has an
+        // emoji-presentation variant that iOS renders as a green emoji, ignoring
+        // the white foreground. U+2731 has no emoji form, so it stays white.
+        case let s where s.contains("claude"): return "\u{2731}"   // ✱
         case let s where s.contains("codex"):  return "C"
         case let s where s.contains("gemini"): return "\u{2726}"   // ✦ four-pointed star
         default:

--- a/App/DesignSystem.swift
+++ b/App/DesignSystem.swift
@@ -1,0 +1,136 @@
+import SwiftUI
+import HerdrKit
+
+// Design tokens for herdr mobile, taken from the Claude Design kit
+// (herdr mobile.dc.html + DESIGN-BRIEF.md). The brief's rules are load-bearing:
+// deep desaturated navy ground (never black); colour is MEANING, not decoration
+// (amber = waiting on you, red = died, blue = working, green = done); monospace is
+// the MACHINE voice, a proportional sans is the APP voice.
+//
+// Fonts: the design specifies Geist (app) + IBM Plex Mono (machine). Those font
+// files are not yet bundled, so this uses the system proportional + monospaced
+// faces as stand-ins; swapping in the real families is a later refinement that
+// won't touch call sites (they go through Typography, not Font directly).
+
+enum Palette {
+    // Ground → elevated. Deep desaturated indigo/navy, not black.
+    static let ground = Color(hex: 0x0B0D1C)      // app background
+    static let groundDeep = Color(hex: 0x0A0C18)  // behind the ground (device edges)
+    static let surface = Color(hex: 0x13162A)      // search field, tab bar
+    static let card = Color(hex: 0x1D2038)         // list cards
+    static let cardRaised = Color(hex: 0x232742)
+    static let hairline = Color(hex: 0x2E3358)     // section rules, borders
+
+    // Text tiers.
+    static let text = Color(hex: 0xEEF0F7)         // primary
+    static let textDim = Color(hex: 0x99A0BC)      // secondary
+    static let textFaint = Color(hex: 0x666D91)    // tertiary / micro-labels
+
+    // Status = meaning. The ONLY palette that carries colour.
+    static let waiting = Color(hex: 0xE9A63C)      // amber — an agent is asking you
+    static let died = Color(hex: 0xE2584E)         // red — exited / crashed
+    static let working = Color(hex: 0x5B9BE8)      // blue — running
+    static let done = Color(hex: 0x5FB37F)         // green — finished
+}
+
+/// Type roles. The contrast encodes WHO is speaking (brief §6).
+enum Typography {
+    /// App voice — proportional sans (screen titles, names, buttons, labels).
+    static func app(_ size: CGFloat, _ weight: Font.Weight = .regular) -> Font {
+        .system(size: size, weight: weight, design: .default)
+    }
+    /// Machine voice — monospace (terminal, pane ids, status words, counts, keys).
+    static func machine(_ size: CGFloat, _ weight: Font.Weight = .regular) -> Font {
+        .system(size: size, weight: weight, design: .monospaced)
+    }
+    /// Uppercase micro-label for section headers, with letter-spacing.
+    static let microLabel = Font.system(size: 11, weight: .semibold, design: .monospaced)
+}
+
+/// The four agent states the design distinguishes — by SHAPE and colour, so they
+/// survive a sideways glance or colour-blindness (brief §9.2).
+enum AgentState: Int, Comparable {
+    case needsYou   // amber, "!" — blocked on a question
+    case stopped    // red, "✕" — exited / died
+    case working    // blue, elapsed time
+    case done       // green, "✓"
+    case idle       // dim
+
+    static func < (l: AgentState, r: AgentState) -> Bool { l.rawValue < r.rawValue }
+
+    /// Best-effort mapping from the API's `agent_status` string.
+    static func from(_ status: String?) -> AgentState {
+        switch (status ?? "").lowercased() {
+        case let s where s.contains("wait") || s.contains("input") || s.contains("pending") || s.contains("ask") || s.contains("block"):
+            return .needsYou
+        case let s where s.contains("exit") || s.contains("dead") || s.contains("stop") || s.contains("error") || s.contains("crash") || s.contains("fail"):
+            return .stopped
+        case let s where s.contains("work") || s.contains("run"):
+            return .working
+        case let s where s.contains("done") || s.contains("complete") || s.contains("finish"):
+            return .done
+        default:
+            return .idle
+        }
+    }
+
+    var color: Color {
+        switch self {
+        case .needsYou: return Palette.waiting
+        case .stopped: return Palette.died
+        case .working: return Palette.working
+        case .done: return Palette.done
+        case .idle: return Palette.textFaint
+        }
+    }
+
+    /// Uppercase section header for a group of this state.
+    var sectionTitle: String {
+        switch self {
+        case .needsYou: return "NEEDS YOU"
+        case .stopped: return "STOPPED"
+        case .working: return "WORKING"
+        case .done: return "DONE"
+        case .idle: return "IDLE"
+        }
+    }
+}
+
+/// A subtle gradient carrying agent identity — the one place colour is allowed to
+/// be decorative (brief §5, from the Termius reference). Keyed by agent kind.
+enum AgentIdentity {
+    static func gradient(for agent: String?) -> LinearGradient {
+        let (a, b): (UInt32, UInt32)
+        switch (agent ?? "").lowercased() {
+        case let s where s.contains("claude"): (a, b) = (0xCE58A4, 0xA32E77)  // magenta
+        case let s where s.contains("codex"):  (a, b) = (0xE8923C, 0xC5622A)  // orange
+        case let s where s.contains("gemini"): (a, b) = (0x5B9BE8, 0x3E6FBF)  // blue
+        default:                                 (a, b) = (0x8B79F6, 0x5B44C9)  // violet
+        }
+        return LinearGradient(colors: [Color(hex: a), Color(hex: b)],
+                              startPoint: .topLeading, endPoint: .bottomTrailing)
+    }
+
+    /// One glyph for the identity chip. Distinct per kind so two same-coloured
+    /// icons never collide on a bare first letter (claude/codex both → "C").
+    /// The marks echo each vendor: Claude's spoked asterisk, a plain C for codex.
+    static func glyph(for agent: String?) -> String {
+        switch (agent ?? "").lowercased() {
+        case let s where s.contains("claude"): return "\u{2733}"   // ✳ eight-spoked asterisk
+        case let s where s.contains("codex"):  return "C"
+        case let s where s.contains("gemini"): return "\u{2726}"   // ✦ four-pointed star
+        default: return String((agent ?? "?").prefix(1)).uppercased()
+        }
+    }
+}
+
+extension Color {
+    init(hex: UInt32) {
+        self.init(
+            .sRGB,
+            red: Double((hex >> 16) & 0xFF) / 255,
+            green: Double((hex >> 8) & 0xFF) / 255,
+            blue: Double(hex & 0xFF) / 255,
+            opacity: 1)
+    }
+}

--- a/App/DesignSystem.swift
+++ b/App/DesignSystem.swift
@@ -24,7 +24,7 @@ enum Palette {
     // Text tiers.
     static let text = Color(hex: 0xEEF0F7)         // primary
     static let textDim = Color(hex: 0x99A0BC)      // secondary
-    static let textFaint = Color(hex: 0x666D91)    // tertiary / micro-labels
+    static let textFaint = Color(hex: 0x7C83A6)    // tertiary / micro-labels (≥4.5:1 on ground)
 
     // Status = meaning. The ONLY palette that carries colour.
     static let waiting = Color(hex: 0xE9A63C)      // amber — an agent is asking you
@@ -80,7 +80,7 @@ enum AgentIdentity {
         switch (agent ?? "").lowercased() {
         case let s where s.contains("claude"): (a, b) = (0xCE58A4, 0xA32E77)  // magenta
         case let s where s.contains("codex"):  (a, b) = (0xE8923C, 0xC5622A)  // orange
-        case let s where s.contains("gemini"): (a, b) = (0x5B9BE8, 0x3E6FBF)  // blue
+        case let s where s.contains("gemini"): (a, b) = (0x4C6EF5, 0x2E44C4)  // indigo (kept off the working blue)
         default:                                 (a, b) = (0x8B79F6, 0x5B44C9)  // violet
         }
         return LinearGradient(colors: [Color(hex: a), Color(hex: b)],
@@ -95,7 +95,12 @@ enum AgentIdentity {
         case let s where s.contains("claude"): return "\u{2733}"   // ✳ eight-spoked asterisk
         case let s where s.contains("codex"):  return "C"
         case let s where s.contains("gemini"): return "\u{2726}"   // ✦ four-pointed star
-        default: return String((agent ?? "?").prefix(1)).uppercased()
+        default:
+            // First letter, but never an empty tile: an empty or whitespace kind
+            // falls back to "?" like a nil one. (Two kinds sharing a first letter
+            // still differ by gradient colour; a blank tile differs from nothing.)
+            let first = String((agent ?? "").trimmingCharacters(in: .whitespaces).prefix(1)).uppercased()
+            return first.isEmpty ? "?" : first
         }
     }
 }

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -206,7 +206,8 @@ struct RootView: View {
         let mockClient = HerdrClient(transport: MockTransport())
         switch mode {
         case .list:
-            TerminalHomeView(client: mockClient, onDisconnect: {}, onTrustHostKey: { _ in false })
+            TerminalHomeView(client: mockClient, onDisconnect: {}, onTrustHostKey: { _ in false },
+                             livePaneIDs: MockTransport.demoLivePaneIDs)
         case .pane:
             NavigationStack {
                 TerminalPaneView(client: mockClient, paneID: "w1:p1", title: "jarvis")
@@ -349,6 +350,11 @@ struct TerminalHomeView: View {
     let client: HerdrClient
     var onDisconnect: () -> Void
     var onTrustHostKey: (String) -> Bool
+    /// The set of panes herdr still lists; anything absent is `stopped`. `nil`
+    /// means no census is available yet (the live default) — every agent is
+    /// treated as live, the only safe reading. The DEBUG mock passes one so the
+    /// stopped section has something to show.
+    var livePaneIDs: Set<String>? = nil
 
     @State private var agents: [AgentInfo] = []
     @State private var error: String?
@@ -356,27 +362,24 @@ struct TerminalHomeView: View {
     @State private var rejectedFingerprint: String?
     @State private var trustFailed = false
     @State private var search = ""
-    // Idle agents are the quiet majority; collapse them by default so the
-    // sections that want attention lead (the mockup shows IDLE collapsed).
-    @State private var collapsed: Set<AgentState> = [.idle]
+    // Only the quiet tail (idle) starts collapsed — the model forbids a
+    // collapsed group from ever hiding something that wants attention.
+    @State private var collapsed: Set<AgentGroup> = Set(AgentGroup.allCases.filter { $0.startsCollapsed })
 
-    /// Order the status groups by urgency; drop empty ones. Idle is last.
-    private var groups: [(state: AgentState, agents: [AgentInfo])] {
-        let filtered = search.isEmpty ? agents : agents.filter {
+    /// The whole list derived from the current agents + census. The grouping,
+    /// fail-closed placement, stable order, count and quiet flag all live in
+    /// HerdrKit's tested `AgentList`, not here.
+    private var fullList: AgentList { AgentList(agents: agents, livePaneIDs: livePaneIDs) }
+
+    /// Sections after applying the search box. Search filters the raw agents and
+    /// re-derives, so counts and grouping stay honest for the filtered view.
+    private var visibleSections: [(group: AgentGroup, rows: [AgentRow])] {
+        guard !search.isEmpty else { return fullList.sections }
+        let filtered = agents.filter {
             $0.displayName.localizedCaseInsensitiveContains(search)
                 || ($0.terminalTitleStripped ?? "").localizedCaseInsensitiveContains(search)
         }
-        let byState = Dictionary(grouping: filtered) { AgentState.from($0.agentStatus) }
-        return [AgentState.needsYou, .stopped, .working, .done, .idle].compactMap { state in
-            guard let items = byState[state], !items.isEmpty else {
-                return nil as (state: AgentState, agents: [AgentInfo])?
-            }
-            return (state: state, agents: items)
-        }
-    }
-
-    private var needsYouCount: Int {
-        agents.filter { AgentState.from($0.agentStatus) == .needsYou }.count
+        return AgentList(agents: filtered, livePaneIDs: livePaneIDs).sections
     }
 
     var body: some View {
@@ -408,9 +411,15 @@ struct TerminalHomeView: View {
             Spacer()
             VStack(spacing: 2) {
                 Text("Agents").font(Typography.app(20, .bold)).foregroundStyle(Palette.text)
-                if needsYouCount > 0 {
-                    Text("\(needsYouCount) need you")
+                // The one number, and its restful inverse. Blocked count leads in
+                // amber; when the model says nothing is blocked AND nothing is
+                // uninterpretable, say so plainly.
+                if fullList.needsYouCount > 0 {
+                    Text("\(fullList.needsYouCount) need you")
                         .font(Typography.machine(12)).foregroundStyle(Palette.waiting)
+                } else if fullList.isQuiet && !agents.isEmpty {
+                    Text("nothing needs you")
+                        .font(Typography.machine(12)).foregroundStyle(Palette.textFaint)
                 }
             }
             Spacer()
@@ -470,25 +479,34 @@ struct TerminalHomeView: View {
         ScrollView {
             searchField
             if agents.isEmpty {
-                Text("no agents").font(Typography.app(15)).foregroundStyle(Palette.textDim).padding(.top, 44)
+                emptyLine("no agents")
+            } else if visibleSections.isEmpty {
+                // Agents exist but the search matched none — say so, rather than
+                // leave a blank scroll that reads as "no agents".
+                emptyLine("no matches")
             } else {
-                ForEach(groups, id: \.state) { group in
-                    section(group.state, group.agents)
+                ForEach(visibleSections, id: \.group) { section in
+                    sectionView(section.group, section.rows)
                 }
             }
         }
     }
 
-    private func section(_ state: AgentState, _ items: [AgentInfo]) -> some View {
-        let isCollapsed = collapsed.contains(state)
+    private func emptyLine(_ text: String) -> some View {
+        Text(text).font(Typography.app(15)).foregroundStyle(Palette.textDim)
+            .frame(maxWidth: .infinity).padding(.top, 44)
+    }
+
+    private func sectionView(_ group: AgentGroup, _ rows: [AgentRow]) -> some View {
+        let isCollapsed = collapsed.contains(group)
         return VStack(alignment: .leading, spacing: 6) {
             Button {
-                if isCollapsed { collapsed.remove(state) } else { collapsed.insert(state) }
+                if isCollapsed { collapsed.remove(group) } else { collapsed.insert(group) }
             } label: {
                 HStack(spacing: 8) {
                     // Count is shown when collapsed (so hidden work is legible);
                     // an expanded section speaks for itself through its cards.
-                    Text(isCollapsed ? "\(state.sectionTitle) · \(items.count)" : state.sectionTitle)
+                    Text(isCollapsed ? "\(group.sectionTitle) · \(rows.count)" : group.sectionTitle)
                         .font(Typography.microLabel).tracking(1.2).foregroundStyle(Palette.textFaint)
                     Image(systemName: isCollapsed ? "chevron.right" : "chevron.down")
                         .font(.system(size: 9, weight: .semibold)).foregroundStyle(Palette.textFaint)
@@ -499,11 +517,11 @@ struct TerminalHomeView: View {
             .padding(.horizontal, 16).padding(.top, 10)
 
             if !isCollapsed {
-                ForEach(items) { agent in
+                ForEach(rows) { row in
                     NavigationLink {
-                        TerminalPaneView(client: client, paneID: agent.paneID, title: agent.displayName)
+                        TerminalPaneView(client: client, paneID: row.info.paneID, title: row.title)
                     } label: {
-                        card(agent, state)
+                        card(row)
                     }
                     .buttonStyle(.plain)
                 }
@@ -511,21 +529,21 @@ struct TerminalHomeView: View {
         }
     }
 
-    private func card(_ agent: AgentInfo, _ state: AgentState) -> some View {
+    private func card(_ row: AgentRow) -> some View {
         HStack(spacing: 12) {
             ZStack {
-                RoundedRectangle(cornerRadius: 10).fill(AgentIdentity.gradient(for: agent.agent))
+                RoundedRectangle(cornerRadius: 10).fill(AgentIdentity.gradient(for: row.info.agent))
                     .frame(width: 40, height: 40)
-                Text(AgentIdentity.glyph(for: agent.agent))
+                Text(AgentIdentity.glyph(for: row.info.agent))
                     .font(Typography.app(18, .bold)).foregroundStyle(.white)
             }
             VStack(alignment: .leading, spacing: 3) {
-                Text(agent.displayName).font(Typography.app(16, .semibold)).foregroundStyle(Palette.text)
-                Text(agent.terminalTitleStripped ?? agent.paneID)
+                Text(row.title).font(Typography.app(16, .semibold)).foregroundStyle(Palette.text)
+                Text(row.info.terminalTitleStripped ?? row.info.paneID)
                     .font(Typography.machine(12)).foregroundStyle(Palette.textDim).lineLimit(1)
             }
             Spacer(minLength: 8)
-            statusBadge(state)
+            statusBadge(row.group)
         }
         .padding(12)
         .background(Palette.card)
@@ -534,13 +552,16 @@ struct TerminalHomeView: View {
     }
 
     @ViewBuilder
-    private func statusBadge(_ state: AgentState) -> some View {
-        switch state {
-        case .needsYou: badgeCircle("exclamationmark", Palette.waiting)
-        case .stopped: badgeCircle("xmark", Palette.died)
-        case .working: Text("now").font(Typography.machine(12)).foregroundStyle(Palette.working)
-        case .done: badgeCircle("checkmark", Palette.done)
-        case .idle: EmptyView()
+    private func statusBadge(_ group: AgentGroup) -> some View {
+        switch group {
+        case .needsYou: badgeCircle("exclamationmark", group.color)
+        case .stopped: badgeCircle("xmark", group.color)
+        case .unrecognised: badgeCircle("questionmark", group.color)
+        case .working: Text("now").font(Typography.machine(12)).foregroundStyle(group.color)
+        case .idle:
+            // Not bare, not loud: a small hollow dot so an expanded idle row still
+            // has a right-edge anchor.
+            Circle().stroke(Palette.textFaint, lineWidth: 1.5).frame(width: 8, height: 8)
         }
     }
 
@@ -711,18 +732,29 @@ struct MockTransport: HerdrTransport {
         AsyncThrowingStream { $0.finish() }
     }
 
+    // Realistic herdr statuses only (idle|working|blocked|done|unknown). "needs
+    // you" is `blocked`; the STOPPED row is NOT a status string — it comes from
+    // liveness (w2:p1 is absent from demoLivePaneIDs below), exactly as the real
+    // model derives it. done folds into idle.
     static let agentList = #"""
     {"id":"mock","result":{"type":"agent_list","agents":[
-      {"pane_id":"w1:p1","name":"codex","agent":"codex","agent_status":"input_pending","terminal_title_stripped":"herdr-ios · asking to run tests"},
-      {"pane_id":"w1:p2","name":"claude","agent":"claude","agent_status":"waiting","terminal_title_stripped":"vetrina · overwrite config.ts?"},
-      {"pane_id":"w2:p1","name":"codex","agent":"codex","agent_status":"exited","terminal_title_stripped":"trend-scout · exited, code 1"},
+      {"pane_id":"w1:p1","name":"codex","agent":"codex","agent_status":"blocked","terminal_title_stripped":"herdr-ios · asking to run tests"},
+      {"pane_id":"w1:p2","name":"claude","agent":"claude","agent_status":"blocked","terminal_title_stripped":"vetrina · overwrite config.ts?"},
+      {"pane_id":"w2:p1","name":"codex","agent":"codex","agent_status":"idle","terminal_title_stripped":"trend-scout · exited, code 1"},
       {"pane_id":"w2:p2","name":"claude","agent":"claude","agent_status":"working","terminal_title_stripped":"herdr · editing src/acp.rs"},
       {"pane_id":"w3:p1","name":"claude","agent":"claude","agent_status":"idle","terminal_title_stripped":"clientloop · amigo-poc scaffold"},
       {"pane_id":"w3:p2","name":"codex","agent":"codex","agent_status":"idle","terminal_title_stripped":"aste-screener · apify-harvest"},
       {"pane_id":"w4:p1","name":"gemini","agent":"gemini","agent_status":"idle","terminal_title_stripped":"discovery · redaction-pass v3"},
-      {"pane_id":"w4:p2","name":"claude","agent":"claude","agent_status":"idle","terminal_title_stripped":"bank-qa · deal-assistant rag"}
+      {"pane_id":"w4:p2","name":"claude","agent":"claude","agent_status":"done","terminal_title_stripped":"bank-qa · deal-assistant rag"}
     ]}}
     """#
+
+    /// The panes herdr still lists, for the mock render. Excludes w2:p1 so that
+    /// row lands in STOPPED via liveness (not a status string). MUST stay in sync
+    /// with the census the fixture test uses.
+    static let demoLivePaneIDs: Set<String> = [
+        "w1:p1", "w1:p2", "w2:p2", "w3:p1", "w3:p2", "w4:p1", "w4:p2",
+    ]
 
     static let agentRead = #"""
     {"id":"mock","result":{"read":{"pane_id":"w1:p1","text":"$ herdr agent attach codex\n\n> may I run `just test` on herdr-ios?\n  177 tests, ~30s, no network\n\n  [y] allow   [n] deny   [a] always\n\n[demo data - mock render mode, no live connection]","truncated":false,"source":"recent_unwrapped","format":"text"}}}

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -713,7 +713,16 @@ enum ScreenshotMock {
     static var mode: ScreenshotMock? {
         let env = ProcessInfo.processInfo.environment["HERDR_SCREENSHOT_MOCK"]?.lowercased()
         let arg = ProcessInfo.processInfo.arguments.contains("-herdrScreenshotMock")
+        #if SCREENSHOT_MOCK_DEFAULT
+        // VERIFICATION SCAFFOLD — REMOVE BEFORE MERGE. The buildbox launches the
+        // app with no env and no args, so to screenshot a redesigned screen we
+        // default into the mock list. Defined ONLY in the Debug config of a
+        // design-iteration branch (project.yml); main's Debug build must still
+        // boot to ConnectView. Still mock-data-only — no key is ever rendered.
+        guard env != nil || arg else { return .list }
+        #else
         guard env != nil || arg else { return nil }
+        #endif
         return env == "pane" ? .pane : .list
     }
 }

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -277,7 +277,7 @@ struct ConnectView: View {
                 VStack(alignment: .leading, spacing: 18) {
                     Text("herdr")
                         .font(.system(size: 34, weight: .bold, design: .monospaced))
-                        .foregroundStyle(Palette.working)
+                        .foregroundStyle(Palette.text)   // wordmark is monochrome; blue means "working"
                     Text("connect to a host")
                         .font(.system(.subheadline, design: .monospaced))
                         .foregroundStyle(Palette.textDim)
@@ -317,8 +317,8 @@ struct ConnectView: View {
                             .font(.system(.body, design: .monospaced).weight(.semibold))
                             .frame(maxWidth: .infinity)
                             .padding(.vertical, 14)
-                            .background(canConnect ? Palette.working : Palette.surface)
-                            .foregroundStyle(canConnect ? Palette.ground : Palette.textDim)
+                            .background(canConnect ? Palette.cardRaised : Palette.surface)
+                            .foregroundStyle(canConnect ? Palette.text : Palette.textDim)
                             .clipShape(RoundedRectangle(cornerRadius: 10))
                     }
                     .disabled(!canConnect)
@@ -411,21 +411,28 @@ struct TerminalHomeView: View {
             Spacer()
             VStack(spacing: 2) {
                 Text("Agents").font(Typography.app(20, .bold)).foregroundStyle(Palette.text)
-                // The one number, and its restful inverse. Blocked count leads in
-                // amber; when the model says nothing is blocked AND nothing is
-                // uninterpretable, say so plainly.
-                if fullList.needsYouCount > 0 {
-                    Text("\(fullList.needsYouCount) need you")
-                        .font(Typography.machine(12)).foregroundStyle(Palette.waiting)
-                } else if fullList.isQuiet && !agents.isEmpty {
-                    Text("nothing needs you")
-                        .font(Typography.machine(12)).foregroundStyle(Palette.textFaint)
-                }
+                // The line is ALWAYS present (reserved height) so the title does
+                // not jump as it appears; its text is the one number or its
+                // restful inverse.
+                Text(headerSubtitle.text)
+                    .font(Typography.machine(12)).foregroundStyle(headerSubtitle.color)
+                    .frame(height: 15)
             }
             Spacer()
-            circleButton("plus") { }   // new-agent screen (04) is not built yet
+            // The new-agent screen (04) does not exist yet — a visible but inert
+            // affordance, not a live control that does nothing.
+            circleButton("plus") { }.disabled(true).opacity(0.35)
         }
         .padding(.horizontal, 16).padding(.top, 8).padding(.bottom, 10)
+    }
+
+    /// The one number leads in amber; when the model reports nothing blocked AND
+    /// nothing uninterpretable, the quiet state says so. A space holds the line
+    /// while loading/empty so nothing above it moves.
+    private var headerSubtitle: (text: String, color: Color) {
+        if fullList.needsYouCount > 0 { return ("\(fullList.needsYouCount) need you", Palette.waiting) }
+        if fullList.isQuiet && !agents.isEmpty { return ("nothing needs you", Palette.textFaint) }
+        return (" ", Palette.textFaint)
     }
 
     private func circleButton(_ system: String, _ action: @escaping () -> Void) -> some View {
@@ -476,17 +483,21 @@ struct TerminalHomeView: View {
     // MARK: list
 
     private var agentList: some View {
-        ScrollView {
-            searchField
-            if agents.isEmpty {
-                emptyLine("no agents")
-            } else if visibleSections.isEmpty {
-                // Agents exist but the search matched none — say so, rather than
-                // leave a blank scroll that reads as "no agents".
-                emptyLine("no matches")
-            } else {
-                ForEach(visibleSections, id: \.group) { section in
-                    sectionView(section.group, section.rows)
+        VStack(spacing: 0) {
+            searchField   // pinned above the scroll, as the mockup/Termius have it
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 0) {
+                    if agents.isEmpty {
+                        emptyLine("no agents")
+                    } else if visibleSections.isEmpty {
+                        // Agents exist but the search matched none — say so, rather
+                        // than leave a blank scroll that reads as "no agents".
+                        emptyLine("no matches")
+                    } else {
+                        ForEach(visibleSections, id: \.group) { section in
+                            sectionView(section.group, section.rows)
+                        }
+                    }
                 }
             }
         }
@@ -498,7 +509,9 @@ struct TerminalHomeView: View {
     }
 
     private func sectionView(_ group: AgentGroup, _ rows: [AgentRow]) -> some View {
-        let isCollapsed = collapsed.contains(group)
+        // An active search overrides collapse — a match inside IDLE must not stay
+        // hidden behind a shut section the user did not open.
+        let isCollapsed = search.isEmpty && collapsed.contains(group)
         return VStack(alignment: .leading, spacing: 6) {
             Button {
                 if isCollapsed { collapsed.remove(group) } else { collapsed.insert(group) }
@@ -539,7 +552,7 @@ struct TerminalHomeView: View {
             }
             VStack(alignment: .leading, spacing: 3) {
                 Text(row.title).font(Typography.app(16, .semibold)).foregroundStyle(Palette.text)
-                Text(row.info.terminalTitleStripped ?? row.info.paneID)
+                Text(subtitle(row.info))
                     .font(Typography.machine(12)).foregroundStyle(Palette.textDim).lineLimit(1)
             }
             Spacer(minLength: 8)
@@ -551,12 +564,35 @@ struct TerminalHomeView: View {
         .padding(.horizontal, 16).padding(.vertical, 4)
     }
 
-    @ViewBuilder
+    /// "folder · activity": folder is the last path component of `cwd`, activity
+    /// is the stripped terminal title. Either may be missing; the pane id is the
+    /// last resort so a row is never subtitle-less.
+    private func subtitle(_ info: AgentInfo) -> String {
+        let folder = info.cwd
+            .map { URL(fileURLWithPath: $0).lastPathComponent }
+            .flatMap { $0.isEmpty || $0 == "/" ? nil : $0 }
+        switch (folder, info.terminalTitleStripped) {
+        case let (f?, a?): return "\(f) · \(a)"
+        case let (f?, nil): return f
+        case let (nil, a?): return a
+        case (nil, nil): return info.paneID
+        }
+    }
+
     private func statusBadge(_ group: AgentGroup) -> some View {
+        // The status is colour+shape; name it for VoiceOver too.
+        badgeContent(group).accessibilityLabel(Text(group.label))
+    }
+
+    @ViewBuilder
+    private func badgeContent(_ group: AgentGroup) -> some View {
         switch group {
         case .needsYou: badgeCircle("exclamationmark", group.color)
         case .stopped: badgeCircle("xmark", group.color)
         case .unrecognised: badgeCircle("questionmark", group.color)
+        // "now" is a non-temporal "active" marker, not an elapsed timer — there
+        // is no start timestamp in AgentInfo to count from, so it does not claim
+        // a duration it cannot know.
         case .working: Text("now").font(Typography.machine(12)).foregroundStyle(group.color)
         case .idle:
             // Not bare, not loud: a small hollow dot so an expanded idle row still
@@ -596,9 +632,13 @@ struct TerminalHomeView: View {
                         .font(Typography.app(12)).foregroundStyle(Palette.died).multilineTextAlignment(.center)
                 }
             }
+            // Plain retry ONLY for non-host-key errors. After a host-key
+            // rejection a bare reconnect could first-contact-trust whatever key
+            // next appears (bypassing the fingerprint the user must verify), so
+            // the only routes then are "trust this key" above or disconnect.
             if rejectedFingerprint == nil {
                 Button("retry") { Task { await load() } }
-                    .font(Typography.app(15, .semibold)).foregroundStyle(Palette.working)
+                    .font(Typography.app(15, .semibold)).foregroundStyle(Palette.text)
             }
         }
         .padding(24)
@@ -673,7 +713,7 @@ struct TerminalPaneView: View {
             Button {
                 Task { await refresh() }
             } label: {
-                Image(systemName: "arrow.clockwise").foregroundStyle(Palette.working)
+                Image(systemName: "arrow.clockwise").foregroundStyle(Palette.textDim)
             }
         }
     }
@@ -747,14 +787,14 @@ struct MockTransport: HerdrTransport {
     // model derives it. done folds into idle.
     static let agentList = #"""
     {"id":"mock","result":{"type":"agent_list","agents":[
-      {"pane_id":"w1:p1","name":"codex","agent":"codex","agent_status":"blocked","terminal_title_stripped":"herdr-ios · asking to run tests"},
-      {"pane_id":"w1:p2","name":"claude","agent":"claude","agent_status":"blocked","terminal_title_stripped":"vetrina · overwrite config.ts?"},
-      {"pane_id":"w2:p1","name":"codex","agent":"codex","agent_status":"idle","terminal_title_stripped":"trend-scout · exited, code 1"},
-      {"pane_id":"w2:p2","name":"claude","agent":"claude","agent_status":"working","terminal_title_stripped":"herdr · editing src/acp.rs"},
-      {"pane_id":"w3:p1","name":"claude","agent":"claude","agent_status":"idle","terminal_title_stripped":"clientloop · amigo-poc scaffold"},
-      {"pane_id":"w3:p2","name":"codex","agent":"codex","agent_status":"idle","terminal_title_stripped":"aste-screener · apify-harvest"},
-      {"pane_id":"w4:p1","name":"gemini","agent":"gemini","agent_status":"idle","terminal_title_stripped":"discovery · redaction-pass v3"},
-      {"pane_id":"w4:p2","name":"claude","agent":"claude","agent_status":"done","terminal_title_stripped":"bank-qa · deal-assistant rag"}
+      {"pane_id":"w1:p1","name":"jarvis","agent":"claude","agent_status":"blocked","cwd":"/root/herdr-ios","terminal_title_stripped":"asking to run tests"},
+      {"pane_id":"w1:p2","name":"vetrina","agent":"codex","agent_status":"blocked","cwd":"/root/vetrina","terminal_title_stripped":"overwrite config.ts?"},
+      {"pane_id":"w2:p1","name":"trend-scout","agent":"codex","agent_status":"idle","cwd":"/root/trend-scout","terminal_title_stripped":"exited, code 1"},
+      {"pane_id":"w2:p2","name":"herdr-app","agent":"claude","agent_status":"working","cwd":"/root/herdr","terminal_title_stripped":"editing src/acp.rs"},
+      {"pane_id":"w3:p1","name":"clientloop","agent":"claude","agent_status":"idle","cwd":"/root/clientloop","terminal_title_stripped":"amigo-poc scaffold"},
+      {"pane_id":"w3:p2","name":"aste-screener","agent":"codex","agent_status":"idle","cwd":"/root/aste-screener","terminal_title_stripped":"apify-harvest"},
+      {"pane_id":"w4:p1","name":"discovery","agent":"gemini","agent_status":"idle","cwd":"/root/discovery-calls","terminal_title_stripped":"redaction-pass v3"},
+      {"pane_id":"w4:p2","name":"bank-qa","agent":"claude","agent_status":"done","cwd":"/root/bank-qa","terminal_title_stripped":"deal-assistant rag"}
     ]}}
     """#
 
@@ -766,7 +806,7 @@ struct MockTransport: HerdrTransport {
     ]
 
     static let agentRead = #"""
-    {"id":"mock","result":{"read":{"pane_id":"w1:p1","text":"$ herdr agent attach codex\n\n> may I run `just test` on herdr-ios?\n  177 tests, ~30s, no network\n\n  [y] allow   [n] deny   [a] always\n\n[demo data - mock render mode, no live connection]","truncated":false,"source":"recent_unwrapped","format":"text"}}}
+    {"id":"mock","result":{"read":{"pane_id":"w1:p1","text":"$ herdr agent attach jarvis\n\n> may I run `just test` on herdr-ios?\n  177 tests, ~30s, no network\n\n  [y] allow   [n] deny   [a] always\n\n[demo data - mock render mode, no live connection]","truncated":false,"source":"recent_unwrapped","format":"text"}}}
     """#
 }
 #endif

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -753,16 +753,7 @@ enum ScreenshotMock {
     static var mode: ScreenshotMock? {
         let env = ProcessInfo.processInfo.environment["HERDR_SCREENSHOT_MOCK"]?.lowercased()
         let arg = ProcessInfo.processInfo.arguments.contains("-herdrScreenshotMock")
-        #if SCREENSHOT_MOCK_DEFAULT
-        // VERIFICATION SCAFFOLD — REMOVE BEFORE MERGE. The buildbox launches the
-        // app with no env and no args, so to screenshot a redesigned screen we
-        // default into the mock list. Defined ONLY in the Debug config of a
-        // design-iteration branch (project.yml); main's Debug build must still
-        // boot to ConnectView. Still mock-data-only — no key is ever rendered.
-        guard env != nil || arg else { return .list }
-        #else
         guard env != nil || arg else { return nil }
-        #endif
         return env == "pane" ? .pane : .list
     }
 }

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -15,14 +15,7 @@ struct HerdrApp: App {
     }
 }
 
-/// Termius-inspired dark palette.
-enum Palette {
-    static let bg = Color(red: 0.043, green: 0.055, blue: 0.078)       // ~#0B0E14
-    static let surface = Color(red: 0.086, green: 0.102, blue: 0.137)  // ~#161A23
-    static let text = Color(red: 0.90, green: 0.91, blue: 0.93)
-    static let dim = Color(red: 0.55, green: 0.58, blue: 0.64)
-    static let accent = Color(red: 0.30, green: 0.85, blue: 0.68)      // teal-green
-}
+// Palette / Typography / status tokens now live in DesignSystem.swift.
 
 /// Cross-launch TOFU: the persistent `HostKeyPolicy` the transport contract
 /// assigns to the app (HerdrKit's `PinStore` is in-memory only and cannot be
@@ -278,15 +271,15 @@ struct ConnectView: View {
 
     var body: some View {
         ZStack {
-            Palette.bg.ignoresSafeArea()
+            Palette.ground.ignoresSafeArea()
             ScrollView {
                 VStack(alignment: .leading, spacing: 18) {
                     Text("herdr")
                         .font(.system(size: 34, weight: .bold, design: .monospaced))
-                        .foregroundStyle(Palette.accent)
+                        .foregroundStyle(Palette.working)
                     Text("connect to a host")
                         .font(.system(.subheadline, design: .monospaced))
-                        .foregroundStyle(Palette.dim)
+                        .foregroundStyle(Palette.textDim)
 
                     field("host", text: $host)
                     field("port", text: $port)
@@ -298,7 +291,7 @@ struct ConnectView: View {
 
                     VStack(alignment: .leading, spacing: 6) {
                         Text("private key (ed25519 PEM)")
-                            .font(.caption).foregroundStyle(Palette.dim)
+                            .font(.caption).foregroundStyle(Palette.textDim)
                         TextEditor(text: $keyPEM)
                             .font(.system(.footnote, design: .monospaced))
                             .foregroundStyle(Palette.text)
@@ -323,8 +316,8 @@ struct ConnectView: View {
                             .font(.system(.body, design: .monospaced).weight(.semibold))
                             .frame(maxWidth: .infinity)
                             .padding(.vertical, 14)
-                            .background(canConnect ? Palette.accent : Palette.surface)
-                            .foregroundStyle(canConnect ? Palette.bg : Palette.dim)
+                            .background(canConnect ? Palette.working : Palette.surface)
+                            .foregroundStyle(canConnect ? Palette.ground : Palette.textDim)
                             .clipShape(RoundedRectangle(cornerRadius: 10))
                     }
                     .disabled(!canConnect)
@@ -337,7 +330,7 @@ struct ConnectView: View {
     @ViewBuilder
     private func field(_ label: String, text: Binding<String>) -> some View {
         VStack(alignment: .leading, spacing: 4) {
-            Text(label).font(.caption).foregroundStyle(Palette.dim)
+            Text(label).font(.caption).foregroundStyle(Palette.textDim)
             TextField("", text: text)
                 .textInputAutocapitalization(.never)
                 .autocorrectionDisabled()
@@ -362,97 +355,233 @@ struct TerminalHomeView: View {
     @State private var loading = true
     @State private var rejectedFingerprint: String?
     @State private var trustFailed = false
+    @State private var search = ""
+    // Idle agents are the quiet majority; collapse them by default so the
+    // sections that want attention lead (the mockup shows IDLE collapsed).
+    @State private var collapsed: Set<AgentState> = [.idle]
+
+    /// Order the status groups by urgency; drop empty ones. Idle is last.
+    private var groups: [(state: AgentState, agents: [AgentInfo])] {
+        let filtered = search.isEmpty ? agents : agents.filter {
+            $0.displayName.localizedCaseInsensitiveContains(search)
+                || ($0.terminalTitleStripped ?? "").localizedCaseInsensitiveContains(search)
+        }
+        let byState = Dictionary(grouping: filtered) { AgentState.from($0.agentStatus) }
+        return [AgentState.needsYou, .stopped, .working, .done, .idle].compactMap { state in
+            guard let items = byState[state], !items.isEmpty else {
+                return nil as (state: AgentState, agents: [AgentInfo])?
+            }
+            return (state: state, agents: items)
+        }
+    }
+
+    private var needsYouCount: Int {
+        agents.filter { AgentState.from($0.agentStatus) == .needsYou }.count
+    }
 
     var body: some View {
         NavigationStack {
             ZStack {
-                Palette.bg.ignoresSafeArea()
-                content
-            }
-            .navigationTitle("agents")
-            .toolbar {
-                ToolbarItem(placement: .topBarLeading) {
-                    Button("disconnect") { onDisconnect() }
-                        .foregroundStyle(Palette.dim)
+                Palette.ground.ignoresSafeArea()
+                VStack(spacing: 0) {
+                    header
+                    if let error {
+                        errorView(error)
+                    } else if loading {
+                        Spacer(); ProgressView().tint(Palette.textDim); Spacer()
+                    } else {
+                        agentList
+                    }
+                    tabBar
                 }
             }
+            .toolbar(.hidden, for: .navigationBar)
             .task { await load() }
         }
     }
 
-    @ViewBuilder
-    private var content: some View {
-        if let error {
-            VStack(spacing: 14) {
-                Text(error)
-                    .font(.system(.footnote, design: .monospaced))
-                    .foregroundStyle(.red)
-                    .multilineTextAlignment(.center)
-                if let fingerprint = rejectedFingerprint {
-                    VStack(spacing: 8) {
-                        Text("the host key changed. the server now presents:")
-                            .font(.caption).foregroundStyle(Palette.dim)
-                        Text(fingerprint)
-                            .font(.system(.caption2, design: .monospaced))
-                            .foregroundStyle(Palette.text)
-                            .textSelection(.enabled)
-                            .multilineTextAlignment(.center)
-                        Text("trust it ONLY if this exactly matches the key you verified out of band.")
-                            .font(.caption).foregroundStyle(Palette.dim)
-                            .multilineTextAlignment(.center)
-                    }
-                    Button("trust this key & reconnect") {
-                        trustFailed = !onTrustHostKey(fingerprint)
-                    }
-                    .font(.system(.body, design: .monospaced))
-                    .foregroundStyle(.red)
-                    if trustFailed {
-                        Text("could not save the verified key to the keychain — not reconnecting. try again.")
-                            .font(.caption).foregroundStyle(.red)
-                            .multilineTextAlignment(.center)
-                    }
-                }
-                // Plain retry ONLY for non-host-key errors. After a host-key
-                // rejection a bare reconnect could first-contact-trust whatever
-                // key next appears (bypassing the fingerprint the user must
-                // verify) — so the only routes then are the bound "trust this
-                // key" above or disconnect.
-                if rejectedFingerprint == nil {
-                    Button("retry") { Task { await load() } }
-                        .font(.system(.body, design: .monospaced))
-                        .foregroundStyle(Palette.accent)
+    // MARK: chrome
+
+    private var header: some View {
+        HStack {
+            circleButton("chevron.left") { onDisconnect() }
+            Spacer()
+            VStack(spacing: 2) {
+                Text("Agents").font(Typography.app(20, .bold)).foregroundStyle(Palette.text)
+                if needsYouCount > 0 {
+                    Text("\(needsYouCount) need you")
+                        .font(Typography.machine(12)).foregroundStyle(Palette.waiting)
                 }
             }
-            .padding()
-        } else if loading {
-            ProgressView().tint(Palette.accent)
-        } else if agents.isEmpty {
-            Text("no agents")
-                .font(.system(.body, design: .monospaced))
-                .foregroundStyle(Palette.dim)
-        } else {
-            List(agents) { agent in
-                NavigationLink {
-                    TerminalPaneView(client: client, paneID: agent.paneID, title: agent.displayName)
-                } label: {
-                    HStack(spacing: 10) {
-                        Circle()
-                            .fill(agent.isWorking ? Palette.accent : Palette.dim)
-                            .frame(width: 8, height: 8)
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text(agent.displayName)
-                                .font(.system(.body, design: .monospaced))
-                                .foregroundStyle(Palette.text)
-                            Text(agent.paneID)
-                                .font(.caption)
-                                .foregroundStyle(Palette.dim)
-                        }
-                    }
-                }
-                .listRowBackground(Palette.surface)
-            }
-            .scrollContentBackground(.hidden)
+            Spacer()
+            circleButton("plus") { }   // new-agent screen (04) is not built yet
         }
+        .padding(.horizontal, 16).padding(.top, 8).padding(.bottom, 10)
+    }
+
+    private func circleButton(_ system: String, _ action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Image(systemName: system)
+                .font(.system(size: 15, weight: .medium))
+                .foregroundStyle(Palette.textDim)
+                .frame(width: 36, height: 36)
+                .background(Palette.surface)
+                .clipShape(Circle())
+        }
+    }
+
+    private var searchField: some View {
+        TextField("Search", text: $search)
+            .font(Typography.app(15)).foregroundStyle(Palette.text)
+            .textInputAutocapitalization(.never).autocorrectionDisabled()
+            .padding(.horizontal, 16).padding(.vertical, 11)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(Palette.surface)
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+            .padding(.horizontal, 16).padding(.top, 4).padding(.bottom, 4)
+    }
+
+    private var tabBar: some View {
+        HStack(spacing: 4) {
+            tabItem("square.grid.2x2.fill", "Agents", active: true)
+            tabItem("terminal", "Terminal", active: false)
+            tabItem("gearshape", "Settings", active: false)
+        }
+        .padding(6)
+        .background(Palette.surface)
+        .clipShape(RoundedRectangle(cornerRadius: 22))
+        .padding(.horizontal, 36).padding(.bottom, 4)
+    }
+
+    private func tabItem(_ system: String, _ label: String, active: Bool) -> some View {
+        VStack(spacing: 3) {
+            Image(systemName: system).font(.system(size: 16, weight: .medium))
+            Text(label).font(Typography.app(11, active ? .semibold : .regular))
+        }
+        .foregroundStyle(active ? Palette.text : Palette.textFaint)
+        .frame(maxWidth: .infinity).padding(.vertical, 8)
+        .background(active ? Palette.card : Color.clear)
+        .clipShape(RoundedRectangle(cornerRadius: 16))
+    }
+
+    // MARK: list
+
+    private var agentList: some View {
+        ScrollView {
+            searchField
+            if agents.isEmpty {
+                Text("no agents").font(Typography.app(15)).foregroundStyle(Palette.textDim).padding(.top, 44)
+            } else {
+                ForEach(groups, id: \.state) { group in
+                    section(group.state, group.agents)
+                }
+            }
+        }
+    }
+
+    private func section(_ state: AgentState, _ items: [AgentInfo]) -> some View {
+        let isCollapsed = collapsed.contains(state)
+        return VStack(alignment: .leading, spacing: 6) {
+            Button {
+                if isCollapsed { collapsed.remove(state) } else { collapsed.insert(state) }
+            } label: {
+                HStack(spacing: 8) {
+                    // Count is shown when collapsed (so hidden work is legible);
+                    // an expanded section speaks for itself through its cards.
+                    Text(isCollapsed ? "\(state.sectionTitle) · \(items.count)" : state.sectionTitle)
+                        .font(Typography.microLabel).tracking(1.2).foregroundStyle(Palette.textFaint)
+                    Image(systemName: isCollapsed ? "chevron.right" : "chevron.down")
+                        .font(.system(size: 9, weight: .semibold)).foregroundStyle(Palette.textFaint)
+                    Rectangle().fill(Palette.hairline).frame(height: 1)
+                }
+            }
+            .buttonStyle(.plain)
+            .padding(.horizontal, 16).padding(.top, 10)
+
+            if !isCollapsed {
+                ForEach(items) { agent in
+                    NavigationLink {
+                        TerminalPaneView(client: client, paneID: agent.paneID, title: agent.displayName)
+                    } label: {
+                        card(agent, state)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        }
+    }
+
+    private func card(_ agent: AgentInfo, _ state: AgentState) -> some View {
+        HStack(spacing: 12) {
+            ZStack {
+                RoundedRectangle(cornerRadius: 10).fill(AgentIdentity.gradient(for: agent.agent))
+                    .frame(width: 40, height: 40)
+                Text(AgentIdentity.glyph(for: agent.agent))
+                    .font(Typography.app(18, .bold)).foregroundStyle(.white)
+            }
+            VStack(alignment: .leading, spacing: 3) {
+                Text(agent.displayName).font(Typography.app(16, .semibold)).foregroundStyle(Palette.text)
+                Text(agent.terminalTitleStripped ?? agent.paneID)
+                    .font(Typography.machine(12)).foregroundStyle(Palette.textDim).lineLimit(1)
+            }
+            Spacer(minLength: 8)
+            statusBadge(state)
+        }
+        .padding(12)
+        .background(Palette.card)
+        .clipShape(RoundedRectangle(cornerRadius: 14))
+        .padding(.horizontal, 16).padding(.vertical, 4)
+    }
+
+    @ViewBuilder
+    private func statusBadge(_ state: AgentState) -> some View {
+        switch state {
+        case .needsYou: badgeCircle("exclamationmark", Palette.waiting)
+        case .stopped: badgeCircle("xmark", Palette.died)
+        case .working: Text("now").font(Typography.machine(12)).foregroundStyle(Palette.working)
+        case .done: badgeCircle("checkmark", Palette.done)
+        case .idle: EmptyView()
+        }
+    }
+
+    private func badgeCircle(_ system: String, _ color: Color) -> some View {
+        Image(systemName: system)
+            .font(.system(size: 11, weight: .bold)).foregroundStyle(color)
+            .frame(width: 26, height: 26)
+            .overlay(Circle().stroke(color.opacity(0.55), lineWidth: 1.5))
+    }
+
+    // MARK: error / host-key recovery (functional, restyled to the tokens)
+
+    @ViewBuilder
+    private func errorView(_ error: String) -> some View {
+        Spacer()
+        VStack(spacing: 14) {
+            Text(error).font(Typography.machine(13)).foregroundStyle(Palette.died)
+                .multilineTextAlignment(.center)
+            if let fingerprint = rejectedFingerprint {
+                VStack(spacing: 8) {
+                    Text("the host key changed. the server now presents:")
+                        .font(Typography.app(12)).foregroundStyle(Palette.textDim)
+                    Text(fingerprint).font(Typography.machine(11)).foregroundStyle(Palette.text)
+                        .textSelection(.enabled).multilineTextAlignment(.center)
+                    Text("trust it ONLY if this exactly matches the key you verified out of band.")
+                        .font(Typography.app(12)).foregroundStyle(Palette.textDim).multilineTextAlignment(.center)
+                }
+                Button("trust this key & reconnect") { trustFailed = !onTrustHostKey(fingerprint) }
+                    .font(Typography.app(15, .semibold)).foregroundStyle(Palette.died)
+                if trustFailed {
+                    Text("could not save the verified key to the keychain — not reconnecting. try again.")
+                        .font(Typography.app(12)).foregroundStyle(Palette.died).multilineTextAlignment(.center)
+                }
+            }
+            if rejectedFingerprint == nil {
+                Button("retry") { Task { await load() } }
+                    .font(Typography.app(15, .semibold)).foregroundStyle(Palette.working)
+            }
+        }
+        .padding(24)
+        Spacer()
     }
 
     private func load() async {
@@ -486,7 +615,7 @@ struct TerminalPaneView: View {
 
     var body: some View {
         ZStack {
-            Palette.bg.ignoresSafeArea()
+            Palette.ground.ignoresSafeArea()
             GeometryReader { geo in
                 // Fold from the SETTLED layout width, but cache the result: re-fold
                 // ONLY when the width or the text changes (below), not on every body
@@ -523,7 +652,7 @@ struct TerminalPaneView: View {
             Button {
                 Task { await refresh() }
             } label: {
-                Image(systemName: "arrow.clockwise").foregroundStyle(Palette.accent)
+                Image(systemName: "arrow.clockwise").foregroundStyle(Palette.working)
             }
         }
     }
@@ -584,14 +713,19 @@ struct MockTransport: HerdrTransport {
 
     static let agentList = #"""
     {"id":"mock","result":{"type":"agent_list","agents":[
-      {"pane_id":"w1:p1","name":"jarvis","agent":"claude","agent_status":"working","terminal_title_stripped":"omp-runtime-adapter"},
-      {"pane_id":"w1:p2","name":"herdr-app","agent":"claude","agent_status":"done","terminal_title_stripped":"citadel-transport"},
-      {"pane_id":"w2:p1","name":"trend-scout","agent":"codex","agent_status":"idle","terminal_title_stripped":"digest-pipeline"}
+      {"pane_id":"w1:p1","name":"codex","agent":"codex","agent_status":"input_pending","terminal_title_stripped":"herdr-ios · asking to run tests"},
+      {"pane_id":"w1:p2","name":"claude","agent":"claude","agent_status":"waiting","terminal_title_stripped":"vetrina · overwrite config.ts?"},
+      {"pane_id":"w2:p1","name":"codex","agent":"codex","agent_status":"exited","terminal_title_stripped":"trend-scout · exited, code 1"},
+      {"pane_id":"w2:p2","name":"claude","agent":"claude","agent_status":"working","terminal_title_stripped":"herdr · editing src/acp.rs"},
+      {"pane_id":"w3:p1","name":"claude","agent":"claude","agent_status":"idle","terminal_title_stripped":"clientloop · amigo-poc scaffold"},
+      {"pane_id":"w3:p2","name":"codex","agent":"codex","agent_status":"idle","terminal_title_stripped":"aste-screener · apify-harvest"},
+      {"pane_id":"w4:p1","name":"gemini","agent":"gemini","agent_status":"idle","terminal_title_stripped":"discovery · redaction-pass v3"},
+      {"pane_id":"w4:p2","name":"claude","agent":"claude","agent_status":"idle","terminal_title_stripped":"bank-qa · deal-assistant rag"}
     ]}}
     """#
 
     static let agentRead = #"""
-    {"id":"mock","result":{"read":{"pane_id":"w1:p1","text":"$ herdr agent list\n3 agents running\n\n* jarvis      working   omp-runtime-adapter\n* herdr-app   done      citadel-transport\n* trend-scout idle      digest-pipeline\n\n[demo data - mock render mode, no live connection]","truncated":false,"source":"recent_unwrapped","format":"text"}}}
+    {"id":"mock","result":{"read":{"pane_id":"w1:p1","text":"$ herdr agent attach codex\n\n> may I run `just test` on herdr-ios?\n  177 tests, ~30s, no network\n\n  [y] allow   [n] deny   [a] always\n\n[demo data - mock render mode, no live connection]","truncated":false,"source":"recent_unwrapped","format":"text"}}}
     """#
 }
 #endif

--- a/Tests/HerdrKitTests/MockWireFixtureTests.swift
+++ b/Tests/HerdrKitTests/MockWireFixtureTests.swift
@@ -20,29 +20,51 @@ final class MockWireFixtureTests: XCTestCase {
         }
     }
 
-    func testMockAgentListDecodesAllStates() async throws {
+    func testMockAgentListDecodesRealisticStatuses() async throws {
         let client = HerdrClient(transport: FixtureTransport())
         let agents = try await client.agentList()
-        // The redesigned list groups by status, so the fixture must carry every
-        // section: needs-you, stopped, working, done, idle.
         XCTAssertEqual(agents.count, 8, "mock agent.list did not decode to 8 agents")
         XCTAssertEqual(agents.first?.paneID, "w1:p1")
         XCTAssertEqual(agents.first?.displayName, "codex")
-        XCTAssertEqual(agents.first?.agentStatus, "input_pending",
-                       "first mock agent should be blocked-on-you, driving the NEEDS YOU section")
-        XCTAssertFalse(agents.first?.isWorking ?? true, "a blocked agent is not working")
+        XCTAssertEqual(agents.first?.agentStatus, "blocked",
+                       "first mock agent should be blocked (drives NEEDS YOU)")
 
-        let statuses = Set(agents.compactMap { $0.agentStatus })
-        // One representative from each section the mockup renders: 2 needs-you
-        // (input_pending + waiting), 1 stopped (exited), 1 working, 4 idle.
-        for expected in ["input_pending", "waiting", "exited", "working", "idle"] {
-            XCTAssertTrue(statuses.contains(expected),
-                          "fixture missing an agent with agent_status \(expected)")
+        // Every status here must be a real herdr wire value, or it would decode
+        // as .unrecognised and the mock would render a section the mockup lacks.
+        let known: Set = ["idle", "working", "blocked", "done", "unknown"]
+        for agent in agents {
+            let status = agent.agentStatus ?? "idle"
+            XCTAssertTrue(known.contains(status),
+                          "fixture uses a non-herdr status \(status); it would land in UNRECOGNISED")
         }
-        XCTAssertEqual(agents.filter { $0.agentStatus == "idle" }.count, 4,
-                       "mockup composition is IDLE · 4")
-        XCTAssertEqual(agents.filter { $0.isWorking }.count, 1,
-                       "only the literal \"working\" agent should read as working")
+    }
+
+    /// The whole point of the fixture: rendered through the REAL grouping model
+    /// with the mock census, it must produce the mockup's composition —
+    /// NEEDS YOU 2, STOPPED 1 (from liveness, not a status string), WORKING 1,
+    /// IDLE 4 (done folded in). A regression in fixture OR model trips here.
+    func testMockRendersMockupComposition() async throws {
+        let client = HerdrClient(transport: FixtureTransport())
+        let agents = try await client.agentList()
+        let list = AgentList(agents: agents, livePaneIDs: MockWireFixtures.demoLivePaneIDs)
+
+        XCTAssertEqual(list.sections.map(\.group),
+                       [.needsYou, .stopped, .working, .idle],
+                       "sections did not render in the mockup's order/composition")
+        let counts = Dictionary(uniqueKeysWithValues: list.sections.map { ($0.group, $0.rows.count) })
+        XCTAssertEqual(counts[.needsYou], 2)
+        XCTAssertEqual(counts[.stopped], 1)
+        XCTAssertEqual(counts[.working], 1)
+        XCTAssertEqual(counts[.idle], 4, "the done agent should fold into idle, making IDLE · 4")
+        XCTAssertEqual(list.needsYouCount, 2, "header would show the wrong 'N need you'")
+
+        // STOPPED must come from liveness: w2:p1 is the excluded pane, and its
+        // status string is a quiet 'idle' — so if it shows as stopped, that is
+        // the census talking, which is the behaviour under test.
+        let stopped = try XCTUnwrap(list.sections.first { $0.group == .stopped }).rows
+        XCTAssertEqual(stopped.map(\.info.paneID), ["w2:p1"])
+        XCTAssertEqual(stopped.first?.status, .idle,
+                       "premise: the stopped row's own status is idle; only the census makes it stopped")
     }
 
     func testMockReadDecodesPaneText() async throws {
@@ -59,16 +81,22 @@ final class MockWireFixtureTests: XCTestCase {
 enum MockWireFixtures {
     static let agentList = #"""
     {"id":"mock","result":{"type":"agent_list","agents":[
-      {"pane_id":"w1:p1","name":"codex","agent":"codex","agent_status":"input_pending","terminal_title_stripped":"herdr-ios · asking to run tests"},
-      {"pane_id":"w1:p2","name":"claude","agent":"claude","agent_status":"waiting","terminal_title_stripped":"vetrina · overwrite config.ts?"},
-      {"pane_id":"w2:p1","name":"codex","agent":"codex","agent_status":"exited","terminal_title_stripped":"trend-scout · exited, code 1"},
+      {"pane_id":"w1:p1","name":"codex","agent":"codex","agent_status":"blocked","terminal_title_stripped":"herdr-ios · asking to run tests"},
+      {"pane_id":"w1:p2","name":"claude","agent":"claude","agent_status":"blocked","terminal_title_stripped":"vetrina · overwrite config.ts?"},
+      {"pane_id":"w2:p1","name":"codex","agent":"codex","agent_status":"idle","terminal_title_stripped":"trend-scout · exited, code 1"},
       {"pane_id":"w2:p2","name":"claude","agent":"claude","agent_status":"working","terminal_title_stripped":"herdr · editing src/acp.rs"},
       {"pane_id":"w3:p1","name":"claude","agent":"claude","agent_status":"idle","terminal_title_stripped":"clientloop · amigo-poc scaffold"},
       {"pane_id":"w3:p2","name":"codex","agent":"codex","agent_status":"idle","terminal_title_stripped":"aste-screener · apify-harvest"},
       {"pane_id":"w4:p1","name":"gemini","agent":"gemini","agent_status":"idle","terminal_title_stripped":"discovery · redaction-pass v3"},
-      {"pane_id":"w4:p2","name":"claude","agent":"claude","agent_status":"idle","terminal_title_stripped":"bank-qa · deal-assistant rag"}
+      {"pane_id":"w4:p2","name":"claude","agent":"claude","agent_status":"done","terminal_title_stripped":"bank-qa · deal-assistant rag"}
     ]}}
     """#
+
+    /// The census the App's mock render passes (MockTransport.demoLivePaneIDs).
+    /// Excludes w2:p1 so it groups STOPPED via liveness. Keep in sync with the App.
+    static let demoLivePaneIDs: Set<String> = [
+        "w1:p1", "w1:p2", "w2:p2", "w3:p1", "w3:p2", "w4:p1", "w4:p2",
+    ]
 
     static let agentRead = #"""
     {"id":"mock","result":{"read":{"pane_id":"w1:p1","text":"$ herdr agent attach codex\n\n> may I run `just test` on herdr-ios?\n  177 tests, ~30s, no network\n\n  [y] allow   [n] deny   [a] always\n\n[demo data - mock render mode, no live connection]","truncated":false,"source":"recent_unwrapped","format":"text"}}}

--- a/Tests/HerdrKitTests/MockWireFixtureTests.swift
+++ b/Tests/HerdrKitTests/MockWireFixtureTests.swift
@@ -25,7 +25,11 @@ final class MockWireFixtureTests: XCTestCase {
         let agents = try await client.agentList()
         XCTAssertEqual(agents.count, 8, "mock agent.list did not decode to 8 agents")
         XCTAssertEqual(agents.first?.paneID, "w1:p1")
-        XCTAssertEqual(agents.first?.displayName, "codex")
+        XCTAssertEqual(agents.first?.displayName, "jarvis",
+                       "the card headlines the assigned name; fixtures must carry distinct names")
+        XCTAssertEqual(agents.first?.agent, "claude", "the identity icon is keyed on the kind, not the name")
+        XCTAssertEqual(agents.first?.cwd, "/root/herdr-ios",
+                       "cwd must decode — the card subtitle composes folder from it")
         XCTAssertEqual(agents.first?.agentStatus, "blocked",
                        "first mock agent should be blocked (drives NEEDS YOU)")
 
@@ -81,14 +85,14 @@ final class MockWireFixtureTests: XCTestCase {
 enum MockWireFixtures {
     static let agentList = #"""
     {"id":"mock","result":{"type":"agent_list","agents":[
-      {"pane_id":"w1:p1","name":"codex","agent":"codex","agent_status":"blocked","terminal_title_stripped":"herdr-ios · asking to run tests"},
-      {"pane_id":"w1:p2","name":"claude","agent":"claude","agent_status":"blocked","terminal_title_stripped":"vetrina · overwrite config.ts?"},
-      {"pane_id":"w2:p1","name":"codex","agent":"codex","agent_status":"idle","terminal_title_stripped":"trend-scout · exited, code 1"},
-      {"pane_id":"w2:p2","name":"claude","agent":"claude","agent_status":"working","terminal_title_stripped":"herdr · editing src/acp.rs"},
-      {"pane_id":"w3:p1","name":"claude","agent":"claude","agent_status":"idle","terminal_title_stripped":"clientloop · amigo-poc scaffold"},
-      {"pane_id":"w3:p2","name":"codex","agent":"codex","agent_status":"idle","terminal_title_stripped":"aste-screener · apify-harvest"},
-      {"pane_id":"w4:p1","name":"gemini","agent":"gemini","agent_status":"idle","terminal_title_stripped":"discovery · redaction-pass v3"},
-      {"pane_id":"w4:p2","name":"claude","agent":"claude","agent_status":"done","terminal_title_stripped":"bank-qa · deal-assistant rag"}
+      {"pane_id":"w1:p1","name":"jarvis","agent":"claude","agent_status":"blocked","cwd":"/root/herdr-ios","terminal_title_stripped":"asking to run tests"},
+      {"pane_id":"w1:p2","name":"vetrina","agent":"codex","agent_status":"blocked","cwd":"/root/vetrina","terminal_title_stripped":"overwrite config.ts?"},
+      {"pane_id":"w2:p1","name":"trend-scout","agent":"codex","agent_status":"idle","cwd":"/root/trend-scout","terminal_title_stripped":"exited, code 1"},
+      {"pane_id":"w2:p2","name":"herdr-app","agent":"claude","agent_status":"working","cwd":"/root/herdr","terminal_title_stripped":"editing src/acp.rs"},
+      {"pane_id":"w3:p1","name":"clientloop","agent":"claude","agent_status":"idle","cwd":"/root/clientloop","terminal_title_stripped":"amigo-poc scaffold"},
+      {"pane_id":"w3:p2","name":"aste-screener","agent":"codex","agent_status":"idle","cwd":"/root/aste-screener","terminal_title_stripped":"apify-harvest"},
+      {"pane_id":"w4:p1","name":"discovery","agent":"gemini","agent_status":"idle","cwd":"/root/discovery-calls","terminal_title_stripped":"redaction-pass v3"},
+      {"pane_id":"w4:p2","name":"bank-qa","agent":"claude","agent_status":"done","cwd":"/root/bank-qa","terminal_title_stripped":"deal-assistant rag"}
     ]}}
     """#
 
@@ -99,6 +103,6 @@ enum MockWireFixtures {
     ]
 
     static let agentRead = #"""
-    {"id":"mock","result":{"read":{"pane_id":"w1:p1","text":"$ herdr agent attach codex\n\n> may I run `just test` on herdr-ios?\n  177 tests, ~30s, no network\n\n  [y] allow   [n] deny   [a] always\n\n[demo data - mock render mode, no live connection]","truncated":false,"source":"recent_unwrapped","format":"text"}}}
+    {"id":"mock","result":{"read":{"pane_id":"w1:p1","text":"$ herdr agent attach jarvis\n\n> may I run `just test` on herdr-ios?\n  177 tests, ~30s, no network\n\n  [y] allow   [n] deny   [a] always\n\n[demo data - mock render mode, no live connection]","truncated":false,"source":"recent_unwrapped","format":"text"}}}
     """#
 }

--- a/Tests/HerdrKitTests/MockWireFixtureTests.swift
+++ b/Tests/HerdrKitTests/MockWireFixtureTests.swift
@@ -20,13 +20,29 @@ final class MockWireFixtureTests: XCTestCase {
         }
     }
 
-    func testMockAgentListDecodesToThreeAgents() async throws {
+    func testMockAgentListDecodesAllStates() async throws {
         let client = HerdrClient(transport: FixtureTransport())
         let agents = try await client.agentList()
-        XCTAssertEqual(agents.count, 3, "mock agent.list did not decode to 3 agents")
+        // The redesigned list groups by status, so the fixture must carry every
+        // section: needs-you, stopped, working, done, idle.
+        XCTAssertEqual(agents.count, 8, "mock agent.list did not decode to 8 agents")
         XCTAssertEqual(agents.first?.paneID, "w1:p1")
-        XCTAssertEqual(agents.first?.displayName, "jarvis")
-        XCTAssertTrue(agents.first?.isWorking ?? false, "first mock agent should read as working")
+        XCTAssertEqual(agents.first?.displayName, "codex")
+        XCTAssertEqual(agents.first?.agentStatus, "input_pending",
+                       "first mock agent should be blocked-on-you, driving the NEEDS YOU section")
+        XCTAssertFalse(agents.first?.isWorking ?? true, "a blocked agent is not working")
+
+        let statuses = Set(agents.compactMap { $0.agentStatus })
+        // One representative from each section the mockup renders: 2 needs-you
+        // (input_pending + waiting), 1 stopped (exited), 1 working, 4 idle.
+        for expected in ["input_pending", "waiting", "exited", "working", "idle"] {
+            XCTAssertTrue(statuses.contains(expected),
+                          "fixture missing an agent with agent_status \(expected)")
+        }
+        XCTAssertEqual(agents.filter { $0.agentStatus == "idle" }.count, 4,
+                       "mockup composition is IDLE · 4")
+        XCTAssertEqual(agents.filter { $0.isWorking }.count, 1,
+                       "only the literal \"working\" agent should read as working")
     }
 
     func testMockReadDecodesPaneText() async throws {
@@ -43,13 +59,18 @@ final class MockWireFixtureTests: XCTestCase {
 enum MockWireFixtures {
     static let agentList = #"""
     {"id":"mock","result":{"type":"agent_list","agents":[
-      {"pane_id":"w1:p1","name":"jarvis","agent":"claude","agent_status":"working","terminal_title_stripped":"omp-runtime-adapter"},
-      {"pane_id":"w1:p2","name":"herdr-app","agent":"claude","agent_status":"done","terminal_title_stripped":"citadel-transport"},
-      {"pane_id":"w2:p1","name":"trend-scout","agent":"codex","agent_status":"idle","terminal_title_stripped":"digest-pipeline"}
+      {"pane_id":"w1:p1","name":"codex","agent":"codex","agent_status":"input_pending","terminal_title_stripped":"herdr-ios · asking to run tests"},
+      {"pane_id":"w1:p2","name":"claude","agent":"claude","agent_status":"waiting","terminal_title_stripped":"vetrina · overwrite config.ts?"},
+      {"pane_id":"w2:p1","name":"codex","agent":"codex","agent_status":"exited","terminal_title_stripped":"trend-scout · exited, code 1"},
+      {"pane_id":"w2:p2","name":"claude","agent":"claude","agent_status":"working","terminal_title_stripped":"herdr · editing src/acp.rs"},
+      {"pane_id":"w3:p1","name":"claude","agent":"claude","agent_status":"idle","terminal_title_stripped":"clientloop · amigo-poc scaffold"},
+      {"pane_id":"w3:p2","name":"codex","agent":"codex","agent_status":"idle","terminal_title_stripped":"aste-screener · apify-harvest"},
+      {"pane_id":"w4:p1","name":"gemini","agent":"gemini","agent_status":"idle","terminal_title_stripped":"discovery · redaction-pass v3"},
+      {"pane_id":"w4:p2","name":"claude","agent":"claude","agent_status":"idle","terminal_title_stripped":"bank-qa · deal-assistant rag"}
     ]}}
     """#
 
     static let agentRead = #"""
-    {"id":"mock","result":{"read":{"pane_id":"w1:p1","text":"$ herdr agent list\n3 agents running\n\n* jarvis      working   omp-runtime-adapter\n* herdr-app   done      citadel-transport\n* trend-scout idle      digest-pipeline\n\n[demo data - mock render mode, no live connection]","truncated":false,"source":"recent_unwrapped","format":"text"}}}
+    {"id":"mock","result":{"read":{"pane_id":"w1:p1","text":"$ herdr agent attach codex\n\n> may I run `just test` on herdr-ios?\n  177 tests, ~30s, no network\n\n  [y] allow   [n] deny   [a] always\n\n[demo data - mock render mode, no live connection]","truncated":false,"source":"recent_unwrapped","format":"text"}}}
     """#
 }

--- a/project.yml
+++ b/project.yml
@@ -55,3 +55,10 @@ targets:
         SWIFT_VERSION: "5.9"
         GENERATE_INFOPLIST_FILE: NO
         TARGETED_DEVICE_FAMILY: "1"
+      configs:
+        # VERIFICATION SCAFFOLD — REMOVE BEFORE MERGE. Defines SCREENSHOT_MOCK_DEFAULT
+        # so the buildbox's plain Debug launch boots into the mock list (mock data,
+        # no key) and can screenshot the redesign. main's Debug build must NOT carry
+        # this — it should boot to ConnectView. Paired with ScreenshotMock.mode.
+        Debug:
+          SWIFT_ACTIVE_COMPILATION_CONDITIONS: DEBUG SCREENSHOT_MOCK_DEFAULT

--- a/project.yml
+++ b/project.yml
@@ -55,10 +55,3 @@ targets:
         SWIFT_VERSION: "5.9"
         GENERATE_INFOPLIST_FILE: NO
         TARGETED_DEVICE_FAMILY: "1"
-      configs:
-        # VERIFICATION SCAFFOLD — REMOVE BEFORE MERGE. Defines SCREENSHOT_MOCK_DEFAULT
-        # so the buildbox's plain Debug launch boots into the mock list (mock data,
-        # no key) and can screenshot the redesign. main's Debug build must NOT carry
-        # this — it should boot to ConnectView. Paired with ScreenshotMock.mode.
-        Debug:
-          SWIFT_ACTIVE_COMPILATION_CONDITIONS: DEBUG SCREENSHOT_MOCK_DEFAULT


### PR DESCRIPTION
Applies the Claude Design kit to the agent-list screen (screen 02, the app's hero) — the first screen of the 5-screen design pass the owner greenlit ("the app is not nearly similar to the design files").

## What changed
- **Renders through HerdrKit's tested `AgentList`/`AgentGroup` model**, not an ad-hoc classifier: stopped-from-liveness, unknown statuses surfaced (fail-closed), stable pane-ID order, the fixed 4-group order. This was both reviewers' top finding on the first pass.
- Navy ground; gradient identity chips (claude magenta ✱ / codex orange C / gemini indigo ✦); status-grouped sections (NEEDS YOU / STOPPED / WORKING / IDLE); right-edge badges. **Colour = meaning**: amber = needs you, red = died, blue = working; blue is *only* "working" now (pulled the decorative accent from the wordmark/connect-button/retry/refresh).
- Card headlines the agent's **name**; the icon carries the kind. `folder · activity` subtitle from `cwd`. Header "N need you" / "nothing needs you". Search (pinned), collapsible sections, bottom tab bar.
- New `App/DesignSystem.swift` holds the tokens (Palette / Typography / AgentGroup visual extension / AgentIdentity).

## Verification
- **Two distinct-runtime reviews folded** — codex + omp (never blocked on kimi quota). codex's "won't compile / Hashable" was a false positive the buildbox refuted (raw-value enums synthesize Hashable); every real finding addressed.
- **Buildbox green** (Debug simulator, `BUILD SUCCEEDED`) and the mock-render screenshot verified against `mockups/02-agent-list.png` — sent to the owner.
- **178 Linux tests green** (`swift test -Xswiftc -warnings-as-errors`), incl. a new test pinning that the mock fixture renders the exact mockup composition through the real model.
- The screenshot scaffold (`SCREENSHOT_MOCK_DEFAULT`, Debug-only) was reverted before this head — no shipping behavior change.

Head: e844795. Deferred with intent: Dynamic-Type scaling (arrives with the Geist/IBM Plex Mono bundling), swipe-to-dismiss / pull-to-refresh (later interaction pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)