### PR TITLE
Design pass: connect (01) + terminal (03) screens

### DIFF
--- a/App/DesignSystem.swift
+++ b/App/DesignSystem.swift
@@ -26,6 +26,11 @@ enum Palette {
     static let textDim = Color(hex: 0x99A0BC)      // secondary
     static let textFaint = Color(hex: 0x7C83A6)    // tertiary / micro-labels (≥4.5:1 on ground)
 
+    // The app's ONE interactive/brand colour — violet. Not a status meaning; it
+    // marks the primary action (Connect CTA) and the active tab, matching the
+    // mockups. Distinct from the working blue so colour-as-meaning stays intact.
+    static let brand = Color(hex: 0x7A6FF0)
+
     // Status = meaning. The ONLY palette that carries colour.
     static let waiting = Color(hex: 0xE9A63C)      // amber — an agent is asking you
     static let died = Color(hex: 0xE2584E)         // red — exited / crashed

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -262,10 +262,17 @@ struct ConnectView: View {
     @State private var showingKeySheet = false
 
     // Host accepts "host" or "host:port" (and "[ipv6]:port"); the port lives in
-    // the one field so the form stays the three rows the mockup shows.
-    private var hostPort: (host: String, port: UInt16) { Self.parseHostPort(host) }
+    // the one field so the form stays the three rows the mockup shows. Parsing is
+    // HerdrKit's HostEndpoint (Linux-tested); an explicit bad port yields nil, so
+    // it is rejected here rather than silently connecting to :22.
+    private var endpoint: HostEndpoint? { HostEndpoint.parse(host) }
+    private var trimmedUser: String { username.trimmingCharacters(in: .whitespacesAndNewlines) }
+    private var trimmedKey: String { keyPEM.trimmingCharacters(in: .whitespacesAndNewlines) }
+    private var hostInvalid: Bool {
+        !host.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && endpoint == nil
+    }
     private var canConnect: Bool {
-        !hostPort.host.isEmpty && !username.trimmingCharacters(in: .whitespaces).isEmpty && !keyPEM.isEmpty
+        endpoint != nil && !trimmedUser.isEmpty && !trimmedKey.isEmpty
     }
 
     var body: some View {
@@ -281,15 +288,20 @@ struct ConnectView: View {
                     // The three settings-style rows: label left, value right.
                     VStack(spacing: 10) {
                         fieldRow("Host", text: $host, placeholder: "mac.tail-scale.ts.net")
+                        if hostInvalid {
+                            Text("check host or host:port")
+                                .font(Typography.app(12)).foregroundStyle(Palette.died)
+                                .frame(maxWidth: .infinity, alignment: .leading).padding(.horizontal, 4)
+                        }
                         fieldRow("User", text: $username, placeholder: "jerry")
                         keyRow
                     }
 
                     Button {
-                        let hp = hostPort
+                        guard let ep = endpoint else { return }
                         onConnect(SSHCredentials(
-                            host: hp.host, port: hp.port,
-                            username: username.trimmingCharacters(in: .whitespacesAndNewlines),
+                            host: ep.host, port: ep.port,
+                            username: trimmedUser,
                             privateKeyPEM: keyPEM, remoteSocketPath: ""))
                     } label: {
                         Text("Connect")
@@ -373,21 +385,6 @@ struct ConnectView: View {
                 Button("Done") { showingKeySheet = false }.foregroundStyle(Palette.brand)
             } }
         }
-    }
-
-    /// "host" | "host:port" | "[ipv6]:port" → (host, port). Defaults to 22.
-    static func parseHostPort(_ raw: String) -> (host: String, port: UInt16) {
-        let s = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-        if s.hasPrefix("["), let close = s.firstIndex(of: "]") {
-            let inner = String(s[s.index(after: s.startIndex)..<close])
-            let rest = s[s.index(after: close)...]
-            if rest.hasPrefix(":"), let p = UInt16(rest.dropFirst()), p >= 1 { return (inner, p) }
-            return (inner, 22)
-        }
-        // Exactly one colon splits host:port; a bare IPv6 (many colons) stays whole.
-        let parts = s.split(separator: ":", omittingEmptySubsequences: false)
-        if parts.count == 2, let p = UInt16(parts[1]), p >= 1 { return (String(parts[0]), p) }
-        return (s, 22)
     }
 }
 
@@ -756,7 +753,6 @@ struct TerminalPaneView: View {
                     Text(note).font(Typography.app(12)).foregroundStyle(Palette.textDim)
                         .frame(maxWidth: .infinity, alignment: .leading).padding(.horizontal, 16).padding(.vertical, 4)
                 }
-                if group == .needsYou { approveReject }
                 controlBar
                 replyBar
             }
@@ -769,12 +765,11 @@ struct TerminalPaneView: View {
 
     private var header: some View {
         VStack(spacing: 8) {
-            HStack {
+            HStack(spacing: 12) {
                 Button { dismiss() } label: {
                     Image(systemName: "chevron.left").font(.system(size: 16, weight: .semibold))
                         .foregroundStyle(Palette.textDim)
                 }
-                Spacer()
                 Text(heading).font(Typography.app(16, .semibold)).foregroundStyle(Palette.text).lineLimit(1)
                 Spacer()
                 Button { Task { await refresh() } } label: {
@@ -827,26 +822,11 @@ struct TerminalPaneView: View {
 
     // MARK: input
 
-    /// Only for a blocked agent. Approve/Reject answer the numbered choice the
-    /// pane is showing (1 / 2); in intent mode that submits, in rawKeys it types
-    /// and the reader presses Enter — the deliberate second action.
-    private var approveReject: some View {
-        HStack(spacing: 10) {
-            Button { send(.submitText("1")) } label: {
-                actionLabel("Approve", .white, Palette.brand)
-            }.disabled(sending)
-            Button { send(.submitText("2")) } label: {
-                actionLabel("Reject", Palette.text, Palette.card)
-            }.disabled(sending)
-        }
-        .padding(.horizontal, 14).padding(.top, 6).padding(.bottom, 2)
-    }
-
-    private func actionLabel(_ text: String, _ fg: Color, _ bg: Color) -> some View {
-        Text(text).font(Typography.app(15, .semibold)).frame(maxWidth: .infinity).padding(.vertical, 13)
-            .background(bg).foregroundStyle(fg).clipShape(RoundedRectangle(cornerRadius: 12))
-    }
-
+    // No Approve/Reject buttons: a fixed "1"/"2" mapping assumes a two-option
+    // menu shape the server never guarantees, and both reviewers found it could
+    // submit the OPPOSITE of the label (a menu with a broader grant at 2). Until
+    // the option list is delivered as structured data, the reader answers by
+    // typing the choice and pressing Return — which is the safe, verifiable path.
     private var controlBar: some View {
         HStack(spacing: 6) {
             keyCap(label: "esc", key: "Escape")
@@ -855,20 +835,25 @@ struct TerminalPaneView: View {
             keyCap(symbol: "chevron.down", key: "Down")
             keyCap(symbol: "chevron.right", key: "Right")
             keyCap(label: "tab", key: "Tab")
+            // The submit affordance rawKeys needs — typing never submits, so
+            // Return is the deliberate second action. Highlighted, as the mockup
+            // shows it.
+            keyCap(symbol: "return", key: "Enter", primary: true)
         }
         .padding(.horizontal, 12).padding(.vertical, 8)
     }
 
-    private func keyCap(label: String? = nil, symbol: String? = nil, key: String) -> some View {
+    private func keyCap(label: String? = nil, symbol: String? = nil, key: String, primary: Bool = false) -> some View {
         Button { send(.key(key)) } label: {
             Group {
                 if let symbol { Image(systemName: symbol).font(.system(size: 12, weight: .semibold)) }
                 else { Text(label ?? key).font(Typography.machine(12)) }
             }
-            .foregroundStyle(Palette.textDim)
+            .foregroundStyle(primary ? .white : Palette.textDim)
             .frame(maxWidth: .infinity, minHeight: 34)
-            .background(Palette.surface).clipShape(RoundedRectangle(cornerRadius: 8))
+            .background(primary ? Palette.brand : Palette.surface).clipShape(RoundedRectangle(cornerRadius: 8))
         }
+        .disabled(sending)
         .accessibilityLabel(Text(key))
     }
 

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -339,7 +339,7 @@ struct ConnectView: View {
                 } else {
                     Text("ed25519 key").font(Typography.machine(15)).foregroundStyle(Palette.text)
                     Image(systemName: "checkmark").font(.system(size: 12, weight: .bold))
-                        .foregroundStyle(Palette.done)
+                        .foregroundStyle(Palette.text)   // white ✓, per the mockup (not a status colour)
                 }
             }
             .padding(.horizontal, 16).padding(.vertical, 14)

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -942,15 +942,7 @@ enum ScreenshotMock {
     static var mode: ScreenshotMock? {
         let env = ProcessInfo.processInfo.environment["HERDR_SCREENSHOT_MOCK"]?.lowercased()
         let arg = ProcessInfo.processInfo.arguments.contains("-herdrScreenshotMock")
-        #if SCREENSHOT_MOCK_DEFAULT
-        // VERIFICATION SCAFFOLD — REMOVE BEFORE MERGE. The buildbox launches the
-        // app with no env/args; this boots into the PANE mock so the terminal
-        // screen can be screenshotted. Debug-config-only (project.yml), mock data
-        // only — no key is ever rendered.
-        guard env != nil || arg else { return .pane }
-        #else
         guard env != nil || arg else { return nil }
-        #endif
         return env == "pane" ? .pane : .list
     }
 }

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -302,7 +302,10 @@ struct ConnectView: View {
                         onConnect(SSHCredentials(
                             host: ep.host, port: ep.port,
                             username: trimmedUser,
-                            privateKeyPEM: keyPEM, remoteSocketPath: ""))
+                            // Gated on trimmedKey, so send trimmedKey — a trailing
+                            // space/CR otherwise enables Connect then throws
+                            // InvalidOpenSSHBoundary in Citadel's parser.
+                            privateKeyPEM: trimmedKey, remoteSocketPath: ""))
                     } label: {
                         Text("Connect")
                             .font(Typography.app(16, .semibold))
@@ -708,10 +711,12 @@ struct TerminalHomeView: View {
 }
 
 /// One agent's pane: a styled header, the folded monospace output, and the input
-/// surface (Approve/Reject when the agent is blocked, a control-key row, a reply
-/// box). Input goes through HerdrKit's InputRouter so intent-mode prompts submit
-/// while shell/TUI keys pass through literally — the "send intent, not keystrokes"
-/// contract, not a raw byte pipe.
+/// surface (a control-key row with a Return cap, and a reply box). Input goes
+/// through HerdrKit's InputRouter so intent-mode prompts submit while shell/TUI
+/// keys pass through literally — the "send intent, not keystrokes" contract, not
+/// a raw byte pipe. Answering a blocked agent is by typing the choice + Return;
+/// there are deliberately no Approve/Reject buttons (a fixed 1/2 mapping cannot be
+/// verified against an agent-specific menu — structured menu actions are a follow-up).
 struct TerminalPaneView: View {
     let client: HerdrClient
     let paneID: String
@@ -993,8 +998,8 @@ struct MockTransport: HerdrTransport {
     """#
 
     /// A decoded blocked agent for the pane screenshot: status "blocked" groups
-    /// as NEEDS YOU, so the pane renders its status badge and Approve/Reject. No
-    /// composer field, so input falls to rawKeys — fine for a static shot.
+    /// as NEEDS YOU, so the pane renders its status badge. No composer field, so
+    /// input falls to rawKeys — fine for a static shot.
     static let demoPaneAgent: AgentInfo? = try? JSONDecoder().decode(
         AgentInfo.self,
         from: Data(#"{"pane_id":"w1:p1","name":"jarvis","agent":"claude","agent_status":"blocked","cwd":"/root/herdr-ios","terminal_title_stripped":"asking to run tests"}"#.utf8))

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -210,7 +210,8 @@ struct RootView: View {
                              livePaneIDs: MockTransport.demoLivePaneIDs)
         case .pane:
             NavigationStack {
-                TerminalPaneView(client: mockClient, paneID: "w1:p1", title: "jarvis")
+                TerminalPaneView(client: mockClient, paneID: "w1:p1", title: "jarvis",
+                                 agent: MockTransport.demoPaneAgent)
             }
         }
     }
@@ -578,7 +579,7 @@ struct TerminalHomeView: View {
             if !isCollapsed {
                 ForEach(rows) { row in
                     NavigationLink {
-                        TerminalPaneView(client: client, paneID: row.info.paneID, title: row.title)
+                        TerminalPaneView(client: client, paneID: row.info.paneID, title: row.title, agent: row.info)
                     } label: {
                         card(row)
                     }
@@ -709,65 +710,217 @@ struct TerminalHomeView: View {
     }
 }
 
-/// Reads a pane and renders it as folded monospace lines. Folds to the measured
-/// view width, and refresh reuses that same width.
+/// One agent's pane: a styled header, the folded monospace output, and the input
+/// surface (Approve/Reject when the agent is blocked, a control-key row, a reply
+/// box). Input goes through HerdrKit's InputRouter so intent-mode prompts submit
+/// while shell/TUI keys pass through literally — the "send intent, not keystrokes"
+/// contract, not a raw byte pipe.
 struct TerminalPaneView: View {
     let client: HerdrClient
     let paneID: String
     let title: String
+    /// The agent this pane hosts, when known (drives identity, status badge, and
+    /// input mode). Nil when opened without list context — input falls back to
+    /// rawKeys, the safe reading.
+    var agent: AgentInfo? = nil
 
+    @Environment(\.dismiss) private var dismiss
     @State private var rawText = ""
     @State private var lines: [String] = []
     @State private var error: String?
+    @State private var reply = ""
+    @State private var sending = false
+    @State private var actionNote: String?
+
+    private let router = InputRouter()
+
+    private var group: AgentGroup? { agent.map { AgentRow(info: $0).group } }
+    /// "kind · folder" for the header, e.g. "claude · herdr-ios".
+    private var heading: String {
+        let kind = agent?.agent ?? title
+        if let cwd = agent?.cwd {
+            let folder = URL(fileURLWithPath: cwd).lastPathComponent
+            if !folder.isEmpty && folder != "/" { return "\(kind) · \(folder)" }
+        }
+        return kind
+    }
+    private var canSend: Bool { !reply.trimmingCharacters(in: .whitespaces).isEmpty && !sending }
 
     var body: some View {
         ZStack {
             Palette.ground.ignoresSafeArea()
-            GeometryReader { geo in
-                // Fold from the SETTLED layout width, but cache the result: re-fold
-                // ONLY when the width or the text changes (below), not on every body
-                // evaluation — folding 200 lines each frame cost ~13ms during
-                // scroll. Reading the width in `.task` (an earlier bug) measured it
-                // before layout and over-wrapped at the ~20-col minimum.
-                let columns = columnCount(for: geo.size.width)
-                ScrollView {
-                    VStack(alignment: .leading, spacing: 0) {
-                        if let error {
-                            Text(error)
-                                .font(.system(.footnote, design: .monospaced))
-                                .foregroundStyle(.red)
-                        }
-                        ForEach(Array(lines.enumerated()), id: \.offset) { _, line in
-                            Text(line.isEmpty ? " " : line)
-                                .font(.system(.footnote, design: .monospaced))
-                                .foregroundStyle(Palette.text)
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                                .textSelection(.enabled)
-                        }
-                    }
-                    .padding(12)
+            VStack(spacing: 0) {
+                header
+                paneScroll
+                if let note = actionNote {
+                    Text(note).font(Typography.app(12)).foregroundStyle(Palette.textDim)
+                        .frame(maxWidth: .infinity, alignment: .leading).padding(.horizontal, 16).padding(.vertical, 4)
                 }
-                .task(id: paneID) { await refresh() }
-                // `initial: true` folds once on appear too, so `lines` is never
-                // left empty if the text arrives before the first width change.
-                .onChange(of: columns, initial: true) { _, newColumns in refold(columns: newColumns) }
-                .onChange(of: rawText) { _, _ in refold(columns: columns) }
+                if group == .needsYou { approveReject }
+                controlBar
+                replyBar
             }
         }
-        .navigationTitle(title)
-        .toolbar {
-            Button {
-                Task { await refresh() }
-            } label: {
-                Image(systemName: "arrow.clockwise").foregroundStyle(Palette.textDim)
+        .toolbar(.hidden, for: .navigationBar)
+        .task(id: paneID) { await refresh() }
+    }
+
+    // MARK: header
+
+    private var header: some View {
+        VStack(spacing: 8) {
+            HStack {
+                Button { dismiss() } label: {
+                    Image(systemName: "chevron.left").font(.system(size: 16, weight: .semibold))
+                        .foregroundStyle(Palette.textDim)
+                }
+                Spacer()
+                Text(heading).font(Typography.app(16, .semibold)).foregroundStyle(Palette.text).lineLimit(1)
+                Spacer()
+                Button { Task { await refresh() } } label: {
+                    Image(systemName: "arrow.clockwise").font(.system(size: 15)).foregroundStyle(Palette.textDim)
+                }
+            }
+            if let group {
+                HStack(spacing: 6) {
+                    Circle().fill(group.color).frame(width: 7, height: 7)
+                    Text(group.sectionTitle).font(Typography.microLabel).tracking(1).foregroundStyle(group.color)
+                    Spacer()
+                }
+                .padding(.horizontal, 10).padding(.vertical, 5)
+                .background(group.color.opacity(0.12)).clipShape(Capsule())
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+        .padding(.horizontal, 16).padding(.top, 8).padding(.bottom, 10)
+        .background(Palette.surface)
+    }
+
+    // MARK: pane output (fold cache preserved)
+
+    private var paneScroll: some View {
+        GeometryReader { geo in
+            // Fold from the SETTLED layout width, but cache the result: re-fold
+            // ONLY when the width or the text changes, not on every body eval —
+            // folding 200 lines each frame cost ~13ms during scroll.
+            let columns = columnCount(for: geo.size.width)
+            ScrollView {
+                VStack(alignment: .leading, spacing: 0) {
+                    if let error {
+                        Text(error).font(Typography.machine(12)).foregroundStyle(Palette.died)
+                    }
+                    ForEach(Array(lines.enumerated()), id: \.offset) { _, line in
+                        Text(line.isEmpty ? " " : line)
+                            .font(Typography.machine(12.5)).foregroundStyle(Palette.text)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .textSelection(.enabled)
+                    }
+                }
+                .padding(14)
+            }
+            // `initial: true` folds once on appear too, so `lines` is never left
+            // empty if the text arrives before the first width change.
+            .onChange(of: columns, initial: true) { _, newColumns in refold(columns: newColumns) }
+            .onChange(of: rawText) { _, _ in refold(columns: columns) }
+        }
+    }
+
+    // MARK: input
+
+    /// Only for a blocked agent. Approve/Reject answer the numbered choice the
+    /// pane is showing (1 / 2); in intent mode that submits, in rawKeys it types
+    /// and the reader presses Enter — the deliberate second action.
+    private var approveReject: some View {
+        HStack(spacing: 10) {
+            Button { send(.submitText("1")) } label: {
+                actionLabel("Approve", .white, Palette.brand)
+            }.disabled(sending)
+            Button { send(.submitText("2")) } label: {
+                actionLabel("Reject", Palette.text, Palette.card)
+            }.disabled(sending)
+        }
+        .padding(.horizontal, 14).padding(.top, 6).padding(.bottom, 2)
+    }
+
+    private func actionLabel(_ text: String, _ fg: Color, _ bg: Color) -> some View {
+        Text(text).font(Typography.app(15, .semibold)).frame(maxWidth: .infinity).padding(.vertical, 13)
+            .background(bg).foregroundStyle(fg).clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+
+    private var controlBar: some View {
+        HStack(spacing: 6) {
+            keyCap(label: "esc", key: "Escape")
+            keyCap(symbol: "chevron.left", key: "Left")
+            keyCap(symbol: "chevron.up", key: "Up")
+            keyCap(symbol: "chevron.down", key: "Down")
+            keyCap(symbol: "chevron.right", key: "Right")
+            keyCap(label: "tab", key: "Tab")
+        }
+        .padding(.horizontal, 12).padding(.vertical, 8)
+    }
+
+    private func keyCap(label: String? = nil, symbol: String? = nil, key: String) -> some View {
+        Button { send(.key(key)) } label: {
+            Group {
+                if let symbol { Image(systemName: symbol).font(.system(size: 12, weight: .semibold)) }
+                else { Text(label ?? key).font(Typography.machine(12)) }
+            }
+            .foregroundStyle(Palette.textDim)
+            .frame(maxWidth: .infinity, minHeight: 34)
+            .background(Palette.surface).clipShape(RoundedRectangle(cornerRadius: 8))
+        }
+        .accessibilityLabel(Text(key))
+    }
+
+    private var replyBar: some View {
+        HStack(spacing: 8) {
+            TextField("type a reply…", text: $reply)
+                .font(Typography.app(15)).foregroundStyle(Palette.text)
+                .textInputAutocapitalization(.never).autocorrectionDisabled()
+                .padding(.horizontal, 16).padding(.vertical, 11)
+                .background(Palette.surface).clipShape(Capsule())
+            Button { send(.submitText(reply)) } label: {
+                Image(systemName: "arrow.up").font(.system(size: 15, weight: .bold)).foregroundStyle(.white)
+                    .frame(width: 40, height: 40)
+                    .background(canSend ? Palette.brand : Palette.surface).clipShape(Circle())
+            }
+            .disabled(!canSend)
+        }
+        .padding(.horizontal, 12).padding(.top, 4).padding(.bottom, 8)
+    }
+
+    /// Routes a reader action through InputRouter, then executes the plan. A
+    /// refusal is shown, never a silent no-op.
+    private func send(_ action: InputAction) {
+        let mode = agent.map { router.mode(for: $0) } ?? .rawKeys
+        let plan = router.plan(action: action, pane: paneID, mode: mode)
+        Task {
+            sending = true
+            defer { sending = false }
+            do {
+                switch plan {
+                case .prompt(let pane, let text): try await client.prompt(pane: pane, text: text)
+                case .text(let pane, let text): try await client.sendText(pane: pane, text: text)
+                case .keys(let pane, let keys): try await client.sendKeys(pane: pane, keys: keys)
+                case .refused(let reason): actionNote = "not sent: \(reason)"; return
+                }
+                actionNote = nil
+                if case .submitText = action { reply = "" }
+                // Give the pane a beat to reflect the input, then re-read.
+                try? await Task.sleep(nanoseconds: 300_000_000)
+                await refresh()
+            } catch {
+                actionNote = "send failed: \(error)"
             }
         }
     }
 
-    /// Rough monospace column count for the footnote font (~7pt advance), less the
-    /// 12pt horizontal padding on each side.
+    // MARK: data
+
+    /// Rough monospace column count for the pane font (~7.2pt advance), less the
+    /// 14pt horizontal padding on each side.
     private func columnCount(for width: CGFloat) -> Int {
-        max(20, Int((width - 24) / 7.2))
+        max(20, Int((width - 28) / 7.2))
     }
 
     /// Folds `rawText` to `columns` into the cached `lines`. Called only from the
@@ -799,7 +952,15 @@ enum ScreenshotMock {
     static var mode: ScreenshotMock? {
         let env = ProcessInfo.processInfo.environment["HERDR_SCREENSHOT_MOCK"]?.lowercased()
         let arg = ProcessInfo.processInfo.arguments.contains("-herdrScreenshotMock")
+        #if SCREENSHOT_MOCK_DEFAULT
+        // VERIFICATION SCAFFOLD — REMOVE BEFORE MERGE. The buildbox launches the
+        // app with no env/args; this boots into the PANE mock so the terminal
+        // screen can be screenshotted. Debug-config-only (project.yml), mock data
+        // only — no key is ever rendered.
+        guard env != nil || arg else { return .pane }
+        #else
         guard env != nil || arg else { return nil }
+        #endif
         return env == "pane" ? .pane : .list
     }
 }
@@ -843,7 +1004,14 @@ struct MockTransport: HerdrTransport {
     ]
 
     static let agentRead = #"""
-    {"id":"mock","result":{"read":{"pane_id":"w1:p1","text":"$ herdr agent attach jarvis\n\n> may I run `just test` on herdr-ios?\n  177 tests, ~30s, no network\n\n  [y] allow   [n] deny   [a] always\n\n[demo data - mock render mode, no live connection]","truncated":false,"source":"recent_unwrapped","format":"text"}}}
+    {"id":"mock","result":{"read":{"pane_id":"w1:p1","text":"$ herdr agent attach jarvis\n\n> Ran 146 tests, 0 failures\n> Edited SessionRecoveryTests.swift  +18 -4\n\nRun `swift test` with -Xswiftc -warnings-as-errors?\n  1. yes\n  2. no, skip it\n>\n\n[demo data - mock render mode, no live connection]","truncated":false,"source":"recent_unwrapped","format":"text"}}}
     """#
+
+    /// A decoded blocked agent for the pane screenshot: status "blocked" groups
+    /// as NEEDS YOU, so the pane renders its status badge and Approve/Reject. No
+    /// composer field, so input falls to rawKeys — fine for a static shot.
+    static let demoPaneAgent: AgentInfo? = try? JSONDecoder().decode(
+        AgentInfo.self,
+        from: Data(#"{"pane_id":"w1:p1","name":"jarvis","agent":"claude","agent_status":"blocked","cwd":"/root/herdr-ios","terminal_title_stripped":"asking to run tests"}"#.utf8))
 }
 #endif

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -256,91 +256,137 @@ struct ConnectView: View {
     var onConnect: (SSHCredentials) -> Void
 
     @State private var host = ""
-    @State private var port = "22"
     @State private var username = ""
     @State private var keyPEM = ""
+    @State private var showingKeySheet = false
 
-    /// A valid SSH port, or nil — invalid input is rejected here rather than
-    /// silently coerced to 22.
-    private var portValue: UInt16? {
-        UInt16(port.trimmingCharacters(in: .whitespaces)).flatMap { $0 >= 1 ? $0 : nil }
-    }
-    private var portInvalid: Bool { !port.isEmpty && portValue == nil }
+    // Host accepts "host" or "host:port" (and "[ipv6]:port"); the port lives in
+    // the one field so the form stays the three rows the mockup shows.
+    private var hostPort: (host: String, port: UInt16) { Self.parseHostPort(host) }
     private var canConnect: Bool {
-        !host.isEmpty && !username.isEmpty && !keyPEM.isEmpty && portValue != nil
+        !hostPort.host.isEmpty && !username.trimmingCharacters(in: .whitespaces).isEmpty && !keyPEM.isEmpty
     }
 
     var body: some View {
         ZStack {
             Palette.ground.ignoresSafeArea()
             ScrollView {
-                VStack(alignment: .leading, spacing: 18) {
+                VStack(alignment: .leading, spacing: 16) {
                     Text("herdr")
-                        .font(.system(size: 34, weight: .bold, design: .monospaced))
-                        .foregroundStyle(Palette.text)   // wordmark is monochrome; blue means "working"
-                    Text("connect to a host")
-                        .font(.system(.subheadline, design: .monospaced))
-                        .foregroundStyle(Palette.textDim)
+                        .font(Typography.app(24, .bold))
+                        .foregroundStyle(Palette.text)
+                        .padding(.bottom, 4)
 
-                    field("host", text: $host)
-                    field("port", text: $port)
-                    if portInvalid {
-                        Text("invalid port (1–65535)")
-                            .font(.caption).foregroundStyle(.red)
-                    }
-                    field("user", text: $username)
-
-                    VStack(alignment: .leading, spacing: 6) {
-                        Text("private key (ed25519 PEM)")
-                            .font(.caption).foregroundStyle(Palette.textDim)
-                        TextEditor(text: $keyPEM)
-                            .font(.system(.footnote, design: .monospaced))
-                            .foregroundStyle(Palette.text)
-                            .scrollContentBackground(.hidden)
-                            .frame(height: 130)
-                            .padding(8)
-                            .background(Palette.surface)
-                            .clipShape(RoundedRectangle(cornerRadius: 8))
+                    // The three settings-style rows: label left, value right.
+                    VStack(spacing: 10) {
+                        fieldRow("Host", text: $host, placeholder: "mac.tail-scale.ts.net")
+                        fieldRow("User", text: $username, placeholder: "jerry")
+                        keyRow
                     }
 
                     Button {
-                        guard let port = portValue else { return }
-                        let credentials = SSHCredentials(
-                            host: host.trimmingCharacters(in: .whitespacesAndNewlines),
-                            port: port,
+                        let hp = hostPort
+                        onConnect(SSHCredentials(
+                            host: hp.host, port: hp.port,
                             username: username.trimmingCharacters(in: .whitespacesAndNewlines),
-                            privateKeyPEM: keyPEM,
-                            remoteSocketPath: "")
-                        onConnect(credentials)
+                            privateKeyPEM: keyPEM, remoteSocketPath: ""))
                     } label: {
-                        Text("connect")
-                            .font(.system(.body, design: .monospaced).weight(.semibold))
-                            .frame(maxWidth: .infinity)
-                            .padding(.vertical, 14)
-                            .background(canConnect ? Palette.cardRaised : Palette.surface)
-                            .foregroundStyle(canConnect ? Palette.text : Palette.textDim)
-                            .clipShape(RoundedRectangle(cornerRadius: 10))
+                        Text("Connect")
+                            .font(Typography.app(16, .semibold))
+                            .frame(maxWidth: .infinity).padding(.vertical, 15)
+                            .background(canConnect ? Palette.brand : Palette.surface)
+                            .foregroundStyle(canConnect ? .white : Palette.textFaint)
+                            .clipShape(RoundedRectangle(cornerRadius: 12))
                     }
                     .disabled(!canConnect)
+                    .padding(.top, 6)
+
+                    Text("Connects over your Tailscale network. Nothing is exposed publicly.")
+                        .font(Typography.app(13)).foregroundStyle(Palette.textDim)
+                        .padding(.top, 2)
                 }
-                .padding(24)
+                .padding(22)
             }
+        }
+        .sheet(isPresented: $showingKeySheet) { keySheet }
+    }
+
+    /// A row with the label on the left and a right-aligned monospace value.
+    private func fieldRow(_ label: String, text: Binding<String>, placeholder: String) -> some View {
+        HStack {
+            Text(label).font(Typography.app(15)).foregroundStyle(Palette.textDim)
+            TextField(placeholder, text: text)
+                .multilineTextAlignment(.trailing)
+                .textInputAutocapitalization(.never).autocorrectionDisabled()
+                .font(Typography.machine(15)).foregroundStyle(Palette.text)
+        }
+        .padding(.horizontal, 16).padding(.vertical, 14)
+        .background(Palette.surface).clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+
+    /// The key row NEVER renders the key itself — only whether one is loaded.
+    /// That is both the mockup ("id_ed25519 ✓") and the security rule: the
+    /// connect screen is screenshotted onto an open port, so the PEM must not be
+    /// on screen. Tapping opens a sheet to paste it.
+    private var keyRow: some View {
+        Button { showingKeySheet = true } label: {
+            HStack {
+                Text("Key").font(Typography.app(15)).foregroundStyle(Palette.textDim)
+                Spacer()
+                if keyPEM.isEmpty {
+                    Text("Add private key").font(Typography.app(15)).foregroundStyle(Palette.textFaint)
+                } else {
+                    Text("ed25519 key").font(Typography.machine(15)).foregroundStyle(Palette.text)
+                    Image(systemName: "checkmark").font(.system(size: 12, weight: .bold))
+                        .foregroundStyle(Palette.done)
+                }
+            }
+            .padding(.horizontal, 16).padding(.vertical, 14)
+            .background(Palette.surface).clipShape(RoundedRectangle(cornerRadius: 12))
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var keySheet: some View {
+        NavigationStack {
+            ZStack {
+                Palette.ground.ignoresSafeArea()
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("Paste your ed25519 private key (PEM). It is held only in memory and sent over the SSH connection — never shown again.")
+                        .font(Typography.app(13)).foregroundStyle(Palette.textDim)
+                    TextEditor(text: $keyPEM)
+                        .font(Typography.machine(13)).foregroundStyle(Palette.text)
+                        .scrollContentBackground(.hidden)
+                        .padding(10).background(Palette.surface)
+                        .clipShape(RoundedRectangle(cornerRadius: 10))
+                    if !keyPEM.isEmpty {
+                        Button("Clear key") { keyPEM = "" }
+                            .font(Typography.app(14)).foregroundStyle(Palette.died)
+                    }
+                    Spacer()
+                }
+                .padding(20)
+            }
+            .navigationTitle("Private key")
+            .toolbar { ToolbarItem(placement: .topBarTrailing) {
+                Button("Done") { showingKeySheet = false }.foregroundStyle(Palette.brand)
+            } }
         }
     }
 
-    @ViewBuilder
-    private func field(_ label: String, text: Binding<String>) -> some View {
-        VStack(alignment: .leading, spacing: 4) {
-            Text(label).font(.caption).foregroundStyle(Palette.textDim)
-            TextField("", text: text)
-                .textInputAutocapitalization(.never)
-                .autocorrectionDisabled()
-                .font(.system(.body, design: .monospaced))
-                .foregroundStyle(Palette.text)
-                .padding(10)
-                .background(Palette.surface)
-                .clipShape(RoundedRectangle(cornerRadius: 8))
+    /// "host" | "host:port" | "[ipv6]:port" → (host, port). Defaults to 22.
+    static func parseHostPort(_ raw: String) -> (host: String, port: UInt16) {
+        let s = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        if s.hasPrefix("["), let close = s.firstIndex(of: "]") {
+            let inner = String(s[s.index(after: s.startIndex)..<close])
+            let rest = s[s.index(after: close)...]
+            if rest.hasPrefix(":"), let p = UInt16(rest.dropFirst()), p >= 1 { return (inner, p) }
+            return (inner, 22)
         }
+        // Exactly one colon splits host:port; a bare IPv6 (many colons) stays whole.
+        let parts = s.split(separator: ":", omittingEmptySubsequences: false)
+        if parts.count == 2, let p = UInt16(parts[1]), p >= 1 { return (String(parts[0]), p) }
+        return (s, 22)
     }
 }
 

--- a/Sources/HerdrKit/HostEndpoint.swift
+++ b/Sources/HerdrKit/HostEndpoint.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+/// A parsed SSH destination — host plus port. Lives in HerdrKit (not on the
+/// SwiftUI view) so it is covered by the Linux suite: it is pure string logic
+/// with a real hazard, and the app target cannot be compiled or tested on Linux.
+///
+/// The load-bearing rule: an EXPLICIT port that does not parse is REJECTED, never
+/// silently replaced with 22. Substituting 22 for a typo'd port ("[fe80::1]:80222")
+/// reaches a real host on a port the user never typed and TOFU-pins whatever
+/// service answers there — a wrong-target connect, not a harmless default.
+public struct HostEndpoint: Equatable, Sendable {
+    public let host: String
+    public let port: UInt16
+
+    public init(host: String, port: UInt16) {
+        self.host = host
+        self.port = port
+    }
+
+    /// Parses "host" | "host:port" | "[ipv6]" | "[ipv6]:port". Returns nil when
+    /// input is empty, a bracket is malformed, or a port is present but not a
+    /// valid 1–65535 — so the caller can refuse rather than connect somewhere
+    /// unintended. A bare IPv6 literal (many colons, no brackets) stays whole on
+    /// the default port.
+    public static func parse(_ raw: String) -> HostEndpoint? {
+        let s = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !s.isEmpty else { return nil }
+
+        if s.hasPrefix("[") {
+            guard let close = s.firstIndex(of: "]") else { return nil }   // no closing bracket
+            let inner = String(s[s.index(after: s.startIndex)..<close])
+            guard !inner.isEmpty else { return nil }                       // "[]"
+            let rest = s[s.index(after: close)...]
+            if rest.isEmpty { return HostEndpoint(host: inner, port: 22) } // "[ipv6]"
+            // Anything after "]" must be exactly ":<valid port>", else reject —
+            // this is the branch that used to fail OPEN to :22.
+            guard rest.hasPrefix(":"), let port = validPort(rest.dropFirst()) else { return nil }
+            return HostEndpoint(host: inner, port: port)
+        }
+
+        // Unbracketed. Exactly one colon is host:port; zero or many (a bare IPv6)
+        // is the whole string on the default port.
+        let parts = s.split(separator: ":", omittingEmptySubsequences: false)
+        if parts.count == 2 {
+            guard !parts[0].isEmpty, let port = validPort(parts[1]) else { return nil }
+            return HostEndpoint(host: String(parts[0]), port: port)
+        }
+        return HostEndpoint(host: s, port: 22)
+    }
+
+    private static func validPort(_ s: Substring) -> UInt16? {
+        guard let p = UInt16(s), p >= 1 else { return nil }  // UInt16 rejects >65535; guard rejects 0
+        return p
+    }
+}

--- a/Sources/HerdrKit/HostEndpoint.swift
+++ b/Sources/HerdrKit/HostEndpoint.swift
@@ -49,7 +49,10 @@ public struct HostEndpoint: Equatable, Sendable {
     }
 
     private static func validPort(_ s: Substring) -> UInt16? {
-        guard let p = UInt16(s), p >= 1 else { return nil }  // UInt16 rejects >65535; guard rejects 0
+        // ASCII digits only: UInt16("+22") parses to 22 and UInt16 accepts other
+        // sign/format oddities, so require the text to read exactly as a number.
+        guard !s.isEmpty, s.allSatisfy({ $0.isASCII && $0.isNumber }),
+              let p = UInt16(s), p >= 1 else { return nil }  // UInt16 rejects >65535; guard rejects 0
         return p
     }
 }

--- a/Sources/HerdrKit/InputIntent.swift
+++ b/Sources/HerdrKit/InputIntent.swift
@@ -77,6 +77,17 @@ public struct InputRouter: Sendable {
             // TUI panes unable to receive a single character, which made the
             // "keys elsewhere" half of this design fictional (herdr-ios#3).
             guard !text.isEmpty else { return .refused(reason: "empty input") }
+            // A newline in this path WOULD submit — send_text writes it to the
+            // pty and a shell runs the line. That is the exact "text lands and
+            // executes somewhere unintended" hazard rawKeys exists to prevent, so
+            // the no-submit guarantee is a lie if CR/LF pass through. Enter stays
+            // a separate, explicit key (.key("Enter")); a pasted or typed newline
+            // is refused, not silently executed. Scan UNICODE SCALARS, not
+            // Characters: Swift clusters "\r\n" into ONE grapheme that equals
+            // neither "\n" nor "\r", so a Character scan would wave CRLF through.
+            guard !text.unicodeScalars.contains(where: { $0 == "\n" || $0 == "\r" }) else {
+                return .refused(reason: "newline not allowed here — press Enter to submit")
+            }
             return .text(pane: pane, text)
 
         case (.key(let k), _):

--- a/Tests/HerdrKitTests/HostEndpointTests.swift
+++ b/Tests/HerdrKitTests/HostEndpointTests.swift
@@ -1,0 +1,71 @@
+import XCTest
+@testable import HerdrKit
+
+final class HostEndpointTests: XCTestCase {
+
+    // MARK: - the valid shapes
+
+    func testPlainHostDefaultsTo22() {
+        XCTAssertEqual(HostEndpoint.parse("mac.tail-scale.ts.net"), HostEndpoint(host: "mac.tail-scale.ts.net", port: 22))
+    }
+
+    func testHostColonPort() {
+        XCTAssertEqual(HostEndpoint.parse("host:2222"), HostEndpoint(host: "host", port: 2222))
+    }
+
+    func testBracketedIPv6WithPort() {
+        XCTAssertEqual(HostEndpoint.parse("[::1]:22"), HostEndpoint(host: "::1", port: 22))
+    }
+
+    func testBracketedIPv6WithoutPortDefaults() {
+        XCTAssertEqual(HostEndpoint.parse("[fe80::1]"), HostEndpoint(host: "fe80::1", port: 22))
+    }
+
+    /// AXIS: a bare IPv6 literal (many colons, no brackets) is NOT split into
+    /// host:port — the whole thing is the host on the default port.
+    func testBareIPv6StaysWhole() {
+        XCTAssertEqual(HostEndpoint.parse("::1"), HostEndpoint(host: "::1", port: 22))
+        XCTAssertEqual(HostEndpoint.parse("fe80::1"), HostEndpoint(host: "fe80::1", port: 22))
+    }
+
+    func testWhitespaceIsTrimmed() {
+        XCTAssertEqual(HostEndpoint.parse("  host:2222 \n"), HostEndpoint(host: "host", port: 2222))
+    }
+
+    // MARK: - the fail-OPEN class the reviewers found
+
+    /// AXIS: an EXPLICIT but invalid port is REJECTED, never silently defaulted
+    /// to 22. Before the fix the bracketed branch returned the valid inner host on
+    /// port 22 for every one of these, connecting to a port the user never typed
+    /// and TOFU-pinning whatever answered there. Each case must now be nil.
+    func testBracketedInvalidPortIsRejectedNotDefaulted() {
+        for bad in ["[fe80::1]:80222",   // > 65535 (UInt16 overflow)
+                    "[fe80::1]:0",        // port 0
+                    "[fe80::1]:notaport", // non-numeric
+                    "[fe80::1]:",         // empty port
+                    "[fe80::1]garbage"] { // junk after the bracket, no colon
+            XCTAssertNil(HostEndpoint.parse(bad),
+                         "\(bad) should be rejected, not silently connected to :22")
+        }
+    }
+
+    /// The unbracketed branch must fail the SAME way — an explicit bad port is a
+    /// rejection, so the two branches agree (they disagreed before the fix).
+    func testUnbracketedInvalidPortIsRejected() {
+        for bad in ["host:notaport", "host:80222", "host:0", "host:"] {
+            XCTAssertNil(HostEndpoint.parse(bad), "\(bad) should be rejected")
+        }
+    }
+
+    func testMalformedBracketsAndEmptyAreRejected() {
+        for bad in ["", "   ", "[::1", "[]", "[]:22", "[]:notaport"] {
+            XCTAssertNil(HostEndpoint.parse(bad), "\(bad.debugDescription) should be rejected")
+        }
+    }
+
+    /// Boundary: the largest valid port parses, one past it does not.
+    func testPortBoundary() {
+        XCTAssertEqual(HostEndpoint.parse("h:65535")?.port, 65535)
+        XCTAssertNil(HostEndpoint.parse("h:65536"))
+    }
+}

--- a/Tests/HerdrKitTests/HostEndpointTests.swift
+++ b/Tests/HerdrKitTests/HostEndpointTests.swift
@@ -57,6 +57,14 @@ final class HostEndpointTests: XCTestCase {
         }
     }
 
+    /// The port must read EXACTLY as a number — no leading sign or spaces that
+    /// UInt16(_:) would quietly normalise ("+22" would otherwise parse to 22).
+    func testNonDigitPortsAreRejected() {
+        for bad in ["host:+22", "host:-1", "host: 22", "[::1]:+1"] {
+            XCTAssertNil(HostEndpoint.parse(bad), "\(bad) should be rejected — port is not plain digits")
+        }
+    }
+
     func testMalformedBracketsAndEmptyAreRejected() {
         for bad in ["", "   ", "[::1", "[]", "[]:22", "[]:notaport"] {
             XCTAssertNil(HostEndpoint.parse(bad), "\(bad.debugDescription) should be rejected")

--- a/Tests/HerdrKitTests/InputIntentTests.swift
+++ b/Tests/HerdrKitTests/InputIntentTests.swift
@@ -56,6 +56,30 @@ final class InputRouterTests: XCTestCase {
         )
     }
 
+    /// AXIS: a newline in rawKeys text WOULD execute (send_text writes it to the
+    /// pty and the shell runs the line). The pre-existing "never submits" test
+    /// used a payload with no newline, so it proved nothing about this — it
+    /// survived because the input could not have submitted either way. These pass
+    /// CR/LF explicitly and require a REFUSAL, never a `.text` reaching the pane.
+    func testRawKeysRefusesNewlineBearingText() {
+        for payload in ["deploy\n", "cmd\r", "a\r\nb", "\n", "ok\n "] {
+            guard case .refused = router.plan(action: .submitText(payload), pane: "p1", mode: .rawKeys) else {
+                return XCTFail("newline-bearing rawKeys text was not refused: \(payload.debugDescription)")
+            }
+        }
+    }
+
+    /// The guarantee stated positively over both submitting and non-submitting
+    /// inputs: NO rawKeys `.text` plan may carry a newline into pane.send_text.
+    func testNoRawKeysTextPlanCarriesANewline() {
+        for payload in ["ls -la", "deploy\n", "x\r", "safe input"] {
+            if case .text(_, let sent) = router.plan(action: .submitText(payload), pane: "p1", mode: .rawKeys) {
+                XCTAssertFalse(sent.contains("\n") || sent.contains("\r"),
+                               "a .text plan carried a newline that would execute: \(sent.debugDescription)")
+            }
+        }
+    }
+
     /// Agent panes still route text as a prompt, not as literal keystrokes.
     func testAgentPanesStillUseIntent() {
         XCTAssertEqual(

--- a/Tests/HerdrKitTests/MockWireFixtureTests.swift
+++ b/Tests/HerdrKitTests/MockWireFixtureTests.swift
@@ -103,6 +103,6 @@ enum MockWireFixtures {
     ]
 
     static let agentRead = #"""
-    {"id":"mock","result":{"read":{"pane_id":"w1:p1","text":"$ herdr agent attach jarvis\n\n> may I run `just test` on herdr-ios?\n  177 tests, ~30s, no network\n\n  [y] allow   [n] deny   [a] always\n\n[demo data - mock render mode, no live connection]","truncated":false,"source":"recent_unwrapped","format":"text"}}}
+    {"id":"mock","result":{"read":{"pane_id":"w1:p1","text":"$ herdr agent attach jarvis\n\n> Ran 146 tests, 0 failures\n> Edited SessionRecoveryTests.swift  +18 -4\n\nRun `swift test` with -Xswiftc -warnings-as-errors?\n  1. yes\n  2. no, skip it\n>\n\n[demo data - mock render mode, no live connection]","truncated":false,"source":"recent_unwrapped","format":"text"}}}
     """#
 }

--- a/project.yml
+++ b/project.yml
@@ -55,3 +55,9 @@ targets:
         SWIFT_VERSION: "5.9"
         GENERATE_INFOPLIST_FILE: NO
         TARGETED_DEVICE_FAMILY: "1"
+      configs:
+        # VERIFICATION SCAFFOLD — REMOVE BEFORE MERGE. Boots the Debug build into
+        # the pane mock so the buildbox screenshots the terminal screen (mock
+        # data, no key). Paired with ScreenshotMock.mode; revert before merge.
+        Debug:
+          SWIFT_ACTIVE_COMPILATION_CONDITIONS: DEBUG SCREENSHOT_MOCK_DEFAULT

--- a/project.yml
+++ b/project.yml
@@ -55,9 +55,3 @@ targets:
         SWIFT_VERSION: "5.9"
         GENERATE_INFOPLIST_FILE: NO
         TARGETED_DEVICE_FAMILY: "1"
-      configs:
-        # VERIFICATION SCAFFOLD — REMOVE BEFORE MERGE. Boots the Debug build into
-        # the pane mock so the buildbox screenshots the terminal screen (mock
-        # data, no key). Paired with ScreenshotMock.mode; revert before merge.
-        Debug:
-          SWIFT_ACTIVE_COMPILATION_CONDITIONS: DEBUG SCREENSHOT_MOCK_DEFAULT


### PR DESCRIPTION
Slices 2–3 of the design pass (agent-list #33 already in main): ConnectView (01) and TerminalPaneView (03) applied to the Claude Design kit, on the shared DesignSystem.

## Screens
- **Connect (01)**: white wordmark, three settings-rows (Host / User / Key), violet Connect CTA, Tailscale footer. The key never appears on the main screen — "Add private key" → "ed25519 key ✓", entered only in a sheet (the connect screen is screenshotted onto an open port, so this is structural, not cosmetic).
- **Terminal (03)**: header (kind · folder + status pill), folded output (fold-cache preserved), a control-key row with a highlighted Return cap, and a reply box. Input routes through HerdrKit's InputRouter — intent prompts submit via agent.prompt, rawKeys types via pane.send_text, named keys via agent.send_keys.

## Review (two distinct runtimes, two rounds each)
codex + omp found **3 HIGH**, all fixed and **mutation-verified** (reverting each fails tests):
1. rawKeys accepted CR/LF → could execute "cmd\n". Now refused at unicode-scalar level (Swift clusters "\r\n" into one grapheme — a Character scan missed it; the adversarial test caught that).
2. Approve/Reject blindly mapped 1/2 — could grant the opposite of the label. Removed; the reader answers by typing + Return (structured menu actions are a follow-up).
3. parseHostPort failed open on an invalid explicit port ([fe80::1]:80222 → :22). Moved to a fallible **HerdrKit HostEndpoint** (Linux-tested), Connect gated on a valid parse.

Both reviewers then **APPROVED** the resolution; residual LOW/nit fixes (send trimmedKey; reject non-digit ports; stale comments) folded and re-confirmed.

## Verification
- **191 Linux tests green** (`swift test -Xswiftc -warnings-as-errors`), incl. new HostEndpointTests (11) + adversarial InputRouter CR/LF tests.
- Buildbox green at head ea55b0c; connect + terminal screenshot-verified against 01/03 mockups (the Debug screenshot scaffold was reverted before this head — merge candidate boots to ConnectView).
- Diff vs main is exactly the connect+terminal+HerdrKit delta (7 files).

Head: ea55b0c.

🤖 Generated with [Claude Code](https://claude.com/claude-code)