### PR TITLE
Live terminal: SwiftTerm over pane.stream (#40 slice 3)

### DIFF
--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -278,6 +278,8 @@ struct ConnectView: View {
     @State private var username = ""
     @State private var keyPEM = ""
     @State private var showingKeySheet = false
+    @ObservedObject private var savedHosts = SavedHostsStore.shared
+    @State private var saveThisHost = false
 
     // Host accepts "host" or "host:port" (and "[ipv6]:port"); the port lives in
     // the one field so the form stays the three rows the mockup shows. Parsing is
@@ -320,6 +322,12 @@ struct ConnectView: View {
                     .padding(.top, 24)
                     .padding(.bottom, 8)
 
+                    // Saved hosts — one-tap reconnect. Hidden on first launch so the
+                    // screen stays the clean three-row form until there is one to show.
+                    if !savedHosts.hosts.isEmpty {
+                        savedHostsSection
+                    }
+
                     // The three settings-style rows: label left, value right.
                     VStack(spacing: 10) {
                         fieldRow("Host", text: $host, placeholder: "mac.tail-scale.ts.net")
@@ -330,12 +338,27 @@ struct ConnectView: View {
                         }
                         fieldRow("User", text: $username, placeholder: "jerry")
                         keyRow
+                        // Save affordance: only offered once the form is complete, so
+                        // it never implies saving an empty/partial host.
+                        if canConnect {
+                            Toggle(isOn: $saveThisHost) {
+                                Text("Save this host for one-tap reconnect")
+                                    .font(Typography.app(13)).foregroundStyle(Palette.textDim)
+                            }
+                            .tint(Palette.text)
+                            .padding(.horizontal, 4).padding(.top, 2)
+                        }
                     }
 
                     // Primary action — INK fill. The design carries NO accent colour; the
                     // one near-white fill in the whole app marks the control that ACTS.
                     Button {
                         guard let ep = endpoint else { return }
+                        // Persist BEFORE connecting (the key is in hand here). save()
+                        // stores host+user in UserDefaults + the key in the Keychain.
+                        if saveThisHost {
+                            savedHosts.save(host: host, username: trimmedUser, privateKeyPEM: trimmedKey)
+                        }
                         onConnect(SSHCredentials(
                             host: ep.host, port: ep.port,
                             username: trimmedUser,
@@ -382,6 +405,55 @@ struct ConnectView: View {
         }
         .padding(.horizontal, 16).padding(.vertical, 14)
         .background(Palette.surface).clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+
+    private var savedHostsSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 8) {
+                Text("SAVED").font(Typography.microLabel).tracking(1.2).foregroundStyle(Palette.textFaint)
+                Rectangle().fill(Palette.hairline).frame(height: 1)
+            }
+            ForEach(savedHosts.hosts) { saved in savedHostRow(saved) }
+        }
+    }
+
+    private func savedHostRow(_ saved: SavedHost) -> some View {
+        Button { tapSavedHost(saved) } label: {
+            HStack(spacing: 12) {
+                Image(systemName: "desktopcomputer")
+                    .font(.system(size: 15, weight: .medium)).foregroundStyle(Palette.textDim)
+                    .frame(width: 36, height: 36)
+                    .background(Palette.surface).clipShape(RoundedRectangle(cornerRadius: 10))
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(saved.host).font(Typography.machine(14)).foregroundStyle(Palette.text).lineLimit(1)
+                    Text(saved.username).font(Typography.machine(12)).foregroundStyle(Palette.textFaint)
+                }
+                Spacer(minLength: 8)
+                Image(systemName: "arrow.right.circle.fill")
+                    .font(.system(size: 18)).foregroundStyle(Palette.textDim)
+            }
+            .padding(12)
+            .background(Palette.card).clipShape(RoundedRectangle(cornerRadius: 14))
+        }
+        .buttonStyle(.plain)
+        .contextMenu {
+            Button(role: .destructive) { savedHosts.delete(saved) } label: {
+                Label("Remove", systemImage: "trash")
+            }
+        }
+    }
+
+    /// One-tap connect from a saved host. Pre-fills host+user FIRST, so if the key
+    /// is unreadable (deleted/device locked) the form is ready for a quick re-entry
+    /// rather than a silent dead tap; otherwise it builds the credentials and connects.
+    private func tapSavedHost(_ saved: SavedHost) {
+        host = saved.host
+        username = saved.username
+        guard let ep = HostEndpoint.parse(saved.host),
+              let key = savedHosts.key(for: saved)?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !key.isEmpty else { return }
+        onConnect(SSHCredentials(host: ep.host, port: ep.port, username: saved.username,
+                                 privateKeyPEM: key, remoteSocketPath: ""))
     }
 
     /// The key row NEVER renders the key itself — only whether one is loaded.

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -710,6 +710,15 @@ struct TerminalHomeView: View {
     /// HerdrKit's tested `AgentList`, not here.
     private var fullList: AgentList { AgentList(agents: agents, livePaneIDs: livePaneIDs) }
 
+    /// The agent the Terminal tab opens: the herdr-focused pane if the session
+    /// reports one (`AgentInfo.focused`), else the top of the sorted list — which is
+    /// the highest-priority row (needs-you first), so the tab always lands on the most
+    /// useful terminal rather than nothing. Nil only when there are no agents at all.
+    private var terminalTarget: AgentRow? {
+        let rows = fullList.sections.flatMap { $0.rows }
+        return rows.first(where: { $0.info.focused == true }) ?? rows.first
+    }
+
     /// Sections after applying the search box. Search filters the raw agents and
     /// re-derives, so counts and grouping stay honest for the filtered view.
     private var visibleSections: [(group: AgentGroup, rows: [AgentRow])] {
@@ -833,7 +842,18 @@ struct TerminalHomeView: View {
     private var tabBar: some View {
         HStack(spacing: 4) {
             tabItem("square.grid.2x2.fill", "Agents", active: true)
-            tabItem("terminal", "Terminal", active: false)
+            // Terminal → the focused agent's pane (or the top of the list). Reuses the
+            // openedPane push with an EMPTY task, so there is no pre-fill/auto-delivery
+            // (pendingPrefill stays false); the pane re-resolves its own agent identity.
+            Button {
+                if let t = terminalTarget {
+                    openedPane = PaneToOpen(paneID: t.info.paneID, name: t.title, task: "")
+                }
+            } label: {
+                tabItem("terminal", "Terminal", active: false)
+            }
+            .buttonStyle(.plain)
+            .disabled(terminalTarget == nil)
             Button { activeCover = .settings } label: {
                 tabItem("gearshape", "Settings", active: false)
             }

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -715,7 +715,11 @@ struct TerminalHomeView: View {
     /// the highest-priority row (needs-you first), so the tab always lands on the most
     /// useful terminal rather than nothing. Nil only when there are no agents at all.
     private var terminalTarget: AgentRow? {
-        let rows = fullList.sections.flatMap { $0.rows }
+        // LIVE rows only. A stopped pane is absent from the census (not live) — its
+        // pane is gone, so never open it, not even if it is the focused one; and if
+        // every known agent is dead the list is empty and the tab correctly disables.
+        // (When there is no census, AgentRow defaults isLive=true, so nothing is lost.)
+        let rows = fullList.sections.flatMap { $0.rows }.filter(\.isLive)
         return rows.first(where: { $0.info.focused == true }) ?? rows.first
     }
 

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -1175,9 +1175,6 @@ struct TerminalPaneView: View {
     let title: String
 
     @Environment(\.dismiss) private var dismiss
-    @State private var rawText = ""
-    @State private var lines: [String] = []
-    @State private var error: String?
     @State private var reply: String
     /// The agent this pane hosts (drives identity, status badge, and input mode).
     /// Seeded from the caller's list context, then RE-RESOLVED from agent.list on
@@ -1244,7 +1241,12 @@ struct TerminalPaneView: View {
             Palette.groundMachine.ignoresSafeArea()
             VStack(spacing: 0) {
                 header
-                paneScroll
+                // The live terminal: a real SwiftTerm VT fed by the pane.stream raw
+                // byte firehose (#40), full-bleed as the machine ground. Read-only —
+                // input stays on the keycaps + reply bar below (sendText/sendKeys/
+                // prompt), never routed through the terminal itself.
+                LiveTerminalView(client: client, paneID: paneID)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
                 if let note = actionNote {
                     Text(note).font(Typography.app(12)).foregroundStyle(Palette.textDim)
                         .frame(maxWidth: .infinity, alignment: .leading).padding(.horizontal, 16).padding(.vertical, 4)
@@ -1288,35 +1290,6 @@ struct TerminalPaneView: View {
         }
         .padding(.horizontal, 16).padding(.top, 8).padding(.bottom, 10)
         .background(Palette.surface)
-    }
-
-    // MARK: pane output (fold cache preserved)
-
-    private var paneScroll: some View {
-        GeometryReader { geo in
-            // Fold from the SETTLED layout width, but cache the result: re-fold
-            // ONLY when the width or the text changes, not on every body eval —
-            // folding 200 lines each frame cost ~13ms during scroll.
-            let columns = columnCount(for: geo.size.width)
-            ScrollView {
-                VStack(alignment: .leading, spacing: 0) {
-                    if let error {
-                        Text(error).font(Typography.machine(12)).foregroundStyle(Palette.died)
-                    }
-                    ForEach(Array(lines.enumerated()), id: \.offset) { _, line in
-                        Text(line.isEmpty ? " " : line)
-                            .font(Typography.machine(Self.paneFontSize)).foregroundStyle(Palette.text)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .textSelection(.enabled)
-                    }
-                }
-                .padding(14)
-            }
-            // `initial: true` folds once on appear too, so `lines` is never left
-            // empty if the text arrives before the first width change.
-            .onChange(of: columns, initial: true) { _, newColumns in refold(columns: newColumns) }
-            .onChange(of: rawText) { _, _ in refold(columns: columns) }
-        }
     }
 
     // MARK: input
@@ -1405,41 +1378,12 @@ struct TerminalPaneView: View {
 
     // MARK: data
 
-    /// The pane's monospace size — shared by the renderer and the column math so the
-    /// two can't drift. IBM Plex Mono's advance is exactly 0.6 em (measured hmtx 600 /
-    /// head 1000 upem), so one glyph is `paneFontSize * 0.6` points.
-    static let paneFontSize: CGFloat = 12.5
-    static let paneAdvance: CGFloat = paneFontSize * 0.6   // 7.5pt at 12.5 (IBM Plex Mono)
-
-    /// Rough monospace column count for the pane font, less the 14pt horizontal
-    /// padding on each side. The advance is DERIVED from the font (0.6 em), not a
-    /// literal — the old 7.2 was calibrated for SF Mono, which this build replaced.
-    private func columnCount(for width: CGFloat) -> Int {
-        max(20, Int((width - 28) / Self.paneAdvance))
-    }
-
-    /// Folds `rawText` to `columns` into the cached `lines`. Called only from the
-    /// width/text `onChange`, so scrolling does not re-fold.
-    private func refold(columns: Int) {
-        lines = TerminalWrap.fold(rawText.components(separatedBy: "\n"), width: columns).flatMap { $0.lines }
-    }
-
+    /// The live terminal (`LiveTerminalView`) renders the pane output itself from
+    /// the raw byte stream, so refreshing here is only about the agent: re-resolve
+    /// it so the status badge and input mode track the live pane. (There is no
+    /// snapshot read anymore — the stream is the source of truth for output.)
     private func refresh() async {
-        await readPane()
         await reresolveAgent()
-    }
-
-    /// Reads the pane's recent output into `rawText`. Isolated so a list hiccup in
-    /// `reresolveAgent` cannot blank the text we just read (and so the pre-fill
-    /// poll can refresh content without a second agent.list per tick).
-    private func readPane() async {
-        do {
-            let read = try await client.read(pane: paneID, source: .recentUnwrapped, format: .text, lines: 200)
-            rawText = read.text
-            error = nil
-        } catch {
-            self.error = "\(error)"
-        }
     }
 
     /// Re-resolves this pane's agent so the status badge and input mode track the
@@ -1511,8 +1455,9 @@ struct TerminalPaneView: View {
                 return   // stop polling; pendingPrefill stays true → Send is prompt-only
             }
             try? await Task.sleep(nanoseconds: 1_500_000_000)
-            if Task.isCancelled { return }     // don't issue a stray read after teardown
-            await readPane()                   // keep the booting pane visible
+            if Task.isCancelled { return }     // don't spin after teardown
+            // The live terminal already shows the boot as it streams; no snapshot
+            // read is needed to keep the pane visible while we wait to deliver.
         }
     }
 
@@ -1735,11 +1680,22 @@ struct MockTransport: HerdrTransport {
     func roundTrip(_ requestLine: String) async throws -> String {
         if requestLine.contains("agent.list") { return Self.agentList }
         if requestLine.contains("agent.read") { return Self.agentRead }
+        if requestLine.contains("pane.set_pty_size") { return Self.panePtySize }
         return #"{"id":"mock","result":{}}"#
     }
 
     func stream(_ requestLine: String) -> AsyncThrowingStream<String, Error> {
-        AsyncThrowingStream { $0.finish() }
+        // `pane.stream` (the live terminal): reply with the stream_started ack, then
+        // a full-screen reset seed, then finish — so the DEBUG pane screenshot shows
+        // a rendered SwiftTerm terminal, not an empty one.
+        if requestLine.contains("pane.stream") {
+            return AsyncThrowingStream { continuation in
+                continuation.yield(Self.paneStreamAck)
+                continuation.yield(Self.paneStreamReset)
+                continuation.finish()
+            }
+        }
+        return AsyncThrowingStream { $0.finish() }
     }
 
     // Realistic herdr statuses only (idle|working|blocked|done|unknown). "needs
@@ -1769,6 +1725,16 @@ struct MockTransport: HerdrTransport {
     static let agentRead = #"""
     {"id":"mock","result":{"read":{"pane_id":"w1:p1","text":"$ herdr agent attach jarvis\n\n> Ran 146 tests, 0 failures\n> Edited SessionRecoveryTests.swift  +18 -4\n\nRun `swift test` with -Xswiftc -warnings-as-errors?\n  1. yes\n  2. no, skip it\n>\n\n[demo data - mock render mode, no live connection]","truncated":false,"source":"recent_unwrapped","format":"text"}}}
     """#
+
+    // pane.stream / pane.set_pty_size fixtures for the live terminal. Byte-identical
+    // to MockWireFixtures in Tests/HerdrKitTests/MockWireFixtureTests.swift, which is
+    // where they are machine-checked to decode through the real HerdrClient path.
+    static let paneStreamAck =
+        #"{"id":"mock","result":{"type":"stream_started","pane_id":"w1:p1","epoch":7,"cols":80,"rows":24,"base_seq":0,"resync":true}}"#
+    static let paneStreamReset =
+        #"{"stream":"pane.bytes","frame":"reset","seq":0,"epoch":7,"cols":80,"rows":24,"data_b64":"G1syShtbSBtbMTszODs1OzM5bWhlcmRyG1swbSBsaXZlIHRlcm1pbmFsIOKAlCBtb2NrIHJlbmRlcg0KDQokIGhlcmRyIGFnZW50IGF0dGFjaCBqYXJ2aXMNCj4gUmFuIDE0NiB0ZXN0cywgMCBmYWlsdXJlcw0KDQpbZGVtbyBkYXRhIOKAlCBubyBsaXZlIGNvbm5lY3Rpb25dDQo="}"#
+    static let panePtySize =
+        #"{"id":"mock","result":{"type":"pane_pty_size","pane_id":"w1:p1","cols":80,"rows":24,"locked":false}}"#
 
     /// A decoded blocked agent for the pane screenshot: status "blocked" groups
     /// as NEEDS YOU, so the pane renders its status badge. No composer field, so

--- a/App/LiveTerminalView.swift
+++ b/App/LiveTerminalView.swift
@@ -1,0 +1,323 @@
+#if canImport(UIKit)
+import SwiftUI
+import UIKit
+import SwiftTerm
+import HerdrKit
+
+/// A read-only, LIVE SwiftTerm terminal for a herdr pane (#40). It consumes
+/// `client.streamTerminal(pane:)` — herdr's raw PTY byte firehose — and feeds the
+/// bytes to a real VT emulator, so the phone renders a grid-faithful terminal
+/// instead of a reflowed snapshot.
+///
+/// READ-ONLY on purpose: #40 is render + resize only; raw-bytes-to-PTY INPUT is a
+/// separate follow-up. The view never becomes first responder (no keyboard) and
+/// its delegate `send` is a no-op, so SwiftTerm keystrokes are never routed to the
+/// PTY. Input stays exclusively on the reply/Send + keycap affordances in
+/// `TerminalPaneView`, which use the existing `sendText`/`sendKeys`/`prompt` paths.
+///
+/// Geometry: the view reports its own laid-out grid to the server via `setPTYSize`
+/// so the stream is generated at the phone's width. This resizes the SHARED PTY
+/// (one winsize per pane), so a co-viewing desktop reflows to the phone's grid until
+/// it re-asserts — we pass `lock:false` so we never PIN that shrink, but we do cause
+/// it transiently. Rendering the agent's real TUI at the phone's width is the point.
+struct LiveTerminalView: UIViewRepresentable {
+    let client: HerdrClient
+    let paneID: String
+
+    func makeCoordinator() -> Coordinator { Coordinator(client: client, paneID: paneID) }
+
+    func makeUIView(context: Context) -> ReadOnlyTerminalView {
+        let view = ReadOnlyTerminalView(frame: .zero, font: Coordinator.paneFont)
+        context.coordinator.attach(view)
+        return view
+    }
+
+    func updateUIView(_ uiView: ReadOnlyTerminalView, context: Context) {}
+
+    static func dismantleUIView(_ uiView: ReadOnlyTerminalView, coordinator: Coordinator) {
+        coordinator.stop()
+    }
+
+    /// A `TerminalView` that never accepts keyboard input — display + scroll only.
+    /// Blocking first-responder status is what keeps this observe-only: no keyboard
+    /// appears and no keystroke can reach the (unwired) PTY input path.
+    final class ReadOnlyTerminalView: TerminalView {
+        override var canBecomeFirstResponder: Bool { false }
+        override func becomeFirstResponder() -> Bool { false }
+    }
+
+    /// Owns the stream task and marshals frames onto the main actor. Retained by
+    /// SwiftUI (via `makeCoordinator`); the `TerminalView` holds only a weak ref
+    /// back through `terminalDelegate`.
+    final class Coordinator: NSObject, TerminalViewDelegate {
+        private let client: HerdrClient
+        private let paneID: String
+        private weak var view: ReadOnlyTerminalView?
+        private var streamTask: Task<Void, Never>?
+        /// The single serialized resize drain, if running. Only ever ONE at a time —
+        /// it awaits each set_pty_size before the next (so remote resizes can't
+        /// complete out of order) and loops until `desired == lastSent`. Cancelled on
+        /// teardown.
+        private var resizeTask: Task<Void, Never>?
+        /// The grid we WANT the PTY at — the latest size `sendPTYSize` was asked for.
+        /// The drain drives `lastSent` toward this. Dedup is measured against THIS
+        /// (the target), never the last committed size, so a request matching the
+        /// committed size while a DIFFERENT resize is in flight is not wrongly dropped.
+        private var desiredCols = 0
+        private var desiredRows = 0
+        /// Last geometry the server CONFIRMED (committed only after a successful
+        /// set_pty_size). The drain stops once this equals `desired`.
+        private var lastSentCols = 0
+        private var lastSentRows = 0
+        /// Consecutive failures for the CURRENT target, so the drain's self-retry
+        /// backs off and is capped; reset whenever a new target is requested.
+        private var resizeRetries = 0
+        /// Set once the server sends an `exited` frame, so a normal stream end is
+        /// distinguished from an unexpected EOF (which must surface, not freeze).
+        private var sawExited = false
+
+        /// IBM Plex Mono (the design's MACHINE voice) at the pane size, falling back
+        /// to the system monospace if the bundled face is unavailable. The
+        /// PostScript name matches `DesignSystem.Typography`'s mono regular cut.
+        static let paneFontSize: CGFloat = 12.5
+        static let paneFont: UIFont =
+            UIFont(name: "IBMPlexMono", size: paneFontSize)
+            ?? UIFont.monospacedSystemFont(ofSize: paneFontSize, weight: .regular)
+
+        init(client: HerdrClient, paneID: String) {
+            self.client = client
+            self.paneID = paneID
+        }
+
+        func attach(_ view: ReadOnlyTerminalView) {
+            self.view = view
+            view.terminalDelegate = self
+            style(view)
+            start()
+        }
+
+        func stop() {
+            streamTask?.cancel()
+            streamTask = nil
+            resizeTask?.cancel()
+            resizeTask = nil
+        }
+
+        // MARK: styling (the design's machine voice)
+
+        private func style(_ view: ReadOnlyTerminalView) {
+            view.font = Self.paneFont
+            // groundMachine #0B0D1C behind, ink #EEF0F7 text, working-blue caret —
+            // the same tokens `DesignSystem.Palette` uses, so the terminal is the
+            // one darker ground the design calls for.
+            view.nativeBackgroundColor = Self.color(0x0B0D1C)
+            view.nativeForegroundColor = Self.color(0xEEF0F7)
+            view.backgroundColor = Self.color(0x0B0D1C)
+            view.caretColor = Self.color(0x5B9BE8)
+            view.isOpaque = true
+            // A 16-colour ANSI palette close to the design (status hues in the
+            // matching slots). installColors is a no-op unless given exactly 16.
+            view.installColors(Self.ansiPalette)
+        }
+
+        // MARK: streaming
+
+        private func start() {
+            streamTask?.cancel()
+            sawExited = false
+            streamTask = Task { [weak self] in
+                guard let self else { return }
+                do {
+                    for try await event in self.client.streamTerminal(pane: self.paneID) {
+                        if Task.isCancelled { return }
+                        await self.handle(event)
+                    }
+                    await self.streamEnded(nil)
+                } catch {
+                    await self.streamEnded(error)
+                }
+            }
+        }
+
+        @MainActor
+        private func handle(_ event: TerminalStreamEvent) {
+            guard let view else { return }
+            switch event {
+            case .started(let started):
+                // Align the emulator to the pane's real geometry the ack carries.
+                resizeEmulator(cols: started.cols, rows: started.rows, in: view)
+            case .frame(let frame):
+                switch frame {
+                case .reset(_, _, let cols, let rows, let data, _):
+                    // Clear screen + scrollback + home, then paint the full-screen
+                    // seed. `lagged` resets seed identically (the server already
+                    // collapsed the backlog into this keyframe).
+                    view.feed(byteArray: Self.clearSequence[...])
+                    resizeEmulator(cols: cols, rows: rows, in: view)
+                    if !data.isEmpty { view.feed(byteArray: [UInt8](data)[...]) }
+                case .data(_, _, let data):
+                    if !data.isEmpty { view.feed(byteArray: [UInt8](data)[...]) }
+                case .resize(_, _, let cols, let rows):
+                    resizeEmulator(cols: cols, rows: rows, in: view)
+                case .ping:
+                    break   // heartbeat only
+                case .exited:
+                    sawExited = true
+                    view.feed(byteArray: Self.exitedNotice[...])
+                    stop()
+                }
+            }
+        }
+
+        @MainActor
+        private func streamEnded(_ error: Error?) {
+            guard let view else { return }
+            // An `exited` frame already painted the terminal's final state — nothing
+            // to add. ANY other end (a thrown error, OR a clean EOF with no `exited`)
+            // means the feed died while the process may still be live: surface it so a
+            // frozen last frame is not mistaken for a live terminal.
+            if sawExited { return }
+            let reason = error.map { "unavailable: \($0)" } ?? "connection closed"
+            let notice = "\r\n\u{1b}[2m— live terminal \(reason); reopen to reconnect —\u{1b}[0m\r\n"
+            view.feed(byteArray: [UInt8](notice.utf8)[...])
+        }
+
+        // MARK: geometry
+
+        /// Aligns the emulator grid to the server's authoritative PTY size so the
+        /// byte stream lays out correctly. Does NOT call set_pty_size — driving the
+        /// server is the VIEW's job (see `sizeChanged`), and echoing the server's
+        /// own size back would be a needless round-trip.
+        @MainActor
+        private func resizeEmulator(cols: Int, rows: Int, in view: ReadOnlyTerminalView) {
+            view.getTerminal().resize(cols: max(4, cols), rows: max(2, rows))
+        }
+
+        /// The view laid out (first appearance, rotation, keyboard) and computed a
+        /// new grid from its pixels + the mono cell metrics. Tell the server so the
+        /// PTY — and therefore the stream — lays out at the phone's width. NOTE this
+        /// resizes the SHARED PTY (see `sendPTYSize`): one winsize per pane, so a
+        /// co-viewing desktop reflows to the phone's grid until it re-asserts.
+        func sizeChanged(source: TerminalView, newCols: Int, newRows: Int) {
+            sendPTYSize(cols: newCols, rows: newRows)
+        }
+
+        /// Main-thread only (called from the UIKit layout callback above). Records the
+        /// desired PTY grid and ensures the drain converges to it.
+        ///
+        /// The model is `desired` vs `lastSent`: `sendPTYSize` records the newest
+        /// target; a single serialized drain drives the server toward it and stops
+        /// only when `lastSent == desired`. Because at most ONE `set_pty_size` is ever
+        /// in flight (the drain awaits each before the next), two resizes can never
+        /// complete server-side out of order. Dedup is measured against `desired` (the
+        /// target we're driving toward), NOT `lastSent` — so a request that matches
+        /// the committed size while a different resize is in flight still supersedes
+        /// it. A failed target is retried by the drain itself (0.5s backoff, capped)
+        /// so convergence never depends on a future layout callback. `lock:false`
+        /// still resizes the shared PTY (herdr resizes then releases ownership); we
+        /// accept the transient co-viewer reflow but never pin it.
+        private func sendPTYSize(cols: Int, rows: Int) {
+            guard cols >= 4, rows >= 2 else { return }
+            // Redundant ONLY if we are already driving toward (or sitting at) this
+            // exact size: same as the current target with a drain in flight, or same
+            // as the confirmed size with no drain. A size we gave up on (target set
+            // but never reached, no drain) is NOT redundant — it restarts the drain.
+            if cols == desiredCols, rows == desiredRows,
+               resizeTask != nil || (cols == lastSentCols && rows == lastSentRows) {
+                return
+            }
+            desiredCols = cols
+            desiredRows = rows
+            resizeRetries = 0        // a new target gets a fresh retry budget
+            guard resizeTask == nil else { return }   // a drain is running; it re-reads `desired`
+            let cell = Self.cellPixels()
+            resizeTask = Task { @MainActor [weak self] in
+                while let self, !Task.isCancelled,
+                      self.desiredCols != self.lastSentCols || self.desiredRows != self.lastSentRows {
+                    let c = self.desiredCols        // always drive toward the LATEST target
+                    let r = self.desiredRows
+                    do {
+                        _ = try await self.client.setPTYSize(
+                            pane: self.paneID, cols: c, rows: r,
+                            cellWidthPx: cell.width, cellHeightPx: cell.height, lock: false)
+                        self.lastSentCols = c        // confirmed
+                        self.lastSentRows = r
+                        self.resizeRetries = 0
+                    } catch {
+                        if Task.isCancelled { break }
+                        // If `desired` still equals what we just tried, it is the same
+                        // target failing: back off, capped, then give up (a later
+                        // sendPTYSize restarts a fresh drain). If `desired` changed
+                        // during the await, the loop simply converges to the new one
+                        // with the fresh budget sendPTYSize already reset.
+                        if self.desiredCols == c, self.desiredRows == r {
+                            if self.resizeRetries >= 3 { break }
+                            self.resizeRetries += 1
+                            try? await Task.sleep(nanoseconds: 500_000_000)
+                        }
+                    }
+                }
+                // Clear our own handle on natural completion only. On cancellation
+                // stop() already cleared it (and may have started a new drain), so do
+                // not stomp that newer task.
+                if !Task.isCancelled { self?.resizeTask = nil }
+            }
+        }
+
+        /// Cell size from the actual mono font — the DPI hint the server stores.
+        private static func cellPixels() -> (width: UInt32, height: UInt32) {
+            let attrs: [NSAttributedString.Key: Any] = [.font: paneFont]
+            let advance = ("W" as NSString).size(withAttributes: attrs).width
+            let lineHeight = paneFont.lineHeight
+            return (UInt32(max(1, advance.rounded())), UInt32(max(1, lineHeight.rounded())))
+        }
+
+        // MARK: TerminalViewDelegate — read-only, so most are inert
+
+        /// READ-ONLY: swallow any bytes SwiftTerm would send upstream. #40 does not
+        /// wire input; the PTY is never written from here.
+        func send(source: TerminalView, data: ArraySlice<UInt8>) {}
+        func scrolled(source: TerminalView, position: Double) {}
+        func setTerminalTitle(source: TerminalView, title: String) {}
+        func hostCurrentDirectoryUpdate(source: TerminalView, directory: String?) {}
+        func requestOpenLink(source: TerminalView, link: String, params: [String: String]) {}
+        func rangeChanged(source: TerminalView, startY: Int, endY: Int) {}
+        /// Required on the pinned SwiftTerm (v1.11.2 has no default impl for it; a
+        /// later version added one). No-op: the read-only terminal never copies.
+        func clipboardCopy(source: TerminalView, content: Data) {}
+
+        // MARK: palette helpers
+
+        /// Clear screen + clear scrollback + cursor home, fed before a reset seed.
+        private static let clearSequence = [UInt8]("\u{1b}[2J\u{1b}[3J\u{1b}[H".utf8)
+        /// The dim terminated marker shown when the process exits.
+        private static let exitedNotice = [UInt8]("\r\n\u{1b}[2m— process exited —\u{1b}[0m\r\n".utf8)
+
+        private static func color(_ hex: UInt32) -> UIColor {
+            UIColor(
+                red: CGFloat((hex >> 16) & 0xFF) / 255,
+                green: CGFloat((hex >> 8) & 0xFF) / 255,
+                blue: CGFloat(hex & 0xFF) / 255,
+                alpha: 1)
+        }
+
+        /// A SwiftTerm palette entry from 8-bit hex (SwiftTerm uses 16-bit channels;
+        /// 0xFF -> 0xFFFF via *257).
+        private static func ansi(_ hex: UInt32) -> SwiftTerm.Color {
+            SwiftTerm.Color(
+                red: UInt16((hex >> 16) & 0xFF) * 257,
+                green: UInt16((hex >> 8) & 0xFF) * 257,
+                blue: UInt16(hex & 0xFF) * 257)
+        }
+
+        /// 16 ANSI colours (normal 0–7, bright 8–15). Status hues match the design:
+        /// red = died, green = done, yellow = waiting, blue = working.
+        static let ansiPalette: [SwiftTerm.Color] = [
+            ansi(0x1A1D2E), ansi(0xE2584E), ansi(0x5FB37F), ansi(0xE9A63C),
+            ansi(0x5B9BE8), ansi(0xB58BF0), ansi(0x4FB8C8), ansi(0xC7CBD9),
+            ansi(0x3A3F5C), ansi(0xF07A70), ansi(0x7FC89A), ansi(0xF2BE63),
+            ansi(0x82B6F0), ansi(0xC9A9F5), ansi(0x74CEDC), ansi(0xEEF0F7),
+        ]
+    }
+}
+#endif

--- a/App/SavedHosts.swift
+++ b/App/SavedHosts.swift
@@ -57,10 +57,16 @@ final class SavedHostsStore: ObservableObject {
     /// — the caller must treat that as "cannot reconnect", not "empty key".
     func key(for host: SavedHost) -> String? { keychain.load(account: host.id.uuidString) }
 
-    func delete(_ host: SavedHost) {
-        keychain.delete(account: host.id.uuidString)
+    /// Removes a saved host. Deletes the KEY first and drops the host record ONLY if
+    /// the key is confirmed gone — a failed Keychain delete must not leave the private
+    /// key orphaned while the host vanishes from the UI. Returns whether it removed;
+    /// on false the row stays put (a visible "it didn't remove") so the user can retry.
+    @discardableResult
+    func delete(_ host: SavedHost) -> Bool {
+        guard keychain.delete(account: host.id.uuidString) else { return false }
         hosts.removeAll { $0.id == host.id }
         persist()
+        return true
     }
 
     private func persist() {
@@ -113,12 +119,18 @@ struct KeychainCredentialStore {
         return secret
     }
 
-    func delete(account: String) {
+    /// Deletes the secret. Returns true only when it is actually GONE — errSecSuccess
+    /// (deleted) or errSecItemNotFound (already absent). Any other OSStatus (e.g. the
+    /// Keychain temporarily unavailable) returns false, so the caller does not drop the
+    /// host record while the key still lives here.
+    @discardableResult
+    func delete(account: String) -> Bool {
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,
             kSecAttrAccount as String: account,
         ]
-        SecItemDelete(query as CFDictionary)   // idempotent: errSecItemNotFound is fine
+        let status = SecItemDelete(query as CFDictionary)
+        return status == errSecSuccess || status == errSecItemNotFound
     }
 }

--- a/App/SavedHosts.swift
+++ b/App/SavedHosts.swift
@@ -1,0 +1,124 @@
+import Foundation
+import Security
+
+/// A saved connection target for one-tap reconnect. Holds ONLY the non-secret
+/// fields (host — which may include ":port" — and username). The private key is
+/// NEVER stored here; it lives in the Keychain (`KeychainCredentialStore`), keyed
+/// by `id`. So the on-disk (UserDefaults) list can be read without exposing a key.
+struct SavedHost: Codable, Identifiable, Hashable {
+    let id: UUID
+    var host: String
+    var username: String
+}
+
+/// Persists saved hosts: the host+username list in UserDefaults, each host's
+/// private key in the Keychain (device-local, unlock-gated). The two are kept in
+/// lockstep — `save` only records a host once its key persists, and `delete`
+/// removes both — so a listed host is always one-tap reconnectable.
+final class SavedHostsStore: ObservableObject {
+    static let shared = SavedHostsStore()
+
+    private let defaultsKey = "dev.herdr.savedHosts.v1"
+    private let keychain = KeychainCredentialStore(service: "dev.herdr.credentials")
+
+    @Published private(set) var hosts: [SavedHost]
+
+    init() {
+        if let data = UserDefaults.standard.data(forKey: defaultsKey),
+           let decoded = try? JSONDecoder().decode([SavedHost].self, from: data) {
+            hosts = decoded
+        } else {
+            hosts = []
+        }
+    }
+
+    /// Saves (or updates in place) a host by host+username identity and stores its
+    /// key in the Keychain. Returns false — WITHOUT recording the host — if the key
+    /// could not be persisted, so the UI never offers a one-tap host it cannot open.
+    @discardableResult
+    func save(host: String, username: String, privateKeyPEM: String) -> Bool {
+        let h = host.trimmingCharacters(in: .whitespacesAndNewlines)
+        let u = username.trimmingCharacters(in: .whitespacesAndNewlines)
+        let key = privateKeyPEM.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !h.isEmpty, !u.isEmpty, !key.isEmpty else { return false }
+
+        let existing = hosts.first { $0.host.compare(h, options: .caseInsensitive) == .orderedSame && $0.username == u }
+        let id = existing?.id ?? UUID()
+        // Persist the key FIRST; only record the host if the key actually stuck.
+        guard keychain.save(account: id.uuidString, secret: key) else { return false }
+        if existing == nil {
+            hosts.insert(SavedHost(id: id, host: h, username: u), at: 0)
+            persist()
+        }
+        return true
+    }
+
+    /// The private key for a saved host, from the Keychain. Nil if missing/unreadable
+    /// — the caller must treat that as "cannot reconnect", not "empty key".
+    func key(for host: SavedHost) -> String? { keychain.load(account: host.id.uuidString) }
+
+    func delete(_ host: SavedHost) {
+        keychain.delete(account: host.id.uuidString)
+        hosts.removeAll { $0.id == host.id }
+        persist()
+    }
+
+    private func persist() {
+        guard let data = try? JSONEncoder().encode(hosts) else { return }
+        UserDefaults.standard.set(data, forKey: defaultsKey)
+    }
+}
+
+/// A Keychain store for per-host secrets (the private SSH key). Mirrors
+/// `KeychainHostKeyPolicy`'s storage discipline — checked statuses, update-in-place
+/// rather than delete-then-add — but is its own service and uses
+/// `WhenUnlockedThisDeviceOnly`: a private key is more sensitive than a host-key
+/// pin, so it is reachable only while the device is unlocked and NEVER syncs to
+/// iCloud or another device. The secret is only ever returned by `load`; it is
+/// never logged or surfaced elsewhere.
+struct KeychainCredentialStore {
+    let service: String
+
+    @discardableResult
+    func save(account: String, secret: String) -> Bool {
+        let base: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+        ]
+        // Update the value IN PLACE if the item exists (no window where the key is
+        // absent); only add when there is nothing to update. Every status checked.
+        let updated = SecItemUpdate(base as CFDictionary,
+                                    [kSecValueData as String: Data(secret.utf8)] as CFDictionary)
+        if updated == errSecSuccess { return true }
+        guard updated == errSecItemNotFound else { return false }
+        var add = base
+        add[kSecValueData as String] = Data(secret.utf8)
+        add[kSecAttrAccessible as String] = kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+        return SecItemAdd(add as CFDictionary, nil) == errSecSuccess
+    }
+
+    func load(account: String) -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+        var item: CFTypeRef?
+        guard SecItemCopyMatching(query as CFDictionary, &item) == errSecSuccess,
+              let data = item as? Data,
+              let secret = String(data: data, encoding: .utf8) else { return nil }
+        return secret
+    }
+
+    func delete(account: String) {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+        ]
+        SecItemDelete(query as CFDictionary)   // idempotent: errSecItemNotFound is fine
+    }
+}

--- a/Sources/HerdrKit/HerdrClient.swift
+++ b/Sources/HerdrKit/HerdrClient.swift
@@ -73,12 +73,13 @@ public actor HerdrClient {
     /// Requesting `.ansi` with `.detection` silently yields plain text, so this
     /// refuses that combination rather than returning unstyled output that the
     /// caller believes is styled.
-    /// Defaults to `.recentUnwrapped` on the panel's ruling: the API exposes no
-    /// pane geometry and no PTY resize (`PaneInfo` carries no cols/rows), so the
-    /// phone renders whatever width the desktop chose and cannot change it. A
-    /// 100-column pane at readable size does not fit a phone, which makes
-    /// grid-faithful and readable mutually exclusive. Reflowed transcript is
-    /// therefore the default reading surface, not a toggle. Styling survives it.
+    /// Defaults to `.recentUnwrapped`: `read` is the REFLOWED-SNAPSHOT surface —
+    /// a 100-column pane at readable size does not fit a phone, so a transcript
+    /// reflowed to the phone's width is the right default for skimming. Styling
+    /// survives it. This is now the COMPLEMENT to the live path, not the only
+    /// option: `streamTerminal(pane:)` renders a real grid-faithful VT from the
+    /// raw byte stream, and `setPTYSize(...)` drives the actual PTY geometry that
+    /// `PaneInfo` never exposed. `read` stays the cheap, reflowed snapshot.
     public func read(
         pane: String,
         source: ReadSource = .recentUnwrapped,
@@ -271,6 +272,127 @@ public actor HerdrClient {
             return .event(kind: kind, paneID: obj["pane_id"] as? String, raw: line)
         }
         return .other(raw: line)
+    }
+
+    // MARK: - Live terminal stream
+
+    /// Opens `pane.stream` — herdr's persistent server->client raw PTY byte firehose
+    /// — and yields the opening `stream_started` ack (geometry + epoch) followed by
+    /// the ordered `\n`-delimited frames. Cloned from `subscribe()`: same Transport
+    /// line framing, no busy-poll (the server pushes as bytes arrive off the PTY). A
+    /// line that fails to decode as a valid frame THROWS and finishes the stream — a
+    /// stateful byte stream can't skip a corrupt line without desyncing the emulator,
+    /// so the view surfaces the failure and re-opening the pane reseeds a fresh reset.
+    /// The connection also ends when the peer closes or the task is cancelled (closing
+    /// the SSH channel = unsubscribe).
+    public nonisolated func streamTerminal(
+        pane: String,
+        includeHistory: Bool = true,
+        maxFrameBytes: Int? = nil,
+        scrollbackLines: Int? = nil
+    ) -> AsyncThrowingStream<TerminalStreamEvent, Error> {
+        let encoder = JSONEncoder()
+        let env = RequestEnvelope(
+            id: "herdrkit:pane.stream:\(pane)",
+            method: "pane.stream",
+            params: PaneStreamParams(
+                paneID: pane, includeHistory: includeHistory,
+                resumeFrom: nil, epoch: nil,
+                maxFrameBytes: maxFrameBytes, scrollbackLines: scrollbackLines)
+        )
+        guard let data = try? encoder.encode(env) else {
+            return AsyncThrowingStream { $0.finish(throwing: TransportError.closedBeforeResponse) }
+        }
+        let requestLine = String(decoding: data, as: UTF8.self)
+        let raw = transport.stream(requestLine)
+
+        return AsyncThrowingStream { continuation in
+            let task = Task {
+                let decoder = JSONDecoder()
+                var sawAck = false
+                do {
+                    for try await line in raw {
+                        if !sawAck {
+                            sawAck = true
+                            switch Self.decodeStreamAck(line, decoder) {
+                            case .started(let started):
+                                continuation.yield(.started(started))
+                                continue
+                            case .error(let apiError):
+                                // pane_not_found, or an older server rejecting the
+                                // unknown method — surface it and stop cleanly.
+                                continuation.finish(throwing: apiError)
+                                return
+                            case .undecodable:
+                                // Not the ack we expected: fall through and try this
+                                // line as a frame. If it is a valid frame it is
+                                // yielded; if not, the strict decode below THROWS and
+                                // ends the stream (a stray non-frame leading line is
+                                // not silently swallowed).
+                                break
+                            }
+                        }
+                        // STRICT: every line after the ack must be a valid pane.bytes
+                        // frame. A stateful byte stream cannot skip a corrupt line
+                        // without desyncing the emulator (feeding the next frame mid
+                        // escape-sequence), so a decode failure THROWS — the stream
+                        // ends with an error, the view surfaces it, and re-opening the
+                        // pane reseeds a fresh full-screen reset. The ack fall-through
+                        // above lands here too, so a non-ack/non-frame leading line
+                        // also fails loudly rather than being silently swallowed.
+                        let frame = try decoder.decode(StreamFrame.self, from: Data(line.utf8))
+                        continuation.yield(.frame(frame))
+                    }
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+            continuation.onTermination = { _ in task.cancel() }
+        }
+    }
+
+    private enum StreamAck {
+        case started(StreamStarted)
+        case error(APIError)
+        case undecodable
+    }
+
+    /// Classifies the first `pane.stream` line: the `stream_started` ack, a server
+    /// error envelope, or something else (which the caller then re-tries as a frame).
+    private nonisolated static func decodeStreamAck(_ line: String, _ decoder: JSONDecoder) -> StreamAck {
+        let data = Data(line.utf8)
+        if let err = try? decoder.decode(ErrorEnvelope.self, from: data) {
+            return .error(err.error)
+        }
+        if let ok = try? decoder.decode(ResultEnvelope<StreamStarted>.self, from: data) {
+            return .started(ok.result)
+        }
+        return .undecodable
+    }
+
+    /// Sets the pane's real PTY winsize and takes/releases geometry ownership.
+    /// One-shot request/response on the single-shot control socket, dispatched via
+    /// the same `call(...)` path as `read`/`sendText`. NOTE `lock:false` (the
+    /// default) is NOT side-effect-free: the server applies the winsize resize FIRST
+    /// and only then releases ownership, so this DOES resize the shared PTY (a
+    /// co-viewing desktop reflows until its next render reclaims the size). `false`
+    /// only means "don't PIN the geometry"; it does not mean "don't resize". cols/
+    /// rows are clamped to the server's floor (cols>=4, rows>=2) before the round-trip.
+    public func setPTYSize(
+        pane: String,
+        cols: Int,
+        rows: Int,
+        cellWidthPx: UInt32? = nil,
+        cellHeightPx: UInt32? = nil,
+        lock: Bool = false
+    ) async throws -> PanePtySize {
+        let clampedCols = min(max(cols, 4), Int(UInt16.max))
+        let clampedRows = min(max(rows, 2), Int(UInt16.max))
+        let params = PaneSetPtySizeParams(
+            paneID: pane, cols: clampedCols, rows: clampedRows,
+            cellWidthPx: cellWidthPx, cellHeightPx: cellHeightPx, lock: lock)
+        return try await call("pane.set_pty_size", params, as: PanePtySize.self)
     }
 }
 

--- a/Sources/HerdrKit/Wire.swift
+++ b/Sources/HerdrKit/Wire.swift
@@ -161,7 +161,12 @@ struct PaneReadResult: Decodable {
 /// the server (`EventKind::PaneOutputChanged`) but is absent from the
 /// `Subscription` enum, so subscribing to it is rejected. Verified by reading
 /// the server's own rejection message. The consequence is that events give only
-/// coarse invalidation — there is no per-output tick to drive terminal refresh.
+/// coarse invalidation — there is no per-output tick HERE to drive terminal refresh.
+///
+/// The per-output push this comment used to lament is now delivered out-of-band by
+/// the `pane.stream` method (`HerdrClient.streamTerminal`), which streams the raw
+/// PTY bytes themselves rather than an invalidation tick — see the "Live terminal
+/// stream" section below. `events.subscribe` stays the coarse status channel.
 public enum SubscriptionType: String, Codable, Sendable {
     case paneUpdated = "pane.updated"
     case paneFocused = "pane.focused"
@@ -202,4 +207,215 @@ public enum StreamLine: Sendable, Equatable {
     case subscriptionStarted
     case event(kind: String, paneID: String?, raw: String)
     case other(raw: String)
+}
+
+// MARK: - Live terminal stream (pane.stream / pane.set_pty_size)
+//
+// Wire types for herdr's `pane.stream` raw PTY byte firehose and its companion
+// `pane.set_pty_size`. Field names mirror the herdr Rust schema EXACTLY so the
+// app decodes the server byte-for-byte:
+//   - request params:  src/api/schema/panes.rs::PaneStreamParams / PaneSetPtySizeParams
+//   - open ack:        src/api/schema/response.rs::ResponseResult::StreamStarted
+//   - frame lines:     src/api/server/pane_output_stream.rs::StreamFrameLine
+//   - resize result:   src/api/schema/response.rs::ResponseResult::PanePtySize
+// Frames ride the SAME `\n`-delimited framing `events.subscribe` uses, but the raw
+// PTY bytes are carried base64'd in `data_b64` because raw terminal output holds
+// 0x0A, control bytes, and partial UTF-8 that a JSON string / line-framing cannot.
+
+/// The first line of a `pane.stream` response: the `stream_started` ack, carrying
+/// the pane geometry (cols/rows) and the runtime generation the app previously
+/// lacked. `type` is `stream_started`; extra keys are ignored on decode.
+public struct StreamStarted: Decodable, Sendable, Equatable {
+    public let paneID: String
+    public let epoch: UInt64
+    public let cols: Int
+    public let rows: Int
+    /// Absolute byte offset of the seed's first byte since pane birth. Carried for
+    /// a later gap-free resume; v1 always re-seeds a fresh reset.
+    public let baseSeq: UInt64
+    public let resync: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case paneID = "pane_id"
+        case epoch, cols, rows, resync
+        case baseSeq = "base_seq"
+    }
+}
+
+/// One decoded `pane.stream` frame line. The discriminator is the `frame` field
+/// (herdr's `StreamFrameLine.frame`), tagged `"stream":"pane.bytes"`. `data_b64`
+/// is decoded to raw `Data` here so callers feed bytes straight to a VT emulator.
+public enum StreamFrame: Sendable, Equatable {
+    /// Full-screen (re)seed. `lagged` = the client fell behind and the server
+    /// dropped the backlog and re-seeded, so the caller should clear before feeding.
+    case reset(seq: UInt64, epoch: UInt64, cols: Int, rows: Int, data: Data, lagged: Bool)
+    /// Raw PTY delta bytes, to be fed to the emulator in `seq` order.
+    case data(seq: UInt64, epoch: UInt64, data: Data)
+    /// In-band SIGWINCH: the PTY winsize changed at this offset.
+    case resize(seq: UInt64, epoch: UInt64, cols: Int, rows: Int)
+    /// ~20s idle heartbeat; carries no payload and can be ignored.
+    case ping(seq: UInt64, epoch: UInt64)
+    /// The process is gone; the server closes the socket after this frame.
+    case exited(seq: UInt64, epoch: UInt64)
+}
+
+extension StreamFrame: Decodable {
+    private enum CodingKeys: String, CodingKey {
+        case stream, frame, seq, epoch, cols, rows
+        case dataB64 = "data_b64"
+        case lagged
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        // A pane.stream frame line MUST carry the `pane.bytes` stream tag. Anything
+        // else on this channel is a foreign or corrupt line — reject it so the caller
+        // FAILS the stream (and reconnects to a fresh reset) rather than feeding a
+        // stateful VT emulator bytes from an unknown source.
+        let stream = try c.decode(String.self, forKey: .stream)
+        guard stream == "pane.bytes" else {
+            throw DecodingError.dataCorruptedError(
+                forKey: .stream, in: c,
+                debugDescription: "unexpected stream '\(stream)' (want pane.bytes)")
+        }
+        let frame = try c.decode(String.self, forKey: .frame)
+        // Decoding is STRICT. A raw byte stream is stateful: silently dropping a
+        // frame (or its bytes) would resume the emulator mid-CSI/OSC/UTF-8 and
+        // corrupt the screen permanently. So seq/epoch are required, and a
+        // malformed line throws here — the caller then tears the stream down and
+        // reconnects for a clean full-screen reset instead of feeding garbage.
+        let seq = try c.decode(UInt64.self, forKey: .seq)
+        let epoch = try c.decode(UInt64.self, forKey: .epoch)
+        // `data_b64` is base64 of raw PTY bytes; on the frames that carry it it is
+        // required AND must be valid base64, so a truncated payload fails loudly.
+        func payload() throws -> Data {
+            let b64 = try c.decode(String.self, forKey: .dataB64)
+            guard let bytes = Data(base64Encoded: b64) else {
+                throw DecodingError.dataCorruptedError(
+                    forKey: .dataB64, in: c,
+                    debugDescription: "data_b64 is not valid base64")
+            }
+            return bytes
+        }
+        switch frame {
+        case "reset":
+            let cols = try c.decode(Int.self, forKey: .cols)
+            let rows = try c.decode(Int.self, forKey: .rows)
+            // Server omits `lagged` when false (skip_serializing_if is_false).
+            let lagged = (try? c.decode(Bool.self, forKey: .lagged)) ?? false
+            self = .reset(seq: seq, epoch: epoch, cols: cols, rows: rows, data: try payload(), lagged: lagged)
+        case "data":
+            self = .data(seq: seq, epoch: epoch, data: try payload())
+        case "resize":
+            let cols = try c.decode(Int.self, forKey: .cols)
+            let rows = try c.decode(Int.self, forKey: .rows)
+            self = .resize(seq: seq, epoch: epoch, cols: cols, rows: rows)
+        case "ping":
+            self = .ping(seq: seq, epoch: epoch)
+        case "exited":
+            self = .exited(seq: seq, epoch: epoch)
+        default:
+            throw DecodingError.dataCorruptedError(
+                forKey: .frame, in: c,
+                debugDescription: "unknown pane.stream frame '\(frame)'")
+        }
+    }
+}
+
+/// What `streamTerminal` yields, mirroring how `subscribe` unifies its ack + event
+/// lines into one `StreamLine`: the opening `stream_started` ack, then frames.
+public enum TerminalStreamEvent: Sendable, Equatable {
+    case started(StreamStarted)
+    case frame(StreamFrame)
+}
+
+/// `pane.stream` subscription params. Only `pane_id` is required; the rest carry
+/// server defaults / resume hints (v1 ignores resume and always re-seeds). Nil
+/// optionals are omitted by the synthesized encoder, matching serde's
+/// `skip_serializing_if = "Option::is_none"`.
+public struct PaneStreamParams: Encodable, Sendable {
+    public let paneID: String
+    public let includeHistory: Bool
+    public let resumeFrom: UInt64?
+    public let epoch: UInt64?
+    public let maxFrameBytes: Int?
+    public let scrollbackLines: Int?
+
+    public init(
+        paneID: String,
+        includeHistory: Bool = true,
+        resumeFrom: UInt64? = nil,
+        epoch: UInt64? = nil,
+        maxFrameBytes: Int? = nil,
+        scrollbackLines: Int? = nil
+    ) {
+        self.paneID = paneID
+        self.includeHistory = includeHistory
+        self.resumeFrom = resumeFrom
+        self.epoch = epoch
+        self.maxFrameBytes = maxFrameBytes
+        self.scrollbackLines = scrollbackLines
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case paneID = "pane_id"
+        case includeHistory = "include_history"
+        case resumeFrom = "resume_from"
+        case epoch
+        case maxFrameBytes = "max_frame_bytes"
+        case scrollbackLines = "scrollback_lines"
+    }
+}
+
+/// `pane.set_pty_size` params — sets the REAL PTY winsize (distinct from
+/// `pane.resize`, which is a layout split ratio). `lock:true` takes geometry
+/// ownership so the desktop TUI stops re-asserting layout size. `lock:false` still
+/// resizes the shared PTY (the server resizes, then releases ownership), so a
+/// co-viewing desktop reflows transiently — it just is not pinned to the new size.
+public struct PaneSetPtySizeParams: Encodable, Sendable {
+    public let paneID: String
+    public let cols: Int
+    public let rows: Int
+    public let cellWidthPx: UInt32?
+    public let cellHeightPx: UInt32?
+    public let lock: Bool
+
+    public init(
+        paneID: String,
+        cols: Int,
+        rows: Int,
+        cellWidthPx: UInt32? = nil,
+        cellHeightPx: UInt32? = nil,
+        lock: Bool = false
+    ) {
+        self.paneID = paneID
+        self.cols = cols
+        self.rows = rows
+        self.cellWidthPx = cellWidthPx
+        self.cellHeightPx = cellHeightPx
+        self.lock = lock
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case paneID = "pane_id"
+        case cols, rows, lock
+        case cellWidthPx = "cell_width_px"
+        case cellHeightPx = "cell_height_px"
+    }
+}
+
+/// Result of `pane.set_pty_size` (`type: "pane_pty_size"`): the size actually
+/// applied and whether geometry ownership is now locked. Mirrors the server's
+/// `ResponseResult::PanePtySize` EXACTLY — `pane_id/cols/rows/locked`, no `epoch`
+/// (the resize result carries none; the stream ack is where an epoch would live).
+public struct PanePtySize: Decodable, Sendable, Equatable {
+    public let paneID: String
+    public let cols: Int
+    public let rows: Int
+    public let locked: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case paneID = "pane_id"
+        case cols, rows, locked
+    }
 }

--- a/Tests/HerdrKitTests/MockWireFixtureTests.swift
+++ b/Tests/HerdrKitTests/MockWireFixtureTests.swift
@@ -13,10 +13,20 @@ final class MockWireFixtureTests: XCTestCase {
         func roundTrip(_ requestLine: String) async throws -> String {
             if requestLine.contains("agent.list") { return MockWireFixtures.agentList }
             if requestLine.contains("agent.read") { return MockWireFixtures.agentRead }
+            if requestLine.contains("pane.set_pty_size") { return MockWireFixtures.panePtySize }
             return #"{"id":"x","result":{}}"#
         }
         func stream(_ requestLine: String) -> AsyncThrowingStream<String, Error> {
-            AsyncThrowingStream { $0.finish() }
+            // Mirror MockTransport: `pane.stream` replies with the stream_started
+            // ack, then a full-screen reset seed, then finishes.
+            if requestLine.contains("pane.stream") {
+                return AsyncThrowingStream { continuation in
+                    continuation.yield(MockWireFixtures.paneStreamAck)
+                    continuation.yield(MockWireFixtures.paneStreamReset)
+                    continuation.finish()
+                }
+            }
+            return AsyncThrowingStream { $0.finish() }
         }
     }
 
@@ -77,6 +87,116 @@ final class MockWireFixtureTests: XCTestCase {
         XCTAssertEqual(read.paneID, "w1:p1")
         XCTAssertTrue(read.text.contains("demo data"), "mock pane text missing its marker: \(read.text.prefix(80))")
     }
+
+    // MARK: - Live terminal stream (pane.stream / pane.set_pty_size)
+
+    /// The mock `pane.stream` reply must decode through `streamTerminal`: the
+    /// stream_started ack first (carrying the geometry the app lacked), then a
+    /// reset seed whose base64 payload decodes to the demo screen. The App's
+    /// MockTransport embeds the same two fixtures verbatim.
+    func testMockPaneStreamDecodesAckThenResetSeed() async throws {
+        let client = HerdrClient(transport: FixtureTransport())
+        var events: [TerminalStreamEvent] = []
+        for try await ev in client.streamTerminal(pane: "w1:p1") { events.append(ev) }
+
+        XCTAssertEqual(events.count, 2, "expected the ack + one reset seed")
+        guard case .started(let started)? = events.first else {
+            return XCTFail("first stream event was not the stream_started ack")
+        }
+        XCTAssertEqual(started.paneID, "w1:p1")
+        XCTAssertEqual(started.cols, 80)
+        XCTAssertEqual(started.rows, 24)
+        XCTAssertEqual(started.epoch, 7)
+        XCTAssertTrue(started.resync)
+
+        guard events.count >= 2, case .frame(let frame) = events[1],
+              case .reset(_, let epoch, let cols, let rows, let data, let lagged) = frame else {
+            return XCTFail("second stream event was not a reset frame")
+        }
+        XCTAssertEqual(epoch, 7)
+        XCTAssertEqual(cols, 80)
+        XCTAssertEqual(rows, 24)
+        XCTAssertFalse(lagged, "the initial seed is not a lagged resync")
+        XCTAssertTrue(String(decoding: data, as: UTF8.self).contains("mock render"),
+                      "reset seed base64 did not decode to the demo screen")
+    }
+
+    /// `setPTYSize` round-trips the applied geometry. The result mirrors the server's
+    /// `PanePtySize` EXACTLY — pane_id/cols/rows/locked, no `epoch`.
+    func testSetPTYSizeDecodesAppliedSize() async throws {
+        let client = HerdrClient(transport: FixtureTransport())
+        let size = try await client.setPTYSize(pane: "w1:p1", cols: 80, rows: 24)
+        XCTAssertEqual(size.paneID, "w1:p1")
+        XCTAssertEqual(size.cols, 80)
+        XCTAssertEqual(size.rows, 24)
+        XCTAssertFalse(size.locked)
+    }
+
+    /// Decodes every `StreamFrame` variant off its `frame` discriminator, mirroring
+    /// the herdr Rust frame-shape tests (pane_output_stream.rs): a `data` frame's
+    /// payload is base64 ("aGk=" -> "hi"), `resize` carries cols/rows, a `reset`
+    /// with `lagged:true` flags the resync, and an unknown frame is rejected.
+    func testStreamFrameDecodesEachVariant() throws {
+        let decoder = JSONDecoder()
+        func frame(_ json: String) throws -> StreamFrame {
+            try decoder.decode(StreamFrame.self, from: Data(json.utf8))
+        }
+
+        guard case .data(let seq, let epoch, let bytes) =
+            try frame(#"{"stream":"pane.bytes","frame":"data","seq":42,"epoch":7,"data_b64":"aGk="}"#) else {
+            return XCTFail("data frame did not decode")
+        }
+        XCTAssertEqual(seq, 42)
+        XCTAssertEqual(epoch, 7)
+        XCTAssertEqual(String(decoding: bytes, as: UTF8.self), "hi")
+
+        guard case .resize(_, _, let cols, let rows) =
+            try frame(#"{"stream":"pane.bytes","frame":"resize","seq":5,"epoch":7,"cols":100,"rows":30}"#) else {
+            return XCTFail("resize frame did not decode")
+        }
+        XCTAssertEqual(cols, 100)
+        XCTAssertEqual(rows, 30)
+
+        guard case .reset(_, _, _, _, _, let lagged) =
+            try frame(#"{"stream":"pane.bytes","frame":"reset","seq":1,"epoch":7,"cols":80,"rows":24,"data_b64":"","lagged":true}"#) else {
+            return XCTFail("lagged reset frame did not decode")
+        }
+        XCTAssertTrue(lagged)
+
+        if case .ping = try frame(#"{"stream":"pane.bytes","frame":"ping","seq":9,"epoch":7}"#) {} else {
+            XCTFail("ping frame did not decode")
+        }
+        if case .exited = try frame(#"{"stream":"pane.bytes","frame":"exited","seq":9,"epoch":7}"#) {} else {
+            XCTFail("exited frame did not decode")
+        }
+        XCTAssertThrowsError(try frame(#"{"stream":"pane.bytes","frame":"wat","seq":1,"epoch":7}"#),
+                             "an unknown frame discriminator must be rejected")
+    }
+
+    /// STRICT decode is a stream-integrity guard (PR #47 review): a stateful byte
+    /// stream cannot skip a corrupt line without desyncing the emulator, so a
+    /// malformed frame must THROW — the client then tears the stream down and
+    /// reconnects to a fresh reset instead of feeding a plausible-but-wrong frame.
+    /// Covers a foreign stream tag, missing required fields, and bad base64.
+    func testMalformedStreamFramesAreRejected() throws {
+        let decoder = JSONDecoder()
+        func frame(_ json: String) throws -> StreamFrame {
+            try decoder.decode(StreamFrame.self, from: Data(json.utf8))
+        }
+        // Foreign stream tag — a line from another channel must not be fed as bytes.
+        XCTAssertThrowsError(try frame(#"{"stream":"pane.graphics","frame":"data","seq":1,"epoch":7,"data_b64":"aGk="}"#),
+                             "a non pane.bytes stream tag must be rejected")
+        // seq/epoch are required — never silently defaulted to 0 (that would hide a gap).
+        XCTAssertThrowsError(try frame(#"{"stream":"pane.bytes","frame":"data","epoch":7,"data_b64":"aGk="}"#),
+                             "a frame missing seq must be rejected")
+        XCTAssertThrowsError(try frame(#"{"stream":"pane.bytes","frame":"data","seq":1,"data_b64":"aGk="}"#),
+                             "a frame missing epoch must be rejected")
+        // A data/reset frame must carry a valid base64 payload — no empty-degrade.
+        XCTAssertThrowsError(try frame(#"{"stream":"pane.bytes","frame":"data","seq":1,"epoch":7}"#),
+                             "a data frame with no data_b64 must be rejected")
+        XCTAssertThrowsError(try frame(#"{"stream":"pane.bytes","frame":"data","seq":1,"epoch":7,"data_b64":"@@not base64@@"}"#),
+                             "an invalid base64 payload must be rejected")
+    }
 }
 
 /// THE FIXTURES. Duplicated verbatim in App/HerdrApp.swift's MockTransport (the
@@ -105,4 +225,20 @@ enum MockWireFixtures {
     static let agentRead = #"""
     {"id":"mock","result":{"read":{"pane_id":"w1:p1","text":"$ herdr agent attach jarvis\n\n> Ran 146 tests, 0 failures\n> Edited SessionRecoveryTests.swift  +18 -4\n\nRun `swift test` with -Xswiftc -warnings-as-errors?\n  1. yes\n  2. no, skip it\n>\n\n[demo data - mock render mode, no live connection]","truncated":false,"source":"recent_unwrapped","format":"text"}}}
     """#
+
+    // MARK: pane.stream / pane.set_pty_size fixtures (mirrored in App MockTransport)
+
+    /// The `pane.stream` open ack: the geometry-carrying `stream_started` line.
+    static let paneStreamAck =
+        #"{"id":"mock","result":{"type":"stream_started","pane_id":"w1:p1","epoch":7,"cols":80,"rows":24,"base_seq":0,"resync":true}}"#
+
+    /// The reset seed frame. `data_b64` is a full-screen ANSI snapshot (clear +
+    /// home + a demo screen); it decodes to text containing "mock render".
+    static let paneStreamReset =
+        #"{"stream":"pane.bytes","frame":"reset","seq":0,"epoch":7,"cols":80,"rows":24,"data_b64":"G1syShtbSBtbMTszODs1OzM5bWhlcmRyG1swbSBsaXZlIHRlcm1pbmFsIOKAlCBtb2NrIHJlbmRlcg0KDQokIGhlcmRyIGFnZW50IGF0dGFjaCBqYXJ2aXMNCj4gUmFuIDE0NiB0ZXN0cywgMCBmYWlsdXJlcw0KDQpbZGVtbyBkYXRhIOKAlCBubyBsaXZlIGNvbm5lY3Rpb25dDQo="}"#
+
+    /// The `pane.set_pty_size` reply. The current server's `PanePtySize` variant is
+    /// exactly {pane_id, cols, rows, locked} — no epoch.
+    static let panePtySize =
+        #"{"id":"mock","result":{"type":"pane_pty_size","pane_id":"w1:p1","cols":80,"rows":24,"locked":false}}"#
 }

--- a/project.yml
+++ b/project.yml
@@ -35,6 +35,20 @@ packages:
   # covering the layer the app runs on.
   HerdrKit:
     path: .
+  # The VT emulator that renders the live terminal (#40). Added to the APP target
+  # ONLY — never to Package.swift/HerdrKit, which must stay UIKit-free and
+  # Linux-buildable (SwiftTerm is UIKit/AppKit). We use SwiftTerm's default
+  # CoreText renderer, NOT its Metal backend. Pinned to v1.11.2 — the NEWEST tag
+  # that predates the bundled `Shaders.metal` (added in v1.12.0): Xcode 26 makes
+  # the Metal shader-compiler toolchain a separate download the local buildbox
+  # lacks, so a metal-bearing SwiftTerm fails `CompileMetalFile` there. (SwiftTerm
+  # itself only drops the shader when GITHUB_ACTIONS=true, which reaches the SPM
+  # manifest on GH runners but not the local Mac — hence a metal-free pin builds on
+  # BOTH.) iOS floor is under the app's. xcodegen's key is `exactVersion` (SwiftPM's
+  # `exact:` is Package.swift syntax and xcodegen rejects it).
+  SwiftTerm:
+    url: https://github.com/migueldeicaza/SwiftTerm.git
+    exactVersion: "1.11.2"
 
 targets:
   Herdr:
@@ -50,6 +64,11 @@ targets:
       # against ten lines of UI, than later against a thousand.
       - package: HerdrKit
         product: HerdrKit
+      # SwiftTerm rides on the APP target only (it is UIKit/AppKit) — it renders
+      # the live terminal in TerminalPaneView. HerdrKit deliberately does NOT
+      # depend on it so the Linux build/test of the protocol layer stays intact.
+      - package: SwiftTerm
+        product: SwiftTerm
     info:
       path: App/Info.plist
       properties:


### PR DESCRIPTION
## Slice 3 — full live terminal in the app (#40, final slice)

Wires the herdr `pane.stream` firehose + `pane.set_pty_size` (slices 1+2, fork PRs #43/#44) into the app: `TerminalPaneView` now renders a **real SwiftTerm VT** fed the raw PTY byte stream, replacing the reflowed snapshot.

**HerdrKit (Linux-verified):** `Wire.swift` gains `StreamStarted`/`StreamFrame`/`PaneStreamParams`/`PaneSetPtySizeParams`/`PanePtySize` (field names mirror herdr's serde EXACTLY; `PanePtySize` has no `epoch`). Decode is **strict** — a malformed/foreign frame line throws and ends the stream (a byte stream can't skip a line without desyncing the VT). `HerdrClient` gains `streamTerminal(pane:)` + `setPTYSize(...)` (clamped cols≥4/rows≥2).

**App (SwiftTerm):** `LiveTerminalView` (`UIViewRepresentable` over a read-only `TerminalView`) feeds `data`/`reset`/`resize`/`exited`. Resize uses a **serialized `desired`-vs-`lastSent` drain** — one `set_pty_size` in flight at a time, always driving to the latest requested grid, self-retry with backoff (capped), so geometry can't converge to a stale size. Clean EOF surfaces "connection closed." **READ-ONLY** (input out of #40 scope). `lock:false` still resizes the shared PTY (documented honestly).

**SwiftTerm pinned `exactVersion: 1.11.2`, App-target only** (newest metal-free tag; avoids the Xcode-26 Metal-toolchain gap on the buildbox; builds on both buildbox + GH-Actions TestFlight).

### Status: READY
- HerdrKit `swift build` warnings-as-errors clean; **211 tests, 0 failures**.
- **Buildbox: GREEN** at head `a52486a` (App/SwiftTerm compiles + launches; Connect screenshot verified).
- **Two distinct-runtime approvals (codex + kimi)** after 6 review rounds hardening stream-decode and resize logic.
- On-device (owner): verify the geometry-convergence transient.

Stacked on `feat/saved-hosts` (#46). **Do not merge until herdr deploys slices 1+2** (#43/#44) so the stream exists to exercise.
