### PR TITLE
Terminal page: fix reply delivery, fit width, scroll-back, Ctrl/Shift-Tab

### DIFF
--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -1199,6 +1199,10 @@ struct TerminalPaneView: View {
     /// (delivered or timed out) the button re-enables — but ALWAYS routes a pending
     /// pre-fill through the prompt-only path, never rawKeys.
     @State private var autoDelivering = false
+    /// STICKY Ctrl modifier: tapping the `ctrl` cap arms it; the next character
+    /// typed in the reply field is then sent as its control byte (and consumed, not
+    /// added to the message), and the modifier disarms. See `handleReplyChange`.
+    @State private var ctrlArmed = false
 
     private let router = InputRouter()
 
@@ -1299,20 +1303,33 @@ struct TerminalPaneView: View {
     // submit the OPPOSITE of the label (a menu with a broader grant at 2). Until
     // the option list is delivered as structured data, the reader answers by
     // typing the choice and pressing Return — which is the safe, verifiable path.
+    // The keycap row is HORIZONTALLY SCROLLABLE so it can hold more than fits the
+    // phone's width (esc/arrows/tab plus Shift+Tab, Ctrl, ^C, Return) without
+    // collapsing each cap. Caps are intrinsic width (not maxWidth:.infinity, which
+    // would expand infinitely inside a horizontal scroll view).
     private var controlBar: some View {
-        HStack(spacing: 6) {
-            keyCap(label: "esc", key: "Escape")
-            keyCap(symbol: "chevron.left", key: "Left")
-            keyCap(symbol: "chevron.up", key: "Up")
-            keyCap(symbol: "chevron.down", key: "Down")
-            keyCap(symbol: "chevron.right", key: "Right")
-            keyCap(label: "tab", key: "Tab")
-            // The submit affordance rawKeys needs — typing never submits, so
-            // Return is the deliberate second action. Highlighted, as the mockup
-            // shows it.
-            keyCap(symbol: "return", key: "Enter", primary: true)
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 6) {
+                keyCap(label: "esc", key: "Escape")
+                keyCap(symbol: "chevron.left", key: "Left")
+                keyCap(symbol: "chevron.up", key: "Up")
+                keyCap(symbol: "chevron.down", key: "Down")
+                keyCap(symbol: "chevron.right", key: "Right")
+                keyCap(label: "tab", key: "Tab")
+                // Shift+Tab (CBT / back-tab, ESC[Z) — cycles Claude-Code modes. A
+                // raw escape sequence, not a named key: delivered verbatim to the PTY.
+                rawCap(label: "S-Tab", sequence: "\u{1b}[Z")
+                // Sticky Ctrl: arm, then the next typed char becomes its control byte.
+                ctrlCap
+                // ^C (interrupt) — the common one-tap case; a raw control byte.
+                rawCap(label: "^C", sequence: "\u{03}")
+                // The submit affordance rawKeys needs — typing never submits, so
+                // Return is the deliberate second action. Highlighted, as the mockup
+                // shows it.
+                keyCap(symbol: "return", key: "Enter", primary: true)
+            }
+            .padding(.horizontal, 12).padding(.vertical, 8)
         }
-        .padding(.horizontal, 12).padding(.vertical, 8)
     }
 
     private func keyCap(label: String? = nil, symbol: String? = nil, key: String, primary: Bool = false) -> some View {
@@ -1322,7 +1339,8 @@ struct TerminalPaneView: View {
                 else { Text(label ?? key).font(Typography.machine(12)) }
             }
             .foregroundStyle(primary ? Palette.ground : Palette.textDim)
-            .frame(maxWidth: .infinity, minHeight: 34)
+            .padding(.horizontal, 10)
+            .frame(minWidth: 44, minHeight: 34)
             .background(primary ? Palette.text : Palette.surface).clipShape(RoundedRectangle(cornerRadius: 8))
         }
         // Disabled while a pre-fill is pending too: a stray Return during automatic
@@ -1332,6 +1350,39 @@ struct TerminalPaneView: View {
         .accessibilityLabel(Text(key))
     }
 
+    /// A cap that sends a raw byte SEQUENCE (a control byte or an escape sequence)
+    /// straight to the PTY via `pane.send_text` — for keys herdr's named allow-list
+    /// does not cover (Shift+Tab = `ESC[Z`, `^C` = `\u{03}`). Routed through the
+    /// `.rawSequence` action so it is delivered verbatim, not newline-refused.
+    private func rawCap(label: String, sequence: String) -> some View {
+        Button { send(.rawSequence(sequence)) } label: {
+            Text(label).font(Typography.machine(12))
+                .foregroundStyle(Palette.textDim)
+                .padding(.horizontal, 10)
+                .frame(minWidth: 44, minHeight: 34)
+                .background(Palette.surface).clipShape(RoundedRectangle(cornerRadius: 8))
+        }
+        .disabled(sending || pendingPrefill)
+        .accessibilityLabel(Text(label))
+    }
+
+    /// The sticky Ctrl toggle. Tap to arm (it highlights in the working blue); the
+    /// next character typed in the reply field is consumed and sent as its control
+    /// byte (see `handleReplyChange`), then it disarms. Tapping again while armed
+    /// cancels it.
+    private var ctrlCap: some View {
+        Button { ctrlArmed.toggle() } label: {
+            Text("ctrl").font(Typography.machine(12))
+                .foregroundStyle(ctrlArmed ? Palette.ground : Palette.textDim)
+                .padding(.horizontal, 10)
+                .frame(minWidth: 44, minHeight: 34)
+                .background(ctrlArmed ? Palette.working : Palette.surface)
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+        }
+        .disabled(sending || pendingPrefill)
+        .accessibilityLabel(Text(ctrlArmed ? "control armed" : "control"))
+    }
+
     private var replyBar: some View {
         HStack(spacing: 8) {
             TextField("type a reply…", text: $reply)
@@ -1339,6 +1390,11 @@ struct TerminalPaneView: View {
                 .textInputAutocapitalization(.never).autocorrectionDisabled()
                 .padding(.horizontal, 16).padding(.vertical, 11)
                 .background(Palette.surface).clipShape(Capsule())
+                // Ctrl-toggle interception: while armed, the next character typed
+                // here becomes a control byte instead of message text.
+                .onChange(of: reply) { oldValue, newValue in
+                    handleReplyChange(old: oldValue, new: newValue)
+                }
             Button { sendTapped() } label: {
                 Image(systemName: "arrow.up").font(.system(size: 15, weight: .bold))
                     .foregroundStyle(canSend ? Palette.ground : Palette.textFaint)
@@ -1351,7 +1407,7 @@ struct TerminalPaneView: View {
     }
 
     /// Routes a reader action through InputRouter, then executes the plan. A
-    /// refusal is shown, never a silent no-op.
+    /// refusal is shown, never a silent no-op; a rejection surfaces a clear reason.
     private func send(_ action: InputAction) {
         let mode = agent.map { router.mode(for: $0) } ?? .rawKeys
         let plan = router.plan(action: action, pane: paneID, mode: mode)
@@ -1360,19 +1416,91 @@ struct TerminalPaneView: View {
             defer { sending = false }
             do {
                 switch plan {
-                case .prompt(let pane, let text): try await client.prompt(pane: pane, text: text)
-                case .text(let pane, let text): try await client.sendText(pane: pane, text: text)
-                case .keys(let pane, let keys): try await client.sendKeys(pane: pane, keys: keys)
-                case .refused(let reason): actionNote = "not sent: \(reason)"; return
+                case .prompt(let pane, let text):
+                    // submitPrompt confirms delivery and sets the note from it.
+                    try await submitPrompt(pane: pane, text: text)
+                case .text(let pane, let text):
+                    try await client.sendText(pane: pane, text: text); actionNote = nil
+                case .rawText(let pane, let text):
+                    try await client.sendText(pane: pane, text: text); actionNote = nil
+                case .keys(let pane, let keys):
+                    try await client.sendKeys(pane: pane, keys: keys); actionNote = nil
+                case .refused(let reason):
+                    actionNote = "not sent: \(reason)"; return
                 }
-                actionNote = nil
                 if case .submitText = action { reply = "" }
                 // Give the pane a beat to reflect the input, then re-read.
                 try? await Task.sleep(nanoseconds: 300_000_000)
                 await refresh()
+            } catch let apiError as APIError {
+                actionNote = Self.promptFailureNote(for: apiError)
             } catch {
                 actionNote = "send failed: \(error)"
             }
+        }
+    }
+
+    /// While the Ctrl toggle is armed, consume the next TYPED character and send it
+    /// as its control byte instead of adding it to the message. Only reacts to a
+    /// single added character (typing) — not deletion or the programmatic clear
+    /// after a send — so a backspace can never be misread as a chord.
+    private func handleReplyChange(old: String, new: String) {
+        guard ctrlArmed else { return }
+        // Treat ONLY a clean single-char APPEND as a chord: `new` must be `old`
+        // plus one trailing character. A mid-cursor insertion or paste (where the
+        // added char is NOT the suffix) must NOT be read as a chord — otherwise
+        // `removeLast()` would delete the wrong character and `new.last` would send
+        // the wrong Ctrl byte (a spurious ^C could interrupt the pane; review HIGH).
+        // In that case leave the text untouched and just disarm.
+        guard new.count == old.count + 1, new.hasPrefix(old), let typed = new.last else {
+            ctrlArmed = false
+            return
+        }
+        guard let ctrl = InputRouter.controlByte(for: typed) else {
+            // No control code for this character (a digit, space, emoji…): disarm
+            // without consuming it, so the character stays as ordinary text.
+            ctrlArmed = false
+            return
+        }
+        ctrlArmed = false
+        reply.removeLast()     // the appended char was a chord, not message text
+        send(.rawSequence(String(ctrl)))
+    }
+
+    /// Submits a reply as a prompt WITH delivery confirmation. Sets the visible note
+    /// from herdr's `delivery`: a confirmed turn (`submitted`) clears it, while a
+    /// stranded draft (`writtenToPty` — bytes in the composer but no turn started,
+    /// the herdr#18/#26 state) is surfaced rather than shown as sent. Throws the
+    /// server's APIError on rejection so `send` can show a clear reason.
+    private func submitPrompt(pane: String, text: String) async throws {
+        // agent.prompt writes the text AND schedules a guarded Enter, so the reply
+        // submits regardless of the immediate `delivery` — which on the fast
+        // wait-match path is always `written_to_pty` (the Enter is still ~300ms
+        // out). Showing a "waiting to submit" note after every reply would read as
+        // "it didn't send" for the very bug this fixes, and invite a re-send. A
+        // GENUINE non-delivery (occupant changed, agent not ready, input pending)
+        // THROWS an APIError that `send` surfaces via `promptFailureNote`; so on a
+        // clean return, clear the note.
+        _ = try await client.prompt(
+            pane: pane, text: text,
+            waitUntil: HerdrClient.anyAgentStatus, timeoutMs: 6000)
+        actionNote = nil
+    }
+
+    /// Maps a prompt rejection to a note the reader can act on — no more silent
+    /// non-delivery.
+    private static func promptFailureNote(for error: APIError) -> String {
+        switch error.code {
+        case "agent_input_pending":
+            return "answer the on-screen prompt first (use the keys), then send"
+        case "agent_not_ready":
+            return "agent not ready — try again"
+        case "agent_prompt_not_received":
+            return "not delivered — try again"
+        case "timeout":
+            return "sent — awaiting confirmation"
+        default:
+            return "send failed: \(error)"
         }
     }
 

--- a/App/LiveTerminalView.swift
+++ b/App/LiveTerminalView.swift
@@ -16,10 +16,12 @@ import HerdrKit
 /// `TerminalPaneView`, which use the existing `sendText`/`sendKeys`/`prompt` paths.
 ///
 /// Geometry: the view reports its own laid-out grid to the server via `setPTYSize`
-/// so the stream is generated at the phone's width. This resizes the SHARED PTY
-/// (one winsize per pane), so a co-viewing desktop reflows to the phone's grid until
-/// it re-asserts — we pass `lock:false` so we never PIN that shrink, but we do cause
-/// it transiently. Rendering the agent's real TUI at the phone's width is the point.
+/// so the stream is generated at the phone's width. While the terminal view is open
+/// the phone OWNS the pane geometry (`lock:true`, Fix A): the server pins the shared
+/// PTY to the phone's fit, so the agent's TUI lays out at the phone's width and fits
+/// crisply with no horizontal overflow. A co-viewing desktop narrows to that width
+/// while the phone views the pane; on teardown we fire one `lock:false` to hand
+/// ownership back (see `releaseGeometryOwnership`) so the desktop reclaims its width.
 struct LiveTerminalView: UIViewRepresentable {
     let client: HerdrClient
     let paneID: String
@@ -44,6 +46,51 @@ struct LiveTerminalView: UIViewRepresentable {
     final class ReadOnlyTerminalView: TerminalView {
         override var canBecomeFirstResponder: Bool { false }
         override func becomeFirstResponder() -> Bool { false }
+
+        /// FOLLOW-ONLY-AT-BOTTOM (Fix B). `TerminalView` is a `UIScrollView`, and its
+        /// `updateScroller` slams `contentOffset` to the bottom on EVERY streamed
+        /// frame — so a drag-up is snapped straight back and the transcript "looks
+        /// stuck". We intercept PROGRAMMATIC offset writes: while the reader has
+        /// scrolled UP (not following), the auto-snap is ignored so their position
+        /// holds; a user-driven scroll (dragging / decelerating / tracking) is always
+        /// honored and updates the follow state, so returning to the bottom resumes
+        /// auto-follow. This governs only WHERE WE LOOK — it opens no input path, so
+        /// the read-only guarantee is untouched.
+        private var followsBottom = true
+
+        override var contentOffset: CGPoint {
+            get { super.contentOffset }
+            set {
+                let userDriven = isDragging || isDecelerating || isTracking
+                if userDriven {
+                    super.contentOffset = newValue
+                    followsBottom = isAtBottom(newValue)
+                } else if followsBottom {
+                    super.contentOffset = newValue
+                } else {
+                    // Programmatic write while the reader is scrolled up. Distinguish
+                    // SwiftTerm's auto-snap-to-bottom (DROP it — hold the reader's
+                    // position) from UIKit's legitimate CLAMP after contentSize shrank
+                    // (HONOR it — else the offset is stranded out of bounds over a
+                    // blank area; review finding). It's a clamp iff our CURRENT offset
+                    // now exceeds the valid range.
+                    let maxY = max(0, contentSize.height - bounds.height)
+                    if super.contentOffset.y > maxY {
+                        super.contentOffset = CGPoint(x: newValue.x, y: min(newValue.y, maxY))
+                    }
+                    // else: an in-range snap-to-bottom → drop it.
+                }
+            }
+        }
+
+        /// True when `offset` sits within a line of the bottom — i.e. the reader is
+        /// (or is returning to) the live tail. A one-line tolerance keeps sub-pixel
+        /// content-size jitter from spuriously dropping follow.
+        private func isAtBottom(_ offset: CGPoint) -> Bool {
+            let maxY = max(0, contentSize.height - bounds.height)
+            let tolerance = max(1, font.lineHeight)
+            return offset.y >= maxY - tolerance
+        }
     }
 
     /// Owns the stream task and marshals frames onto the main actor. Retained by
@@ -75,6 +122,11 @@ struct LiveTerminalView: UIViewRepresentable {
         /// Set once the server sends an `exited` frame, so a normal stream end is
         /// distinguished from an unexpected EOF (which must surface, not freeze).
         private var sawExited = false
+        /// Set in `stop()` so a LATE async `sizeChanged` callback (SwiftTerm
+        /// dispatches them asynchronously) cannot start a NEW `lock:true` resize
+        /// AFTER we've released geometry ownership — which would re-pin the pane and
+        /// defeat the release (review HIGH). Once stopped, `sendPTYSize` is inert.
+        private var stopped = false
 
         /// IBM Plex Mono (the design's MACHINE voice) at the pane size, falling back
         /// to the system monospace if the bundled face is unavailable. The
@@ -97,10 +149,40 @@ struct LiveTerminalView: UIViewRepresentable {
         }
 
         func stop() {
+            stopped = true                  // no new resize may start after this
+            view?.terminalDelegate = nil    // stop further SwiftTerm callbacks (sizeChanged)
             streamTask?.cancel()
             streamTask = nil
-            resizeTask?.cancel()
+            releaseGeometryOwnership()
+        }
+
+        /// RELEASE the phone's geometry lock (Fix A) when the terminal view closes,
+        /// so a co-viewing desktop reclaims its own width. While the view is open we
+        /// take ownership with `lock:true` (see `sendPTYSize`) so the shared PTY —
+        /// and therefore the agent's TUI — lays out at the phone's width and fits
+        /// crisply; on teardown we fire ONE best-effort `lock:false` at the last
+        /// known size to hand ownership back. Fire-and-forget: errors are ignored
+        /// (the view is going away regardless); it uses the last SENT size, or the
+        /// desired size if nothing was confirmed yet.
+        ///
+        /// ORDERING (review HIGH): the release must land strictly AFTER any in-flight
+        /// `lock:true` resize. We do NOT cancel the resize drain — a cancelled task's
+        /// already-dispatched request can still apply server-side, and if it lands
+        /// AFTER our `lock:false` the pane stays locked (desktop pinned narrow). So we
+        /// hand the drain off and AWAIT it first, so its last `lock:true` round-trip
+        /// completes before we send the releasing `lock:false`.
+        private func releaseGeometryOwnership() {
+            let cols = lastSentCols > 0 ? lastSentCols : desiredCols
+            let rows = lastSentRows > 0 ? lastSentRows : desiredRows
+            let inflight = resizeTask
             resizeTask = nil
+            guard cols >= 4, rows >= 2 else { return }
+            let client = self.client
+            let pane = self.paneID
+            Task.detached {
+                _ = await inflight?.value    // let the in-flight lock:true finish its round-trip
+                _ = try? await client.setPTYSize(pane: pane, cols: cols, rows: rows, lock: false)
+            }
         }
 
         // MARK: styling (the design's machine voice)
@@ -149,9 +231,10 @@ struct LiveTerminalView: UIViewRepresentable {
             case .frame(let frame):
                 switch frame {
                 case .reset(_, _, let cols, let rows, let data, _):
-                    // Clear screen + scrollback + home, then paint the full-screen
-                    // seed. `lagged` resets seed identically (the server already
-                    // collapsed the backlog into this keyframe).
+                    // Clear the VISIBLE screen + home (NOT scrollback — see
+                    // clearSequence, Fix B), then paint the full-screen seed.
+                    // `lagged` resets seed identically (the server already collapsed
+                    // the backlog into this keyframe).
                     view.feed(byteArray: Self.clearSequence[...])
                     resizeEmulator(cols: cols, rows: rows, in: view)
                     if !data.isEmpty { view.feed(byteArray: [UInt8](data)[...]) }
@@ -213,10 +296,12 @@ struct LiveTerminalView: UIViewRepresentable {
         /// target we're driving toward), NOT `lastSent` — so a request that matches
         /// the committed size while a different resize is in flight still supersedes
         /// it. A failed target is retried by the drain itself (0.5s backoff, capped)
-        /// so convergence never depends on a future layout callback. `lock:false`
-        /// still resizes the shared PTY (herdr resizes then releases ownership); we
-        /// accept the transient co-viewer reflow but never pin it.
+        /// so convergence never depends on a future layout callback. `lock:true`
+        /// (Fix A) PINS the shared PTY to the phone's fit so the agent's TUI stops
+        /// overflowing the screen width; `releaseGeometryOwnership` hands ownership
+        /// back with a `lock:false` on teardown so the desktop reclaims its width.
         private func sendPTYSize(cols: Int, rows: Int) {
+            guard !stopped else { return }   // teardown began — no new lock:true (review HIGH)
             guard cols >= 4, rows >= 2 else { return }
             // Redundant ONLY if we are already driving toward (or sitting at) this
             // exact size: same as the current target with a drain in flight, or same
@@ -239,7 +324,7 @@ struct LiveTerminalView: UIViewRepresentable {
                     do {
                         _ = try await self.client.setPTYSize(
                             pane: self.paneID, cols: c, rows: r,
-                            cellWidthPx: cell.width, cellHeightPx: cell.height, lock: false)
+                            cellWidthPx: cell.width, cellHeightPx: cell.height, lock: true)
                         self.lastSentCols = c        // confirmed
                         self.lastSentRows = r
                         self.resizeRetries = 0
@@ -288,8 +373,14 @@ struct LiveTerminalView: UIViewRepresentable {
 
         // MARK: palette helpers
 
-        /// Clear screen + clear scrollback + cursor home, fed before a reset seed.
-        private static let clearSequence = [UInt8]("\u{1b}[2J\u{1b}[3J\u{1b}[H".utf8)
+        /// Clear the VISIBLE screen + cursor home, fed before a reset seed. NOTE we
+        /// deliberately do NOT feed `ESC[3J` (clear SCROLLBACK) here (Fix B): wiping
+        /// scrollback on every reset is what left the normal-buffer (shell) history
+        /// un-scrollable — "it looks stuck". Dropping it lets that history accumulate
+        /// in SwiftTerm so a drag-up actually reveals earlier output. (Alt-screen TUIs
+        /// keep no scrollback of their own regardless; that case is the deferred
+        /// alt-scroll follow-up — see the class note.)
+        private static let clearSequence = [UInt8]("\u{1b}[2J\u{1b}[H".utf8)
         /// The dim terminated marker shown when the process exits.
         private static let exitedNotice = [UInt8]("\r\n\u{1b}[2m— process exited —\u{1b}[0m\r\n".utf8)
 

--- a/Sources/HerdrKit/HerdrClient.swift
+++ b/Sources/HerdrKit/HerdrClient.swift
@@ -100,11 +100,49 @@ public actor HerdrClient {
     struct PromptParams: Encodable {
         let target: String
         let text: String
+        let wait: PromptWaitOptions?
     }
 
+    /// The `wait` block herdr's `agent.prompt` accepts: block until the agent
+    /// settles into one of `until` (an AgentStatus set) or `timeoutMs` elapses.
+    /// Passing it is what makes the server report a REAL `delivery` (submitted vs
+    /// written_to_pty); the no-wait path returns an unconditional written_to_pty.
+    struct PromptWaitOptions: Encodable {
+        let until: [String]
+        let timeoutMs: Int?
+        enum CodingKeys: String, CodingKey {
+            case until
+            case timeoutMs = "timeout_ms"
+        }
+    }
+
+    /// The full AgentStatus set. Passed as `agent.prompt`'s `wait.until` so the
+    /// server returns AS SOON AS it has classified delivery (every real status is
+    /// in the set, so the initial wait-match succeeds immediately and no status
+    /// timeout can fire) — the point is the truthful `delivery`, not to block for a
+    /// particular status.
+    public static let anyAgentStatus = ["working", "idle", "blocked", "done", "unknown"]
+
     /// Submits prompt text as intent rather than as raw keystrokes.
-    public func prompt(pane: String, text: String) async throws {
-        _ = try await call("agent.prompt", PromptParams(target: pane, text: text), as: JSONNull.self)
+    ///
+    /// Pass `waitUntil` (a set of AgentStatus wire values, e.g. `anyAgentStatus`)
+    /// to have the server report a real `delivery`; without it herdr returns an
+    /// unconditional `writtenToPty`, so the app cannot tell a started turn from a
+    /// stranded draft. Returns the server's `delivery` (nil when it did not
+    /// determine one). THROWS the server's `APIError` on rejection (agent_not_ready
+    /// / agent_input_pending / agent_prompt_not_received / timeout), so a
+    /// non-delivery is never silent.
+    @discardableResult
+    public func prompt(
+        pane: String,
+        text: String,
+        waitUntil: [String]? = nil,
+        timeoutMs: Int? = nil
+    ) async throws -> PromptDelivery? {
+        let wait = waitUntil.map { PromptWaitOptions(until: $0, timeoutMs: timeoutMs) }
+        let result = try await call(
+            "agent.prompt", PromptParams(target: pane, text: text, wait: wait), as: PromptResult.self)
+        return result.delivery
     }
 
     struct SendTextParams: Encodable {
@@ -206,17 +244,19 @@ public actor HerdrClient {
         _ = try await call("pane.close", PaneTarget(paneID: paneID), as: JSONNull.self)
     }
 
-    /// True when `pane` reports an agent WITH a composer — the same gate
-    /// `InputRouter` uses to enter intent mode, and the observable proxy for "a
-    /// prompt will be accepted". A freshly-started agent is not promptable for a
-    /// variable window, and there is no reliable readiness flag (interactive_ready
-    /// is nil on this path), so the UI polls THIS to learn when a just-spawned
-    /// agent can receive its pre-filled task — then delivers it as a prompt, never
-    /// as rawKeys send_text into a not-ready agent. Absent pane, or an agent with
-    /// no composer, is NOT promptable (false).
+    /// True when `pane` reports an agent WITH a composer — the observable proxy for
+    /// "a prompt will land NOW". This is the STRICTER new-agent PRE-FILL gate
+    /// (`InputRouter.isPromptable(for:)`), deliberately NOT the reply-routing gate
+    /// (`mode(for:)`, which needs only a named agent): auto-delivering a just-
+    /// spawned agent's task unattended warrants holding out for a confirmed
+    /// composer, since there is no reliable readiness flag (interactive_ready is nil
+    /// on this path). The UI polls THIS to learn when a just-spawned agent can
+    /// receive its pre-filled task — then delivers it as a prompt, never as rawKeys
+    /// send_text into a not-ready agent. Absent pane, or an agent with no composer,
+    /// is NOT promptable (false).
     public func isPromptable(pane: String) async throws -> Bool {
         guard let info = try await agentList().first(where: { $0.paneID == pane }) else { return false }
-        return InputRouter().mode(for: info) == .intent
+        return InputRouter().isPromptable(for: info)
     }
 
     // MARK: - Events

--- a/Sources/HerdrKit/InputIntent.swift
+++ b/Sources/HerdrKit/InputIntent.swift
@@ -24,6 +24,13 @@ public enum InputMode: Equatable, Sendable {
 public enum InputAction: Equatable, Sendable {
     case submitText(String)
     case key(String)
+    /// A raw byte SEQUENCE from a dedicated keycap — a Shift+Tab (`ESC[Z`), a
+    /// `Ctrl+<key>` control byte, a `^C` (`\u{03}`). Unlike `.submitText` in
+    /// rawKeys this is an explicit KEYPRESS, not typed message text, so it is
+    /// delivered verbatim and is NOT newline-guarded: `Ctrl+J`/`Ctrl+M` are
+    /// legitimate here. Produced only by the terminal's fixed control caps /
+    /// the Ctrl-toggle, never by the free-text reply field.
+    case rawSequence(String)
 }
 
 /// What the client should actually send.
@@ -38,6 +45,12 @@ public enum InputPlan: Equatable, Sendable {
     /// unintended; typing without submitting cannot execute anything, and the
     /// reader sees exactly what landed before choosing to run it.
     case text(pane: String, String)
+    /// Raw bytes from a dedicated control cap, delivered via `pane.send_text`
+    /// WITHOUT the newline refusal `.text` enforces. This path exists ONLY for
+    /// explicit control/escape keycaps (Shift+Tab, `Ctrl+<key>`, `^C`) — never for
+    /// typed message text — so an intentional `Ctrl+J`/`Ctrl+M` reaches the PTY
+    /// while typed text still cannot smuggle a submitting newline through `.text`.
+    case rawText(pane: String, String)
     case keys(pane: String, [String])
     /// Refused, with a reason fit to show the reader.
     case refused(reason: String)
@@ -48,13 +61,36 @@ public struct InputRouter: Sendable {
 
     /// Chooses the input mode for a pane from what `agent.list` reports.
     ///
-    /// A pane only qualifies for intent mode when the server both names an agent
-    /// and exposes composer state for it. Absent either, treating text as a
-    /// prompt risks pasting into a shell — the exact "text lands somewhere
-    /// unintended" failure that herdr#26 and #18 are about.
+    /// Gate on the presence of a NAMED agent ALONE — not on composer state.
+    ///
+    /// A pane that hosts a named agent is not a shell, so routing its reply to
+    /// `agent.prompt` is safe. And `agent.prompt` is SERVER-gated: it returns
+    /// agent_not_ready / agent_input_pending when it genuinely cannot deliver, so
+    /// the extra `composer != nil` belt-and-suspenders here bought nothing except
+    /// a silent failure mode. A LIVE agent's composer is TRANSIENTLY nil, and
+    /// requiring it DOWNGRADED that agent to `.rawKeys` — where the reply was
+    /// TYPED into the composer via `send_text` but never submitted, so "the agent
+    /// never received it" (the reported terminal bug). Let the server, which
+    /// actually knows readiness, decide; the client only needs to know a real
+    /// agent is present. (The new-agent PRE-FILL gate is a separate, stricter
+    /// signal — see `isPromptable(for:)` — because auto-delivering an unattended
+    /// task warrants holding out for a confirmed composer.)
     public func mode(for agent: AgentInfo) -> InputMode {
-        guard agent.agent != nil, agent.composer != nil else { return .rawKeys }
+        guard agent.agent != nil else { return .rawKeys }
         return .intent
+    }
+
+    /// The composer-aware readiness gate the new-agent PRE-FILL delivery polls on.
+    ///
+    /// Distinct from `mode(for:)` on purpose: routing a reader's reply only needs
+    /// to know a real agent is there (the server gates actual delivery), but the
+    /// pre-fill loop AUTO-delivers a just-spawned agent's task unattended, so it
+    /// holds out for a positive "a prompt will land now" signal — a present
+    /// composer — before it fires. A named agent WITHOUT a composer is promptable
+    /// enough to ROUTE a manual reply to (`mode == .intent`, server-gated) but is
+    /// not yet a confirmed landing spot for an unattended pre-fill.
+    public func isPromptable(for agent: AgentInfo) -> Bool {
+        agent.agent != nil && agent.composer != nil
     }
 
     /// Turns a reader action into a concrete plan, or refuses it.
@@ -90,12 +126,38 @@ public struct InputRouter: Sendable {
             }
             return .text(pane: pane, text)
 
+        case (.rawSequence(let seq), _):
+            // Deliberate keypress bytes from a dedicated control cap — not typed
+            // message text, so the `.text` newline refusal does NOT apply: a
+            // bracketed `ESC[Z` (Shift+Tab) or a `Ctrl+J`/`Ctrl+M` is exactly what
+            // the reader asked for. Only emptiness is refused; the byte(s) go raw
+            // to the PTY via `pane.send_text`. Mode is irrelevant — a named agent's
+            // TUI and a shell both take a raw keypress the same way.
+            guard !seq.isEmpty else { return .refused(reason: "empty sequence") }
+            return .rawText(pane: pane, seq)
+
         case (.key(let k), _):
             guard let canonical = Self.canonicalKey(k) else {
                 return .refused(reason: "unsupported key \(k)")
             }
             return .keys(pane: pane, [canonical])
         }
+    }
+
+    /// The control byte for a "Ctrl + `character`" chord, or nil if the character
+    /// has no control code. Letters map case-insensitively (`Ctrl+C` == `Ctrl+c`
+    /// == `\u{03}`) and the `@ A-Z [ \ ] ^ _` block maps into `0x00...0x1f`;
+    /// everything else returns nil so the caller leaves the character untouched.
+    /// `Ctrl+J`/`Ctrl+M` legitimately yield LF/CR here — they are delivered via
+    /// the `.rawSequence` keypress path, which (unlike typed text) is not
+    /// newline-guarded, so the intended control byte reaches the PTY.
+    public static func controlByte(for character: Character) -> Character? {
+        guard let ascii = character.asciiValue else { return nil }
+        // 0x40–0x5f (@ A-Z [ \ ] ^ _) and 0x61–0x7a (a-z) have control codes.
+        guard (ascii >= 0x40 && ascii <= 0x5f) || (ascii >= 0x61 && ascii <= 0x7a) else {
+            return nil
+        }
+        return Character(UnicodeScalar(ascii & 0x1f))
     }
 
     /// How a reply tap should be delivered when a pane may hold a PRE-FILLED task

--- a/Sources/HerdrKit/Wire.swift
+++ b/Sources/HerdrKit/Wire.swift
@@ -153,6 +153,27 @@ struct PaneReadResult: Decodable {
     let read: PaneRead
 }
 
+// MARK: - Prompt delivery
+
+/// herdr's `AgentPromptDelivery`: whether the prompt bytes only reached the pane's
+/// composer (`writtenToPty`) or a turn actually STARTED (`submitted`). Mirrors the
+/// server enum's snake_case wire values (src/api/schema/agents.rs). These are
+/// different facts — the whole point of herdr#18/#26 lives in the gap between them
+/// — so the app decodes which one the server confirmed rather than collapsing both
+/// into "sent".
+public enum PromptDelivery: String, Decodable, Sendable, Equatable {
+    case writtenToPty = "written_to_pty"
+    case submitted
+}
+
+/// The `agent.prompt` result (`type: "agent_prompted"`). Only `delivery` is
+/// decoded — the echoed `agent` is deliberately not modelled so a schema change on
+/// it cannot break this decode. `delivery` is optional: the server omits it on
+/// paths that do not determine one.
+public struct PromptResult: Decodable, Sendable, Equatable {
+    public let delivery: PromptDelivery?
+}
+
 // MARK: - Events
 
 /// Subscription types the server actually accepts.

--- a/Tests/HerdrKitTests/InputIntentTests.swift
+++ b/Tests/HerdrKitTests/InputIntentTests.swift
@@ -17,11 +17,33 @@ final class InputRouterTests: XCTestCase {
         XCTAssertEqual(router.mode(for: a), .intent)
     }
 
-    /// A shell pane must not be treated as promptable — that is how text ends up
+    /// A pane with NO named agent is a shell — it must stay rawKeys so text is not
     /// pasted somewhere it was never meant to go.
     func testPaneWithoutAgentFallsBackToRawKeys() throws {
         XCTAssertEqual(router.mode(for: try makeAgent(pane: "p1", agent: nil, hasComposer: true)), .rawKeys)
-        XCTAssertEqual(router.mode(for: try makeAgent(pane: "p1", agent: "claude", hasComposer: false)), .rawKeys)
+    }
+
+    /// THE BUG (herdr-ios terminal): a pane that hosts a NAMED agent whose composer
+    /// is transiently nil must STILL route its reply as intent (→ `agent.prompt`,
+    /// which submits) — not fall to rawKeys `send_text`, which types the reply into
+    /// the composer but never submits it ("the agent never received it"). The gate
+    /// is the agent alone; `agent.prompt` is server-gated for real readiness.
+    /// (Mutation guard: restoring the `composer != nil` half returns `.rawKeys` here
+    /// and re-opens the never-submitted bug, so this assertion KILLs that mutation.)
+    func testNamedAgentWithoutComposerStillRoutesAsIntent() throws {
+        XCTAssertEqual(router.mode(for: try makeAgent(pane: "p1", agent: "claude", hasComposer: false)), .intent)
+    }
+
+    /// The pre-fill readiness gate stays STRICTER than routing on purpose: an
+    /// unattended just-spawned task holds out for a confirmed composer, even though
+    /// a manual reply to the same pane would already route as intent. Composer
+    /// present → promptable; agent-but-no-composer / no-agent → not promptable.
+    func testIsPromptableRequiresComposerEvenThoughRoutingDoesNot() throws {
+        let named = try makeAgent(pane: "p1", agent: "claude", hasComposer: false)
+        XCTAssertEqual(router.mode(for: named), .intent, "routing needs only a named agent")
+        XCTAssertFalse(router.isPromptable(for: named), "pre-fill delivery still needs a composer")
+        XCTAssertTrue(router.isPromptable(for: try makeAgent(pane: "p1", agent: "claude", hasComposer: true)))
+        XCTAssertFalse(router.isPromptable(for: try makeAgent(pane: "p1", agent: nil, hasComposer: true)))
     }
 
     func testTextBecomesAPromptInIntentMode() {
@@ -136,6 +158,49 @@ final class InputRouterTests: XCTestCase {
         XCTAssertNil(InputRouter.canonicalKey("Ctrl+U"))
         XCTAssertNil(InputRouter.canonicalKey(""))
         XCTAssertNotNil(InputRouter.canonicalKey("PageDown"))
+    }
+
+    /// A dedicated control cap's raw sequence goes out as `.rawText` — verbatim, in
+    /// either mode (a named agent's TUI and a shell both take a raw keypress).
+    func testRawSequenceBecomesRawTextInBothModes() {
+        for mode in [InputMode.intent, .rawKeys] {
+            XCTAssertEqual(
+                router.plan(action: .rawSequence("\u{1b}[Z"), pane: "p1", mode: mode),
+                .rawText(pane: "p1", "\u{1b}[Z"))
+        }
+    }
+
+    /// AXIS: `.rawText` is the DELIBERATE-keypress path, so — unlike typed `.text`
+    /// — it is NOT newline-guarded: `Ctrl+J` (LF) and `Ctrl+M` (CR) must pass
+    /// through so those chords actually reach the PTY. (Mutation guard: adding the
+    /// `.text` newline refusal to this path would refuse `Ctrl+J`/`Ctrl+M` and this
+    /// KILLs it.)
+    func testRawSequenceIsNotNewlineGuarded() {
+        XCTAssertEqual(router.plan(action: .rawSequence("\n"), pane: "p1", mode: .intent), .rawText(pane: "p1", "\n"))
+        XCTAssertEqual(router.plan(action: .rawSequence("\r"), pane: "p1", mode: .rawKeys), .rawText(pane: "p1", "\r"))
+        XCTAssertEqual(router.plan(action: .rawSequence("\u{03}"), pane: "p1", mode: .intent), .rawText(pane: "p1", "\u{03}"))
+    }
+
+    func testEmptyRawSequenceIsRefused() {
+        guard case .refused = router.plan(action: .rawSequence(""), pane: "p1", mode: .intent) else {
+            return XCTFail("empty raw sequence must be refused")
+        }
+    }
+
+    /// The Ctrl-toggle chord math: letters map case-insensitively into the control
+    /// range, `Ctrl+J`/`Ctrl+M` are the intentional LF/CR, and a non-control
+    /// character returns nil so the caller leaves it in the message untouched.
+    func testControlByteMapsChordsAndRejectsNonControl() {
+        XCTAssertEqual(InputRouter.controlByte(for: "c"), "\u{03}")
+        XCTAssertEqual(InputRouter.controlByte(for: "C"), "\u{03}", "Ctrl is case-insensitive")
+        XCTAssertEqual(InputRouter.controlByte(for: "a"), "\u{01}")
+        XCTAssertEqual(InputRouter.controlByte(for: "z"), "\u{1a}")
+        XCTAssertEqual(InputRouter.controlByte(for: "j"), "\u{0a}", "Ctrl+J is LF")
+        XCTAssertEqual(InputRouter.controlByte(for: "m"), "\u{0d}", "Ctrl+M is CR")
+        XCTAssertEqual(InputRouter.controlByte(for: "["), "\u{1b}", "Ctrl+[ is ESC")
+        XCTAssertNil(InputRouter.controlByte(for: "1"))
+        XCTAssertNil(InputRouter.controlByte(for: " "))
+        XCTAssertNil(InputRouter.controlByte(for: "é"), "non-ASCII has no control code")
     }
 }
 

--- a/Tests/HerdrKitTests/NewAgentClientTests.swift
+++ b/Tests/HerdrKitTests/NewAgentClientTests.swift
@@ -127,6 +127,70 @@ final class NewAgentClientTests: XCTestCase {
     }
 }
 
+/// `agent.prompt`'s wait/delivery contract (Fix E): the app passes `wait` to get a
+/// real `delivery` back and surfaces rejections instead of failing silently.
+final class PromptDeliveryTests: XCTestCase {
+
+    /// Records the request and replies with a canned `agent_prompted` result whose
+    /// `delivery` the caller chooses.
+    private final class DeliveryTransport: HerdrTransport, @unchecked Sendable {
+        var lastRequest = ""
+        let delivery: String
+        init(delivery: String) { self.delivery = delivery }
+        func roundTrip(_ requestLine: String) async throws -> String {
+            lastRequest = requestLine
+            return #"{"id":"x","result":{"type":"agent_prompted","agent":{"pane_id":"w1:p1","agent":"claude","agent_status":"working"},"delivery":"\#(delivery)"}}"#
+        }
+        func stream(_ r: String) -> AsyncThrowingStream<String, Error> { AsyncThrowingStream { $0.finish() } }
+    }
+
+    func testPromptSendsWaitUntilAndTimeoutAndDecodesSubmitted() async throws {
+        let t = DeliveryTransport(delivery: "submitted")
+        let delivery = try await HerdrClient(transport: t)
+            .prompt(pane: "w1:p1", text: "ship it", waitUntil: HerdrClient.anyAgentStatus, timeoutMs: 6000)
+
+        XCTAssertEqual(delivery, .submitted, "a started turn must decode as .submitted")
+        XCTAssertTrue(t.lastRequest.contains(#""method":"agent.prompt""#), "wrong method")
+        XCTAssertTrue(t.lastRequest.contains(#""text":"ship it""#), "text not sent")
+        // The wait block must carry the until set and the snake_case timeout key.
+        XCTAssertTrue(t.lastRequest.contains(#""until":["#), "wait.until not sent")
+        XCTAssertTrue(t.lastRequest.contains(#""working""#), "wait.until values not sent")
+        XCTAssertTrue(t.lastRequest.contains(#""timeout_ms":6000"#), "timeout_ms not sent under its wire key")
+    }
+
+    func testPromptDecodesWrittenToPtyAsDistinctFromSubmitted() async throws {
+        let delivery = try await HerdrClient(transport: DeliveryTransport(delivery: "written_to_pty"))
+            .prompt(pane: "w1:p1", text: "hi", waitUntil: HerdrClient.anyAgentStatus)
+        XCTAssertEqual(delivery, .writtenToPty,
+                       "bytes-in-composer must NOT collapse into submitted (the stranded-draft state)")
+    }
+
+    /// No wait requested → the `wait` block is omitted entirely (not sent as null).
+    func testPromptOmitsWaitWhenNotRequested() async throws {
+        let t = DeliveryTransport(delivery: "written_to_pty")
+        _ = try await HerdrClient(transport: t).prompt(pane: "w1:p1", text: "hi")
+        XCTAssertFalse(t.lastRequest.contains("\"wait\""), "an unrequested wait must be omitted")
+    }
+
+    /// AXIS: a rejection surfaces as a thrown APIError so the app can show a clear
+    /// reason instead of silently not delivering.
+    func testPromptRejectionSurfacesAsAPIError() async throws {
+        struct RejectTransport: HerdrTransport {
+            func roundTrip(_ r: String) async throws -> String {
+                #"{"id":"x","error":{"code":"agent_input_pending","message":"agent has a pending input prompt"}}"#
+            }
+            func stream(_ r: String) -> AsyncThrowingStream<String, Error> { AsyncThrowingStream { $0.finish() } }
+        }
+        do {
+            _ = try await HerdrClient(transport: RejectTransport())
+                .prompt(pane: "w1:p1", text: "hi", waitUntil: HerdrClient.anyAgentStatus)
+            XCTFail("a rejection must throw, not return silently")
+        } catch let e as APIError {
+            XCTAssertEqual(e.code, "agent_input_pending")
+        }
+    }
+}
+
 /// Normalizing an arbitrary folder name to herdr's agent-name grammar, so
 /// agent.start never fails on the name AFTER a pane was created.
 final class AgentNameTests: XCTestCase {


### PR DESCRIPTION
## Terminal page — on-device fixes (owner feedback, round 2)

Fixes the 4 issues the owner hit testing the live terminal on his iPhone.

**Fix E — reply now reaches the agent (the reported bug).** A reply to an agent whose composer was *transiently* nil fell to `pane.send_text` (typed into the composer, never submitted). Now `InputRouter.mode(for:)` routes any NAMED-agent pane to `agent.prompt` (server-gated, submits); the stricter composer gate is kept for unattended new-agent PRE-FILL via a separate `isPromptable(for:)`. Shell panes (agent==nil) stay type-without-submit (the auto-execute hazard remains guarded). `agent.prompt` now passes `wait` and surfaces rejections (`agent_not_ready`/`agent_input_pending`/…) via `promptFailureNote` — no silent non-delivery.

**Fix A — fits the phone width.** `setPTYSize(lock:true)` while the terminal view is open (phone owns the pane geometry → the agent TUI lays out at the phone's width). Ordered `lock:false` release on teardown: awaits any in-flight resize, and a `stopped` guard + delegate detach block a late `sizeChanged` from re-locking.

**Fix C/D — Ctrl + Shift+Tab + scrollable keycap row.** Horizontal-scroll row; new **S-Tab** (`ESC[Z`) + **^C** (`\u{03}`) raw caps + a sticky **Ctrl** toggle (next typed char → its control byte, append-only guard). Raw control sequences use a dedicated `.rawSequence`/`.rawText` path that bypasses the typed-text newline guard — never used by message text.

**Fix B — scroll-back.** Retain scrollback (drop `ESC[3J` on reset) + follow-only-at-bottom (`contentOffset` override that honors legitimate clamps). Drag-to-scroll a full-screen agent's OWN view (alt-scroll) is a deferred follow-up, held for read-only-gate safety.

### Status: READY
- HerdrKit warnings-as-errors clean, **221 tests** (+10). App-target **buildbox GREEN at c58aea6**.
- **Two distinct-runtime approvals (codex + kimi)** after 3 review rounds — codex caught a teardown-lifecycle or input-edge defect each round; all fixed. Read-only terminal boundary preserved throughout.

Base `main`. Do not self-merge — owner/JARVIS merges.