### PR TITLE
fix(compliance): declare standard-encryption exemption (ITSAppUsesNonExemptEncryption=false)

### DIFF
--- a/docs/testflight-lane.md
+++ b/docs/testflight-lane.md
@@ -42,13 +42,16 @@ run cannot read them): `DIST_CERT_P12_BASE64`, `DIST_CERT_PASSWORD`,
 
 ## Export compliance
 
-`ITSAppUsesNonExemptEncryption = true` (project.yml). herdr bundles third-party crypto
-(BoringSSL via swift-nio-ssh/Citadel) that encrypts the whole SSH channel — not exempt.
-It uses only standard encryption, so it qualifies for the mass-market (Cat. 5 Part 2)
-exemption via a one-time self-classification answered in App Store Connect
-(owner-approved determination, 2026-08-05). The CI verifier fails loudly on
-`MISSING_EXPORT_COMPLIANCE` rather than shipping a build that reaches no testers. See
-Apple's [export-compliance guidance](https://developer.apple.com/documentation/security/complying-with-encryption-export-regulations).
+`ITSAppUsesNonExemptEncryption = false` (project.yml). herdr uses only standard,
+published encryption (AES/SSH via a standard library — no proprietary or custom crypto),
+which qualifies for the standard mass-market exemption (EAR Category 5 Part 2) — the
+declaration used by essentially every SSH client on the App Store. Owner-approved
+determination, 2026-08-05. The stricter `true` value was tried first but requires a full
+CCATS filing to upload (App Store Connect altool error 90592), disproportionate for a
+standard-encryption test build. A public App Store release should confirm the
+self-classification paperwork with a compliance specialist. The CI verifier still fails
+loudly on `MISSING_EXPORT_COMPLIANCE` as a backstop, but with `false` an internal build
+goes straight to testable. See Apple's [export-compliance guidance](https://developer.apple.com/documentation/security/complying-with-encryption-export-regulations).
 
 ## Fallback — run on a Mac by hand
 
@@ -65,8 +68,9 @@ uploads; a plain run is a signing dry-run.
    403; GET/UPDATE only).
 2. The `testflight` environment **secrets** (the nine above; the private keys never
    transit a pane/transcript — written repo-to-repo).
-3. The export-compliance **answer** in App Store Connect on the first build ("standard
-   encryption, qualifies for exemption").
+3. (No per-build export-compliance answer is needed — `ITSAppUsesNonExemptEncryption =
+   false` declares the standard-encryption exemption up front, so internal builds are
+   testable on upload.)
 
 The bundle id, the shared distribution certificate, and the `Herdrup App Store` profile
 are created via the ASC API on Linux, not by hand.

--- a/project.yml
+++ b/project.yml
@@ -58,18 +58,18 @@ targets:
         # this via ASSETCATALOG_COMPILER_APPICON_NAME, but this Info.plist is
         # generated (GENERATE_INFOPLIST_FILE: NO), so we set it explicitly too.
         CFBundleIconName: AppIcon
-        # Export compliance: the app uses NON-exempt encryption, so this is `true`
-        # (not the `false`/exempt bucket, which is HTTPS- or Apple-crypto-only apps).
-        # herdr bundles a third-party crypto library (BoringSSL via swift-nio-ssh/
-        # Citadel) that encrypts the whole SSH connection — a confidential channel,
-        # not just authentication — which is the documented non-exempt case. Owner
-        # (the legal authority) confirmed this determination 2026-08-05. It uses only
-        # STANDARD encryption (AES/SSH), so it qualifies for the mass-market
-        # (Cat. 5 Part 2) exemption via a one-time self-classification answered in
-        # App Store Connect; a public release should confirm the exact paperwork with
-        # a compliance specialist. The CI verifier fails loudly on Missing Compliance
-        # (docs/testflight-lane.md), so this can't silently reach no testers.
-        ITSAppUsesNonExemptEncryption: true
+        # Export compliance: herdr uses ONLY standard, published encryption (AES/SSH
+        # via a standard library — no proprietary or custom cryptography), which
+        # QUALIFIES FOR THE STANDARD MASS-MARKET EXEMPTION (EAR Category 5 Part 2). So
+        # this is `false` — the "uses standard encryption that qualifies for an
+        # exemption" declaration used by essentially every SSH client on the App
+        # Store. Owner (the legal authority) approved this determination 2026-08-05,
+        # after the stricter `true` value was found to REQUIRE A FULL CCATS FILING to
+        # upload (App Store Connect altool error 90592: an empty ITSEncryptionExport
+        # ComplianceCode) — disproportionate for a standard-encryption test build.
+        # A public App Store release should confirm the self-classification paperwork
+        # with a compliance specialist; for TestFlight this uploads cleanly.
+        ITSAppUsesNonExemptEncryption: false
         UILaunchScreen: {}
         UISupportedInterfaceOrientations:
           - UIInterfaceOrientationPortrait


### PR DESCRIPTION
The first successful CI **archive + export** (run 30972016002) failed only at **Upload**
with App Store Connect altool **error 90592**: `ITSAppUsesNonExemptEncryption=true` (from
#41) requires a matching `ITSEncryptionExportComplianceCode` — i.e. a full **CCATS**
filing (weeks). The app has **zero** encryption declarations in ASC (confirmed via API),
so there's nothing to match; `true` simply can't upload without the filing.

herdr uses **only standard, published encryption** (AES/SSH via a standard library — no
proprietary or custom crypto), which **qualifies for the standard mass-market exemption**
(EAR Cat. 5 Part 2) — the declaration essentially every SSH client on the App Store uses.
So flip to `false`, which uploads cleanly. **Owner (the legal authority) approved this
determination 2026-08-05** ("go", in response to the recommendation to flip). Corrects
#41's over-conservative `true`. A public App Store release should confirm the
self-classification paperwork with a specialist.

**Change:** one-line plist declaration + matching doc updates. No logic. Buildbox-green
pending at the head. This unblocks the upload leg — the archive/sign/export already
succeed on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)