### PR TITLE
Terminal tab → focused agent (item 2)

### DIFF
--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -710,6 +710,15 @@ struct TerminalHomeView: View {
     /// HerdrKit's tested `AgentList`, not here.
     private var fullList: AgentList { AgentList(agents: agents, livePaneIDs: livePaneIDs) }
 
+    /// The agent the Terminal tab opens: the herdr-focused pane if the session
+    /// reports one (`AgentInfo.focused`), else the top of the sorted list — which is
+    /// the highest-priority row (needs-you first), so the tab always lands on the most
+    /// useful terminal rather than nothing. Nil only when there are no agents at all.
+    private var terminalTarget: AgentRow? {
+        let rows = fullList.sections.flatMap { $0.rows }
+        return rows.first(where: { $0.info.focused == true }) ?? rows.first
+    }
+
     /// Sections after applying the search box. Search filters the raw agents and
     /// re-derives, so counts and grouping stay honest for the filtered view.
     private var visibleSections: [(group: AgentGroup, rows: [AgentRow])] {
@@ -833,7 +842,18 @@ struct TerminalHomeView: View {
     private var tabBar: some View {
         HStack(spacing: 4) {
             tabItem("square.grid.2x2.fill", "Agents", active: true)
-            tabItem("terminal", "Terminal", active: false)
+            // Terminal → the focused agent's pane (or the top of the list). Reuses the
+            // openedPane push with an EMPTY task, so there is no pre-fill/auto-delivery
+            // (pendingPrefill stays false); the pane re-resolves its own agent identity.
+            Button {
+                if let t = terminalTarget {
+                    openedPane = PaneToOpen(paneID: t.info.paneID, name: t.title, task: "")
+                }
+            } label: {
+                tabItem("terminal", "Terminal", active: false)
+            }
+            .buttonStyle(.plain)
+            .disabled(terminalTarget == nil)
             Button { activeCover = .settings } label: {
                 tabItem("gearshape", "Settings", active: false)
             }

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -715,7 +715,11 @@ struct TerminalHomeView: View {
     /// the highest-priority row (needs-you first), so the tab always lands on the most
     /// useful terminal rather than nothing. Nil only when there are no agents at all.
     private var terminalTarget: AgentRow? {
-        let rows = fullList.sections.flatMap { $0.rows }
+        // LIVE rows only. A stopped pane is absent from the census (not live) — its
+        // pane is gone, so never open it, not even if it is the focused one; and if
+        // every known agent is dead the list is empty and the tab correctly disables.
+        // (When there is no census, AgentRow defaults isLive=true, so nothing is lost.)
+        let rows = fullList.sections.flatMap { $0.rows }.filter(\.isLive)
         return rows.first(where: { $0.info.focused == true }) ?? rows.first
     }
 


### PR DESCRIPTION
Wires the bottom-bar **Terminal** button (previously a dead label) to open a terminal — the owner's chosen behaviour (item 2 of the on-device UX requests).

### What it does
- Opens the **herdr-focused pane** (`AgentInfo.focused == true`) if the session reports one; otherwise the **top of the sorted list** (highest-priority — needs-you first), so the tab always lands on a useful terminal.
- **Disabled** when there are no agents.
- Reuses the existing `openedPane` navigation push with an **empty task**, so `pendingPrefill` stays false — no pre-fill, no auto-delivery (the execute-in-shell hazard is not in play). The pane re-resolves its own agent identity via `reresolveAgent()`.

### Verification
Buildbox App-target green at `cba2c1a`. Behaviour verified on-device by the owner (the tab-navigation isn't in the launch-screen frame). No new dependencies.

> Stacked on the design PR (#44); base is `feat/design-system-realign` until that merges, then rebased onto main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)