### PR TITLE
feat(terminal): smoother Claude Code scroll + End/Ctrl+End/Ctrl+Home keycaps

### DIFF
--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -1353,6 +1353,14 @@ struct TerminalPaneView: View {
                 keyCap(symbol: "chevron.up", key: "Up")
                 keyCap(symbol: "chevron.down", key: "Down")
                 keyCap(symbol: "chevron.right", key: "Right")
+                // End (end-of-line cursor) + the two scroll jumps for a mouse-mode agent
+                // like Claude Code: Ctrl+Home = jump to TOP, Ctrl+End = jump to BOTTOM
+                // (and re-enable auto-follow). ESC[1;5H / ESC[1;5F are the xterm Ctrl+Home
+                // / Ctrl+End sequences Claude Code's readline keymap honors (End alone is a
+                // cursor key there, not a scroll — hence the two Ctrl jumps for scrolling).
+                keyCap(label: "end", key: "End")
+                rawCap(symbol: "arrow.up.to.line", sequence: "\u{1b}[1;5H")
+                rawCap(symbol: "arrow.down.to.line", sequence: "\u{1b}[1;5F")
                 keyCap(label: "tab", key: "Tab")
                 // Shift+Tab (CBT / back-tab, ESC[Z) — cycles Claude-Code modes. A
                 // raw escape sequence, not a named key: delivered verbatim to the PTY.
@@ -1392,16 +1400,19 @@ struct TerminalPaneView: View {
     /// straight to the PTY via `pane.send_text` — for keys herdr's named allow-list
     /// does not cover (Shift+Tab = `ESC[Z`, `^C` = `\u{03}`). Routed through the
     /// `.rawSequence` action so it is delivered verbatim, not newline-refused.
-    private func rawCap(label: String, sequence: String) -> some View {
+    private func rawCap(label: String? = nil, symbol: String? = nil, sequence: String) -> some View {
         Button { send(.rawSequence(sequence)) } label: {
-            Text(label).font(Typography.machine(12))
-                .foregroundStyle(Palette.textDim)
-                .padding(.horizontal, 10)
-                .frame(minWidth: 44, minHeight: 34)
-                .background(Palette.surface).clipShape(RoundedRectangle(cornerRadius: 8))
+            Group {
+                if let symbol { Image(systemName: symbol).font(.system(size: 12, weight: .semibold)) }
+                else { Text(label ?? "").font(Typography.machine(12)) }
+            }
+            .foregroundStyle(Palette.textDim)
+            .padding(.horizontal, 10)
+            .frame(minWidth: 44, minHeight: 34)
+            .background(Palette.surface).clipShape(RoundedRectangle(cornerRadius: 8))
         }
         .disabled(sending || pendingPrefill)
-        .accessibilityLabel(Text(label))
+        .accessibilityLabel(Text(label ?? symbol ?? "key"))
     }
 
     /// The sticky Ctrl toggle. Tap to arm (it highlights in the working blue); the

--- a/App/LiveTerminalView.swift
+++ b/App/LiveTerminalView.swift
@@ -438,6 +438,13 @@ struct LiveTerminalView: UIViewRepresentable {
                 let cap = term.mouseMode != .off ? 1 : 4
                 let count = min(abs(ticks), cap)
                 scrollAccum -= CGFloat((ticks > 0 ? 1 : -1) * count) * line
+                // Bound the carry to ONE frame's worth: keeps the decelerating-drag
+                // benefit but stops scrollAccum growing unbounded when demand outruns the
+                // cap — otherwise a direction REVERSAL within one touch keeps firing the
+                // old direction for many frames (scrolls backwards), and in mouse mode the
+                // backlog × Claude Code's own acceleration would over-scroll (reviewer).
+                let maxCarry = CGFloat(cap) * line
+                scrollAccum = min(max(scrollAccum, -maxCarry), maxCarry)
                 emitScroll(up: ticks > 0, count: count,
                            at: gr.location(in: view), term: term)
             default:

--- a/App/LiveTerminalView.swift
+++ b/App/LiveTerminalView.swift
@@ -427,15 +427,18 @@ struct LiveTerminalView: UIViewRepresentable {
                 let line = max(1, Self.paneFont.lineHeight)
                 let ticks = Int(scrollAccum / line)
                 guard ticks != 0 else { return }
-                scrollAccum -= CGFloat(ticks) * line
-                // Emit ONE wheel tick per gesture frame (not a coalesced burst): a
-                // mouse-mode agent like Claude Code accelerates its own scroll by the
-                // GAP between wheel events, so 4 events slammed into one send arrive
-                // ~simultaneously and trip its fast-scroll cap (~36 lines/tick) — the
-                // jumpy leaps. One-per-frame spaces them so its gentle ~3-line regime
-                // applies → smooth, finger-proportional (its own accel still gives fling
-                // speed). scrollAccum already carries the leftover for the next frame.
-                emitScroll(up: ticks > 0, count: 1,
+                // Pace the wheel: a MOUSE-MODE agent (Claude Code) accelerates its own
+                // scroll from the GAP between wheel events, so several events slammed into
+                // one send arrive ~simultaneously and trip its fast cap (~36 lines/tick) —
+                // the jumpy leaps. Emit ONE tick per frame there so the gaps land in its
+                // gentle ~3-line regime → smooth, finger-proportional (its own accel still
+                // supplies fling speed). The ARROW-key fallback (rare non-mouse alt-screen)
+                // doesn't accelerate, so keep up to 4/frame. CONSUME ONLY the ticks we
+                // emit and CARRY the rest in scrollAccum, so a fast drag isn't truncated.
+                let cap = term.mouseMode != .off ? 1 : 4
+                let count = min(abs(ticks), cap)
+                scrollAccum -= CGFloat((ticks > 0 ? 1 : -1) * count) * line
+                emitScroll(up: ticks > 0, count: count,
                            at: gr.location(in: view), term: term)
             default:
                 break

--- a/App/LiveTerminalView.swift
+++ b/App/LiveTerminalView.swift
@@ -428,7 +428,14 @@ struct LiveTerminalView: UIViewRepresentable {
                 let ticks = Int(scrollAccum / line)
                 guard ticks != 0 else { return }
                 scrollAccum -= CGFloat(ticks) * line
-                emitScroll(up: ticks > 0, count: min(abs(ticks), 4),
+                // Emit ONE wheel tick per gesture frame (not a coalesced burst): a
+                // mouse-mode agent like Claude Code accelerates its own scroll by the
+                // GAP between wheel events, so 4 events slammed into one send arrive
+                // ~simultaneously and trip its fast-scroll cap (~36 lines/tick) — the
+                // jumpy leaps. One-per-frame spaces them so its gentle ~3-line regime
+                // applies → smooth, finger-proportional (its own accel still gives fling
+                // speed). scrollAccum already carries the leftover for the next frame.
+                emitScroll(up: ticks > 0, count: 1,
                            at: gr.location(in: view), term: term)
             default:
                 break


### PR DESCRIPTION
## What (owner asks)
Claude Code scroll works (v0.1.12) but is 'not super smooth'; owner wants jump-to-bottom/top nav.

**Smoothness** (`App/LiveTerminalView.swift`, `handleScrollPan`): pace the SGR wheel — emit ONE tick per gesture frame for a mouse-mode agent (Claude Code accelerates its own scroll from the GAP between events, so a coalesced burst tripped its ~36-line fast cap = jumpy). Carry unemitted ticks (don't discard), and bound the carry to one frame (no reversal lag / over-scroll). Arrow-key fallback keeps 4/frame.

**Keycaps** (`App/HerdrApp.swift` controlBar): **End** (named key, end-of-line cursor), **Ctrl+End** = `ESC[1;5F` (jump to bottom + re-enable auto-follow), **Ctrl+Home** = `ESC[1;5H` (jump to top). Sequences byte-verified against Claude Code's readline keymap. `rawCap` gains an optional SF symbol (arrow.down.to.line / arrow.up.to.line). Read-only preserved (`.rawSequence`/`.key` path, like S-Tab/^C).

## Verification
- **CI 31190528016 GREEN**: testClaudeCodeScrollsViaWheel + omp regression pass (the scroll receipt still holds — the pacing change doesn't alter WHAT is emitted).
- **Buildbox BUILD SUCCEEDED** @ 57e0d92.
- **kimi APPROVE** + **omp APPROVE** (distinct runtime; omp ran 3 rounds and caught 2 real pacing regressions — a discard bug and a direction-reversal bug — both fixed with its own suggested bound). Codex reviewer still broken (gpt-5.6-sol).

## Ship
herdr-app merge=none — JARVIS merges; then tag v0.1.13 → TestFlight → owner confirms the smoother scroll + the 3 buttons on device (smoothness is subjective, owner is the final judge).