### PR TITLE
feat(terminal): gesture slice 1 — edge-swipe back, double-tap jump-to-bottom, long-press Stop

### DIFF
--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -1039,10 +1039,18 @@ struct TerminalHomeView: View {
                     }
                     .buttonStyle(.plain)
                     // Long-press an agent → quick actions. Stop = close the pane
-                    // (`pane.close`, the only stop RPC — its inverse is start), then reload.
+                    // (`pane.close`, the only stop RPC — its inverse is start), then reload;
+                    // disclose a failure rather than swallowing it (file convention).
                     .contextMenu {
                         Button(role: .destructive) {
-                            Task { try? await client.closePane(paneID: row.info.paneID); await load() }
+                            Task {
+                                do {
+                                    try await client.closePane(paneID: row.info.paneID)
+                                    await load()
+                                } catch let e {
+                                    error = "couldn't stop \(row.title): \(e.localizedDescription)"
+                                }
+                            }
                         } label: { Label("Stop agent", systemImage: "stop.circle") }
                     }
                 }
@@ -1204,34 +1212,50 @@ struct TerminalHomeView: View {
 /// there are deliberately no Approve/Reject buttons (a fixed 1/2 mapping cannot be
 /// verified against an agent-specific menu — structured menu actions are a follow-up).
 /// A LEFT-EDGE swipe-back for a view whose nav bar is hidden (which disables UIKit's
-/// default interactive-pop). Hosts a `UIScreenEdgePanGestureRecognizer` on a view that
-/// only CLAIMS touches in the ~20pt left strip (`point(inside:)`), so it never intercepts
-/// the terminal scroll or the buttons elsewhere. Overlaid on the pane; fires `action`
-/// (dismiss) on a committed rightward edge swipe.
+/// default interactive-pop). The recognizer is attached to a SHARED ANCESTOR (the window),
+/// with a delegate that recognizes SIMULTANEOUSLY with everything, so it coexists with the
+/// terminal scroll + the buttons rather than carving a touch dead-zone. This view itself
+/// never intercepts a touch (`hitTest` → nil). Fires `action` (dismiss) on a committed
+/// rightward edge swipe; removes the recognizer on teardown.
 struct EdgeSwipeBack: UIViewRepresentable {
     let action: () -> Void
     func makeCoordinator() -> Coord { Coord(action: action) }
     func makeUIView(context: Context) -> UIView {
-        let v = EdgeStripView()
-        v.backgroundColor = .clear
-        let edge = UIScreenEdgePanGestureRecognizer(target: context.coordinator, action: #selector(Coord.fired(_:)))
-        edge.edges = .left
-        v.addGestureRecognizer(edge)
+        let v = PassthroughView()
+        DispatchQueue.main.async { context.coordinator.attach(from: v) }
         return v
     }
     func updateUIView(_ uiView: UIView, context: Context) { context.coordinator.action = action }
-    final class Coord: NSObject {
+    static func dismantleUIView(_ uiView: UIView, coordinator: Coord) { coordinator.detach() }
+
+    final class Coord: NSObject, UIGestureRecognizerDelegate {
         var action: () -> Void
+        private weak var host: UIView?
+        private var edge: UIScreenEdgePanGestureRecognizer?
         init(action: @escaping () -> Void) { self.action = action }
+        func attach(from v: UIView) {
+            guard edge == nil else { return }
+            guard let window = v.window else {   // not in the hierarchy yet — retry next runloop
+                DispatchQueue.main.async { [weak self, weak v] in if let v { self?.attach(from: v) } }
+                return
+            }
+            let g = UIScreenEdgePanGestureRecognizer(target: self, action: #selector(fired(_:)))
+            g.edges = .left
+            g.delegate = self
+            window.addGestureRecognizer(g)
+            host = window; edge = g
+        }
+        func detach() { if let g = edge { host?.removeGestureRecognizer(g) }; edge = nil; host = nil }
         @objc func fired(_ gr: UIScreenEdgePanGestureRecognizer) {
             guard gr.state == .ended, let v = gr.view else { return }
-            // Commit only on a real rightward swipe, not an edge twitch.
-            if gr.translation(in: v).x > 40 || gr.velocity(in: v).x > 300 { action() }
+            if gr.translation(in: v).x > 40 || gr.velocity(in: v).x > 300 { action() }   // real swipe, not a twitch
         }
+        func gestureRecognizer(_ g: UIGestureRecognizer,
+                               shouldRecognizeSimultaneouslyWith other: UIGestureRecognizer) -> Bool { true }
     }
-    /// Transparent to touches except the left edge strip (where the edge-pan lives).
-    final class EdgeStripView: UIView {
-        override func point(inside point: CGPoint, with event: UIEvent?) -> Bool { point.x <= 20 }
+    /// Never intercepts touches — the recognizer lives on the window, not this view.
+    final class PassthroughView: UIView {
+        override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? { nil }
     }
 }
 

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -1038,6 +1038,13 @@ struct TerminalHomeView: View {
                         card(row)
                     }
                     .buttonStyle(.plain)
+                    // Long-press an agent → quick actions. Stop = close the pane
+                    // (`pane.close`, the only stop RPC — its inverse is start), then reload.
+                    .contextMenu {
+                        Button(role: .destructive) {
+                            Task { try? await client.closePane(paneID: row.info.paneID); await load() }
+                        } label: { Label("Stop agent", systemImage: "stop.circle") }
+                    }
                 }
             }
         }
@@ -1196,6 +1203,38 @@ struct TerminalHomeView: View {
 /// a raw byte pipe. Answering a blocked agent is by typing the choice + Return;
 /// there are deliberately no Approve/Reject buttons (a fixed 1/2 mapping cannot be
 /// verified against an agent-specific menu — structured menu actions are a follow-up).
+/// A LEFT-EDGE swipe-back for a view whose nav bar is hidden (which disables UIKit's
+/// default interactive-pop). Hosts a `UIScreenEdgePanGestureRecognizer` on a view that
+/// only CLAIMS touches in the ~20pt left strip (`point(inside:)`), so it never intercepts
+/// the terminal scroll or the buttons elsewhere. Overlaid on the pane; fires `action`
+/// (dismiss) on a committed rightward edge swipe.
+struct EdgeSwipeBack: UIViewRepresentable {
+    let action: () -> Void
+    func makeCoordinator() -> Coord { Coord(action: action) }
+    func makeUIView(context: Context) -> UIView {
+        let v = EdgeStripView()
+        v.backgroundColor = .clear
+        let edge = UIScreenEdgePanGestureRecognizer(target: context.coordinator, action: #selector(Coord.fired(_:)))
+        edge.edges = .left
+        v.addGestureRecognizer(edge)
+        return v
+    }
+    func updateUIView(_ uiView: UIView, context: Context) { context.coordinator.action = action }
+    final class Coord: NSObject {
+        var action: () -> Void
+        init(action: @escaping () -> Void) { self.action = action }
+        @objc func fired(_ gr: UIScreenEdgePanGestureRecognizer) {
+            guard gr.state == .ended, let v = gr.view else { return }
+            // Commit only on a real rightward swipe, not an edge twitch.
+            if gr.translation(in: v).x > 40 || gr.velocity(in: v).x > 300 { action() }
+        }
+    }
+    /// Transparent to touches except the left edge strip (where the edge-pan lives).
+    final class EdgeStripView: UIView {
+        override func point(inside point: CGPoint, with event: UIEvent?) -> Bool { point.x <= 20 }
+    }
+}
+
 struct TerminalPaneView: View {
     let client: HerdrClient
     let paneID: String
@@ -1297,6 +1336,9 @@ struct TerminalPaneView: View {
                 replyBar
             }
         }
+        // Left-edge swipe → back to the agents list (the hidden nav bar disables the
+        // default interactive-pop). Edge-only, so it never fights the terminal scroll.
+        .overlay(EdgeSwipeBack { dismiss() })
         .toolbar(.hidden, for: .navigationBar)
         .task(id: paneID) {
             await refresh()

--- a/App/LiveTerminalView.swift
+++ b/App/LiveTerminalView.swift
@@ -137,13 +137,20 @@ struct LiveTerminalView: UIViewRepresentable {
             view.addGestureRecognizer(pan)
             scrollPan = pan
             // Double-tap → jump to the live tail. A UIKit recognizer (NOT a SwiftUI
-            // .onTapGesture, which starves the scroll pan — HerdrApp.swift note) that
-            // recognizes simultaneously with everything (delegate below); SwiftTerm's own
-            // double-tap word-select is inert on this read-only view.
+            // .onTapGesture, which starves the scroll pan — HerdrApp.swift note).
             let doubleTap = UITapGestureRecognizer(target: self, action: #selector(handleDoubleTap(_:)))
             doubleTap.numberOfTapsRequired = 2
             doubleTap.delegate = self
             view.addGestureRecognizer(doubleTap)
+            // SUPERSEDE SwiftTerm's own double-tap (word-select): make it wait for ours to
+            // FAIL, so a double-tap jumps to the tail without starting a word selection and
+            // its lingering selection pan (which would otherwise fight the next scroll on an
+            // idle shell pane — SwiftTerm's doubleTap has no read-only guard).
+            for gr in view.gestureRecognizers ?? [] where gr !== doubleTap {
+                if let t = gr as? UITapGestureRecognizer, t.numberOfTapsRequired == 2 {
+                    t.require(toFail: doubleTap)
+                }
+            }
             style(view)
             start()
         }
@@ -161,8 +168,12 @@ struct LiveTerminalView: UIViewRepresentable {
                     _ = try? await self.client.sendText(pane: self.paneID, text: "\u{1b}[1;5F")
                 }
             } else {
+                // animated:false — an animated jump is cancelled mid-flight on a streaming
+                // pane (SwiftTerm's updateScroller writes the offset back and leaves
+                // userScrolling stuck true). A direct set runs contentOffset's didSet →
+                // syncYDispFromContentOffset synchronously and re-engages auto-follow.
                 let maxY = max(0, view.contentSize.height - view.bounds.height)
-                view.setContentOffset(CGPoint(x: 0, y: maxY), animated: true)
+                view.setContentOffset(CGPoint(x: 0, y: maxY), animated: false)
             }
         }
 

--- a/App/LiveTerminalView.swift
+++ b/App/LiveTerminalView.swift
@@ -136,8 +136,34 @@ struct LiveTerminalView: UIViewRepresentable {
             pan.delegate = self
             view.addGestureRecognizer(pan)
             scrollPan = pan
+            // Double-tap → jump to the live tail. A UIKit recognizer (NOT a SwiftUI
+            // .onTapGesture, which starves the scroll pan — HerdrApp.swift note) that
+            // recognizes simultaneously with everything (delegate below); SwiftTerm's own
+            // double-tap word-select is inert on this read-only view.
+            let doubleTap = UITapGestureRecognizer(target: self, action: #selector(handleDoubleTap(_:)))
+            doubleTap.numberOfTapsRequired = 2
+            doubleTap.delegate = self
+            view.addGestureRecognizer(doubleTap)
             style(view)
             start()
+        }
+
+        /// Double-tap the terminal → jump to the live tail. A mouse-mode/alt agent
+        /// (Claude Code) captures the wheel and keeps its own viewport, so send it
+        /// Ctrl+End (`ESC[1;5F` → scroll-to-bottom + re-enable auto-follow) — read-only,
+        /// exactly like the scroll bytes, never a keystroke. A plain shell has native
+        /// SwiftTerm scrollback, so jump its UIScrollView to the maximum offset.
+        @objc private func handleDoubleTap(_ gr: UITapGestureRecognizer) {
+            guard !stopped, let view else { return }
+            if view.getTerminal().isCurrentBufferAlternate || view.getTerminal().mouseMode != .off {
+                Task { @MainActor [weak self] in
+                    guard let self, !self.stopped else { return }
+                    _ = try? await self.client.sendText(pane: self.paneID, text: "\u{1b}[1;5F")
+                }
+            } else {
+                let maxY = max(0, view.contentSize.height - view.bounds.height)
+                view.setContentOffset(CGPoint(x: 0, y: maxY), animated: true)
+            }
         }
 
         func stop() {


### PR DESCRIPTION
## What (owner request)
First slice of new gestures. Terminal-space gestures are UIKit recognizers in LiveTerminalView's Coordinator (coexisting with the scroll pan via the existing simultaneous-recognition delegate); actions in SwiftUI — never a SwiftUI gesture on the representable (starves scroll).
- **Left-edge swipe → back to agents** (the hidden nav bar disabled the default interactive-pop). Recognizer on a shared ancestor (the window) + simultaneous delegate; passthrough view — no touch dead-zone.
- **Double-tap terminal → jump to the live tail** — Ctrl+End (ESC[1;5F) for a mouse-mode/alt agent (Claude Code re-follows), non-animated native scroll-to-max for a plain shell. Supersedes SwiftTerm's own double-tap word-select. Read-only.
- **Long-press an agent card → Stop** (pane.close, the only stop RPC) + reload; failures disclosed.

Swipe-between-agents (nav-model change) is a deliberate follow-up slice.

## Verification
- **CI 31202129988 GREEN**: both scroll receipts still pass (no regression from the new recognizers).
- **Buildbox BUILD SUCCEEDED** @ eaac885.
- **kimi + omp APPROVE** (distinct runtimes). omp ran 2 rounds and caught 2 real HIGH bugs (an edge-swipe touch dead-zone; an animated jump cancelled by SwiftTerm mid-flight) + the word-select collision + a swallowed error — all fixed, then 'All four round-1 items are correctly fixed and the mechanisms are accurate.' Codex reviewer still down (per JARVIS).

## Ship
herdr-app merge=none — JARVIS merges; then tag v0.1.14 → TestFlight → owner tries the gestures on device (interactive → owner is the feel-check).