### PR TITLE
Design pass: new-agent screen (04) + spawn flow

### DIFF
--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -423,6 +423,9 @@ struct NewAgentView: View {
     @State private var task: String
     @State private var starting = false
     @State private var errorMessage: String?
+    /// Set when the agent DID start but the task didn't land — the agent is live,
+    /// so we must not clean up or let a blind retry duplicate it.
+    @State private var partialSpawn = false
 
     private static let kinds = ["claude", "codex", "gemini"]
 
@@ -437,7 +440,7 @@ struct NewAgentView: View {
     }
 
     private var canStart: Bool {
-        !task.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && !starting
+        !task.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && !starting && !partialSpawn
     }
     /// The agent's name — the folder's basename, else the kind. herdr validates
     /// the name; a duplicate surfaces as a start error rather than being guessed.
@@ -483,6 +486,7 @@ struct NewAgentView: View {
     private var header: some View {
         HStack {
             Button("Cancel") { onCancel() }.font(Typography.app(15)).foregroundStyle(Palette.brand)
+                .disabled(starting)   // no dismiss mid-spawn — the op would keep running off-screen
             Spacer()
             Text("New agent").font(Typography.app(17, .semibold)).foregroundStyle(Palette.text)
             Spacer()
@@ -548,41 +552,65 @@ struct NewAgentView: View {
     }
 
     private var startButton: some View {
-        Button { start() } label: {
+        // After a partial spawn the agent already exists, so the primary action
+        // becomes "go see it", not "Start again" (which would duplicate it).
+        let enabled = partialSpawn ? true : canStart
+        return Button { partialSpawn ? onStarted() : start() } label: {
             HStack(spacing: 8) {
                 if starting { ProgressView().tint(.white) }
-                Text(starting ? "Starting…" : "Start").font(Typography.app(16, .semibold))
+                Text(partialSpawn ? "Go to the agent" : (starting ? "Starting…" : "Start"))
+                    .font(Typography.app(16, .semibold))
             }
             .frame(maxWidth: .infinity).padding(.vertical, 15)
-            .background(canStart ? Palette.brand : Palette.surface)
-            .foregroundStyle(canStart ? .white : Palette.textFaint)
+            .background(enabled ? Palette.brand : Palette.surface)
+            .foregroundStyle(enabled ? .white : Palette.textFaint)
             .clipShape(RoundedRectangle(cornerRadius: 12))
         }
-        .disabled(!canStart)
+        .disabled(!enabled)
         .padding(.horizontal, 16).padding(.top, 16)
     }
 
-    /// The three-step spawn. Steps are sequential and a failure at any step is
-    /// surfaced (never a silent half-spawn): split a pane in the folder, start the
-    /// agent kind in it, then send the task as its first prompt.
+    /// The spawn: split a pane in the folder, start the agent, WAIT for it to be
+    /// ready, then send the task. Every failure is surfaced honestly, and the
+    /// partial state is handled by WHERE it failed:
+    ///   - before the agent starts → clean up the orphan pane (safe), retry OK.
+    ///   - after the agent starts   → the agent is LIVE; do NOT clean up or retry
+    ///     (would kill it / duplicate the name) — disclose and send them to it.
     private func start() {
+        guard !starting else { return }   // re-entry invariant, not just Button.disabled
         starting = true
         errorMessage = nil
         let cwd = folder.trimmingCharacters(in: .whitespacesAndNewlines)
         let taskText = task.trimmingCharacters(in: .whitespacesAndNewlines)
-        let name = derivedName
+        let name = AgentName.normalize(derivedName)   // to the server grammar BEFORE splitting
         let chosenKind = kind
         Task {
             defer { starting = false }
+            var createdPane: String?
+            var agentStarted = false
             do {
-                let paneID = try await client.splitPane(cwd: cwd.isEmpty ? nil : cwd, direction: .down)
+                let paneID = try await client.splitPane(cwd: cwd.isEmpty ? nil : cwd)
+                createdPane = paneID
                 _ = try await client.startAgent(name: name, kind: chosenKind, paneID: paneID)
+                agentStarted = true
+                // agent.start only INITIATES launch; prompting before ready returns
+                // agent_not_ready, so wait for the composer first.
+                try await client.waitForReady(pane: paneID)
                 if !taskText.isEmpty {
                     try await client.prompt(pane: paneID, text: taskText)
                 }
                 onStarted()
             } catch {
-                errorMessage = "could not start: \(error)"
+                if agentStarted {
+                    partialSpawn = true
+                    errorMessage = "'\(name)' started, but the task didn't send (\(error)). "
+                        + "Open it from the list to send the task."
+                } else if let pane = createdPane {
+                    try? await client.closePane(paneID: pane)
+                    errorMessage = "couldn't start the agent: \(error)"
+                } else {
+                    errorMessage = "couldn't create the pane: \(error)"
+                }
             }
         }
     }

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -405,6 +405,185 @@ struct ConnectView: View {
     }
 }
 
+/// New agent (screen 04): pick a folder, an agent kind, and a task, then spawn a
+/// real agent. HIGH-STAKES — "Start" splits a pane, launches the agent, and sends
+/// the task (splitPane → startAgent → prompt), which begins spending tokens. The
+/// footer says so.
+struct NewAgentView: View {
+    let client: HerdrClient
+    let onStarted: () -> Void
+    let onCancel: () -> Void
+
+    @State private var folder: String
+    @State private var kind: String
+    @State private var task: String
+    @State private var starting = false
+    @State private var errorMessage: String?
+
+    private static let kinds = ["claude", "codex", "gemini"]
+
+    init(client: HerdrClient, onStarted: @escaping () -> Void = {}, onCancel: @escaping () -> Void = {},
+         initialFolder: String = "", initialKind: String = "claude", initialTask: String = "") {
+        self.client = client
+        self.onStarted = onStarted
+        self.onCancel = onCancel
+        _folder = State(initialValue: initialFolder)
+        _kind = State(initialValue: initialKind)
+        _task = State(initialValue: initialTask)
+    }
+
+    private var canStart: Bool {
+        !task.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && !starting
+    }
+    /// The agent's name — the folder's basename, else the kind. herdr validates
+    /// the name; a duplicate surfaces as a start error rather than being guessed.
+    private var derivedName: String {
+        let f = folder.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !f.isEmpty {
+            let base = URL(fileURLWithPath: f).lastPathComponent
+            if !base.isEmpty && base != "/" { return base }
+        }
+        return kind
+    }
+
+    var body: some View {
+        ZStack {
+            Palette.ground.ignoresSafeArea()
+            VStack(spacing: 0) {
+                header
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 0) {
+                        sectionLabel("WHERE")
+                        folderRow
+                        sectionLabel("WHO")
+                        agentRow
+                        sectionLabel("WHAT")
+                        taskEditor
+                        if let errorMessage {
+                            Text(errorMessage).font(Typography.machine(12)).foregroundStyle(Palette.died)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .padding(.horizontal, 16).padding(.top, 10)
+                        }
+                        startButton
+                        Text("Starts a real agent and begins spending tokens.")
+                            .font(Typography.app(12)).foregroundStyle(Palette.textFaint)
+                            .frame(maxWidth: .infinity).multilineTextAlignment(.center)
+                            .padding(.horizontal, 24).padding(.top, 10)
+                    }
+                    .padding(.bottom, 16)
+                }
+            }
+        }
+    }
+
+    private var header: some View {
+        HStack {
+            Button("Cancel") { onCancel() }.font(Typography.app(15)).foregroundStyle(Palette.brand)
+            Spacer()
+            Text("New agent").font(Typography.app(17, .semibold)).foregroundStyle(Palette.text)
+            Spacer()
+            Color.clear.frame(width: 52, height: 1)   // balances the Cancel button width
+        }
+        .padding(.horizontal, 16).padding(.top, 8).padding(.bottom, 10)
+        .overlay(alignment: .bottom) { Rectangle().fill(Palette.hairline).frame(height: 1) }
+    }
+
+    private func sectionLabel(_ text: String) -> some View {
+        HStack(spacing: 8) {
+            Text(text).font(Typography.microLabel).tracking(1.2).foregroundStyle(Palette.textFaint)
+            Rectangle().fill(Palette.hairline).frame(height: 1)
+        }
+        .padding(.horizontal, 16).padding(.top, 18).padding(.bottom, 8)
+    }
+
+    private var folderRow: some View {
+        HStack {
+            Text("Folder").font(Typography.app(15)).foregroundStyle(Palette.textDim)
+            TextField("~/project", text: $folder)
+                .multilineTextAlignment(.trailing)
+                .textInputAutocapitalization(.never).autocorrectionDisabled()
+                .font(Typography.machine(15)).foregroundStyle(Palette.text)
+        }
+        .padding(.horizontal, 16).padding(.vertical, 14)
+        .overlay(RoundedRectangle(cornerRadius: 12).stroke(Palette.hairline, lineWidth: 1))
+        .padding(.horizontal, 16)
+    }
+
+    private var agentRow: some View {
+        HStack {
+            Text("Agent").font(Typography.app(15)).foregroundStyle(Palette.textDim)
+            Spacer()
+            Menu {
+                ForEach(Self.kinds, id: \.self) { k in Button(k) { kind = k } }
+            } label: {
+                HStack(spacing: 6) {
+                    Text(kind).font(Typography.machine(15)).foregroundStyle(Palette.text)
+                    Image(systemName: "chevron.down").font(.system(size: 11, weight: .semibold)).foregroundStyle(Palette.textFaint)
+                }
+            }
+        }
+        .padding(.horizontal, 16).padding(.vertical, 14)
+        .overlay(RoundedRectangle(cornerRadius: 12).stroke(Palette.hairline, lineWidth: 1))
+        .padding(.horizontal, 16).padding(.top, 10)
+    }
+
+    private var taskEditor: some View {
+        TextEditor(text: $task)
+            .font(Typography.app(15)).foregroundStyle(Palette.text)
+            .scrollContentBackground(.hidden)
+            .frame(minHeight: 90)
+            .padding(8)
+            .overlay(RoundedRectangle(cornerRadius: 12).stroke(Palette.hairline, lineWidth: 1))
+            .overlay(alignment: .topLeading) {
+                if task.isEmpty {
+                    Text("What should it do?").font(Typography.app(15)).foregroundStyle(Palette.textFaint)
+                        .padding(.horizontal, 13).padding(.top, 16).allowsHitTesting(false)
+                }
+            }
+            .padding(.horizontal, 16).padding(.top, 10)
+    }
+
+    private var startButton: some View {
+        Button { start() } label: {
+            HStack(spacing: 8) {
+                if starting { ProgressView().tint(.white) }
+                Text(starting ? "Starting…" : "Start").font(Typography.app(16, .semibold))
+            }
+            .frame(maxWidth: .infinity).padding(.vertical, 15)
+            .background(canStart ? Palette.brand : Palette.surface)
+            .foregroundStyle(canStart ? .white : Palette.textFaint)
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+        }
+        .disabled(!canStart)
+        .padding(.horizontal, 16).padding(.top, 16)
+    }
+
+    /// The three-step spawn. Steps are sequential and a failure at any step is
+    /// surfaced (never a silent half-spawn): split a pane in the folder, start the
+    /// agent kind in it, then send the task as its first prompt.
+    private func start() {
+        starting = true
+        errorMessage = nil
+        let cwd = folder.trimmingCharacters(in: .whitespacesAndNewlines)
+        let taskText = task.trimmingCharacters(in: .whitespacesAndNewlines)
+        let name = derivedName
+        let chosenKind = kind
+        Task {
+            defer { starting = false }
+            do {
+                let paneID = try await client.splitPane(cwd: cwd.isEmpty ? nil : cwd, direction: .down)
+                _ = try await client.startAgent(name: name, kind: chosenKind, paneID: paneID)
+                if !taskText.isEmpty {
+                    try await client.prompt(pane: paneID, text: taskText)
+                }
+                onStarted()
+            } catch {
+                errorMessage = "could not start: \(error)"
+            }
+        }
+    }
+}
+
 /// Lists the agents on the host; tapping one opens its pane. A failed load is
 /// recoverable (retry, or disconnect back to the connect form).
 struct TerminalHomeView: View {

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -218,6 +218,10 @@ struct RootView: View {
             }
         case .settings:
             SettingsView(host: "mac.tail-scale.ts.net")
+        case .newAgent:
+            NewAgentView(client: mockClient,
+                         initialFolder: "~/herdr-ios", initialKind: "codex",
+                         initialTask: "Fix the failing schema artifact test and push")
         }
     }
     #endif
@@ -605,6 +609,7 @@ struct TerminalHomeView: View {
     @State private var trustFailed = false
     @State private var search = ""
     @State private var showingSettings = false
+    @State private var showingNewAgent = false
     // Only the quiet tail (idle) starts collapsed — the model forbids a
     // collapsed group from ever hiding something that wants attention.
     @State private var collapsed: Set<AgentGroup> = Set(AgentGroup.allCases.filter { $0.startsCollapsed })
@@ -655,6 +660,12 @@ struct TerminalHomeView: View {
                 onReconnect: { showingSettings = false; onReconnect() },
                 onClose: { showingSettings = false })
         }
+        .fullScreenCover(isPresented: $showingNewAgent) {
+            NewAgentView(
+                client: client,
+                onStarted: { showingNewAgent = false; Task { await load() } },
+                onCancel: { showingNewAgent = false })
+        }
     }
 
     // MARK: chrome
@@ -675,7 +686,7 @@ struct TerminalHomeView: View {
             Spacer()
             // The new-agent screen (04) does not exist yet — a visible but inert
             // affordance, not a live control that does nothing.
-            circleButton("plus") { }.disabled(true).opacity(0.35)
+            circleButton("plus") { showingNewAgent = true }
         }
         .padding(.horizontal, 16).padding(.top, 8).padding(.bottom, 10)
     }
@@ -1305,15 +1316,23 @@ private extension View {
 /// `HERDR_SCREENSHOT_MOCK=list` (default) or `=pane`, or the `-herdrScreenshotMock`
 /// launch argument.
 enum ScreenshotMock {
-    case list, pane, settings
+    case list, pane, settings, newAgent
 
     static var mode: ScreenshotMock? {
         let env = ProcessInfo.processInfo.environment["HERDR_SCREENSHOT_MOCK"]?.lowercased()
         let arg = ProcessInfo.processInfo.arguments.contains("-herdrScreenshotMock")
+        #if SCREENSHOT_MOCK_DEFAULT
+        // VERIFICATION SCAFFOLD — REMOVE BEFORE MERGE. The buildbox launches the app
+        // with no env/args; this boots into the new-agent mock so that screen can be
+        // screenshotted. Debug-config-only (project.yml), mock data only — no key.
+        guard env != nil || arg else { return .newAgent }
+        #else
         guard env != nil || arg else { return nil }
+        #endif
         switch env {
         case "pane": return .pane
         case "settings": return .settings
+        case "newagent": return .newAgent
         default: return .list
         }
     }

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -1364,14 +1364,7 @@ enum ScreenshotMock {
     static var mode: ScreenshotMock? {
         let env = ProcessInfo.processInfo.environment["HERDR_SCREENSHOT_MOCK"]?.lowercased()
         let arg = ProcessInfo.processInfo.arguments.contains("-herdrScreenshotMock")
-        #if SCREENSHOT_MOCK_DEFAULT
-        // VERIFICATION SCAFFOLD — REMOVE BEFORE MERGE. The buildbox launches the app
-        // with no env/args; this boots into the new-agent mock so that screen can be
-        // screenshotted. Debug-config-only (project.yml), mock data only — no key.
-        guard env != nil || arg else { return .newAgent }
-        #else
         guard env != nil || arg else { return nil }
-        #endif
         switch env {
         case "pane": return .pane
         case "settings": return .settings

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -220,7 +220,7 @@ struct RootView: View {
             SettingsView(host: "mac.tail-scale.ts.net")
         case .newAgent:
             NewAgentView(client: mockClient,
-                         initialFolder: "~/herdr-ios", initialKind: "codex",
+                         initialFolder: "/root/herdr-ios", initialKind: "codex",
                          initialTask: "Fix the failing schema artifact test and push")
         }
     }
@@ -439,8 +439,15 @@ struct NewAgentView: View {
         _task = State(initialValue: initialTask)
     }
 
+    private var trimmedFolder: String { folder.trimmingCharacters(in: .whitespacesAndNewlines) }
+    /// A folder must be ABSOLUTE (or blank = follow the focused pane). The phone
+    /// cannot expand "~" or a relative path — the remote $HOME is unknown here —
+    /// and the server would silently drop a non-directory and spawn in $HOME. So
+    /// reject anything non-absolute at the form rather than run in the wrong place.
+    private var folderValid: Bool { trimmedFolder.isEmpty || trimmedFolder.hasPrefix("/") }
     private var canStart: Bool {
-        !task.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && !starting && !partialSpawn
+        !task.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && folderValid && !starting && !partialSpawn
     }
     /// The agent's name — the folder's basename, else the kind. herdr validates
     /// the name; a duplicate surfaces as a start error rather than being guessed.
@@ -487,10 +494,8 @@ struct NewAgentView: View {
         HStack {
             Button("Cancel") { onCancel() }.font(Typography.app(15)).foregroundStyle(Palette.brand)
                 .disabled(starting)   // no dismiss mid-spawn — the op would keep running off-screen
-            Spacer()
             Text("New agent").font(Typography.app(17, .semibold)).foregroundStyle(Palette.text)
             Spacer()
-            Color.clear.frame(width: 52, height: 1)   // balances the Cancel button width
         }
         .padding(.horizontal, 16).padding(.top, 8).padding(.bottom, 10)
         .overlay(alignment: .bottom) { Rectangle().fill(Palette.hairline).frame(height: 1) }
@@ -505,15 +510,20 @@ struct NewAgentView: View {
     }
 
     private var folderRow: some View {
-        HStack {
-            Text("Folder").font(Typography.app(15)).foregroundStyle(Palette.textDim)
-            TextField("~/project", text: $folder)
-                .multilineTextAlignment(.trailing)
-                .textInputAutocapitalization(.never).autocorrectionDisabled()
-                .font(Typography.machine(15)).foregroundStyle(Palette.text)
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Text("Folder").font(Typography.app(15)).foregroundStyle(Palette.textDim)
+                TextField("/root/project", text: $folder)
+                    .multilineTextAlignment(.trailing)
+                    .textInputAutocapitalization(.never).autocorrectionDisabled()
+                    .font(Typography.machine(15)).foregroundStyle(Palette.text)
+            }
+            .rowShell()
+            if !folderValid {
+                Text("use an absolute path (starts with /), or leave blank to use the current folder")
+                    .font(Typography.app(12)).foregroundStyle(Palette.died).padding(.horizontal, 4)
+            }
         }
-        .padding(.horizontal, 16).padding(.vertical, 14)
-        .overlay(RoundedRectangle(cornerRadius: 12).stroke(Palette.hairline, lineWidth: 1))
         .padding(.horizontal, 16)
     }
 
@@ -530,8 +540,7 @@ struct NewAgentView: View {
                 }
             }
         }
-        .padding(.horizontal, 16).padding(.vertical, 14)
-        .overlay(RoundedRectangle(cornerRadius: 12).stroke(Palette.hairline, lineWidth: 1))
+        .rowShell()
         .padding(.horizontal, 16).padding(.top, 10)
     }
 
@@ -541,7 +550,7 @@ struct NewAgentView: View {
             .scrollContentBackground(.hidden)
             .frame(minHeight: 90)
             .padding(8)
-            .overlay(RoundedRectangle(cornerRadius: 12).stroke(Palette.hairline, lineWidth: 1))
+            .background(Palette.card).clipShape(RoundedRectangle(cornerRadius: 12))   // filled card, per the mockup
             .overlay(alignment: .topLeading) {
                 if task.isEmpty {
                     Text("What should it do?").font(Typography.app(15)).foregroundStyle(Palette.textFaint)
@@ -636,8 +645,12 @@ struct TerminalHomeView: View {
     @State private var rejectedFingerprint: String?
     @State private var trustFailed = false
     @State private var search = ""
-    @State private var showingSettings = false
-    @State private var showingNewAgent = false
+    @State private var activeCover: ActiveCover?
+
+    private enum ActiveCover: Int, Identifiable {
+        case settings, newAgent
+        var id: Int { rawValue }
+    }
     // Only the quiet tail (idle) starts collapsed — the model forbids a
     // collapsed group from ever hiding something that wants attention.
     @State private var collapsed: Set<AgentGroup> = Set(AgentGroup.allCases.filter { $0.startsCollapsed })
@@ -677,22 +690,26 @@ struct TerminalHomeView: View {
             .toolbar(.hidden, for: .navigationBar)
             .task { await load() }
         }
-        .fullScreenCover(isPresented: $showingSettings) {
-            SettingsView(
-                host: host,
-                connected: error == nil && !loading,
-                // Withhold reconnect during a host-key rejection — reconnecting
-                // then would first-contact-trust the next key (same gate as the
-                // recovery screen's withheld retry).
-                canReconnect: rejectedFingerprint == nil,
-                onReconnect: { showingSettings = false; onReconnect() },
-                onClose: { showingSettings = false })
-        }
-        .fullScreenCover(isPresented: $showingNewAgent) {
-            NewAgentView(
-                client: client,
-                onStarted: { showingNewAgent = false; Task { await load() } },
-                onCancel: { showingNewAgent = false })
+        // ONE item-based cover, not two stacked isPresented covers (stacked
+        // presentation modifiers on a single view are historically fragile).
+        .fullScreenCover(item: $activeCover) { cover in
+            switch cover {
+            case .settings:
+                SettingsView(
+                    host: host,
+                    connected: error == nil && !loading,
+                    // Withhold reconnect during a host-key rejection — reconnecting
+                    // then would first-contact-trust the next key (same gate as the
+                    // recovery screen's withheld retry).
+                    canReconnect: rejectedFingerprint == nil,
+                    onReconnect: { activeCover = nil; onReconnect() },
+                    onClose: { activeCover = nil })
+            case .newAgent:
+                NewAgentView(
+                    client: client,
+                    onStarted: { activeCover = nil; Task { await load() } },
+                    onCancel: { activeCover = nil })
+            }
         }
     }
 
@@ -712,9 +729,7 @@ struct TerminalHomeView: View {
                     .frame(height: 15)
             }
             Spacer()
-            // The new-agent screen (04) does not exist yet — a visible but inert
-            // affordance, not a live control that does nothing.
-            circleButton("plus") { showingNewAgent = true }
+            circleButton("plus") { activeCover = .newAgent }
         }
         .padding(.horizontal, 16).padding(.top, 8).padding(.bottom, 10)
     }
@@ -754,7 +769,7 @@ struct TerminalHomeView: View {
         HStack(spacing: 4) {
             tabItem("square.grid.2x2.fill", "Agents", active: true)
             tabItem("terminal", "Terminal", active: false)
-            Button { showingSettings = true } label: {
+            Button { activeCover = .settings } label: {
                 tabItem("gearshape", "Settings", active: false)
             }
             .buttonStyle(.plain)

--- a/Sources/HerdrKit/AgentName.swift
+++ b/Sources/HerdrKit/AgentName.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+/// Normalizes an arbitrary string (e.g. a folder basename) to herdr's agent-name
+/// grammar, `^[a-z][a-z0-9_-]{0,31}$`.
+///
+/// This exists so `agent.start` does not fail AFTER a pane was already created: a
+/// folder like "Herdr-iOS", "~/My Project", or "工作" would otherwise pass the UI
+/// and be rejected by the server mid-spawn, stranding the pane. Normalizing up
+/// front turns those into names the server accepts. Duplicate normalized names
+/// still surface `agent_name_taken` — that is the server's call, not guessed here.
+public enum AgentName {
+    public static func normalize(_ raw: String) -> String {
+        var out = ""
+        for scalar in raw.lowercased().unicodeScalars {
+            let c = Character(scalar)
+            if out.isEmpty {
+                // Must start with a letter; drop anything (digits, symbols) before it.
+                if ("a"..."z").contains(c) { out.append(c) }
+            } else if ("a"..."z").contains(c) || ("0"..."9").contains(c) || c == "-" || c == "_" {
+                out.append(c)
+            } else {
+                out.append("-")   // any other character becomes a separator
+            }
+            if out.count >= 32 { break }
+        }
+        return out.isEmpty ? "agent" : out
+    }
+}

--- a/Sources/HerdrKit/HerdrClient.swift
+++ b/Sources/HerdrKit/HerdrClient.swift
@@ -180,9 +180,41 @@ public actor HerdrClient {
 
     /// Starts an agent of `kind` (claude/codex/gemini/…) named `name` in an
     /// existing pane (the one from `splitPane`). Returns the started agent.
+    ///
+    /// NOTE: this only INITIATES launch. `agent.start` returns while the agent is
+    /// still `launch_pending`, and `agent.prompt` refuses (agent_not_ready) until
+    /// launch completes — so a caller sending a task must `waitForReady` first.
     public func startAgent(name: String, kind: String, paneID: String) async throws -> AgentInfo {
         let params = AgentStartParams(name: name, kind: kind, paneID: paneID)
         return try await call("agent.start", params, as: AgentStartedResult.self).agent
+    }
+
+    struct PaneTarget: Encodable {
+        let paneID: String
+        enum CodingKeys: String, CodingKey { case paneID = "pane_id" }
+    }
+
+    /// Closes a pane — used to clean up the pane a failed spawn left behind, so a
+    /// retry does not accumulate orphan panes.
+    public func closePane(paneID: String) async throws {
+        _ = try await call("pane.close", PaneTarget(paneID: paneID), as: JSONNull.self)
+    }
+
+    public enum ReadyError: Error, Equatable { case timedOut(pane: String) }
+
+    /// Polls until the agent in `pane` reports `interactive_ready` (its composer
+    /// accepts a prompt), or throws `ReadyError.timedOut` after `timeoutMs`. The
+    /// readiness signal is the exact one `agent.prompt` gates on, so a caller that
+    /// awaits this then prompts will not hit agent_not_ready on the happy path.
+    public func waitForReady(pane: String, timeoutMs: Int = 60_000, pollMs: Int = 500) async throws {
+        var elapsed = 0
+        while true {
+            let ready = try await agentList().first { $0.paneID == pane }?.interactiveReady ?? false
+            if ready { return }
+            if elapsed >= timeoutMs { throw ReadyError.timedOut(pane: pane) }
+            try await Task.sleep(nanoseconds: UInt64(max(1, pollMs)) * 1_000_000)
+            elapsed += pollMs
+        }
     }
 
     // MARK: - Events

--- a/Sources/HerdrKit/HerdrClient.swift
+++ b/Sources/HerdrKit/HerdrClient.swift
@@ -131,6 +131,60 @@ public actor HerdrClient {
         _ = try await call("agent.send_keys", SendKeysParams(target: pane, keys: keys), as: JSONNull.self)
     }
 
+    // MARK: - Spawning agents
+
+    /// A new pane splits off horizontally (`right`) or vertically (`down`). herdr
+    /// supports only these two — there is no left/up split.
+    public enum SplitDirection: String, Sendable {
+        case right, down
+    }
+
+    struct PaneSplitParams: Encodable {
+        let direction: String
+        let cwd: String?
+        let focus: Bool
+    }
+
+    struct PaneInfoResult: Decodable {
+        let pane: PaneRef
+        /// Only the id is needed here; the rest of `pane` is deliberately not
+        /// modelled so a schema addition on the server cannot break this decode.
+        struct PaneRef: Decodable {
+            let paneID: String
+            enum CodingKeys: String, CodingKey { case paneID = "pane_id" }
+        }
+    }
+
+    /// Splits the currently focused pane and returns the NEW pane's id. `cwd` is
+    /// the working directory the new pane (and the agent started in it) runs in —
+    /// the "folder" of the new-agent form; nil follows the split pane's cwd.
+    /// No target pane is sent, so the server splits whatever is focused.
+    public func splitPane(cwd: String?, direction: SplitDirection = .down) async throws -> String {
+        let params = PaneSplitParams(direction: direction.rawValue, cwd: cwd, focus: true)
+        return try await call("pane.split", params, as: PaneInfoResult.self).pane.paneID
+    }
+
+    struct AgentStartParams: Encodable {
+        let name: String
+        let kind: String
+        let paneID: String
+        enum CodingKeys: String, CodingKey {
+            case name, kind
+            case paneID = "pane_id"
+        }
+    }
+
+    struct AgentStartedResult: Decodable {
+        let agent: AgentInfo
+    }
+
+    /// Starts an agent of `kind` (claude/codex/gemini/…) named `name` in an
+    /// existing pane (the one from `splitPane`). Returns the started agent.
+    public func startAgent(name: String, kind: String, paneID: String) async throws -> AgentInfo {
+        let params = AgentStartParams(name: name, kind: kind, paneID: paneID)
+        return try await call("agent.start", params, as: AgentStartedResult.self).agent
+    }
+
     // MARK: - Events
 
     /// Opens the persistent event stream.

--- a/Tests/HerdrKitTests/NewAgentClientTests.swift
+++ b/Tests/HerdrKitTests/NewAgentClientTests.swift
@@ -60,4 +60,84 @@ final class NewAgentClientTests: XCTestCase {
         XCTAssertTrue(t.lastRequest.contains("\"kind\""), "kind was not sent")
         XCTAssertTrue(t.lastRequest.contains("fix-tests"), "name was not sent")
     }
+
+    func testClosePaneSendsPaneID() async throws {
+        let t = CapturingTransport()
+        try await HerdrClient(transport: t).closePane(paneID: "w1:p9")
+        XCTAssertTrue(t.lastRequest.contains("pane.close"), "wrong method")
+        XCTAssertTrue(t.lastRequest.contains("\"pane_id\""), "pane_id must use the snake_case wire key")
+        XCTAssertTrue(t.lastRequest.contains("w1:p9"))
+    }
+
+    /// AXIS: the happy path must not prompt before the agent is ready. waitForReady
+    /// polls agent.list until interactive_ready is true; here it flips true on the
+    /// 2nd poll, so the call must poll at least twice and then return.
+    func testWaitForReadyPollsUntilInteractiveReady() async throws {
+        final class ReadyAfterTwo: HerdrTransport, @unchecked Sendable {
+            var listCalls = 0
+            func roundTrip(_ requestLine: String) async throws -> String {
+                if requestLine.contains("agent.list") {
+                    listCalls += 1
+                    let ready = listCalls >= 2 ? "true" : "false"
+                    return #"{"id":"x","result":{"type":"agent_list","agents":[{"pane_id":"w1:p9","interactive_ready":\#(ready)}]}}"#
+                }
+                return #"{"id":"x","result":{}}"#
+            }
+            func stream(_ r: String) -> AsyncThrowingStream<String, Error> { AsyncThrowingStream { $0.finish() } }
+        }
+        let t = ReadyAfterTwo()
+        try await HerdrClient(transport: t).waitForReady(pane: "w1:p9", timeoutMs: 1000, pollMs: 1)
+        XCTAssertGreaterThanOrEqual(t.listCalls, 2, "should have polled until ready")
+    }
+
+    /// AXIS: a never-ready agent must TIME OUT, not spin forever — the caller then
+    /// surfaces an honest error rather than blocking the UI.
+    func testWaitForReadyTimesOut() async throws {
+        final class NeverReady: HerdrTransport, @unchecked Sendable {
+            func roundTrip(_ r: String) async throws -> String {
+                #"{"id":"x","result":{"type":"agent_list","agents":[{"pane_id":"w1:p9","interactive_ready":false}]}}"#
+            }
+            func stream(_ r: String) -> AsyncThrowingStream<String, Error> { AsyncThrowingStream { $0.finish() } }
+        }
+        do {
+            try await HerdrClient(transport: NeverReady()).waitForReady(pane: "w1:p9", timeoutMs: 5, pollMs: 1)
+            XCTFail("expected a timeout")
+        } catch let error as HerdrClient.ReadyError {
+            XCTAssertEqual(error, .timedOut(pane: "w1:p9"))
+        }
+    }
+}
+
+/// Normalizing an arbitrary folder name to herdr's agent-name grammar, so
+/// agent.start never fails on the name AFTER a pane was created.
+final class AgentNameTests: XCTestCase {
+    func testKeepsAlreadyValidName() { XCTAssertEqual(AgentName.normalize("herdr-ios"), "herdr-ios") }
+    func testLowercases() { XCTAssertEqual(AgentName.normalize("Herdr-iOS"), "herdr-ios") }
+    func testDropsLeadingNonLettersAndMapsSeparators() { XCTAssertEqual(AgentName.normalize("~/My Project"), "my-project") }
+    func testLeadingDigitsDropped() { XCTAssertEqual(AgentName.normalize("123abc"), "abc") }
+
+    func testEmptyAndAllInvalidFallBackToAgent() {
+        XCTAssertEqual(AgentName.normalize(""), "agent")
+        XCTAssertEqual(AgentName.normalize("工作"), "agent")
+        XCTAssertEqual(AgentName.normalize("///"), "agent")
+    }
+
+    func testTruncatesTo32() {
+        XCTAssertEqual(AgentName.normalize(String(repeating: "a", count: 40)).count, 32)
+    }
+
+    /// AXIS: whatever the input, the output ALWAYS matches ^[a-z][a-z0-9_-]{0,31}$.
+    func testOutputAlwaysMatchesGrammar() {
+        for raw in ["herdr-ios", "Herdr-iOS", "~/My Project", "123", "工作", "",
+                    "UPPER_CASE.dot", "a b c d e f g h i j k l m n o p q r"] {
+            let n = AgentName.normalize(raw)
+            XCTAssertFalse(n.isEmpty, "\(raw.debugDescription) produced an empty name")
+            XCTAssertLessThanOrEqual(n.count, 32)
+            XCTAssertTrue(("a"..."z").contains(n.first!), "\(n) must start with a letter")
+            for ch in n {
+                XCTAssertTrue(("a"..."z").contains(ch) || ("0"..."9").contains(ch) || ch == "-" || ch == "_",
+                              "\(n) has an invalid character \(ch)")
+            }
+        }
+    }
 }

--- a/Tests/HerdrKitTests/NewAgentClientTests.swift
+++ b/Tests/HerdrKitTests/NewAgentClientTests.swift
@@ -31,12 +31,14 @@ final class NewAgentClientTests: XCTestCase {
         let pane = try await HerdrClient(transport: t).splitPane(cwd: "/root/herdr-ios", direction: .down)
 
         XCTAssertEqual(pane, "w1:p9", "did not decode pane_id from pane.split's PaneInfo{pane} result")
-        XCTAssertTrue(t.lastRequest.contains("pane.split"), "wrong method")
+        // Anchor the method to the whole value so a suffix (pane.splitx) fails.
+        XCTAssertTrue(t.lastRequest.contains(#""method":"pane.split""#), "wrong method")
         // Slash-independent: JSONEncoder escapes "/" as "\/", so match the key +
         // the (slashless) folder name rather than the literal path.
         XCTAssertTrue(t.lastRequest.contains("\"cwd\""), "cwd key (the folder) was not sent")
         XCTAssertTrue(t.lastRequest.contains("herdr-ios"), "cwd value (the folder) was not sent")
-        XCTAssertTrue(t.lastRequest.contains("down"), "direction was not sent")
+        XCTAssertTrue(t.lastRequest.contains(#""direction":"down""#), "direction was not sent")
+        XCTAssertTrue(t.lastRequest.contains(#""focus":true"#), "focus flag was not sent as expected")
     }
 
     func testSplitPaneOmitsCwdWhenNil() async throws {
@@ -54,11 +56,31 @@ final class NewAgentClientTests: XCTestCase {
         XCTAssertEqual(agent.paneID, "w1:p9")
         XCTAssertEqual(agent.agent, "codex")
         XCTAssertEqual(agent.displayName, "fix-tests")
-        XCTAssertTrue(t.lastRequest.contains("agent.start"), "wrong method")
-        // The pane id must go out under the wire key the server expects, not paneID.
-        XCTAssertTrue(t.lastRequest.contains("\"pane_id\""), "pane_id must use the snake_case wire key")
-        XCTAssertTrue(t.lastRequest.contains("\"kind\""), "kind was not sent")
-        XCTAssertTrue(t.lastRequest.contains("fix-tests"), "name was not sent")
+        XCTAssertTrue(t.lastRequest.contains(#""method":"agent.start""#), "wrong method")
+        // Pin the key:value PAIRS, not just the keys — otherwise transposing name
+        // and kind (spawn the wrong kind under the wrong name) survives.
+        XCTAssertTrue(t.lastRequest.contains(#""name":"fix-tests""#), "name/value not sent correctly")
+        XCTAssertTrue(t.lastRequest.contains(#""kind":"codex""#), "kind/value not sent correctly")
+        // The pane id must go out under the snake_case wire key the server expects.
+        XCTAssertTrue(t.lastRequest.contains(#""pane_id":"w1:p9""#), "pane_id must use the snake_case wire key")
+    }
+
+    /// AXIS: a server error envelope from these methods surfaces as a thrown
+    /// APIError — the property the whole spawn flow's error handling leans on.
+    func testServerErrorSurfacesAsAPIError() async throws {
+        struct ErrorTransport: HerdrTransport {
+            func roundTrip(_ r: String) async throws -> String {
+                #"{"id":"x","error":{"code":"agent_not_ready","message":"agent w1:p9 is not ready"}}"#
+            }
+            func stream(_ r: String) -> AsyncThrowingStream<String, Error> { AsyncThrowingStream { $0.finish() } }
+        }
+        let client = HerdrClient(transport: ErrorTransport())
+        do {
+            _ = try await client.splitPane(cwd: "/x")
+            XCTFail("expected the error envelope to throw")
+        } catch let e as APIError {
+            XCTAssertEqual(e.code, "agent_not_ready")
+        }
     }
 
     func testClosePaneSendsPaneID() async throws {

--- a/Tests/HerdrKitTests/NewAgentClientTests.swift
+++ b/Tests/HerdrKitTests/NewAgentClientTests.swift
@@ -1,0 +1,63 @@
+import XCTest
+@testable import HerdrKit
+
+/// The two client calls the new-agent flow adds: splitPane (make a pane in a
+/// folder) and startAgent (launch a kind in that pane). Both the request encoding
+/// and the response decoding are pinned against herdr's actual wire shapes
+/// (pane.split -> ResponseResult::PaneInfo{pane}; agent.start ->
+/// ResponseResult::AgentStarted{agent,argv}).
+final class NewAgentClientTests: XCTestCase {
+
+    /// Records the request line and replies with a canned response per method.
+    private final class CapturingTransport: HerdrTransport, @unchecked Sendable {
+        var lastRequest = ""
+        func roundTrip(_ requestLine: String) async throws -> String {
+            lastRequest = requestLine
+            if requestLine.contains("pane.split") {
+                return #"{"id":"x","result":{"type":"pane_info","pane":{"pane_id":"w1:p9"}}}"#
+            }
+            if requestLine.contains("agent.start") {
+                return #"{"id":"x","result":{"type":"agent_started","agent":{"pane_id":"w1:p9","name":"fix-tests","agent":"codex","agent_status":"working"},"argv":["codex"]}}"#
+            }
+            return #"{"id":"x","result":{}}"#
+        }
+        func stream(_ requestLine: String) -> AsyncThrowingStream<String, Error> {
+            AsyncThrowingStream { $0.finish() }
+        }
+    }
+
+    func testSplitPaneSendsFolderAndDirectionAndReturnsNewPaneID() async throws {
+        let t = CapturingTransport()
+        let pane = try await HerdrClient(transport: t).splitPane(cwd: "/root/herdr-ios", direction: .down)
+
+        XCTAssertEqual(pane, "w1:p9", "did not decode pane_id from pane.split's PaneInfo{pane} result")
+        XCTAssertTrue(t.lastRequest.contains("pane.split"), "wrong method")
+        // Slash-independent: JSONEncoder escapes "/" as "\/", so match the key +
+        // the (slashless) folder name rather than the literal path.
+        XCTAssertTrue(t.lastRequest.contains("\"cwd\""), "cwd key (the folder) was not sent")
+        XCTAssertTrue(t.lastRequest.contains("herdr-ios"), "cwd value (the folder) was not sent")
+        XCTAssertTrue(t.lastRequest.contains("down"), "direction was not sent")
+    }
+
+    func testSplitPaneOmitsCwdWhenNil() async throws {
+        let t = CapturingTransport()
+        _ = try await HerdrClient(transport: t).splitPane(cwd: nil)
+        // A nil cwd must not be sent as an explicit null/empty — the server then
+        // follows the split pane's own cwd.
+        XCTAssertFalse(t.lastRequest.contains("\"cwd\""), "nil cwd should be omitted, not sent")
+    }
+
+    func testStartAgentSendsSnakeCasePaneIDAndDecodesTheAgent() async throws {
+        let t = CapturingTransport()
+        let agent = try await HerdrClient(transport: t).startAgent(name: "fix-tests", kind: "codex", paneID: "w1:p9")
+
+        XCTAssertEqual(agent.paneID, "w1:p9")
+        XCTAssertEqual(agent.agent, "codex")
+        XCTAssertEqual(agent.displayName, "fix-tests")
+        XCTAssertTrue(t.lastRequest.contains("agent.start"), "wrong method")
+        // The pane id must go out under the wire key the server expects, not paneID.
+        XCTAssertTrue(t.lastRequest.contains("\"pane_id\""), "pane_id must use the snake_case wire key")
+        XCTAssertTrue(t.lastRequest.contains("\"kind\""), "kind was not sent")
+        XCTAssertTrue(t.lastRequest.contains("fix-tests"), "name was not sent")
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -55,3 +55,9 @@ targets:
         SWIFT_VERSION: "5.9"
         GENERATE_INFOPLIST_FILE: NO
         TARGETED_DEVICE_FAMILY: "1"
+      configs:
+        # VERIFICATION SCAFFOLD — REMOVE BEFORE MERGE. Boots the Debug build into the
+        # new-agent mock so the buildbox screenshots that screen. Paired with
+        # ScreenshotMock.mode; revert before merge.
+        Debug:
+          SWIFT_ACTIVE_COMPILATION_CONDITIONS: DEBUG SCREENSHOT_MOCK_DEFAULT

--- a/project.yml
+++ b/project.yml
@@ -55,9 +55,3 @@ targets:
         SWIFT_VERSION: "5.9"
         GENERATE_INFOPLIST_FILE: NO
         TARGETED_DEVICE_FAMILY: "1"
-      configs:
-        # VERIFICATION SCAFFOLD — REMOVE BEFORE MERGE. Boots the Debug build into the
-        # new-agent mock so the buildbox screenshots that screen. Paired with
-        # ScreenshotMock.mode; revert before merge.
-        Debug:
-          SWIFT_ACTIVE_COMPILATION_CONDITIONS: DEBUG SCREENSHOT_MOCK_DEFAULT


### PR DESCRIPTION
The final slice of the design pass (screens 01/02/03/05 already in main): NewAgentView (screen 04) — a form (Folder / Agent / What) whose Start **spawns a real agent and spends tokens** — plus the HerdrKit client layer it needs. No herdr fork change.

## Flow
`splitPane(cwd: folder)` → `startAgent(name, kind, pane_id)` → `waitForReady` → `prompt(task)`. All existing herdr API methods; the "+" on the agent list presents it.

## Review — two rounds, two blockers caught + fixed (both mutation-verified)
Two distinct-runtime reviewers read herdr's server source and found two bugs that would each end with a real agent running in a state the user didn't ask for:
- **agent_not_ready**: `agent.start` only *initiates* launch; prompting immediately returned `agent_not_ready`, so the agent spawned but the task never sent. Fixed: `client.waitForReady` polls `interactive_ready` (bounded 60s) before prompting.
- **cwd → wrong folder**: `~/…` is never expanded; the server drops a non-directory and silently runs in `$HOME`. Fixed: the folder must be **absolute** (or blank = follow the focused pane), gated at the form with a hint; placeholder/mock use `/root/…`.

Also: `derivedName` normalized to herdr's `^[a-z][a-z0-9_-]{0,31}$` (HerdrKit `AgentName`); partial-spawn handled by *where* it failed (orphan pane closed via `pane.close`; a live agent is disclosed, not blindly retried); Cancel disabled mid-spawn; two stacked `fullScreenCover`s collapsed to one item-based cover.

## Verification
- **Two-witness APPROVE at the final reviewed head** ed6f4a2: **codex** + **kimi** (omp's job died mid-stream twice, so kimi is the second distinct runtime, per the use-any-available-runtime rule).
- **205 Linux tests green** (`-warnings-as-errors`); new client + `AgentName` tests, mutation-verified (name/kind transposition, snake_case `pane_id`, error-envelope→APIError all KILL on reversion).
- Buildbox green; screenshot-verified vs `04-new-agent.png`. Scaffold reverted in the final commit (`516f62a`) — boots to ConnectView.

Head: 516f62a (ed6f4a2 + the disclosed scaffold revert).

🤖 Generated with [Claude Code](https://claude.com/claude-code)