### PR TITLE
fix(terminal): restore omp scroll — don't write contentOffset during a live pan

### DIFF
--- a/App/LiveTerminalView.swift
+++ b/App/LiveTerminalView.swift
@@ -104,7 +104,14 @@ struct LiveTerminalView: UIViewRepresentable {
                 followsBottom = true
                 return
             }
-            guard !followsBottom else { return }
+            // CRITICAL: never write contentOffset while a pan/momentum is LIVE — a
+            // programmatic write into an active UIScrollView pan re-baselines its
+            // translation and, once per streamed frame under a firehose, swamps the
+            // finger → DEAD scroll (the v0.1.8 regression). `isDragging` (active drag)
+            // and `isDecelerating` (momentum) are excluded; `isTracking` is NOT — a
+            // finger merely RESTING (touch down, not moving) still holds position, which
+            // is the reader's "output snapped me down while I was resting" case.
+            guard !followsBottom, !isDragging, !isDecelerating else { return }
             let maxY = max(0, contentSize.height - bounds.height)
             contentOffset = CGPoint(x: 0, y: min(held, maxY))
         }
@@ -140,7 +147,9 @@ struct LiveTerminalView: UIViewRepresentable {
             let held = contentOffset.y
             super.layoutSubviews()          // size change → processSizeChange → updateScroller → snap
             lastLayoutSize = bounds.size
-            guard resized, !followsBottom else { return }
+            // Same rule: don't fight a live pan/momentum if a resize lands mid-gesture
+            // (a resting-finger resize still holds — isTracking not excluded).
+            guard resized, !followsBottom, !isDragging, !isDecelerating else { return }
             let maxY = max(0, contentSize.height - bounds.height)
             if held < maxY - max(1, font.lineHeight) {
                 // Still genuinely scrolled up in the new geometry → keep the reader there.


### PR DESCRIPTION
## Restore omp scroll — v0.1.8 dead-scroll regression fix

v0.1.8 (PR #53) made omp scroll COMPLETELY DEAD (v0.1.7 could scroll, just snapped back).

**Confirmed root cause** (git-diff v0.1.7→v0.1.8 + read-only investigation): v0.1.8's `feedHoldingPosition` writes `contentOffset` on **every** streamed `.data` frame while `followsBottom == false` — which is the state during a drag (`scrollViewWillBeginDragging` sets it false). A programmatic `contentOffset` write into a **live** `UIScrollView` pan re-baselines the pan's translation accounting; one such write per firehose frame swamps the finger → the drag nets no movement = dead. `feedHoldingPosition` is the only v0.1.8 change that runs on every frame of a live omp drag (the removed v0.1.7 setter override was transparent to the finger; `layoutSubviews` only runs on a size change; the alt-screen `scrollPan` early-returns on the normal buffer — all ruled out).

**Fix (2-flag guard):** never write `contentOffset` while a pan/momentum is live. `guard !followsBottom else` → `guard !followsBottom, !isDragging, !isDecelerating else`. `isTracking` deliberately NOT excluded, so a finger merely **resting** still holds position (the reader's "output snapped me down while resting" case). Same guard added to `layoutSubviews`.

**Behavior:** scroll works (finger never fought); position holds when resting/lifted (Jerry's complaint fixed); during an *active* firehose drag the snap isn't held (same as v0.1.7, jumpy-but-scrollable, self-corrects on next touch-move).

Single-file, +11/−2. HerdrKit build green.

**Review focus:** confirm that guarding on `!isDragging && !isDecelerating` stops the per-frame `contentOffset` write from fighting the live pan (restoring scroll), while still holding when the finger rests (`isTracking`) or lifts. Any case where the write still lands during an active pan/momentum?

Reviewed by 2 distinct runtimes · do not self-merge.
