### PR TITLE
Saved hosts: one-tap reconnect (item 5)

### DIFF
--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -278,6 +278,8 @@ struct ConnectView: View {
     @State private var username = ""
     @State private var keyPEM = ""
     @State private var showingKeySheet = false
+    @ObservedObject private var savedHosts = SavedHostsStore.shared
+    @State private var saveThisHost = false
 
     // Host accepts "host" or "host:port" (and "[ipv6]:port"); the port lives in
     // the one field so the form stays the three rows the mockup shows. Parsing is
@@ -320,6 +322,12 @@ struct ConnectView: View {
                     .padding(.top, 24)
                     .padding(.bottom, 8)
 
+                    // Saved hosts — one-tap reconnect. Hidden on first launch so the
+                    // screen stays the clean three-row form until there is one to show.
+                    if !savedHosts.hosts.isEmpty {
+                        savedHostsSection
+                    }
+
                     // The three settings-style rows: label left, value right.
                     VStack(spacing: 10) {
                         fieldRow("Host", text: $host, placeholder: "mac.tail-scale.ts.net")
@@ -330,12 +338,27 @@ struct ConnectView: View {
                         }
                         fieldRow("User", text: $username, placeholder: "jerry")
                         keyRow
+                        // Save affordance: only offered once the form is complete, so
+                        // it never implies saving an empty/partial host.
+                        if canConnect {
+                            Toggle(isOn: $saveThisHost) {
+                                Text("Save this host for one-tap reconnect")
+                                    .font(Typography.app(13)).foregroundStyle(Palette.textDim)
+                            }
+                            .tint(Palette.text)
+                            .padding(.horizontal, 4).padding(.top, 2)
+                        }
                     }
 
                     // Primary action — INK fill. The design carries NO accent colour; the
                     // one near-white fill in the whole app marks the control that ACTS.
                     Button {
                         guard let ep = endpoint else { return }
+                        // Persist BEFORE connecting (the key is in hand here). save()
+                        // stores host+user in UserDefaults + the key in the Keychain.
+                        if saveThisHost {
+                            savedHosts.save(host: host, username: trimmedUser, privateKeyPEM: trimmedKey)
+                        }
                         onConnect(SSHCredentials(
                             host: ep.host, port: ep.port,
                             username: trimmedUser,
@@ -382,6 +405,55 @@ struct ConnectView: View {
         }
         .padding(.horizontal, 16).padding(.vertical, 14)
         .background(Palette.surface).clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+
+    private var savedHostsSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 8) {
+                Text("SAVED").font(Typography.microLabel).tracking(1.2).foregroundStyle(Palette.textFaint)
+                Rectangle().fill(Palette.hairline).frame(height: 1)
+            }
+            ForEach(savedHosts.hosts) { saved in savedHostRow(saved) }
+        }
+    }
+
+    private func savedHostRow(_ saved: SavedHost) -> some View {
+        Button { tapSavedHost(saved) } label: {
+            HStack(spacing: 12) {
+                Image(systemName: "desktopcomputer")
+                    .font(.system(size: 15, weight: .medium)).foregroundStyle(Palette.textDim)
+                    .frame(width: 36, height: 36)
+                    .background(Palette.surface).clipShape(RoundedRectangle(cornerRadius: 10))
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(saved.host).font(Typography.machine(14)).foregroundStyle(Palette.text).lineLimit(1)
+                    Text(saved.username).font(Typography.machine(12)).foregroundStyle(Palette.textFaint)
+                }
+                Spacer(minLength: 8)
+                Image(systemName: "arrow.right.circle.fill")
+                    .font(.system(size: 18)).foregroundStyle(Palette.textDim)
+            }
+            .padding(12)
+            .background(Palette.card).clipShape(RoundedRectangle(cornerRadius: 14))
+        }
+        .buttonStyle(.plain)
+        .contextMenu {
+            Button(role: .destructive) { savedHosts.delete(saved) } label: {
+                Label("Remove", systemImage: "trash")
+            }
+        }
+    }
+
+    /// One-tap connect from a saved host. Pre-fills host+user FIRST, so if the key
+    /// is unreadable (deleted/device locked) the form is ready for a quick re-entry
+    /// rather than a silent dead tap; otherwise it builds the credentials and connects.
+    private func tapSavedHost(_ saved: SavedHost) {
+        host = saved.host
+        username = saved.username
+        guard let ep = HostEndpoint.parse(saved.host),
+              let key = savedHosts.key(for: saved)?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !key.isEmpty else { return }
+        onConnect(SSHCredentials(host: ep.host, port: ep.port, username: saved.username,
+                                 privateKeyPEM: key, remoteSocketPath: ""))
     }
 
     /// The key row NEVER renders the key itself — only whether one is loaded.

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -710,6 +710,15 @@ struct TerminalHomeView: View {
     /// HerdrKit's tested `AgentList`, not here.
     private var fullList: AgentList { AgentList(agents: agents, livePaneIDs: livePaneIDs) }
 
+    /// The agent the Terminal tab opens: the herdr-focused pane if the session
+    /// reports one (`AgentInfo.focused`), else the top of the sorted list — which is
+    /// the highest-priority row (needs-you first), so the tab always lands on the most
+    /// useful terminal rather than nothing. Nil only when there are no agents at all.
+    private var terminalTarget: AgentRow? {
+        let rows = fullList.sections.flatMap { $0.rows }
+        return rows.first(where: { $0.info.focused == true }) ?? rows.first
+    }
+
     /// Sections after applying the search box. Search filters the raw agents and
     /// re-derives, so counts and grouping stay honest for the filtered view.
     private var visibleSections: [(group: AgentGroup, rows: [AgentRow])] {
@@ -833,7 +842,18 @@ struct TerminalHomeView: View {
     private var tabBar: some View {
         HStack(spacing: 4) {
             tabItem("square.grid.2x2.fill", "Agents", active: true)
-            tabItem("terminal", "Terminal", active: false)
+            // Terminal → the focused agent's pane (or the top of the list). Reuses the
+            // openedPane push with an EMPTY task, so there is no pre-fill/auto-delivery
+            // (pendingPrefill stays false); the pane re-resolves its own agent identity.
+            Button {
+                if let t = terminalTarget {
+                    openedPane = PaneToOpen(paneID: t.info.paneID, name: t.title, task: "")
+                }
+            } label: {
+                tabItem("terminal", "Terminal", active: false)
+            }
+            .buttonStyle(.plain)
+            .disabled(terminalTarget == nil)
             Button { activeCover = .settings } label: {
                 tabItem("gearshape", "Settings", active: false)
             }

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -715,7 +715,11 @@ struct TerminalHomeView: View {
     /// the highest-priority row (needs-you first), so the tab always lands on the most
     /// useful terminal rather than nothing. Nil only when there are no agents at all.
     private var terminalTarget: AgentRow? {
-        let rows = fullList.sections.flatMap { $0.rows }
+        // LIVE rows only. A stopped pane is absent from the census (not live) — its
+        // pane is gone, so never open it, not even if it is the focused one; and if
+        // every known agent is dead the list is empty and the tab correctly disables.
+        // (When there is no census, AgentRow defaults isLive=true, so nothing is lost.)
+        let rows = fullList.sections.flatMap { $0.rows }.filter(\.isLive)
         return rows.first(where: { $0.info.focused == true }) ?? rows.first
     }
 

--- a/App/SavedHosts.swift
+++ b/App/SavedHosts.swift
@@ -57,10 +57,16 @@ final class SavedHostsStore: ObservableObject {
     /// — the caller must treat that as "cannot reconnect", not "empty key".
     func key(for host: SavedHost) -> String? { keychain.load(account: host.id.uuidString) }
 
-    func delete(_ host: SavedHost) {
-        keychain.delete(account: host.id.uuidString)
+    /// Removes a saved host. Deletes the KEY first and drops the host record ONLY if
+    /// the key is confirmed gone — a failed Keychain delete must not leave the private
+    /// key orphaned while the host vanishes from the UI. Returns whether it removed;
+    /// on false the row stays put (a visible "it didn't remove") so the user can retry.
+    @discardableResult
+    func delete(_ host: SavedHost) -> Bool {
+        guard keychain.delete(account: host.id.uuidString) else { return false }
         hosts.removeAll { $0.id == host.id }
         persist()
+        return true
     }
 
     private func persist() {
@@ -113,12 +119,18 @@ struct KeychainCredentialStore {
         return secret
     }
 
-    func delete(account: String) {
+    /// Deletes the secret. Returns true only when it is actually GONE — errSecSuccess
+    /// (deleted) or errSecItemNotFound (already absent). Any other OSStatus (e.g. the
+    /// Keychain temporarily unavailable) returns false, so the caller does not drop the
+    /// host record while the key still lives here.
+    @discardableResult
+    func delete(account: String) -> Bool {
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,
             kSecAttrAccount as String: account,
         ]
-        SecItemDelete(query as CFDictionary)   // idempotent: errSecItemNotFound is fine
+        let status = SecItemDelete(query as CFDictionary)
+        return status == errSecSuccess || status == errSecItemNotFound
     }
 }

--- a/App/SavedHosts.swift
+++ b/App/SavedHosts.swift
@@ -1,0 +1,124 @@
+import Foundation
+import Security
+
+/// A saved connection target for one-tap reconnect. Holds ONLY the non-secret
+/// fields (host — which may include ":port" — and username). The private key is
+/// NEVER stored here; it lives in the Keychain (`KeychainCredentialStore`), keyed
+/// by `id`. So the on-disk (UserDefaults) list can be read without exposing a key.
+struct SavedHost: Codable, Identifiable, Hashable {
+    let id: UUID
+    var host: String
+    var username: String
+}
+
+/// Persists saved hosts: the host+username list in UserDefaults, each host's
+/// private key in the Keychain (device-local, unlock-gated). The two are kept in
+/// lockstep — `save` only records a host once its key persists, and `delete`
+/// removes both — so a listed host is always one-tap reconnectable.
+final class SavedHostsStore: ObservableObject {
+    static let shared = SavedHostsStore()
+
+    private let defaultsKey = "dev.herdr.savedHosts.v1"
+    private let keychain = KeychainCredentialStore(service: "dev.herdr.credentials")
+
+    @Published private(set) var hosts: [SavedHost]
+
+    init() {
+        if let data = UserDefaults.standard.data(forKey: defaultsKey),
+           let decoded = try? JSONDecoder().decode([SavedHost].self, from: data) {
+            hosts = decoded
+        } else {
+            hosts = []
+        }
+    }
+
+    /// Saves (or updates in place) a host by host+username identity and stores its
+    /// key in the Keychain. Returns false — WITHOUT recording the host — if the key
+    /// could not be persisted, so the UI never offers a one-tap host it cannot open.
+    @discardableResult
+    func save(host: String, username: String, privateKeyPEM: String) -> Bool {
+        let h = host.trimmingCharacters(in: .whitespacesAndNewlines)
+        let u = username.trimmingCharacters(in: .whitespacesAndNewlines)
+        let key = privateKeyPEM.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !h.isEmpty, !u.isEmpty, !key.isEmpty else { return false }
+
+        let existing = hosts.first { $0.host.compare(h, options: .caseInsensitive) == .orderedSame && $0.username == u }
+        let id = existing?.id ?? UUID()
+        // Persist the key FIRST; only record the host if the key actually stuck.
+        guard keychain.save(account: id.uuidString, secret: key) else { return false }
+        if existing == nil {
+            hosts.insert(SavedHost(id: id, host: h, username: u), at: 0)
+            persist()
+        }
+        return true
+    }
+
+    /// The private key for a saved host, from the Keychain. Nil if missing/unreadable
+    /// — the caller must treat that as "cannot reconnect", not "empty key".
+    func key(for host: SavedHost) -> String? { keychain.load(account: host.id.uuidString) }
+
+    func delete(_ host: SavedHost) {
+        keychain.delete(account: host.id.uuidString)
+        hosts.removeAll { $0.id == host.id }
+        persist()
+    }
+
+    private func persist() {
+        guard let data = try? JSONEncoder().encode(hosts) else { return }
+        UserDefaults.standard.set(data, forKey: defaultsKey)
+    }
+}
+
+/// A Keychain store for per-host secrets (the private SSH key). Mirrors
+/// `KeychainHostKeyPolicy`'s storage discipline — checked statuses, update-in-place
+/// rather than delete-then-add — but is its own service and uses
+/// `WhenUnlockedThisDeviceOnly`: a private key is more sensitive than a host-key
+/// pin, so it is reachable only while the device is unlocked and NEVER syncs to
+/// iCloud or another device. The secret is only ever returned by `load`; it is
+/// never logged or surfaced elsewhere.
+struct KeychainCredentialStore {
+    let service: String
+
+    @discardableResult
+    func save(account: String, secret: String) -> Bool {
+        let base: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+        ]
+        // Update the value IN PLACE if the item exists (no window where the key is
+        // absent); only add when there is nothing to update. Every status checked.
+        let updated = SecItemUpdate(base as CFDictionary,
+                                    [kSecValueData as String: Data(secret.utf8)] as CFDictionary)
+        if updated == errSecSuccess { return true }
+        guard updated == errSecItemNotFound else { return false }
+        var add = base
+        add[kSecValueData as String] = Data(secret.utf8)
+        add[kSecAttrAccessible as String] = kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+        return SecItemAdd(add as CFDictionary, nil) == errSecSuccess
+    }
+
+    func load(account: String) -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+        var item: CFTypeRef?
+        guard SecItemCopyMatching(query as CFDictionary, &item) == errSecSuccess,
+              let data = item as? Data,
+              let secret = String(data: data, encoding: .utf8) else { return nil }
+        return secret
+    }
+
+    func delete(account: String) {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+        ]
+        SecItemDelete(query as CFDictionary)   // idempotent: errSecItemNotFound is fine
+    }
+}


### PR DESCRIPTION
Adds saved hosts + one-tap reconnect (owner request, item 5). **Security-bearing** — handles the private SSH key.

### Storage split
- **host + username** → UserDefaults (`SavedHost: Codable`, keyed by a per-host `UUID`).
- **private key** → Keychain (`KeychainCredentialStore`, service `dev.herdr.credentials`, `kSecAttrAccessibleWhenUnlockedThisDeviceOnly` — device-local, unlock-gated, never synced to iCloud/another device), keyed by the host's UUID.
- The key is **never** in UserDefaults and **never rendered** (the Connect frame is published to an open port; saved rows show host+username only).

### Behaviour
- `ConnectView` gains a **SAVED** section (hidden until a host exists); tap → load key from Keychain → rebuild `SSHCredentials` → connect. Pre-fills host+user first, so an unreadable/locked key falls back to the form rather than a silent dead tap.
- **"Save this host"** toggle (shown only when the form is complete) records on connect. `save()` persists the key FIRST and only records the host if it stuck — a listed host is always reconnectable.
- Long-press → **Remove** (deletes both the UserDefaults entry and the Keychain key).

### Review focus
- Keychain accessibility class + update-in-place (no delete-then-add window), mirroring `KeychainHostKeyPolicy`.
- No key leakage (UserDefaults, logs, screenshots, or the saved-host rows).
- save-first-then-record ordering; the tap fallback; delete removes both stores.

### Verification
Buildbox App-target green at `13e8bb2`. Security framework is iOS-only (no Linux test); verified by compile + this review + on-device. Stacked on #45 (base `feat/terminal-tab`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)