### PR TITLE
terminal: hold scroll position, trim margin, dismiss keyboard, pre-warm connect

### DIFF
--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -228,9 +228,17 @@ struct RootView: View {
 
     private func connect(_ creds: SSHCredentials) {
         let newTransport = CitadelTransport(credentials: creds, hostKeyPolicy: pins)
+        let newClient = HerdrClient(transport: newTransport)
         credentials = creds
         transport = newTransport
-        client = HerdrClient(transport: newTransport)
+        client = newClient
+        // PRE-WARM: start the SSH handshake + first agent fetch the instant Connect
+        // is tapped, so it overlaps the ConnectView→TerminalHomeView transition
+        // instead of following it. The transport dedups concurrent connects, so this
+        // and the home view's own load() coalesce into ONE session — no double
+        // connect. Result is discarded; the view re-fetches (and reuses the warm
+        // connection). Best-effort: a failure here surfaces normally in load().
+        Task { _ = try? await newClient.agentList() }
     }
 
     private func disconnect() {
@@ -1203,6 +1211,9 @@ struct TerminalPaneView: View {
     /// typed in the reply field is then sent as its control byte (and consumed, not
     /// added to the message), and the modifier disarms. See `handleReplyChange`.
     @State private var ctrlArmed = false
+    /// Focus of the reply field, so the software keyboard can be DISMISSED — via the
+    /// keyboard-toolbar chevron or a tap on the (read-only) terminal.
+    @FocusState private var replyFocused: Bool
 
     private let router = InputRouter()
 
@@ -1251,6 +1262,15 @@ struct TerminalPaneView: View {
                 // prompt), never routed through the terminal itself.
                 LiveTerminalView(client: client, paneID: paneID)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    // A small horizontal inset so the grid gets a clean, symmetric
+                    // margin instead of the last column hugging the right edge.
+                    .padding(.horizontal, 8)
+                    // Tap the (read-only) terminal to dismiss the keyboard. Best-effort
+                    // alongside the toolbar chevron; the terminal takes no first
+                    // responder, so a tap here is otherwise unused (the alt-scroll pan
+                    // still handles drags).
+                    .contentShape(Rectangle())
+                    .onTapGesture { replyFocused = false }
                 if let note = actionNote {
                     Text(note).font(Typography.app(12)).foregroundStyle(Palette.textDim)
                         .frame(maxWidth: .infinity, alignment: .leading).padding(.horizontal, 16).padding(.vertical, 4)
@@ -1390,6 +1410,18 @@ struct TerminalPaneView: View {
                 .textInputAutocapitalization(.never).autocorrectionDisabled()
                 .padding(.horizontal, 16).padding(.vertical, 11)
                 .background(Palette.surface).clipShape(Capsule())
+                .focused($replyFocused)
+                // A chevron in the keyboard's accessory toolbar so the software
+                // keyboard can be collapsed once it has been raised.
+                .toolbar {
+                    ToolbarItemGroup(placement: .keyboard) {
+                        Spacer()
+                        Button { replyFocused = false } label: {
+                            Image(systemName: "keyboard.chevron.compact.down")
+                                .foregroundStyle(Palette.text)
+                        }
+                    }
+                }
                 // Ctrl-toggle interception: while armed, the next character typed
                 // here becomes a control byte instead of message text.
                 .onChange(of: reply) { oldValue, newValue in

--- a/App/LiveTerminalView.swift
+++ b/App/LiveTerminalView.swift
@@ -45,7 +45,15 @@ struct LiveTerminalView: UIViewRepresentable {
     /// A `TerminalView` that never accepts keyboard input — display + scroll only.
     /// Blocking first-responder status is what keeps this observe-only: no keyboard
     /// appears and no keystroke can reach the (unwired) PTY input path.
-    final class ReadOnlyTerminalView: TerminalView, UIScrollViewDelegate {
+    /// NOTE: `TerminalView` already conforms to `UIScrollViewDelegate` (SwiftTerm
+    /// declares it on the base class) but implements none of the `scrollView*`
+    /// methods and never assigns `self.delegate` — so we inherit the conformance
+    /// (re-declaring it errors "redundant conformance") and simply claim the free
+    /// delegate slot. The three methods below are marked `@objc` explicitly so the
+    /// runtime's optional-protocol dispatch (`respondsToSelector:`) finds them:
+    /// inferred `@objc` is not guaranteed when the conformance is inherited rather
+    /// than stated here, and without it the follow-logic would be dead code.
+    final class ReadOnlyTerminalView: TerminalView {
         override var canBecomeFirstResponder: Bool { false }
         override func becomeFirstResponder() -> Bool { false }
 
@@ -73,15 +81,15 @@ struct LiveTerminalView: UIViewRepresentable {
         // Real user scrolling moves bounds.origin and fires the delegate (NOT the
         // property setter). Programmatic writes also fire this, but with dragging/
         // decelerating false, so they don't disturb the follow state.
-        func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        @objc func scrollViewDidScroll(_ scrollView: UIScrollView) {
             if scrollView.isDragging || scrollView.isDecelerating {
                 followsBottom = isAtBottom(scrollView.contentOffset)
             }
         }
-        func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
+        @objc func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
             if !decelerate { followsBottom = isAtBottom(scrollView.contentOffset) }
         }
-        func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
+        @objc func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
             followsBottom = isAtBottom(scrollView.contentOffset)
         }
 

--- a/App/LiveTerminalView.swift
+++ b/App/LiveTerminalView.swift
@@ -117,11 +117,18 @@ struct LiveTerminalView: UIViewRepresentable {
                     let maxY = max(0, contentSize.height - bounds.height)
                     if super.contentOffset.y > maxY {
                         super.contentOffset = CGPoint(x: newValue.x, y: min(newValue.y, maxY))
-                        // The shrink parked us at the tail (there is nothing below to
-                        // hold onto). Re-arm follow so a live pane doesn't sit at the
-                        // bottom looking frozen until the user manually drags — the
-                        // symptom is indistinguishable from a dead stream.
-                        followsBottom = isAtBottom(super.contentOffset)
+                        // Re-arm follow ONLY for a NON-INTERACTIVE clamp: a content
+                        // shrink (screen clear / alt-screen exit) parks us at the tail
+                        // with nothing below to hold, so resume follow — otherwise a
+                        // live pane sits at the bottom looking frozen. A finger-driven
+                        // bottom-edge rubber-band ALSO transiently pushes the offset
+                        // past maxY; re-arming there would re-affirm follow mid-drag
+                        // (the very bug this file fixes, milder). While a gesture is in
+                        // flight the end-dragging / end-decelerating callbacks own the
+                        // follow state, so leave it to them.
+                        if !isDragging && !isTracking && !isDecelerating {
+                            followsBottom = isAtBottom(super.contentOffset)
+                        }
                     }
                 }
             }

--- a/App/LiveTerminalView.swift
+++ b/App/LiveTerminalView.swift
@@ -45,42 +45,60 @@ struct LiveTerminalView: UIViewRepresentable {
     /// A `TerminalView` that never accepts keyboard input — display + scroll only.
     /// Blocking first-responder status is what keeps this observe-only: no keyboard
     /// appears and no keystroke can reach the (unwired) PTY input path.
-    final class ReadOnlyTerminalView: TerminalView {
+    final class ReadOnlyTerminalView: TerminalView, UIScrollViewDelegate {
         override var canBecomeFirstResponder: Bool { false }
         override func becomeFirstResponder() -> Bool { false }
 
-        /// FOLLOW-ONLY-AT-BOTTOM (Fix B). `TerminalView` is a `UIScrollView`, and its
+        /// FOLLOW-ONLY-AT-BOTTOM. `TerminalView` is a `UIScrollView` whose
         /// `updateScroller` slams `contentOffset` to the bottom on EVERY streamed
-        /// frame — so a drag-up is snapped straight back and the transcript "looks
-        /// stuck". We intercept PROGRAMMATIC offset writes: while the reader has
-        /// scrolled UP (not following), the auto-snap is ignored so their position
-        /// holds; a user-driven scroll (dragging / decelerating / tracking) is always
-        /// honored and updates the follow state, so returning to the bottom resumes
-        /// auto-follow. This governs only WHERE WE LOOK — it opens no input path, so
-        /// the read-only guarantee is untouched.
+        /// frame — so without intervention a scrolled-up reader is yanked back ("scrolls
+        /// back automatically to the bottom"). We DROP that programmatic snap while the
+        /// reader has scrolled up, and resume auto-follow when they return to the tail.
+        /// Governs only WHERE WE LOOK — opens no input path.
+        ///
+        /// `followsBottom` is driven from GENUINE user scrolls via the scroll-view
+        /// DELEGATE, NOT the `contentOffset` setter: UIKit moves an interactive drag
+        /// through `bounds.origin`, which never invokes the property setter (the classic
+        /// trap that made the setter-based version never register a drag, so it stayed
+        /// following and always snapped). SwiftTerm never claims the delegate slot on
+        /// iOS, so we take it.
         private var followsBottom = true
+
+        override init(frame: CGRect, font: UIFont?) {
+            super.init(frame: frame, font: font)
+            delegate = self
+        }
+        required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+        // Real user scrolling moves bounds.origin and fires the delegate (NOT the
+        // property setter). Programmatic writes also fire this, but with dragging/
+        // decelerating false, so they don't disturb the follow state.
+        func scrollViewDidScroll(_ scrollView: UIScrollView) {
+            if scrollView.isDragging || scrollView.isDecelerating {
+                followsBottom = isAtBottom(scrollView.contentOffset)
+            }
+        }
+        func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
+            if !decelerate { followsBottom = isAtBottom(scrollView.contentOffset) }
+        }
+        func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
+            followsBottom = isAtBottom(scrollView.contentOffset)
+        }
 
         override var contentOffset: CGPoint {
             get { super.contentOffset }
             set {
-                let userDriven = isDragging || isDecelerating || isTracking
-                if userDriven {
-                    super.contentOffset = newValue
-                    followsBottom = isAtBottom(newValue)
-                } else if followsBottom {
+                if followsBottom {
                     super.contentOffset = newValue
                 } else {
-                    // Programmatic write while the reader is scrolled up. Distinguish
-                    // SwiftTerm's auto-snap-to-bottom (DROP it — hold the reader's
-                    // position) from UIKit's legitimate CLAMP after contentSize shrank
-                    // (HONOR it — else the offset is stranded out of bounds over a
-                    // blank area; review finding). It's a clamp iff our CURRENT offset
-                    // now exceeds the valid range.
+                    // Not following: a programmatic write while the reader is scrolled
+                    // up. Honor it ONLY as a legit CLAMP (current offset now out of
+                    // range because contentSize shrank — else the offset strands over
+                    // blank space); DROP an in-range snap-to-bottom so position holds.
                     let maxY = max(0, contentSize.height - bounds.height)
                     if super.contentOffset.y > maxY {
                         super.contentOffset = CGPoint(x: newValue.x, y: min(newValue.y, maxY))
                     }
-                    // else: an in-range snap-to-bottom → drop it.
                 }
             }
         }

--- a/App/LiveTerminalView.swift
+++ b/App/LiveTerminalView.swift
@@ -123,10 +123,13 @@ struct LiveTerminalView: UIViewRepresentable {
                         // live pane sits at the bottom looking frozen. A finger-driven
                         // bottom-edge rubber-band ALSO transiently pushes the offset
                         // past maxY; re-arming there would re-affirm follow mid-drag
-                        // (the very bug this file fixes, milder). While a gesture is in
-                        // flight the end-dragging / end-decelerating callbacks own the
-                        // follow state, so leave it to them.
-                        if !isDragging && !isTracking && !isDecelerating {
+                        // (the very bug this file fixes, milder). A rubber-band only
+                        // occurs while DRAGGING or DECELERATING, so those two flags
+                        // fully exclude it. We must NOT also gate on isTracking: a
+                        // finger merely resting (touch-hold, no drag) sets isTracking
+                        // but fires no didEndDragging, so gating on it would strand
+                        // follow OFF through a content shrink under a still finger.
+                        if !isDragging && !isDecelerating {
                             followsBottom = isAtBottom(super.contentOffset)
                         }
                     }

--- a/App/LiveTerminalView.swift
+++ b/App/LiveTerminalView.swift
@@ -75,16 +75,27 @@ struct LiveTerminalView: UIViewRepresentable {
         override init(frame: CGRect, font: UIFont?) {
             super.init(frame: frame, font: font)
             delegate = self
+            // Keep the bottom-detection math inset-free. With automatic inset
+            // adjustment a safe-area / keyboard inset would shift the true maximum
+            // offset out from under `isAtBottom`, silently wedging follow off.
+            contentInsetAdjustmentBehavior = .never
         }
         required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
 
-        // Real user scrolling moves bounds.origin and fires the delegate (NOT the
-        // property setter). Programmatic writes also fire this, but with dragging/
-        // decelerating false, so they don't disturb the follow state.
-        @objc func scrollViewDidScroll(_ scrollView: UIScrollView) {
-            if scrollView.isDragging || scrollView.isDecelerating {
-                followsBottom = isAtBottom(scrollView.contentOffset)
-            }
+        // A user drag RELEASES follow at its very first movement, so the streamed
+        // snap-to-bottom (in the contentOffset setter) stops fighting the finger.
+        //
+        // We deliberately do NOT track follow in `scrollViewDidScroll`: SwiftTerm's
+        // updateScroller writes `contentOffset` once per streamed line, and because
+        // `contentOffset` is an ObjC property that programmatic write RE-ENTERS the
+        // delegate while `isDragging == true` (the finger is still down). A
+        // "does this look like the bottom?" check there would re-affirm follow
+        // mid-drag and pin a slow drag back to the tail under continuous output —
+        // the exact reported bug, one layer up from the setter version it replaced.
+        // Instead: release on drag-start; re-arm only when the gesture SETTLES at
+        // the tail (end-dragging without momentum, or end-decelerating).
+        @objc func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
+            followsBottom = false
         }
         @objc func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
             if !decelerate { followsBottom = isAtBottom(scrollView.contentOffset) }
@@ -106,6 +117,11 @@ struct LiveTerminalView: UIViewRepresentable {
                     let maxY = max(0, contentSize.height - bounds.height)
                     if super.contentOffset.y > maxY {
                         super.contentOffset = CGPoint(x: newValue.x, y: min(newValue.y, maxY))
+                        // The shrink parked us at the tail (there is nothing below to
+                        // hold onto). Re-arm follow so a live pane doesn't sit at the
+                        // bottom looking frozen until the user manually drags — the
+                        // symptom is indistinguishable from a dead stream.
+                        followsBottom = isAtBottom(super.contentOffset)
                     }
                 }
             }

--- a/Sources/HerdrKit/CitadelTransport.swift
+++ b/Sources/HerdrKit/CitadelTransport.swift
@@ -91,13 +91,24 @@ public actor CitadelTransport: HerdrTransport {
             sshEd25519: Data(credentials.privateKeyPEM.utf8),
             decryptionKey: credentials.passphrase.map { Data($0.utf8) }
         )
-        return try await SSHClient.connect(
+        let connected = try await SSHClient.connect(
             host: credentials.host,
             port: Int(credentials.port),
             authenticationMethod: .ed25519(username: credentials.username, privateKey: privateKey),
             hostKeyValidator: hostKeyValidator,
             reconnect: .never
         )
+        // If close() cancelled us WHILE the handshake was in flight — e.g. the user
+        // disconnected right after the connect-time prewarm started the session —
+        // the freshly opened client would otherwise be handed back to
+        // connectedClient() and re-assigned to `self.client` AFTER close() already
+        // nil'd it, leaking a live SSH session. Reap it here and abort instead.
+        // (connectTask is the ONLY thing close() cancels, so isCancelled ⟺ abandon.)
+        if Task.isCancelled {
+            try? await connected.close()
+            throw CancellationError()
+        }
+        return connected
     }
 
     /// Conservative ceiling on the full command line, well under the kernel's

--- a/Sources/HerdrKit/CitadelTransport.swift
+++ b/Sources/HerdrKit/CitadelTransport.swift
@@ -29,6 +29,12 @@ public actor CitadelTransport: HerdrTransport {
     /// A connect in flight, so concurrent first-use awaits one attempt (see
     /// `connectedClient`) rather than each opening — and leaking — its own session.
     private var connectTask: Task<SSHClient, Error>?
+    /// Bumped by `close()`. A connect that resolves after its starting generation is
+    /// STALE: close() has already torn down and believes there is no live session, so
+    /// the resolved client must be reaped, never installed. This closes the residual
+    /// window where a handshake completing exactly as the user disconnects would
+    /// otherwise re-install a live session behind close()'s back (leak).
+    private var generation = 0
 
     /// - Parameters:
     ///   - credentials: host/port/username, the Ed25519 private key, and the
@@ -71,17 +77,36 @@ public actor CitadelTransport: HerdrTransport {
     /// task instead.
     private func connectedClient() async throws -> SSHClient {
         if let client, client.isConnected { return client }
-        if let connectTask { return try await connectTask.value }
 
-        let task = Task<SSHClient, Error> { try await self.makeConnection() }
-        connectTask = task
+        // Capture the generation BEFORE awaiting: if close() runs during the
+        // handshake it bumps `generation`, marking whatever resolves as stale.
+        let gen = generation
+        let task: Task<SSHClient, Error>
+        if let connectTask {
+            task = connectTask                      // join the in-flight attempt
+        } else {
+            let created = Task<SSHClient, Error> { try await self.makeConnection() }
+            connectTask = created
+            task = created
+        }
         do {
             let connected = try await task.value
+            // Validate AFTER the suspension, under actor isolation. If close() ran
+            // while we awaited, this session is orphaned — close() already believes
+            // there is nothing to tear down, so reap it rather than installing a live
+            // client behind close()'s back. BOTH the creator and any joined waiter
+            // pass through this same check.
+            guard gen == generation else {
+                try? await connected.close()
+                throw CancellationError()
+            }
             client = connected
-            connectTask = nil
+            if connectTask == task { connectTask = nil }
             return connected
         } catch {
-            connectTask = nil   // a failed attempt must not wedge every later call
+            // Only clear the slot if it still holds OUR task — never clobber a newer
+            // connect started after a close() bumped the generation.
+            if connectTask == task { connectTask = nil }
             throw error
         }
     }
@@ -91,24 +116,16 @@ public actor CitadelTransport: HerdrTransport {
             sshEd25519: Data(credentials.privateKeyPEM.utf8),
             decryptionKey: credentials.passphrase.map { Data($0.utf8) }
         )
-        let connected = try await SSHClient.connect(
+        // A client that resolves after a concurrent close() is reaped by the
+        // generation check in connectedClient() (the only publisher of `self.client`),
+        // so no cancellation handling is needed here.
+        return try await SSHClient.connect(
             host: credentials.host,
             port: Int(credentials.port),
             authenticationMethod: .ed25519(username: credentials.username, privateKey: privateKey),
             hostKeyValidator: hostKeyValidator,
             reconnect: .never
         )
-        // If close() cancelled us WHILE the handshake was in flight — e.g. the user
-        // disconnected right after the connect-time prewarm started the session —
-        // the freshly opened client would otherwise be handed back to
-        // connectedClient() and re-assigned to `self.client` AFTER close() already
-        // nil'd it, leaking a live SSH session. Reap it here and abort instead.
-        // (connectTask is the ONLY thing close() cancels, so isCancelled ⟺ abandon.)
-        if Task.isCancelled {
-            try? await connected.close()
-            throw CancellationError()
-        }
-        return connected
     }
 
     /// Conservative ceiling on the full command line, well under the kernel's
@@ -227,6 +244,9 @@ public actor CitadelTransport: HerdrTransport {
 
     /// Closes the held SSH connection. Idempotent.
     public func close() async {
+        // Invalidate any in-flight connect so a handshake that resolves after this
+        // point is reaped by connectedClient() rather than installed post-close.
+        generation &+= 1
         connectTask?.cancel()
         connectTask = nil
         try? await client?.close()

--- a/Sources/HerdrKit/CitadelTransport.swift
+++ b/Sources/HerdrKit/CitadelTransport.swift
@@ -249,8 +249,15 @@ public actor CitadelTransport: HerdrTransport {
         generation &+= 1
         connectTask?.cancel()
         connectTask = nil
-        try? await client?.close()
+        // Snapshot and CLEAR the slot BEFORE awaiting teardown. Awaiting the old
+        // client's close is a suspension point, and actor reentrancy lets a NEW
+        // generation connect install a fresh client during it (a legitimate
+        // reconnect). A trailing unconditional `client = nil` would then discard that
+        // live session unclosed. Nil-before-await confines this teardown to the OLD
+        // client and never clobbers a reconnect that lands mid-close.
+        let old = client
         client = nil
+        try? await old?.close()
     }
 }
 


### PR DESCRIPTION
## Round-3 terminal polish (on-device feedback from v0.1.4 TestFlight)

Four App-target fixes; **no herdr/server change**.

### 1. Scroll-follow HOLDS position (stop the auto-jump-to-bottom)
`omp` sessions were scrollable but every streamed frame yanked the reader back to
the tail. Root cause: the old `contentOffset`-setter override never registered
interactive drags — UIKit routes a finger drag through `bounds.origin`, not the
property setter — so `followsBottom` stayed `true` and the auto-snap was always
honored. Now `followsBottom` is driven from genuine user scrolls via the scroll-view
**delegate** (`scrollViewDidScroll` / `…DidEndDragging` / `…DidEndDecelerating`).
The setter override remains only to DROP the programmatic snap while scrolled up
(still honoring legit clamps after `contentSize` shrinks). Return to the bottom →
auto-follow resumes.

`TerminalView` already conforms to `UIScrollViewDelegate` and never claims its own
`delegate` slot, so the view takes it. The three methods are `@objc` so
`respondsToSelector:` optional dispatch finds them (inherited, not re-declared,
conformance).

### 2. Trim right-edge crowding
`.padding(.horizontal, 8)` on the terminal → SwiftTerm floors one fewer column →
clean symmetric margin instead of the last column hugging the edge.

### 3. Keyboard-dismiss affordance
`@FocusState` on the reply field + a keyboard-toolbar chevron, plus tap-the-terminal
to dismiss.

### 4. Speed up agent-list load
Pre-warm the SSH handshake + first fetch at Connect so it overlaps the
ConnectView→TerminalHomeView transition. The `CitadelTransport` actor dedups
concurrent connects, so the pre-warm and the home view's own `load()` coalesce into
one session (no double connect; a pre-warm failure can't wedge the real load).

### Verification
- HerdrKit `swift build -Xswiftc -warnings-as-errors` + **221 tests green**.
- Buildbox App target **GREEN** at `a47258f` (status 0); launch screenshot renders.
- Two distinct-runtime witness reviews (codex + kimi) — see comments.

Reviewed-by: 2 distinct runtimes required · **do not self-merge** (JARVIS/owner merges).
