### PR TITLE
fix(terminal): fix scroll at the root — upgrade SwiftTerm 1.11.2→1.15.0 (issue #486) + automated scroll receipt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,96 @@
+# Simulator compile-check + UI scroll-test for herdr-ios. Runs on feature-branch
+# pushes and PRs — NO signing secrets, NO TestFlight upload (that stays in
+# testflight.yml, gated to main + v* tags). This is the fast feedback loop for the
+# SwiftTerm 1.15.0 upgrade: it proves the Metal-bearing SwiftTerm compiles (with the
+# downloaded Metal toolchain) and that the app builds against the 1.15.0 API, then
+# runs the XCUITest that drags a scrollback-seeded REAL SwiftTerm and asserts the
+# content moves (the on-device gesture receipt JARVIS rule 47874 requires).
+name: CI
+
+on:
+  push:
+    branches-ignore: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-uitest:
+    runs-on: macos-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Select Xcode and assert the iOS SDK
+        run: |
+          echo "Xcodes present:"; ls -d /Applications/Xcode*.app || true
+          LATEST=$(ls -d /Applications/Xcode*.app | sort -V | tail -1)
+          echo "selecting: $LATEST"; sudo xcode-select -s "$LATEST"; xcodebuild -version
+          SDK=$(xcodebuild -showsdks | grep -oE 'iphonesimulator[0-9.]+' | sed 's/iphonesimulator//' | sort -V | tail -1)
+          echo "newest iOS simulator SDK: ${SDK:-<none>}"
+
+      - name: Download the Metal toolchain
+        # SwiftTerm >=1.12.0 bundles Apple/Metal/Shaders.metal unconditionally; Xcode 26
+        # ships the Metal shader compiler as a separate component. Idempotent — a no-op
+        # if already present. Without it `CompileMetalFile` fails.
+        run: |
+          xcodebuild -downloadComponent MetalToolchain 2>&1 | tail -20 || \
+            echo "::warning::-downloadComponent MetalToolchain returned nonzero (may already be present); continuing"
+
+      - name: Install XcodeGen
+        run: brew install xcodegen
+
+      - name: Generate project
+        run: xcodegen generate
+
+      - name: Pick a simulator destination
+        run: |
+          DEST=$(xcrun simctl list devices available | grep -oE 'iPhone [0-9]+' | sort -V | tail -1)
+          echo "SIM_NAME=${DEST:-iPhone 15}" >> "$GITHUB_ENV"
+          echo "using simulator: ${DEST:-iPhone 15}"
+
+      - name: Build for simulator (compile check — SwiftTerm 1.15.0 + Metal + app)
+        run: |
+          set -o pipefail
+          xcodebuild build \
+            -project Herdr.xcodeproj -scheme Herdr \
+            -destination "platform=iOS Simulator,name=${SIM_NAME}" \
+            -derivedDataPath .build-dd \
+            CODE_SIGNING_ALLOWED=NO | xcbeautify || xcodebuild build \
+            -project Herdr.xcodeproj -scheme Herdr \
+            -destination "platform=iOS Simulator,name=${SIM_NAME}" \
+            -derivedDataPath .build-dd \
+            CODE_SIGNING_ALLOWED=NO
+
+      - name: Run UI scroll-test (the gesture receipt)
+        # Runs only if the HerdrUITests target exists in the generated project.
+        run: |
+          if xcodebuild -project Herdr.xcodeproj -list 2>/dev/null | grep -q HerdrUITests; then
+            set -o pipefail
+            xcodebuild test \
+              -project Herdr.xcodeproj -scheme Herdr \
+              -destination "platform=iOS Simulator,name=${SIM_NAME}" \
+              -only-testing:HerdrUITests \
+              -derivedDataPath .build-dd \
+              -resultBundlePath TestResults.xcresult \
+              CODE_SIGNING_ALLOWED=NO | xcbeautify || \
+            xcodebuild test \
+              -project Herdr.xcodeproj -scheme Herdr \
+              -destination "platform=iOS Simulator,name=${SIM_NAME}" \
+              -only-testing:HerdrUITests \
+              -derivedDataPath .build-dd \
+              -resultBundlePath TestResults.xcresult \
+              CODE_SIGNING_ALLOWED=NO
+          else
+            echo "HerdrUITests target not present yet — skipping (compile-check only run)."
+          fi
+
+      - name: Upload test result bundle (scroll receipt screenshots)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: scroll-test-results
+          path: TestResults.xcresult
+          if-no-files-found: ignore

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -222,6 +222,15 @@ struct RootView: View {
             NewAgentView(client: mockClient,
                          initialFolder: "/root/herdr-ios", initialKind: "codex",
                          initialTask: "Fix the failing schema artifact test and push")
+        case .scroll:
+            // A REAL SwiftTerm pane (not a stub) fed 200 lines of scrollback, so the
+            // HerdrUITests swipe exercises the actual library scroll path — the only
+            // test that proves the SwiftTerm 1.15.0 scroll fix on device.
+            NavigationStack {
+                TerminalPaneView(client: HerdrClient(transport: MockTransport(scrollback: true)),
+                                 paneID: "w1:p1", title: "scrolltest",
+                                 agent: MockTransport.demoPaneAgent)
+            }
         }
     }
     #endif
@@ -1820,7 +1829,7 @@ private extension View {
 /// `HERDR_SCREENSHOT_MOCK=list` (default) or `=pane`, or the `-herdrScreenshotMock`
 /// launch argument.
 enum ScreenshotMock {
-    case list, pane, settings, newAgent
+    case list, pane, settings, newAgent, scroll
 
     static var mode: ScreenshotMock? {
         let env = ProcessInfo.processInfo.environment["HERDR_SCREENSHOT_MOCK"]?.lowercased()
@@ -1830,6 +1839,9 @@ enum ScreenshotMock {
         case "pane": return .pane
         case "settings": return .settings
         case "newagent": return .newAgent
+        // `scroll` drives the HerdrUITests scroll receipt: a real SwiftTerm pane seeded
+        // with 200 distinct lines of scrollback so a swipe visibly moves the content.
+        case "scroll": return .scroll
         default: return .list
         }
     }
@@ -1839,6 +1851,11 @@ enum ScreenshotMock {
 /// in Tests/HerdrKitTests/MockWireFixtureTests.swift (the app target can't be
 /// compiled on Linux) — keep the two fixtures in sync.
 struct MockTransport: HerdrTransport {
+    /// When true, `pane.stream` seeds MANY lines of scrollback (for the UI scroll
+    /// receipt) instead of the short screenshot seed. Default false keeps the
+    /// buildbox screenshot fixtures unchanged.
+    var scrollback = false
+
     func roundTrip(_ requestLine: String) async throws -> String {
         if requestLine.contains("agent.list") { return Self.agentList }
         if requestLine.contains("agent.read") { return Self.agentRead }
@@ -1848,16 +1865,34 @@ struct MockTransport: HerdrTransport {
 
     func stream(_ requestLine: String) -> AsyncThrowingStream<String, Error> {
         // `pane.stream` (the live terminal): reply with the stream_started ack, then
-        // a full-screen reset seed, then finish — so the DEBUG pane screenshot shows
-        // a rendered SwiftTerm terminal, not an empty one.
+        // a reset seed, then finish — so the DEBUG pane shows a rendered SwiftTerm
+        // terminal, not an empty one. The scrollback seed (UI test) feeds 200 lines so
+        // there is real history to scroll; the default seed is the short screenshot one.
         if requestLine.contains("pane.stream") {
+            let reset = scrollback ? Self.scrollbackResetFrame() : Self.paneStreamReset
             return AsyncThrowingStream { continuation in
                 continuation.yield(Self.paneStreamAck)
-                continuation.yield(Self.paneStreamReset)
+                continuation.yield(reset)
                 continuation.finish()
             }
         }
         return AsyncThrowingStream { $0.finish() }
+    }
+
+    /// A reset frame carrying 200 DISTINCT numbered lines so the terminal has real
+    /// scrollback and a swipe visibly changes the rendered content. Hides the cursor
+    /// (ESC[?25l) so an un-swiped terminal renders byte-identically frame to frame —
+    /// which makes the UI test's "did the content move?" an exact before/after image
+    /// compare with no blinking-cursor false positive. Same reset shape as
+    /// `paneStreamReset`; base64 built at runtime (DEBUG/UI-test-only, not a fixture).
+    static func scrollbackResetFrame() -> String {
+        var body = "\u{1b}[?25l"   // hide cursor: static frames stay byte-identical
+        for i in 1...200 {
+            body += String(format: "SCROLLTEST line %03d  the quick brown fox jumps over the lazy dog\r\n", i)
+        }
+        body += "SCROLLTEST end — swipe down to reveal earlier lines"
+        let b64 = Data(body.utf8).base64EncodedString()
+        return "{\"stream\":\"pane.bytes\",\"frame\":\"reset\",\"seq\":0,\"epoch\":7,\"cols\":80,\"rows\":24,\"data_b64\":\"\(b64)\"}"
     }
 
     // Realistic herdr statuses only (idle|working|blocked|done|unknown). "needs

--- a/App/LiveTerminalView.swift
+++ b/App/LiveTerminalView.swift
@@ -45,111 +45,31 @@ struct LiveTerminalView: UIViewRepresentable {
     /// A `TerminalView` that never accepts keyboard input — display + scroll only.
     /// Blocking first-responder status is what keeps this observe-only: no keyboard
     /// appears and no keystroke can reach the (unwired) PTY input path.
-    /// NOTE: `TerminalView` already conforms to `UIScrollViewDelegate` (SwiftTerm
-    /// declares it on the base class) but implements none of the `scrollView*`
-    /// methods and never assigns `self.delegate` — so we inherit the conformance
-    /// (re-declaring it errors "redundant conformance") and simply claim the free
-    /// delegate slot. The three methods below are marked `@objc` explicitly so the
-    /// runtime's optional-protocol dispatch (`respondsToSelector:`) finds them:
-    /// inferred `@objc` is not guaranteed when the conformance is inherited rather
-    /// than stated here, and without it the follow-logic would be dead code.
+    ///
+    /// SCROLL is the LIBRARY's job now. On a normal (shell) buffer the reader
+    /// finger-scrolls the retained scrollback through SwiftTerm's own `UIScrollView`,
+    /// native and unmodified. SwiftTerm ≥1.14.0 (we ship 1.15.0) fixed the iOS scroll
+    /// wiring (issue #486 / PR #587: a `contentOffset`→`yDisp` sync plus a
+    /// `terminal.userScrolling` flag), so a scrolled-up reader holds position even
+    /// while output streams. We deliberately do NOT override `contentOffset`, claim the
+    /// scroll delegate, or run any follow/hold logic here: doing exactly that on
+    /// SwiftTerm 1.11.2 SHADOWED the (then-broken) library and dead-locked scrolling
+    /// across ~7 TestFlight builds — the defect was in the library, not this file.
+    /// The ONLY scroll code we keep is the ALTERNATE-screen pan
+    /// (`Coordinator.handleScrollPan`), which sends wheel/arrow scroll INTO a
+    /// full-screen TUI that keeps no scrollback of its own.
     final class ReadOnlyTerminalView: TerminalView {
         override var canBecomeFirstResponder: Bool { false }
         override func becomeFirstResponder() -> Bool { false }
 
-        /// FOLLOW-ONLY-AT-BOTTOM. `TerminalView` is a `UIScrollView` whose
-        /// `updateScroller` slams `contentOffset` to the bottom on EVERY streamed
-        /// frame — so without intervention a scrolled-up reader is yanked back ("scrolls
-        /// back automatically to the bottom"). We DROP that programmatic snap while the
-        /// reader has scrolled up, and resume auto-follow when they return to the tail.
-        /// Governs only WHERE WE LOOK — opens no input path.
-        ///
-        /// `followsBottom` is driven from GENUINE user scrolls via the scroll-view
-        /// DELEGATE, NOT the `contentOffset` setter: UIKit moves an interactive drag
-        /// through `bounds.origin`, which never invokes the property setter (the classic
-        /// trap that made the setter-based version never register a drag, so it stayed
-        /// following and always snapped). SwiftTerm never claims the delegate slot on
-        /// iOS, so we take it.
-        private var followsBottom = true
-
         override init(frame: CGRect, font: UIFont?) {
             super.init(frame: frame, font: font)
-            delegate = self
-            // Keep the bottom-detection math inset-free. With automatic inset
-            // adjustment a safe-area / keyboard inset would shift the true maximum
-            // offset out from under `isAtBottom`, silently wedging follow off.
+            // Inset-free, matching SwiftTerm's own iOS example host: keeps the grid
+            // flush and the library's scroll-offset math (`maxContentOffsetY`) free of a
+            // shifting safe-area / keyboard inset.
             contentInsetAdjustmentBehavior = .never
         }
         required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
-
-        // `followsBottom` state machine, driven by the scroll-view delegate (SwiftTerm
-        // leaves the delegate slot free on iOS): RELEASE follow the moment a drag
-        // begins, and re-arm it only when the gesture SETTLES at the tail. The
-        // contentOffset setter honors interactive writes regardless of this flag, so
-        // releasing follow here does NOT disable scrolling — it only decides whether
-        // a PROGRAMMATIC snap-to-bottom (finger up) is dropped so the reader's
-        // position holds.
-        //
-        // We do NOT track follow in `scrollViewDidScroll`: SwiftTerm's updateScroller
-        // writes contentOffset once per streamed line, re-entering the delegate while
-        // isDragging == true, so a "does this look like the bottom?" check there would
-        // re-affirm follow mid-drag. (Known limit: under CONTINUOUS streaming the snap
-        // is still honored mid-drag because the finger's write and the stream's write
-        // are indistinguishable while isDragging; the reader's position holds cleanly
-        // once they lift during an output gap. Truly holding through a firehose needs
-        // intercepting updateScroller — a SwiftTerm-level change, deferred.)
-        @objc func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
-            followsBottom = false
-        }
-        @objc func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
-            if !decelerate { followsBottom = isAtBottom(scrollView.contentOffset) }
-        }
-        @objc func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
-            followsBottom = isAtBottom(scrollView.contentOffset)
-        }
-
-        override var contentOffset: CGPoint {
-            get { super.contentOffset }
-            set {
-                // CRITICAL — the finger's OWN scroll commits pass through THIS setter:
-                // the UIScrollView pan writes the `contentOffset` PROPERTY, not merely
-                // `bounds.origin`. (Proven by the v0.1.5/0.1.6 dead-scroll regression —
-                // an earlier version dropped in-range writes whenever followsBottom was
-                // false, and since scrollViewWillBeginDragging sets it false at drag
-                // start, the finger's own writes were dropped and scrolling died on
-                // BOTH omp and Claude Code, which share this native-scrollback path.)
-                //
-                // So an INTERACTIVE write (finger down, or post-lift momentum) is
-                // ALWAYS honored; only a PROGRAMMATIC write — no touch, no momentum —
-                // may be held. The hold branch below is therefore unreachable while a
-                // gesture is active, so it can NEVER swallow a drag.
-                if isDragging || isDecelerating || isTracking || followsBottom {
-                    super.contentOffset = newValue
-                } else {
-                    // Programmatic snap while the reader has scrolled up and lifted:
-                    // DROP an in-range snap-to-bottom so their position holds; HONOR a
-                    // legit CLAMP (contentSize shrank so the current offset is now out
-                    // of range — else it strands over blank space) and re-arm follow,
-                    // since a shrink parks us at the tail with nothing below to hold.
-                    // No interaction flag can be set here (checked above), so the
-                    // re-arm cannot fire mid-drag.
-                    let maxY = max(0, contentSize.height - bounds.height)
-                    if super.contentOffset.y > maxY {
-                        super.contentOffset = CGPoint(x: newValue.x, y: min(newValue.y, maxY))
-                        followsBottom = isAtBottom(super.contentOffset)
-                    }
-                }
-            }
-        }
-
-        /// True when `offset` sits within a line of the bottom — i.e. the reader is
-        /// (or is returning to) the live tail. A one-line tolerance keeps sub-pixel
-        /// content-size jitter from spuriously dropping follow.
-        private func isAtBottom(_ offset: CGPoint) -> Bool {
-            let maxY = max(0, contentSize.height - bounds.height)
-            let tolerance = max(1, font.lineHeight)
-            return offset.y >= maxY - tolerance
-        }
     }
 
     /// Owns the stream task and marshals frames onto the main actor. Retained by

--- a/HerdrUITests/ScrollTests.swift
+++ b/HerdrUITests/ScrollTests.swift
@@ -1,0 +1,96 @@
+import XCTest
+import UIKit
+
+/// The automated SCROLL RECEIPT (JARVIS standing-rule 47874: no scroll change ships on
+/// static review alone — a real drag must be exercised). Launches the app into a REAL
+/// SwiftTerm pane seeded with 200 lines of scrollback (HERDR_SCREENSHOT_MOCK=scroll),
+/// then:
+///   1. proves the terminal is STATIC when untouched (two screenshots ~identical) — so
+///      the scroll assertion can't be faked by ambient animation, and
+///   2. swipes the terminal and asserts the rendered pixels MOVED substantially.
+/// Dead scroll (the 7-build symptom) = unchanged pixels after the swipe = this fails.
+/// Before/after screenshots are attached so the CI artifact is the visual proof.
+final class ScrollTests: XCTestCase {
+
+    override func setUp() { continueAfterFailure = false }
+
+    func testTerminalScrollsWhenSwiped() {
+        let app = XCUIApplication()
+        app.launchEnvironment["HERDR_SCREENSHOT_MOCK"] = "scroll"
+        app.launch()
+
+        // Let the app launch and the mock stream feed all 200 lines into the real
+        // SwiftTerm view (async), so there is scrollback to move.
+        Thread.sleep(forTimeInterval: 3.0)
+
+        // (1) STATIC CHECK: with the cursor hidden by the seed, an untouched terminal
+        // must render essentially identically frame to frame. If it doesn't, some
+        // animation is running and the scroll assertion below would be unreliable.
+        let before = app.screenshot()
+        Thread.sleep(forTimeInterval: 1.0)
+        let beforeAgain = app.screenshot()
+        let idleDiff = pixelDiffFraction(before, beforeAgain)
+        attach(before, name: "01-before")
+        XCTAssertLessThan(idleDiff, 0.02,
+            "Terminal is not static when untouched (diff=\(idleDiff)); a moving element would invalidate the scroll check.")
+
+        // (2) SWIPE: drag DOWN on the terminal body (below the header, above the reply
+        // bar) to reveal older scrollback. Three firm drags to move a clear distance.
+        let high = app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.35))
+        let low  = app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.82))
+        for _ in 0..<3 {
+            high.press(forDuration: 0.05, thenDragTo: low)
+            Thread.sleep(forTimeInterval: 0.2)
+        }
+        Thread.sleep(forTimeInterval: 1.0)   // let scroll settle + repaint
+
+        let after = app.screenshot()
+        attach(after, name: "02-after-swipe")
+        let movedDiff = pixelDiffFraction(before, after)
+
+        // A real scroll shifts ~a screen of distinct numbered lines → a large fraction
+        // of pixels change. Dead scroll leaves them identical (movedDiff ~ 0).
+        XCTAssertGreaterThan(movedDiff, 0.10,
+            "Terminal did NOT scroll: rendered content is unchanged after swiping (diff=\(movedDiff)). This is the dead-scroll symptom.")
+    }
+
+    // MARK: - helpers
+
+    private func attach(_ shot: XCUIScreenshot, name: String) {
+        let a = XCTAttachment(screenshot: shot)
+        a.name = name
+        a.lifetime = .keepAlways
+        add(a)
+    }
+
+    /// Fraction of pixels that differ (beyond a small per-pixel threshold) between two
+    /// screenshots, compared at a fixed small resolution so PNG-encoding jitter and
+    /// antialiasing don't register as change. 0 = identical, 1 = fully different.
+    private func pixelDiffFraction(_ a: XCUIScreenshot, _ b: XCUIScreenshot) -> Double {
+        let w = 90, h = 180
+        guard let bufA = rgbaBuffer(a.image, w: w, h: h),
+              let bufB = rgbaBuffer(b.image, w: w, h: h) else { return 1.0 }
+        var differing = 0
+        var i = 0
+        while i < bufA.count {
+            let d = abs(Int(bufA[i]) - Int(bufB[i]))
+                  + abs(Int(bufA[i + 1]) - Int(bufB[i + 1]))
+                  + abs(Int(bufA[i + 2]) - Int(bufB[i + 2]))
+            if d > 30 { differing += 1 }   // channel-sum threshold: ignores tiny jitter
+            i += 4
+        }
+        return Double(differing) / Double(w * h)
+    }
+
+    private func rgbaBuffer(_ image: UIImage, w: Int, h: Int) -> [UInt8]? {
+        guard let cg = image.cgImage else { return nil }
+        var data = [UInt8](repeating: 0, count: w * h * 4)
+        let cs = CGColorSpaceCreateDeviceRGB()
+        guard let ctx = CGContext(data: &data, width: w, height: h,
+                                  bitsPerComponent: 8, bytesPerRow: w * 4, space: cs,
+                                  bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue) else { return nil }
+        ctx.interpolationQuality = .low
+        ctx.draw(cg, in: CGRect(x: 0, y: 0, width: w, height: h))
+        return data
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -38,17 +38,25 @@ packages:
   # The VT emulator that renders the live terminal (#40). Added to the APP target
   # ONLY — never to Package.swift/HerdrKit, which must stay UIKit-free and
   # Linux-buildable (SwiftTerm is UIKit/AppKit). We use SwiftTerm's default
-  # CoreText renderer, NOT its Metal backend. Pinned to v1.11.2 — the NEWEST tag
-  # that predates the bundled `Shaders.metal` (added in v1.12.0): Xcode 26 makes
-  # the Metal shader-compiler toolchain a separate download the local buildbox
-  # lacks, so a metal-bearing SwiftTerm fails `CompileMetalFile` there. (SwiftTerm
-  # itself only drops the shader when GITHUB_ACTIONS=true, which reaches the SPM
-  # manifest on GH runners but not the local Mac — hence a metal-free pin builds on
-  # BOTH.) iOS floor is under the app's. xcodegen's key is `exactVersion` (SwiftPM's
+  # CoreText renderer, NOT its Metal backend.
+  #
+  # v1.15.0 (was 1.11.2): 1.11.2's iOS `updateScroller()` force-pinned contentOffset
+  # to the bottom every frame with no contentOffset→yDisp sync, so finger-scroll of
+  # the scrollback was BROKEN — a library bug (SwiftTerm issue #486) fixed in v1.14.0
+  # (PR #587: contentOffset override + syncYDispFromContentOffset + terminal.userScrolling).
+  # No app-side workaround exists (proven by ~7 builds); the fix is this upgrade.
+  #
+  # METAL: v1.12.0+ bundles `Apple/Metal/Shaders.metal` UNCONDITIONALLY (v1.15.0
+  # Package.swift `.process("Apple/Metal/Shaders.metal")`; the GITHUB_ACTIONS check
+  # only gates benchmarks now — no shader opt-out). Xcode 26 makes the Metal
+  # shader-compiler toolchain a separate download; both CI and the local buildbox run
+  # `xcodebuild -downloadComponent MetalToolchain` so `CompileMetalFile` succeeds. We
+  # still use CoreText at runtime — the shader is compiled but unused.
+  # iOS floor is under the app's. xcodegen's key is `exactVersion` (SwiftPM's
   # `exact:` is Package.swift syntax and xcodegen rejects it).
   SwiftTerm:
     url: https://github.com/migueldeicaza/SwiftTerm.git
-    exactVersion: "1.11.2"
+    exactVersion: "1.15.0"
 
 targets:
   Herdr:

--- a/project.yml
+++ b/project.yml
@@ -77,6 +77,13 @@ targets:
       # depend on it so the Linux build/test of the protocol layer stays intact.
       - package: SwiftTerm
         product: SwiftTerm
+    # Add the UI-test bundle to the auto-generated `Herdr` scheme's TEST action, so
+    # `xcodebuild test -scheme Herdr -only-testing:HerdrUITests` runs it. This does NOT
+    # touch the scheme's build/archive action, so the TestFlight lane (`-scheme Herdr`
+    # archive) is unaffected.
+    scheme:
+      testTargets:
+        - HerdrUITests
     info:
       path: App/Info.plist
       properties:
@@ -153,3 +160,23 @@ targets:
           CODE_SIGN_STYLE: Manual
           PROVISIONING_PROFILE_SPECIFIER: "Herdrup App Store"
           CODE_SIGN_IDENTITY: "Apple Distribution"
+
+  # UI-test bundle — the automated SCROLL RECEIPT. Launches the app in the
+  # HERDR_SCREENSHOT_MOCK=scroll pane (a real SwiftTerm view fed 200 lines), swipes it,
+  # and asserts the rendered content MOVED (proving the SwiftTerm 1.15.0 scroll fix on a
+  # simulator — the on-device gesture proof JARVIS rule 47874 requires). Simulator only,
+  # never signed, never archived. GENERATE_INFOPLIST_FILE builds the test bundle plist.
+  HerdrUITests:
+    type: bundle.ui-testing
+    platform: iOS
+    sources:
+      - path: HerdrUITests
+    dependencies:
+      - target: Herdr
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.jerryfane.herdr.uitests
+        SWIFT_VERSION: "5.9"
+        GENERATE_INFOPLIST_FILE: YES
+        TARGETED_DEVICE_FAMILY: "1"
+        CODE_SIGNING_ALLOWED: NO


### PR DESCRIPTION
## Root cause (finally)
Terminal scroll was **completely frozen** (owner: both omp and Claude Code, iPhone, even when idle) across ~7 TestFlight builds that each edited `App/LiveTerminalView.swift`. v0.1.10 reverted that file **byte-for-byte to v0.1.7** and it STILL froze — proving the bug was never in our code.

It's a **known bug in SwiftTerm 1.11.2 itself** (issue #486): iOS `updateScroller()` force-pins `contentOffset` to the bottom every frame with no `contentOffset→yDisp` sync and no repaint-on-scroll, so finger-scroll is broken. Fixed upstream in **v1.14.0 (PR #587)**: a `contentOffset` override + `syncYDispFromContentOffset()` + a `terminal.userScrolling` flag. Two independent research passes converged on this.

## The fix
1. **Upgrade SwiftTerm 1.11.2 → 1.15.0** (`project.yml`). v1.12.0+ bundles `Shaders.metal` unconditionally (verified the real v1.15.0 Package.swift), so both CI and the buildbox now `xcodebuild -downloadComponent MetalToolchain`; we still render with CoreText.
2. **Simplify `ReadOnlyTerminalView`** — remove our `contentOffset` override + `followsBottom` follow-hold + scroll-delegate methods. On 1.11.2 those SHADOWED the (broken) library and dead-locked scrolling; 1.15.0's own logic now handles native finger-scroll AND hold-while-streaming (subsumes the deferred defer-feed task). Keep read-only + the alt-screen `handleScrollPan` (TUI wheel/arrow scroll).

## Verification — an actual drag, not just compile-green (JARVIS rule 47874)
New **HerdrUITests/ScrollTests** launches a REAL SwiftTerm pane seeded with 200 lines (cursor hidden so static frames are byte-stable), proves it's static when untouched, then **swipes it and asserts the rendered pixels moved >10%** (dead scroll = unchanged = fail). Before/after screenshots attached as the CI artifact.

**CI run 31159609904 (green):** Metal toolchain downloaded, SwiftTerm 1.15.0 + app compiled, and `ScrollTests` **Executed 1 test, 0 failures** — the automated on-device gesture receipt.

## Ship
Owner-approved plan (upgrade+toolchain, sim-test-first). herdr-app never self-merges — JARVIS merges with the receipt in the witness package; then tag v0.1.11 → TestFlight → owner confirms.