### PR TITLE
Design pass: settings screen (05)

### DIFF
--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -1131,15 +1131,7 @@ enum ScreenshotMock {
     static var mode: ScreenshotMock? {
         let env = ProcessInfo.processInfo.environment["HERDR_SCREENSHOT_MOCK"]?.lowercased()
         let arg = ProcessInfo.processInfo.arguments.contains("-herdrScreenshotMock")
-        #if SCREENSHOT_MOCK_DEFAULT
-        // VERIFICATION SCAFFOLD — REMOVE BEFORE MERGE. The buildbox launches the
-        // app with no env/args; this boots into the SETTINGS mock so that screen
-        // can be screenshotted. Debug-config-only (project.yml), mock data only —
-        // no key is ever rendered.
-        guard env != nil || arg else { return .settings }
-        #else
         guard env != nil || arg else { return nil }
-        #endif
         switch env {
         case "pane": return .pane
         case "settings": return .settings

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -192,6 +192,7 @@ struct RootView: View {
                 client: client,
                 onDisconnect: { disconnect() },
                 host: credentials.host,
+                onReconnect: { reconnect() },
                 onTrustHostKey: { fingerprint in trustAndReconnect(credentials, fingerprint: fingerprint) }
             )
             .id(session)
@@ -236,6 +237,20 @@ struct RootView: View {
         credentials = nil
     }
 
+    /// Drops and re-establishes the connection with the RETAINED credentials —
+    /// the transport is rebuilt and `session` bumped so the home view re-loads.
+    /// Distinct from disconnect(): the user stays connected, they do not fall back
+    /// to re-entering host/key. No pin change, so the existing pin still guards.
+    private func reconnect() {
+        guard let creds = credentials else { return }
+        let closing = transport
+        Task { await closing?.close() }
+        let newTransport = CitadelTransport(credentials: creds, hostKeyPolicy: pins)
+        transport = newTransport
+        client = HerdrClient(transport: newTransport)
+        session += 1
+    }
+
     /// A verified key rotation: pin the EXACT fingerprint the user verified out
     /// of band (from the rejection), then reconnect. Because the pin is bound to
     /// that fingerprint before reconnecting, a substituted key during the
@@ -245,12 +260,7 @@ struct RootView: View {
     /// persisted — reconnecting then would reopen a first-contact TOFU window.
     private func trustAndReconnect(_ creds: SSHCredentials, fingerprint: String) -> Bool {
         guard pins.pin(host: creds.host, port: creds.port, fingerprint: fingerprint) else { return false }
-        let closing = transport
-        Task { await closing?.close() }
-        let newTransport = CitadelTransport(credentials: creds, hostKeyPolicy: pins)
-        transport = newTransport
-        client = HerdrClient(transport: newTransport)
-        session += 1
+        reconnect()   // pin bound above; the reconnect reuses `pins`, so the just-verified key is trusted
         return true
     }
 }
@@ -401,6 +411,7 @@ struct TerminalHomeView: View {
     let client: HerdrClient
     var onDisconnect: () -> Void
     var host: String = ""   // shown in the Settings sheet's connection row
+    var onReconnect: () -> Void = {}
     var onTrustHostKey: (String) -> Bool
     /// The set of panes herdr still lists; anything absent is `stopped`. `nil`
     /// means no census is available yet (the live default) — every agent is
@@ -454,11 +465,15 @@ struct TerminalHomeView: View {
             .toolbar(.hidden, for: .navigationBar)
             .task { await load() }
         }
-        .sheet(isPresented: $showingSettings) {
+        .fullScreenCover(isPresented: $showingSettings) {
             SettingsView(
                 host: host,
-                connected: error == nil,
-                onReconnect: { showingSettings = false; onDisconnect() },
+                connected: error == nil && !loading,
+                // Withhold reconnect during a host-key rejection — reconnecting
+                // then would first-contact-trust the next key (same gate as the
+                // recovery screen's withheld retry).
+                canReconnect: rejectedFingerprint == nil,
+                onReconnect: { showingSettings = false; onReconnect() },
                 onClose: { showingSettings = false })
         }
     }
@@ -952,6 +967,11 @@ struct TerminalPaneView: View {
 struct SettingsView: View {
     var host: String
     var connected: Bool = true
+    /// Whether "Reconnect now" is safe to offer. FALSE while the connection is in
+    /// the host-key-rejection state — a bare reconnect there would first-contact-
+    /// trust whatever key appears next, routing around the very gate the recovery
+    /// screen enforces. The row is disabled with a reason in that state.
+    var canReconnect: Bool = true
     var onReconnect: () -> Void = {}
     var onClose: () -> Void = {}
 
@@ -966,32 +986,69 @@ struct SettingsView: View {
             VStack(spacing: 0) {
                 header
                 ScrollView {
+                    // Grouped into three subviews so the top-level builder stays
+                    // well under SwiftUI's 10-child ViewBuilder ceiling.
                     VStack(alignment: .leading, spacing: 0) {
-                        sectionLabel("CONNECTION")
-                        connectionRow
-                        sectionLabel("NOTIFY ME WHEN")
-                        toggleRow("An agent needs input", $notifyNeedsInput)
-                        toggleRow("An agent dies", $notifyDies)
-                        toggleRow("An agent finishes", $notifyFinishes)
-                        sectionLabel("TROUBLE")
-                        actionRow("Reconnect now") { onReconnect() }
-                        actionRow(copied ? "Copied ✓" : "Copy diagnostics") { copyDiagnostics() }
+                        connectionSection
+                        notifySection
+                        troubleSection
                     }
+                    .padding(.bottom, 16)
                 }
             }
         }
     }
 
+    // Header sits on the ground with a bottom hairline (not a filled bar); the
+    // one accent the kit uses here is the back affordance.
     private var header: some View {
-        HStack {
+        HStack(spacing: 12) {
             Button { onClose() } label: {
-                Image(systemName: "chevron.left").font(.system(size: 16, weight: .semibold)).foregroundStyle(Palette.textDim)
+                Image(systemName: "chevron.left").font(.system(size: 16, weight: .semibold)).foregroundStyle(Palette.brand)
             }
             Text("Settings").font(Typography.app(20, .bold)).foregroundStyle(Palette.text)
             Spacer()
         }
         .padding(.horizontal, 16).padding(.top, 8).padding(.bottom, 10)
-        .background(Palette.surface)
+        .overlay(alignment: .bottom) { Rectangle().fill(Palette.hairline).frame(height: 1) }
+    }
+
+    private var connectionSection: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            sectionLabel("CONNECTION")
+            HStack(spacing: 10) {
+                Circle().fill(connected ? Palette.done : Palette.died).frame(width: 8, height: 8)
+                Text(connected ? "Connected" : "Disconnected")
+                    .font(Typography.app(15, .semibold)).foregroundStyle(Palette.text).layoutPriority(1)
+                Text(host).font(Typography.machine(13)).foregroundStyle(Palette.textFaint)
+                    .lineLimit(1).truncationMode(.middle)
+                Spacer(minLength: 0)
+            }
+            .rowShell()
+        }
+    }
+
+    private var notifySection: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            sectionLabel("NOTIFY ME WHEN")
+            toggleRow("An agent needs input", $notifyNeedsInput)
+            toggleRow("An agent dies", $notifyDies)
+            toggleRow("An agent finishes", $notifyFinishes)
+            // Honest about delivery: the toggles persist the choice, but push
+            // delivery is not wired yet — do not imply live notifications.
+            Text("Delivery is coming soon — these save your preference.")
+                .font(Typography.app(12)).foregroundStyle(Palette.textFaint)
+                .padding(.horizontal, 20).padding(.top, 8)
+        }
+    }
+
+    private var troubleSection: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            sectionLabel("TROUBLE")
+            actionRow("Reconnect now", enabled: canReconnect,
+                      note: "verify the host key first") { onReconnect() }
+            actionRow(copied ? "Copied ✓" : "Copy diagnostics") { copyDiagnostics() }
+        }
     }
 
     private func sectionLabel(_ text: String) -> some View {
@@ -999,56 +1056,65 @@ struct SettingsView: View {
             Text(text).font(Typography.microLabel).tracking(1.2).foregroundStyle(Palette.textFaint)
             Rectangle().fill(Palette.hairline).frame(height: 1)
         }
-        .padding(.horizontal, 16).padding(.top, 20).padding(.bottom, 8)
-    }
-
-    private var connectionRow: some View {
-        HStack(spacing: 10) {
-            Circle().fill(connected ? Palette.done : Palette.died).frame(width: 8, height: 8)
-            Text(connected ? "Connected" : "Disconnected").font(Typography.app(15, .semibold)).foregroundStyle(Palette.text)
-            Text(host).font(Typography.machine(13)).foregroundStyle(Palette.textDim).lineLimit(1)
-            Spacer()
-        }
-        .padding(.horizontal, 16).padding(.vertical, 14)
-        .background(Palette.card).clipShape(RoundedRectangle(cornerRadius: 12))
-        .padding(.horizontal, 16)
+        .padding(.horizontal, 16).padding(.top, 14).padding(.bottom, 8)
     }
 
     private func toggleRow(_ label: String, _ value: Binding<Bool>) -> some View {
         Button { value.wrappedValue.toggle() } label: {
             HStack {
-                Text(label).font(Typography.app(15)).foregroundStyle(Palette.text)
+                Text(label).font(Typography.app(15)).foregroundStyle(Palette.textDim)
                 Spacer()
+                // ON and OFF are BOTH the primary tier — differentiated by the
+                // word, not colour. Brand violet is reserved for the primary
+                // action + active tab, never a toggle state.
                 Text(value.wrappedValue ? "ON" : "OFF")
-                    .font(Typography.machine(13, .bold))
-                    .foregroundStyle(value.wrappedValue ? Palette.brand : Palette.textFaint)
+                    .font(Typography.machine(13, .bold)).foregroundStyle(Palette.text)
             }
-            .padding(.horizontal, 16).padding(.vertical, 14)
-            .background(Palette.card).clipShape(RoundedRectangle(cornerRadius: 12))
-            .padding(.horizontal, 16).padding(.top, 6)
+            .rowShell()
         }
         .buttonStyle(.plain)
+        .padding(.horizontal, 16).padding(.top, 10)
+        .accessibilityValue(Text(value.wrappedValue ? "on" : "off"))
     }
 
-    private func actionRow(_ label: String, _ action: @escaping () -> Void) -> some View {
-        Button(action: action) {
+    private func actionRow(_ label: String, enabled: Bool = true, note: String? = nil, _ action: @escaping () -> Void) -> some View {
+        Button { if enabled { action() } } label: {
             HStack {
-                Text(label).font(Typography.app(15)).foregroundStyle(Palette.text)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(label).font(Typography.app(15)).foregroundStyle(enabled ? Palette.text : Palette.textFaint)
+                    if !enabled, let note {
+                        Text(note).font(Typography.app(11)).foregroundStyle(Palette.textFaint)
+                    }
+                }
                 Spacer()
                 Image(systemName: "chevron.right").font(.system(size: 12, weight: .semibold)).foregroundStyle(Palette.textFaint)
             }
-            .padding(.horizontal, 16).padding(.vertical, 14)
-            .background(Palette.card).clipShape(RoundedRectangle(cornerRadius: 12))
-            .padding(.horizontal, 16).padding(.top, 6)
+            .rowShell()
         }
         .buttonStyle(.plain)
+        .disabled(!enabled)
+        .padding(.horizontal, 16).padding(.top, 10)
     }
 
     private func copyDiagnostics() {
         // Host + app version only — never anything sensitive (no key, ever).
         let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "?"
-        UIPasteboard.general.string = "herdr-ios \(version) — host \(host), connected=\(connected)"
+        UIPasteboard.general.string = "herdr-ios \(version) — host \(host)"
         copied = true
+        // Revert the confirmation so a second copy gives feedback.
+        Task { try? await Task.sleep(nanoseconds: 2_000_000_000); copied = false }
+    }
+}
+
+/// The kit's row shell: transparent fill, a 1px hairline border, and the tap
+/// shape confined to the card (so the outer gutter/gap is not a tap target).
+private extension View {
+    func rowShell() -> some View {
+        self
+            .padding(.horizontal, 16).padding(.vertical, 14)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .overlay(RoundedRectangle(cornerRadius: 12).stroke(Palette.hairline, lineWidth: 1))
+            .contentShape(RoundedRectangle(cornerRadius: 12))
     }
 }
 

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -1025,6 +1025,7 @@ struct SettingsView: View {
                 Spacer(minLength: 0)
             }
             .rowShell()
+            .padding(.horizontal, 16).padding(.top, 10)   // align with the toggle/action rows
         }
     }
 

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import Foundation
 import Security
+import UIKit    // UIPasteboard (Copy diagnostics)
 import Darwin   // inet_pton/inet_ntop for IPv6 canonicalization
 import HerdrKit
 
@@ -190,6 +191,7 @@ struct RootView: View {
             TerminalHomeView(
                 client: client,
                 onDisconnect: { disconnect() },
+                host: credentials.host,
                 onTrustHostKey: { fingerprint in trustAndReconnect(credentials, fingerprint: fingerprint) }
             )
             .id(session)
@@ -213,6 +215,8 @@ struct RootView: View {
                 TerminalPaneView(client: mockClient, paneID: "w1:p1", title: "jarvis",
                                  agent: MockTransport.demoPaneAgent)
             }
+        case .settings:
+            SettingsView(host: "mac.tail-scale.ts.net")
         }
     }
     #endif
@@ -396,6 +400,7 @@ struct ConnectView: View {
 struct TerminalHomeView: View {
     let client: HerdrClient
     var onDisconnect: () -> Void
+    var host: String = ""   // shown in the Settings sheet's connection row
     var onTrustHostKey: (String) -> Bool
     /// The set of panes herdr still lists; anything absent is `stopped`. `nil`
     /// means no census is available yet (the live default) — every agent is
@@ -409,6 +414,7 @@ struct TerminalHomeView: View {
     @State private var rejectedFingerprint: String?
     @State private var trustFailed = false
     @State private var search = ""
+    @State private var showingSettings = false
     // Only the quiet tail (idle) starts collapsed — the model forbids a
     // collapsed group from ever hiding something that wants attention.
     @State private var collapsed: Set<AgentGroup> = Set(AgentGroup.allCases.filter { $0.startsCollapsed })
@@ -447,6 +453,13 @@ struct TerminalHomeView: View {
             }
             .toolbar(.hidden, for: .navigationBar)
             .task { await load() }
+        }
+        .sheet(isPresented: $showingSettings) {
+            SettingsView(
+                host: host,
+                connected: error == nil,
+                onReconnect: { showingSettings = false; onDisconnect() },
+                onClose: { showingSettings = false })
         }
     }
 
@@ -508,7 +521,10 @@ struct TerminalHomeView: View {
         HStack(spacing: 4) {
             tabItem("square.grid.2x2.fill", "Agents", active: true)
             tabItem("terminal", "Terminal", active: false)
-            tabItem("gearshape", "Settings", active: false)
+            Button { showingSettings = true } label: {
+                tabItem("gearshape", "Settings", active: false)
+            }
+            .buttonStyle(.plain)
         }
         .padding(6)
         .background(Palette.surface)
@@ -930,6 +946,112 @@ struct TerminalPaneView: View {
     }
 }
 
+/// Settings (screen 05): connection status, notification preferences, and the
+/// trouble actions. Preferences persist locally via @AppStorage; wiring them to
+/// real push delivery is a follow-up, so they record intent, not delivery.
+struct SettingsView: View {
+    var host: String
+    var connected: Bool = true
+    var onReconnect: () -> Void = {}
+    var onClose: () -> Void = {}
+
+    @AppStorage("notify.needsInput") private var notifyNeedsInput = true
+    @AppStorage("notify.dies") private var notifyDies = true
+    @AppStorage("notify.finishes") private var notifyFinishes = false
+    @State private var copied = false
+
+    var body: some View {
+        ZStack {
+            Palette.ground.ignoresSafeArea()
+            VStack(spacing: 0) {
+                header
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 0) {
+                        sectionLabel("CONNECTION")
+                        connectionRow
+                        sectionLabel("NOTIFY ME WHEN")
+                        toggleRow("An agent needs input", $notifyNeedsInput)
+                        toggleRow("An agent dies", $notifyDies)
+                        toggleRow("An agent finishes", $notifyFinishes)
+                        sectionLabel("TROUBLE")
+                        actionRow("Reconnect now") { onReconnect() }
+                        actionRow(copied ? "Copied ✓" : "Copy diagnostics") { copyDiagnostics() }
+                    }
+                }
+            }
+        }
+    }
+
+    private var header: some View {
+        HStack {
+            Button { onClose() } label: {
+                Image(systemName: "chevron.left").font(.system(size: 16, weight: .semibold)).foregroundStyle(Palette.textDim)
+            }
+            Text("Settings").font(Typography.app(20, .bold)).foregroundStyle(Palette.text)
+            Spacer()
+        }
+        .padding(.horizontal, 16).padding(.top, 8).padding(.bottom, 10)
+        .background(Palette.surface)
+    }
+
+    private func sectionLabel(_ text: String) -> some View {
+        HStack(spacing: 8) {
+            Text(text).font(Typography.microLabel).tracking(1.2).foregroundStyle(Palette.textFaint)
+            Rectangle().fill(Palette.hairline).frame(height: 1)
+        }
+        .padding(.horizontal, 16).padding(.top, 20).padding(.bottom, 8)
+    }
+
+    private var connectionRow: some View {
+        HStack(spacing: 10) {
+            Circle().fill(connected ? Palette.done : Palette.died).frame(width: 8, height: 8)
+            Text(connected ? "Connected" : "Disconnected").font(Typography.app(15, .semibold)).foregroundStyle(Palette.text)
+            Text(host).font(Typography.machine(13)).foregroundStyle(Palette.textDim).lineLimit(1)
+            Spacer()
+        }
+        .padding(.horizontal, 16).padding(.vertical, 14)
+        .background(Palette.card).clipShape(RoundedRectangle(cornerRadius: 12))
+        .padding(.horizontal, 16)
+    }
+
+    private func toggleRow(_ label: String, _ value: Binding<Bool>) -> some View {
+        Button { value.wrappedValue.toggle() } label: {
+            HStack {
+                Text(label).font(Typography.app(15)).foregroundStyle(Palette.text)
+                Spacer()
+                Text(value.wrappedValue ? "ON" : "OFF")
+                    .font(Typography.machine(13, .bold))
+                    .foregroundStyle(value.wrappedValue ? Palette.brand : Palette.textFaint)
+            }
+            .padding(.horizontal, 16).padding(.vertical, 14)
+            .background(Palette.card).clipShape(RoundedRectangle(cornerRadius: 12))
+            .padding(.horizontal, 16).padding(.top, 6)
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func actionRow(_ label: String, _ action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            HStack {
+                Text(label).font(Typography.app(15)).foregroundStyle(Palette.text)
+                Spacer()
+                Image(systemName: "chevron.right").font(.system(size: 12, weight: .semibold)).foregroundStyle(Palette.textFaint)
+            }
+            .padding(.horizontal, 16).padding(.vertical, 14)
+            .background(Palette.card).clipShape(RoundedRectangle(cornerRadius: 12))
+            .padding(.horizontal, 16).padding(.top, 6)
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func copyDiagnostics() {
+        // Host + app version only — never anything sensitive (no key, ever).
+        let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "?"
+        UIPasteboard.general.string = "herdr-ios \(version) — host \(host), connected=\(connected)"
+        copied = true
+    }
+}
+
 #if DEBUG
 /// DEBUG-only screenshot mode: renders the list/pane views from MockTransport —
 /// no connection, no key, so the buildbox can screenshot them SAFELY (the app
@@ -937,13 +1059,25 @@ struct TerminalPaneView: View {
 /// `HERDR_SCREENSHOT_MOCK=list` (default) or `=pane`, or the `-herdrScreenshotMock`
 /// launch argument.
 enum ScreenshotMock {
-    case list, pane
+    case list, pane, settings
 
     static var mode: ScreenshotMock? {
         let env = ProcessInfo.processInfo.environment["HERDR_SCREENSHOT_MOCK"]?.lowercased()
         let arg = ProcessInfo.processInfo.arguments.contains("-herdrScreenshotMock")
+        #if SCREENSHOT_MOCK_DEFAULT
+        // VERIFICATION SCAFFOLD — REMOVE BEFORE MERGE. The buildbox launches the
+        // app with no env/args; this boots into the SETTINGS mock so that screen
+        // can be screenshotted. Debug-config-only (project.yml), mock data only —
+        // no key is ever rendered.
+        guard env != nil || arg else { return .settings }
+        #else
         guard env != nil || arg else { return nil }
-        return env == "pane" ? .pane : .list
+        #endif
+        switch env {
+        case "pane": return .pane
+        case "settings": return .settings
+        default: return .list
+        }
     }
 }
 

--- a/project.yml
+++ b/project.yml
@@ -55,9 +55,3 @@ targets:
         SWIFT_VERSION: "5.9"
         GENERATE_INFOPLIST_FILE: NO
         TARGETED_DEVICE_FAMILY: "1"
-      configs:
-        # VERIFICATION SCAFFOLD — REMOVE BEFORE MERGE. Boots the Debug build into
-        # the settings mock so the buildbox screenshots that screen (mock data,
-        # no key). Paired with ScreenshotMock.mode; revert before merge.
-        Debug:
-          SWIFT_ACTIVE_COMPILATION_CONDITIONS: DEBUG SCREENSHOT_MOCK_DEFAULT

--- a/project.yml
+++ b/project.yml
@@ -55,3 +55,9 @@ targets:
         SWIFT_VERSION: "5.9"
         GENERATE_INFOPLIST_FILE: NO
         TARGETED_DEVICE_FAMILY: "1"
+      configs:
+        # VERIFICATION SCAFFOLD — REMOVE BEFORE MERGE. Boots the Debug build into
+        # the settings mock so the buildbox screenshots that screen (mock data,
+        # no key). Paired with ScreenshotMock.mode; revert before merge.
+        Debug:
+          SWIFT_ACTIVE_COMPILATION_CONDITIONS: DEBUG SCREENSHOT_MOCK_DEFAULT


### PR DESCRIPTION
Slice 5 of the design pass (agent-list #33, connect+terminal #34 already in main): SettingsView (screen 05), built clean off main.

## Screen
CONNECTION status (dot + Connected/Disconnected + host), NOTIFY ME WHEN toggles (persisted via @AppStorage, with a "coming soon" caption — delivery isn't wired), and TROUBLE actions (Reconnect now, Copy diagnostics). Reachable from the agent-list tab bar; presented full-screen to match the mockup. Diagnostics copy host + app version only — never key material.

## Review (two distinct runtimes, three rounds)
Both reviewers passed security + compile, then found **2 HIGH** — both fixed and independently mutation-checked by the reviewers:
- **Reconnect routed around the host-key-rejection gate** (a bare reconnect during a rejection would first-contact-trust an unverified key). Now gated: `canReconnect = rejectedFingerprint == nil` disables the row with a reason; Copy diagnostics stays live.
- **Reconnect was wired to disconnect** (logout + re-paste key). Now a real `RootView.reconnect()` retains credentials and reuses the pin policy (existing pin still guards); `trustAndReconnect` refactored to reuse it, pin-before-reconnect ordering preserved.

Plus fidelity fixes (ON/OFF both white — violet reserved for the back arrow per the kit; transparent hairline-bordered rows, not filled cards; header on the ground; host truncates middle), honesty (toggles + connection state don't overclaim), and a SwiftUI 10-child ceiling fix. Both then **APPROVED** at head 30cdc44.

## Verification
- Two-witness APPROVE (codex + omp) at 30cdc44.
- Buildbox green; screenshot-verified vs 05-settings.png. Scaffold reverted (boots to ConnectView).
- Clean off main — diff is App/HerdrApp.swift + project.yml only, no HerdrKit/test changes.

Head: 30cdc44.

🤖 Generated with [Claude Code](https://claude.com/claude-code)