### PR TITLE
Keep agent terminals mounted for instant reopen + instant list

### DIFF
--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -799,6 +799,10 @@ struct TerminalHomeView: View {
     /// slot's view unmounts ⇒ its stream/SSH connection closes). See `open(_:)`.
     @State private var slots: [PaneSlot] = []
     @State private var frontID: String?
+    /// Pane ids ever OBSERVED live in `agent.list`. A slot is pruned only once it has been seen
+    /// live and then vanishes — so a still-BOOTING spawn pane (absent from agent.list by design
+    /// while its composer comes up) is never reaped mid-delivery.
+    @State private var everLive: Set<String> = []
     /// A freshly-spawned pane held while the New-agent cover animates away, then opened in the
     /// cover's onDismiss (fronting a keep-mounted pane, not a nav push, so the historically
     /// fragile "push while dismissing a cover" no longer applies — but the deferral is kept as
@@ -840,8 +844,16 @@ struct TerminalHomeView: View {
     /// (removal unmounts it → `Coordinator.stop()` closes its stream + SSH connection).
     private func open(_ slot: PaneSlot) {
         if let i = slots.firstIndex(where: { $0.paneID == slot.paneID }) {
+            // Already mounted → keep it warm (instant), but REFRESH its metadata: a re-open from
+            // the list carries a fresh title/agent/roster. Identity is the pane id (`.id`), so
+            // replacing the struct does NOT remount the pane or reset its @State. Guard so a spawn
+            // re-open (`siblings:[]`, which must not page mid-delivery) can't clobber a good
+            // roster, and keep the ORIGINAL one-shot prefill.
             let existing = slots.remove(at: i)
-            slots.append(existing)          // keep the LIVE mounted slot; do not replace it
+            slots.append(PaneSlot(paneID: existing.paneID, title: slot.title,
+                                  agent: slot.agent ?? existing.agent,
+                                  initialReply: existing.initialReply,
+                                  siblings: slot.siblings.isEmpty ? existing.siblings : slot.siblings))
         } else {
             slots.append(slot)
             while slots.count > Self.maxLivePanes {
@@ -1252,10 +1264,13 @@ struct TerminalHomeView: View {
             rejectedFingerprint = nil
             trustFailed = false
             // Prune keep-mounted panes whose agent is gone (Stopped / vanished) so no dead
-            // terminal lingers warm — but never the FRONT pane, so the reader isn't yanked off
-            // an exited terminal they may still be looking at.
+            // terminal lingers warm — but only a slot that was ONCE seen live and has now
+            // vanished (never a still-booting spawn pane, which is absent by design while its
+            // composer comes up — pruning it would cancel its one-shot prefill delivery). Never
+            // prune the FRONT pane, so the reader isn't yanked off an exited terminal.
             let live = Set(fetched.map(\.paneID))
-            slots.removeAll { $0.paneID != frontID && !live.contains($0.paneID) }
+            everLive.formUnion(live)
+            slots.removeAll { $0.paneID != frontID && everLive.contains($0.paneID) && !live.contains($0.paneID) }
         } catch {
             let rejected: String?
             if let transportError = error as? TransportError,

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -213,7 +213,7 @@ struct RootView: View {
                              livePaneIDs: MockTransport.demoLivePaneIDs)
         case .pane:
             NavigationStack {
-                TerminalPaneView(client: mockClient, paneID: "w1:p1", title: "jarvis",
+                TerminalPaneContent(client: mockClient, paneID: "w1:p1", title: "jarvis",
                                  agent: MockTransport.demoPaneAgent)
             }
         case .settings:
@@ -227,7 +227,7 @@ struct RootView: View {
             // HerdrUITests swipe exercises the actual library scroll path — the only
             // test that proves the SwiftTerm 1.15.0 scroll fix on device.
             NavigationStack {
-                TerminalPaneView(client: HerdrClient(transport: MockTransport(scrollback: true)),
+                TerminalPaneContent(client: HerdrClient(transport: MockTransport(scrollback: true)),
                                  paneID: "w1:p1", title: "scrolltest",
                                  agent: MockTransport.demoPaneAgent)
             }
@@ -237,7 +237,7 @@ struct RootView: View {
             // content when the app SENDS it an SGR wheel event, so the HerdrUITests
             // swipe proves the mouse-mode scroll path end to end.
             NavigationStack {
-                TerminalPaneView(client: HerdrClient(transport: MockTransport(ccDriver: CCScrollDriver.shared)),
+                TerminalPaneContent(client: HerdrClient(transport: MockTransport(ccDriver: CCScrollDriver.shared)),
                                  paneID: "w1:p1", title: "claude",
                                  agent: MockTransport.demoPaneAgent)
             }
@@ -787,19 +787,18 @@ struct TerminalHomeView: View {
         var id: Int { rawValue }
     }
 
-    /// A freshly-spawned pane to open with its task pre-filled. Held in
-    /// `pendingOpen` while the New-agent cover animates away, then applied in the
-    /// cover's onDismiss (→ `openedPane`) so the push happens AFTER the cover is
-    /// gone — presenting a navigation push and dismissing a full-screen cover in
-    /// the same frame is the historically fragile case.
-    private struct PaneToOpen: Identifiable, Hashable {
-        let paneID: String
-        let name: String
-        let task: String
-        var id: String { paneID }
-    }
-    @State private var pendingOpen: PaneToOpen?
-    @State private var openedPane: PaneToOpen?
+    /// Recently-opened terminals, kept MOUNTED (in `PaneKeepAliveContainer`) so reopening is
+    /// instant. Most-recently-used LAST; the pane whose id == `frontID` is the one on screen,
+    /// `nil` means the agents list is showing. Bounded to `maxLivePanes` (LRU eviction ⇒ that
+    /// slot's view unmounts ⇒ its stream/SSH connection closes). See `open(_:)`.
+    @State private var slots: [PaneSlot] = []
+    @State private var frontID: String?
+    /// A freshly-spawned pane held while the New-agent cover animates away, then opened in the
+    /// cover's onDismiss (fronting a keep-mounted pane, not a nav push, so the historically
+    /// fragile "push while dismissing a cover" no longer applies — but the deferral is kept as
+    /// cheap safety).
+    @State private var pendingOpenSlot: PaneSlot?
+    private static let maxLivePanes = 3
     // Only the quiet tail (idle) starts collapsed — the model forbids a
     // collapsed group from ever hiding something that wants attention.
     @State private var collapsed: Set<AgentGroup> = Set(AgentGroup.allCases.filter { $0.startsCollapsed })
@@ -829,6 +828,33 @@ struct TerminalHomeView: View {
     /// Snapshotted into the pushed pane at open time.
     private var orderedSiblings: [AgentInfo] { fullList.rows.filter(\.isLive).map(\.info) }
 
+    /// Front a terminal, keeping it (and up to `maxLivePanes-1` others) MOUNTED. Re-opening a
+    /// still-mounted pane just LRU-bumps it — instant, its stream never closed. A new pane is
+    /// appended (MRU) and the least-recently-used non-front slot is evicted past the cap
+    /// (removal unmounts it → `Coordinator.stop()` closes its stream + SSH connection).
+    private func open(_ slot: PaneSlot) {
+        if let i = slots.firstIndex(where: { $0.paneID == slot.paneID }) {
+            let existing = slots.remove(at: i)
+            slots.append(existing)          // keep the LIVE mounted slot; do not replace it
+        } else {
+            slots.append(slot)
+            while slots.count > Self.maxLivePanes {
+                slots.removeFirst()         // LRU is index 0 and never the just-appended new front
+            }
+        }
+        frontID = slot.paneID
+    }
+
+    /// Swipe-page from the fronted pane to its prev/next sibling (clamped). `open()`s the
+    /// neighbour — instant if it is already mounted.
+    private func navigate(from slot: PaneSlot, delta: Int) {
+        guard let i = slot.siblings.firstIndex(where: { $0.paneID == frontID }),
+              slot.siblings.indices.contains(i + delta) else { return }
+        let next = slot.siblings[i + delta]
+        open(PaneSlot(paneID: next.paneID, title: next.displayName, agent: next,
+                      initialReply: "", siblings: slot.siblings))
+    }
+
     /// Sections after applying the search box. Search filters the raw agents and
     /// re-derives, so counts and grouping stay honest for the filtered view.
     private var visibleSections: [(group: AgentGroup, rows: [AgentRow])] {
@@ -841,41 +867,43 @@ struct TerminalHomeView: View {
     }
 
     var body: some View {
-        NavigationStack {
-            ZStack {
-                Palette.ground.ignoresSafeArea()
-                VStack(spacing: 0) {
-                    header
-                    if let error {
-                        errorView(error)
-                    } else if loading {
-                        Spacer(); ProgressView().tint(Palette.textDim); Spacer()
-                    } else {
-                        agentList
+        ZStack {
+            NavigationStack {
+                ZStack {
+                    Palette.ground.ignoresSafeArea()
+                    VStack(spacing: 0) {
+                        header
+                        if let error {
+                            errorView(error)
+                        } else if loading && agents.isEmpty {
+                            // Spinner ONLY on a genuine first load (or after reconnect clears
+                            // `agents`). A re-entry with data in hand refreshes silently rather
+                            // than blanking the still-valid list to a spinner.
+                            Spacer(); ProgressView().tint(Palette.textDim); Spacer()
+                        } else {
+                            agentList
+                        }
+                        tabBar
                     }
-                    tabBar
                 }
+                .toolbar(.hidden, for: .navigationBar)
+                .task { await load() }
             }
-            .toolbar(.hidden, for: .navigationBar)
-            .task { await load() }
-            // Programmatic push for a just-spawned agent's pane, opened with its
-            // task pre-filled. Popping back reloads the list so the new agent shows.
-            .navigationDestination(item: $openedPane) { pane in
-                // A task-less open (the Terminal tab lands on the focused agent) can page
-                // like a list-opened pane. A spawn open carries a pre-fill task and stays
-                // non-paging (siblings: []) so a stray swipe can't interrupt the one-shot
-                // task delivery mid-flight — and it's usually not in the list yet anyway.
-                TerminalPaneView(client: client, paneID: pane.paneID, title: pane.name,
-                                 agent: nil, initialReply: pane.task,
-                                 siblings: pane.task.isEmpty ? orderedSiblings : [])
-                    .onDisappear { Task { await load() } }
-            }
+            // Recently-opened terminals kept MOUNTED so reopening + swiping between them is
+            // instant (nothing torn down or re-streamed). Overlays the list: a fronted pane
+            // covers it and captures touches; otherwise the overlay is fully inert.
+            PaneKeepAliveContainer(
+                client: client, slots: slots, frontID: frontID,
+                onClose: { frontID = nil; Task { await load() } },
+                onNavigate: { slot, delta in navigate(from: slot, delta: delta) })
+                .opacity(frontID != nil ? 1 : 0)
+                .allowsHitTesting(frontID != nil)
         }
         // ONE item-based cover, not two stacked isPresented covers (stacked
         // presentation modifiers on a single view are historically fragile).
         // onDismiss applies a queued open AFTER the cover is fully gone.
         .fullScreenCover(item: $activeCover, onDismiss: {
-            if let pane = pendingOpen { pendingOpen = nil; openedPane = pane }
+            if let slot = pendingOpenSlot { pendingOpenSlot = nil; open(slot) }
         }) { cover in
             switch cover {
             case .settings:
@@ -894,7 +922,8 @@ struct TerminalHomeView: View {
                     // Spawn done: queue the new pane, then dismiss the cover; the
                     // cover's onDismiss opens the pane with the task pre-filled.
                     onStarted: { paneID, name, task in
-                        pendingOpen = PaneToOpen(paneID: paneID, name: name, task: task)
+                        pendingOpenSlot = PaneSlot(paneID: paneID, title: name, agent: nil,
+                                                   initialReply: task, siblings: [])
                         activeCover = nil
                     },
                     onCancel: { activeCover = nil })
@@ -957,12 +986,13 @@ struct TerminalHomeView: View {
     private var tabBar: some View {
         HStack(spacing: 4) {
             tabItem("square.grid.2x2.fill", "Agents", active: true)
-            // Terminal → the focused agent's pane (or the top of the list). Reuses the
-            // openedPane push with an EMPTY task, so there is no pre-fill/auto-delivery
-            // (pendingPrefill stays false); the pane re-resolves its own agent identity.
+            // Terminal → front the focused agent's pane (or the top of the list), keep-mounted
+            // like a list open. EMPTY task, so no pre-fill/auto-delivery (pendingPrefill stays
+            // false); the pane re-resolves its own agent identity.
             Button {
                 if let t = terminalTarget {
-                    openedPane = PaneToOpen(paneID: t.info.paneID, name: t.title, task: "")
+                    open(PaneSlot(paneID: t.info.paneID, title: t.title, agent: t.info,
+                                  initialReply: "", siblings: orderedSiblings))
                 }
             } label: {
                 tabItem("terminal", "Terminal", active: false)
@@ -1048,9 +1078,9 @@ struct TerminalHomeView: View {
 
             if !isCollapsed {
                 ForEach(rows) { row in
-                    NavigationLink {
-                        TerminalPaneView(client: client, paneID: row.info.paneID, title: row.title,
-                                         agent: row.info, siblings: siblings)
+                    Button {
+                        open(PaneSlot(paneID: row.info.paneID, title: row.title,
+                                      agent: row.info, initialReply: "", siblings: siblings))
                     } label: {
                         card(row)
                     }
@@ -1204,20 +1234,39 @@ struct TerminalHomeView: View {
     }
 
     private func load() async {
-        loading = true
-        error = nil
-        rejectedFingerprint = nil
-        trustFailed = false
+        // Spinner ONLY when there is nothing to show yet (genuine first load, or after a
+        // reconnect cleared `agents` via `.id(session)`). A re-entry with a populated list
+        // refreshes silently — stale-while-revalidate — instead of blanking to a spinner.
+        if agents.isEmpty { loading = true }
+        defer { loading = false }
         do {
-            agents = try await client.agentList()
+            let fetched = try await client.agentList()
+            agents = fetched
+            error = nil
+            rejectedFingerprint = nil
+            trustFailed = false
+            // Prune keep-mounted panes whose agent is gone (Stopped / vanished) so no dead
+            // terminal lingers warm — but never the FRONT pane, so the reader isn't yanked off
+            // an exited terminal they may still be looking at.
+            let live = Set(fetched.map(\.paneID))
+            slots.removeAll { $0.paneID != frontID && !live.contains($0.paneID) }
         } catch {
-            self.error = "\(error)"
+            let rejected: String?
             if let transportError = error as? TransportError,
                case .hostKeyRejected(_, let fingerprint) = transportError {
-                rejectedFingerprint = fingerprint
+                rejected = fingerprint
+            } else {
+                rejected = nil
+            }
+            // A BACKGROUND refresh failure keeps the stale-but-good list rather than blowing it
+            // away into the error screen. Surface the error only when there is nothing to show —
+            // EXCEPT a host-key rejection, which always surfaces (a mid-session key change must
+            // never be hidden behind a cached list).
+            if agents.isEmpty || rejected != nil {
+                self.error = "\(error)"
+                rejectedFingerprint = rejected
             }
         }
-        loading = false
     }
 }
 
@@ -1285,87 +1334,26 @@ struct EdgeSwipeBack: UIViewRepresentable {
     }
 }
 
-/// A pushed terminal pane that can PAGE between agents with a horizontal swipe, without
-/// pushing a new navigation level each time. It keeps one pushed screen and swaps which
-/// sibling agent the inner `TerminalPaneContent` shows — keyed on the shown pane id, so
-/// the per-pane state and terminal stream are rebuilt cleanly for the new agent while the
-/// single pushed level (and its edge-back gesture) stay intact.
-///
-/// `siblings` is the ordered agent list to page through (the same order the list shows).
-/// It is EMPTY when the pane is opened without list context — e.g. a just-spawned agent —
-/// in which case swiping is a no-op and this behaves exactly like `TerminalPaneContent`.
-struct TerminalPaneView: View {
-    let client: HerdrClient
-    let paneID: String
-    let title: String
-    let agent: AgentInfo?
-    let initialReply: String
-    let siblings: [AgentInfo]
-
-    /// The pane id currently shown. Starts at the opened pane and moves along `siblings`
-    /// as the reader swipes.
-    @State private var currentID: String
-    /// Set once the reader pages away, so returning to the originally-opened pane can NOT
-    /// re-seed a spawn pre-fill (which would re-run deliverPrefillIfNeeded and deliver the
-    /// task to the agent a second time). The pre-fill is a one-shot for the pane it opened.
-    @State private var prefillConsumed = false
-
-    init(client: HerdrClient, paneID: String, title: String, agent: AgentInfo? = nil,
-         initialReply: String = "", siblings: [AgentInfo] = []) {
-        self.client = client
-        self.paneID = paneID
-        self.title = title
-        self.agent = agent
-        self.initialReply = initialReply
-        self.siblings = siblings
-        _currentID = State(initialValue: paneID)
-    }
-
-    /// The sibling now shown. Nil when there is no list context, or if the shown pane
-    /// fell out of the list (e.g. its agent stopped) — the pane then keeps the identity
-    /// it was opened with.
-    private var current: AgentInfo? { siblings.first { $0.paneID == currentID } }
-
-    var body: some View {
-        TerminalPaneContent(
-            client: client,
-            paneID: current?.paneID ?? paneID,
-            title: current?.displayName ?? title,
-            agent: current ?? agent,
-            // The pre-filled task belongs ONLY to the pane that was actually opened, and only
-            // until the reader pages away once — never to a neighbour, never re-armed on the
-            // way back.
-            initialReply: (!prefillConsumed && currentID == paneID) ? initialReply : "",
-            onNavigate: navigate
-        )
-        // Rebuild the pane (and its stream + per-pane @State) whenever the shown agent
-        // changes — a clean handoff to the neighbour's terminal.
-        .id(currentID)
-    }
-
-    /// Move `delta` steps through the ordered siblings, clamped at both ends. A no-op
-    /// when there is no list context or the move would run past an end.
-    private func navigate(_ delta: Int) {
-        guard let i = siblings.firstIndex(where: { $0.paneID == currentID }) else { return }
-        let j = i + delta
-        guard siblings.indices.contains(j) else { return }
-        prefillConsumed = true
-        currentID = siblings[j].paneID
-    }
-}
-
-/// The pane itself — one agent's live terminal + controls. Its identity (pane id,
-/// per-pane @State, terminal stream) is fixed for its lifetime; paging between agents
-/// is done by the thin `TerminalPaneView` wrapper above, which rebuilds this view for
-/// the new agent. `onNavigate` reports a horizontal swipe (+1 next / -1 previous) up to
-/// that wrapper.
+/// One agent's live terminal + controls. Its identity (pane id, per-pane @State, terminal
+/// stream) is fixed for its lifetime — it is hosted MOUNTED by `PaneKeepAliveContainer` and
+/// never torn down while its slot exists, so reopening it (and swiping/paging to it) is
+/// instant, with scroll position and any typed draft preserved. `onNavigate` reports a
+/// horizontal swipe (+1 next / -1 previous) up to the container, which fronts the neighbour;
+/// `isForeground` drives the PTY width-lock hand-off when the pane hides/shows.
 struct TerminalPaneContent: View {
     let client: HerdrClient
     let paneID: String
     let title: String
     let onNavigate: (Int) -> Void
+    /// True while this pane is the one on screen. Drives the PTY-lock release/re-take
+    /// (via `LiveTerminalView.isForeground`) and a status refresh on re-show; a
+    /// backgrounded keep-mounted pane stays warm but drops the keyboard and stops holding
+    /// the width-lock.
+    let isForeground: Bool
+    /// Back out to the agents list (header chevron / left-edge swipe). Replaces the old
+    /// NavigationStack `dismiss` now that panes live in a keep-alive container, not a push.
+    let onClose: () -> Void
 
-    @Environment(\.dismiss) private var dismiss
     @State private var reply: String
     /// The agent this pane hosts (drives identity, status badge, and input mode).
     /// Seeded from the caller's list context, then RE-RESOLVED from agent.list on
@@ -1407,11 +1395,14 @@ struct TerminalPaneContent: View {
     /// pane. A non-empty `initialReply` puts the view into the pending-delivery
     /// state.
     init(client: HerdrClient, paneID: String, title: String, agent: AgentInfo? = nil,
-         initialReply: String = "", onNavigate: @escaping (Int) -> Void = { _ in }) {
+         initialReply: String = "", isForeground: Bool = true,
+         onNavigate: @escaping (Int) -> Void = { _ in }, onClose: @escaping () -> Void = {}) {
         self.client = client
         self.paneID = paneID
         self.title = title
+        self.isForeground = isForeground
         self.onNavigate = onNavigate
+        self.onClose = onClose
         _agent = State(initialValue: agent)
         _reply = State(initialValue: initialReply)
         _pendingPrefill = State(initialValue: !initialReply.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
@@ -1433,20 +1424,6 @@ struct TerminalPaneContent: View {
     // path (see the replyBar action), so it can never fall to rawKeys send_text.
     private var canSend: Bool { !reply.trimmingCharacters(in: .whitespaces).isEmpty && !sending && !autoDelivering }
 
-    /// Swipe-to-page, gated on the reply draft. Paging rebuilds this whole view (the
-    /// wrapper keys it on the pane id), which would silently discard an unsent reply — and
-    /// the terminal is the largest touch target on screen, so an accidental horizontal
-    /// flick while reading is easy. So hold the page and say why when there's text to lose;
-    /// otherwise drop the keyboard and hand off to the neighbour.
-    private func requestNavigate(_ delta: Int) {
-        if !reply.trimmingCharacters(in: .whitespaces).isEmpty {
-            actionNote = "Send or clear your reply before switching agents"
-            return
-        }
-        replyFocused = false
-        onNavigate(delta)
-    }
-
     var body: some View {
         ZStack {
             // The terminal is its own ground — one shade under the app (groundMachine
@@ -1459,7 +1436,8 @@ struct TerminalPaneContent: View {
                 // byte firehose (#40), full-bleed as the machine ground. Read-only —
                 // input stays on the keycaps + reply bar below (sendText/sendKeys/
                 // prompt), never routed through the terminal itself.
-                LiveTerminalView(client: client, paneID: paneID, onNavigate: requestNavigate)
+                LiveTerminalView(client: client, paneID: paneID,
+                                 onNavigate: onNavigate, isForeground: isForeground)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                     // A small horizontal inset so the grid gets a clean, symmetric
                     // margin instead of the last column hugging the right edge.
@@ -1477,13 +1455,21 @@ struct TerminalPaneContent: View {
                 replyBar
             }
         }
-        // Left-edge swipe → back to the agents list (the hidden nav bar disables the
-        // default interactive-pop). Edge-only, so it never fights the terminal scroll.
-        .overlay(EdgeSwipeBack { dismiss() })
-        .toolbar(.hidden, for: .navigationBar)
+        // Left-edge swipe → back to the agents list. Edge-only, so it never fights the
+        // terminal scroll. Rendered ONLY for the front pane: EdgeSwipeBack attaches its
+        // recognizer to the WINDOW, so N keep-mounted panes would otherwise stack N
+        // recognizers that all fire on one edge swipe.
+        .overlay { if isForeground { EdgeSwipeBack { onClose() } } }
+        // Runs ONCE per slot lifetime now (the pane stays mounted, so paneID never changes):
+        // the one-shot prefill delivery + first status resolve.
         .task(id: paneID) {
             await refresh()
             await deliverPrefillIfNeeded()
+        }
+        // Re-resolve status each time the pane returns to the front; drop the keyboard when it
+        // backgrounds so a hidden keep-mounted pane can't hold the software keyboard.
+        .onChange(of: isForeground) { _, nowFront in
+            if nowFront { Task { await refresh() } } else { replyFocused = false }
         }
     }
 
@@ -1492,7 +1478,7 @@ struct TerminalPaneContent: View {
     private var header: some View {
         VStack(spacing: 8) {
             HStack(spacing: 12) {
-                Button { dismiss() } label: {
+                Button { onClose() } label: {
                     Image(systemName: "chevron.left").font(.system(size: 16, weight: .semibold))
                         .foregroundStyle(Palette.textDim)
                 }

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -241,6 +241,12 @@ struct RootView: View {
                                  paneID: "w1:p1", title: "claude",
                                  agent: MockTransport.demoPaneAgent)
             }
+        case .paging:
+            // Three distinctively-named agents in the real keep-mounted container. A swipe
+            // fronts the neighbour and the header heading changes (ALFA→BRAVO→ALFA) — the
+            // swipe-between-agents receipt. The pane ids are NOT in the mock agent.list, so
+            // reresolveAgent leaves the seeded identity in place and the header stays stable.
+            PagingTestHarness(client: mockClient)
         }
     }
     #endif
@@ -2018,8 +2024,56 @@ private extension View {
 /// otherwise launches to the empty ConnectView). Enable by launching with env
 /// `HERDR_SCREENSHOT_MOCK=list` (default) or `=pane`, or the `-herdrScreenshotMock`
 /// launch argument.
+#if DEBUG
+/// Swipe-between-agents receipt harness (`HERDR_SCREENSHOT_MOCK=paging`). Holds three agents
+/// in the REAL `PaneKeepAliveContainer`, mirroring `TerminalHomeView`'s open/navigate, so an
+/// XCUITest swipe pages the front pane and the header heading changes. No LRU eviction here —
+/// three panes stay mounted so swipe-back is a proven warm hit.
+struct PagingTestHarness: View {
+    let client: HerdrClient
+    @State private var slots: [PaneSlot]
+    @State private var frontID: String?
+
+    init(client: HerdrClient) {
+        self.client = client
+        let sibs = [
+            MockTransport.pagingAgent(kind: "ALFA", pane: "pg:a"),
+            MockTransport.pagingAgent(kind: "BRAVO", pane: "pg:b"),
+            MockTransport.pagingAgent(kind: "CHARLIE", pane: "pg:c"),
+        ]
+        _slots = State(initialValue: [PaneSlot(paneID: "pg:a", title: "ALFA", agent: sibs[0],
+                                               initialReply: "", siblings: sibs)])
+        _frontID = State(initialValue: "pg:a")
+    }
+
+    var body: some View {
+        PaneKeepAliveContainer(
+            client: client, slots: slots, frontID: frontID,
+            onClose: { frontID = nil },
+            onNavigate: { slot, delta in navigate(from: slot, delta: delta) })
+    }
+
+    private func open(_ slot: PaneSlot) {
+        if let i = slots.firstIndex(where: { $0.paneID == slot.paneID }) {
+            let existing = slots.remove(at: i); slots.append(existing)
+        } else {
+            slots.append(slot)
+        }
+        frontID = slot.paneID
+    }
+
+    private func navigate(from slot: PaneSlot, delta: Int) {
+        guard let i = slot.siblings.firstIndex(where: { $0.paneID == frontID }),
+              slot.siblings.indices.contains(i + delta) else { return }
+        let next = slot.siblings[i + delta]
+        open(PaneSlot(paneID: next.paneID, title: next.displayName, agent: next,
+                      initialReply: "", siblings: slot.siblings))
+    }
+}
+#endif
+
 enum ScreenshotMock {
-    case list, pane, settings, newAgent, scroll, ccscroll
+    case list, pane, settings, newAgent, scroll, ccscroll, paging
 
     static var mode: ScreenshotMock? {
         let env = ProcessInfo.processInfo.environment["HERDR_SCREENSHOT_MOCK"]?.lowercased()
@@ -2037,6 +2091,9 @@ enum ScreenshotMock {
         // agent redraws shifted content when it RECEIVES an SGR wheel event — so a swipe
         // proves drag → app emits wheel → content moves.
         case "ccscroll": return .ccscroll
+        // `paging` drives the swipe-between-agents receipt: three distinctively-named agents
+        // in the keep-mounted container; a swipe fronts the neighbour and the header changes.
+        case "paging": return .paging
         default: return .list
         }
     }
@@ -2148,6 +2205,14 @@ struct MockTransport: HerdrTransport {
     static let demoPaneAgent: AgentInfo? = try? JSONDecoder().decode(
         AgentInfo.self,
         from: Data(#"{"pane_id":"w1:p1","name":"jarvis","agent":"claude","agent_status":"blocked","cwd":"/root/herdr-ios","terminal_title_stripped":"asking to run tests"}"#.utf8))
+
+    /// A distinctively-named agent for the `paging` receipt. Its header heading renders
+    /// "<kind> · <kind>" (agent kind · cwd folder), so an XCUITest can assert the header
+    /// CHANGED after a swipe fronts the neighbour. Force-decoded: the literal is fixed + valid.
+    static func pagingAgent(kind: String, pane: String) -> AgentInfo {
+        try! JSONDecoder().decode(AgentInfo.self, from: Data(
+            #"{"pane_id":"\#(pane)","name":"\#(kind)","agent":"\#(kind)","agent_status":"idle","cwd":"/root/\#(kind)"}"#.utf8))
+    }
 }
 
 /// Stateful stand-in for a Claude-Code pane in the `ccscroll` UI test. It puts the REAL

--- a/App/LiveTerminalView.swift
+++ b/App/LiveTerminalView.swift
@@ -152,6 +152,14 @@ struct LiveTerminalView: UIViewRepresentable {
         /// separate SSH channel and leave the VISIBLE pane unlocked. The deferred re-lock clears
         /// it and then drives toward the LIVE grid.
         private var relockPending = false
+        /// The generation whose lock has already been handed back (a `lock:false` release). A
+        /// generation is released AT MOST ONCE: `releaseGeometryOwnership` runs from both
+        /// `setForeground(false)` and `stop()` (which itself can run twice — `.exited` then
+        /// dismantle — and follows a hide at the SAME generation), and none of those bump the
+        /// generation. Without this idempotence a second same-generation release would fire a
+        /// redundant `lock:false` (re-resizing the shared PTY) AND let the first release's
+        /// generation-keyed self-prune clobber the newer release's registry handle.
+        private var releasedGeneration: Int?
         /// The rightward (previous-agent) swipe, remembered so the delegate can cede the
         /// left screen EDGE to the back gesture — a right-swipe there means "go back",
         /// not "previous agent".
@@ -188,7 +196,7 @@ struct LiveTerminalView: UIViewRepresentable {
             relockPending = true
             let pane = paneID
             Task { @MainActor [weak self] in
-                await Self.geometryReleaseTask[pane]?.value
+                await Coordinator.awaitRelease(Self.geometryReleaseTask[pane], timeout: 5)
                 guard let self, !self.stopped, self.myGeometryGeneration == gen else { return }
                 self.relockPending = false
                 if self.desiredCols >= 4, self.desiredRows >= 2 {
@@ -313,6 +321,13 @@ struct LiveTerminalView: UIViewRepresentable {
             // laid out): an older release may still be in flight, and its entry is the only handle
             // a future re-lock has to await it.
             guard cols >= 4, rows >= 2 else { return }
+            // Hand a generation's lock back EXACTLY ONCE (see releasedGeneration). A second
+            // same-generation release — stop() after a hide, or stop()'s .exited+dismantle double
+            // call — is a no-op: after a hide the drain is already nil'd and sendPTYSize is gated,
+            // so there is nothing left to release, and skipping it prevents both a redundant
+            // lock:false and the prune-clobber of a newer chained release's registry handle.
+            guard releasedGeneration != myGeometryGeneration else { return }
+            releasedGeneration = myGeometryGeneration
             let client = self.client
             let pane = self.paneID
             let myGen = self.myGeometryGeneration
@@ -361,7 +376,7 @@ struct LiveTerminalView: UIViewRepresentable {
                 relockPending = true            // hold off ALL sendPTYSize until the release lands
                 let pending = Self.geometryReleaseTask[paneID]
                 Task { @MainActor [weak self] in
-                    await pending?.value        // let any committed lock:false land FIRST
+                    await Coordinator.awaitRelease(pending, timeout: 5)   // let any committed lock:false land first (bounded)
                     guard let self, self.foreground, !self.stopped,
                           self.myGeometryGeneration == gen else { return }   // a newer hide/show superseded us
                     self.relockPending = false
@@ -374,6 +389,22 @@ struct LiveTerminalView: UIViewRepresentable {
         }
 
         // MARK: styling (the design's machine voice)
+
+        /// Await a pending release, but give up after `seconds`. CitadelTransport's RPC has no
+        /// timeout and the detached release tasks are never cancelled, so a wedged SSH channel
+        /// could otherwise pin a deferred re-lock forever (relockPending stuck true → the visible
+        /// pane never re-locks). On timeout the caller clears relockPending and re-locks anyway; if
+        /// the stale `lock:false` lands afterwards the pane simply re-locks on its next layout —
+        /// strictly better than staying unlocked indefinitely.
+        private static func awaitRelease(_ task: Task<Void, Never>?, timeout seconds: Double) async {
+            guard let task else { return }
+            await withTaskGroup(of: Void.self) { group in
+                group.addTask { await task.value }
+                group.addTask { try? await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000)) }
+                _ = await group.next()      // return as soon as the release lands OR the timeout fires
+                group.cancelAll()
+            }
+        }
 
         private func style(_ view: ReadOnlyTerminalView) {
             view.font = Self.paneFont

--- a/App/LiveTerminalView.swift
+++ b/App/LiveTerminalView.swift
@@ -196,7 +196,7 @@ struct LiveTerminalView: UIViewRepresentable {
             relockPending = true
             let pane = paneID
             Task { @MainActor [weak self] in
-                await Coordinator.awaitRelease(Self.geometryReleaseTask[pane], timeout: 5)
+                await Self.geometryReleaseTask[pane]?.value   // let a prior coordinator's release land first
                 guard let self, !self.stopped, self.myGeometryGeneration == gen else { return }
                 self.relockPending = false
                 if self.desiredCols >= 4, self.desiredRows >= 2 {
@@ -347,8 +347,11 @@ struct LiveTerminalView: UIViewRepresentable {
                 let current = await MainActor.run { Coordinator.geometryGeneration[pane] }
                 guard current == myGen else { return }
                 _ = try? await client.setPTYSize(pane: pane, cols: cols, rows: rows, lock: false)
-                // Drop our own registry entry once settled (no newer show/hide bumped the
-                // generation), so the static map doesn't accumulate one entry per pane id opened.
+                // Best-effort: drop our own registry entry once settled (no newer show/hide/attach
+                // bumped the generation). This only runs when the release actually SENT; a release
+                // that bailed on the generation guard above leaves the entry for the newer owner
+                // (which is correct — clearing it there could clobber a live newer release). So the
+                // map holds at most one entry per pane id, overwritten by the next release.
                 await MainActor.run {
                     if Coordinator.geometryGeneration[pane] == myGen { Coordinator.geometryReleaseTask[pane] = nil }
                 }
@@ -376,7 +379,7 @@ struct LiveTerminalView: UIViewRepresentable {
                 relockPending = true            // hold off ALL sendPTYSize until the release lands
                 let pending = Self.geometryReleaseTask[paneID]
                 Task { @MainActor [weak self] in
-                    await Coordinator.awaitRelease(pending, timeout: 5)   // let any committed lock:false land first (bounded)
+                    await pending?.value        // let any committed lock:false land FIRST
                     guard let self, self.foreground, !self.stopped,
                           self.myGeometryGeneration == gen else { return }   // a newer hide/show superseded us
                     self.relockPending = false
@@ -389,22 +392,6 @@ struct LiveTerminalView: UIViewRepresentable {
         }
 
         // MARK: styling (the design's machine voice)
-
-        /// Await a pending release, but give up after `seconds`. CitadelTransport's RPC has no
-        /// timeout and the detached release tasks are never cancelled, so a wedged SSH channel
-        /// could otherwise pin a deferred re-lock forever (relockPending stuck true → the visible
-        /// pane never re-locks). On timeout the caller clears relockPending and re-locks anyway; if
-        /// the stale `lock:false` lands afterwards the pane simply re-locks on its next layout —
-        /// strictly better than staying unlocked indefinitely.
-        private static func awaitRelease(_ task: Task<Void, Never>?, timeout seconds: Double) async {
-            guard let task else { return }
-            await withTaskGroup(of: Void.self) { group in
-                group.addTask { await task.value }
-                group.addTask { try? await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000)) }
-                _ = await group.next()      // return as soon as the release lands OR the timeout fires
-                group.cancelAll()
-            }
-        }
 
         private func style(_ view: ReadOnlyTerminalView) {
             view.font = Self.paneFont

--- a/App/LiveTerminalView.swift
+++ b/App/LiveTerminalView.swift
@@ -12,7 +12,7 @@ import HerdrKit
 /// READ-ONLY for keyboard/typed input: the view never becomes first responder (no
 /// keyboard) and its delegate `send` is a no-op, so SwiftTerm keystrokes are never
 /// routed to the PTY. Command/message input stays exclusively on the reply/Send +
-/// keycap affordances in `TerminalPaneView` (`sendText`/`sendKeys`/`prompt`). The
+/// keycap affordances in `TerminalPaneContent` (`sendText`/`sendKeys`/`prompt`). The
 /// ONE narrow input exception is SCROLL: a pan on the alternate screen sends
 /// constrained wheel/arrow sequences to the agent so its full-screen view can scroll
 /// (see `handleScrollPan`) — never a keystroke, never arbitrary typed text.
@@ -32,6 +32,12 @@ struct LiveTerminalView: UIViewRepresentable {
     /// there is no list context to page through. Refreshed on every update so the
     /// closure never captures a stale view.
     var onNavigate: ((Int) -> Void)? = nil
+    /// Whether this pane is the one on screen. A keep-mounted pane that goes offscreen
+    /// (another agent is fronted, or we're back on the list) stays subscribed but must
+    /// RELEASE the PTY width-lock so it stops pinning a co-viewing desktop to the phone's
+    /// width while nobody's looking; it re-takes the lock when fronted again. Only the
+    /// lock lifecycle changes — the stream and the SwiftTerm view stay warm.
+    var isForeground: Bool = true
 
     func makeCoordinator() -> Coordinator { Coordinator(client: client, paneID: paneID) }
 
@@ -44,6 +50,7 @@ struct LiveTerminalView: UIViewRepresentable {
 
     func updateUIView(_ uiView: ReadOnlyTerminalView, context: Context) {
         context.coordinator.onNavigate = onNavigate
+        context.coordinator.setForeground(isForeground)
     }
 
     static func dismantleUIView(_ uiView: ReadOnlyTerminalView, coordinator: Coordinator) {
@@ -129,6 +136,11 @@ struct LiveTerminalView: UIViewRepresentable {
         /// which hops back via `MainActor.run` — so all access is main-actor-serialized.
         private static var geometryGeneration: [String: Int] = [:]
         private var myGeometryGeneration = 0
+        /// Whether this (keep-mounted) pane is currently on screen. Only the FOREGROUND
+        /// pane holds the PTY width-lock; a backgrounded pane releases it (see
+        /// `setForeground`) so it can't pin a co-viewing desktop while hidden, and a
+        /// hidden pane's async `sizeChanged` tracks the grid but never re-locks.
+        private var foreground = true
         /// The rightward (previous-agent) swipe, remembered so the delegate can cede the
         /// left screen EDGE to the back gesture — a right-swipe there means "go back",
         /// not "previous agent".
@@ -285,6 +297,30 @@ struct LiveTerminalView: UIViewRepresentable {
             }
         }
 
+        /// Front↔background transition for a KEEP-MOUNTED pane. Only the front pane holds the
+        /// PTY width-lock: hiding releases it (WITHOUT tearing the stream down), showing
+        /// re-takes it at the current grid. Reuses `releaseGeometryOwnership` + the
+        /// `geometryGeneration` guard, so a hide's still-in-flight `lock:false` that lands
+        /// after a re-show is skipped (its generation is now stale) and the visible pane is
+        /// never left unlocked. Different panes own different PTYs, so a background-release on
+        /// one and a foreground-retake on another never order against each other.
+        func setForeground(_ f: Bool) {
+            guard !stopped, f != foreground else { return }
+            foreground = f
+            if f {
+                // Claim a new generation (supersede any background lock:false still in flight),
+                // then re-lock at the tracked grid — reset lastSent to defeat sendPTYSize's dedup.
+                let gen = (Self.geometryGeneration[paneID] ?? 0) + 1
+                Self.geometryGeneration[paneID] = gen
+                myGeometryGeneration = gen
+                lastSentCols = 0
+                lastSentRows = 0
+                if desiredCols >= 4, desiredRows >= 2 { sendPTYSize(cols: desiredCols, rows: desiredRows) }
+            } else {
+                releaseGeometryOwnership()   // release lock:false, keep the stream + emulator warm
+            }
+        }
+
         // MARK: styling (the design's machine voice)
 
         private func style(_ view: ReadOnlyTerminalView) {
@@ -414,6 +450,11 @@ struct LiveTerminalView: UIViewRepresentable {
             desiredCols = cols
             desiredRows = rows
             resizeRetries = 0        // a new target gets a fresh retry budget
+            // A backgrounded (keep-mounted) pane TRACKS the latest grid above but does not
+            // send `lock:true` while hidden — it would re-pin a co-viewing desktop to the
+            // phone's width with nobody looking. `setForeground(true)` re-locks at the
+            // tracked size when the pane returns to screen.
+            guard foreground else { return }
             guard resizeTask == nil else { return }   // a drain is running; it re-reads `desired`
             let cell = Self.cellPixels()
             resizeTask = Task { @MainActor [weak self] in

--- a/App/LiveTerminalView.swift
+++ b/App/LiveTerminalView.swift
@@ -136,6 +136,10 @@ struct LiveTerminalView: UIViewRepresentable {
         /// which hops back via `MainActor.run` — so all access is main-actor-serialized.
         private static var geometryGeneration: [String: Int] = [:]
         private var myGeometryGeneration = 0
+        /// The in-flight background `lock:false` release per pane, so a re-show
+        /// (`setForeground(true)`) can AWAIT it before re-locking — the re-lock can then never
+        /// be overtaken by a reordered release that would leave the visible pane unlocked.
+        private static var geometryReleaseTask: [String: Task<Void, Never>] = [:]
         /// Whether this (keep-mounted) pane is currently on screen. Only the FOREGROUND
         /// pane holds the PTY width-lock; a backgrounded pane releases it (see
         /// `setForeground`) so it can't pin a co-viewing desktop while hidden, and a
@@ -282,15 +286,16 @@ struct LiveTerminalView: UIViewRepresentable {
             let rows = lastSentRows > 0 ? lastSentRows : desiredRows
             let inflight = resizeTask
             resizeTask = nil
-            guard cols >= 4, rows >= 2 else { return }
+            guard cols >= 4, rows >= 2 else { Self.geometryReleaseTask[paneID] = nil; return }
             let client = self.client
             let pane = self.paneID
             let myGen = self.myGeometryGeneration
-            Task.detached {
+            Self.geometryReleaseTask[pane] = Task.detached {
                 _ = await inflight?.value    // let the in-flight lock:true finish its round-trip
-                // If a newer coordinator claimed this pane while we awaited (a fast A→B→A
-                // swap), it owns the lock now — releasing here would unlock a pane still on
-                // screen. Bail so the newcomer's lock:true stands.
+                // If a newer coordinator OR a re-show claimed this pane while we awaited, it owns
+                // the lock now — releasing would unlock a pane still on screen. Bail so its
+                // lock:true stands. (And if this release DID commit before the re-show bumped the
+                // generation, `setForeground(true)` AWAITS this task before it re-locks.)
                 let current = await MainActor.run { Coordinator.geometryGeneration[pane] }
                 guard current == myGen else { return }
                 _ = try? await client.setPTYSize(pane: pane, cols: cols, rows: rows, lock: false)
@@ -298,24 +303,32 @@ struct LiveTerminalView: UIViewRepresentable {
         }
 
         /// Front↔background transition for a KEEP-MOUNTED pane. Only the front pane holds the
-        /// PTY width-lock: hiding releases it (WITHOUT tearing the stream down), showing
-        /// re-takes it at the current grid. Reuses `releaseGeometryOwnership` + the
-        /// `geometryGeneration` guard, so a hide's still-in-flight `lock:false` that lands
-        /// after a re-show is skipped (its generation is now stale) and the visible pane is
-        /// never left unlocked. Different panes own different PTYs, so a background-release on
-        /// one and a foreground-retake on another never order against each other.
+        /// PTY width-lock: hiding releases it (WITHOUT tearing the stream down), showing re-takes
+        /// it at the current grid. Ordering is guaranteed two ways so the VISIBLE pane is never
+        /// left unlocked: (1) bumping `geometryGeneration` makes a not-yet-sent background
+        /// `lock:false` bail on its generation guard; (2) if the release ALREADY committed to its
+        /// send, the re-lock below AWAITS that release task before issuing `lock:true`, so the
+        /// lock can't be overtaken by a reordered release. Different panes own different PTYs +
+        /// generation keys, so a background-release on one and a foreground-retake on another
+        /// never order against each other.
         func setForeground(_ f: Bool) {
             guard !stopped, f != foreground else { return }
             foreground = f
             if f {
-                // Claim a new generation (supersede any background lock:false still in flight),
-                // then re-lock at the tracked grid — reset lastSent to defeat sendPTYSize's dedup.
                 let gen = (Self.geometryGeneration[paneID] ?? 0) + 1
                 Self.geometryGeneration[paneID] = gen
                 myGeometryGeneration = gen
-                lastSentCols = 0
+                lastSentCols = 0                // defeat sendPTYSize's dedup so the re-lock re-sends
                 lastSentRows = 0
-                if desiredCols >= 4, desiredRows >= 2 { sendPTYSize(cols: desiredCols, rows: desiredRows) }
+                guard desiredCols >= 4, desiredRows >= 2 else { return }
+                let cols = desiredCols, rows = desiredRows
+                let pending = Self.geometryReleaseTask[paneID]
+                Task { @MainActor [weak self] in
+                    await pending?.value        // let any committed lock:false land FIRST
+                    guard let self, self.foreground, !self.stopped,
+                          self.myGeometryGeneration == gen else { return }   // a newer hide/show superseded us
+                    self.sendPTYSize(cols: cols, rows: rows)   // re-take lock:true, now guaranteed last
+                }
             } else {
                 releaseGeometryOwnership()   // release lock:false, keep the stream + emulator warm
             }
@@ -458,7 +471,11 @@ struct LiveTerminalView: UIViewRepresentable {
             guard resizeTask == nil else { return }   // a drain is running; it re-reads `desired`
             let cell = Self.cellPixels()
             resizeTask = Task { @MainActor [weak self] in
-                while let self, !Task.isCancelled,
+                // `self.foreground` in the condition: if this pane is backgrounded mid-drain (a
+                // keep-mounted hide), STOP driving `lock:true` — a hidden pane must never re-pin a
+                // co-viewing desktop. releaseGeometryOwnership awaits this task, so it then
+                // proceeds to `lock:false`.
+                while let self, !Task.isCancelled, self.foreground,
                       self.desiredCols != self.lastSentCols || self.desiredRows != self.lastSentRows {
                     let c = self.desiredCols        // always drive toward the LATEST target
                     let r = self.desiredRows

--- a/App/LiveTerminalView.swift
+++ b/App/LiveTerminalView.swift
@@ -145,6 +145,13 @@ struct LiveTerminalView: UIViewRepresentable {
         /// `setForeground`) so it can't pin a co-viewing desktop while hidden, and a
         /// hidden pane's async `sizeChanged` tracks the grid but never re-locks.
         private var foreground = true
+        /// True between a re-show (`setForeground(true)`) and its deferred re-lock completing —
+        /// i.e. while we're awaiting the in-flight background `lock:false` before re-taking the
+        /// lock. During this window EVERY `sendPTYSize` caller (including `sizeChanged`) must NOT
+        /// start a drain, or a `lock:true` could race the still-in-flight `lock:false` on a
+        /// separate SSH channel and leave the VISIBLE pane unlocked. The deferred re-lock clears
+        /// it and then drives toward the LIVE grid.
+        private var relockPending = false
         /// The rightward (previous-agent) swipe, remembered so the delegate can cede the
         /// left screen EDGE to the back gesture — a right-swipe there means "go back",
         /// not "previous agent".
@@ -299,18 +306,23 @@ struct LiveTerminalView: UIViewRepresentable {
                 let current = await MainActor.run { Coordinator.geometryGeneration[pane] }
                 guard current == myGen else { return }
                 _ = try? await client.setPTYSize(pane: pane, cols: cols, rows: rows, lock: false)
+                // Drop our own registry entry once settled (no newer show/hide bumped the
+                // generation), so the static map doesn't accumulate one entry per pane id opened.
+                await MainActor.run {
+                    if Coordinator.geometryGeneration[pane] == myGen { Coordinator.geometryReleaseTask[pane] = nil }
+                }
             }
         }
 
         /// Front↔background transition for a KEEP-MOUNTED pane. Only the front pane holds the
         /// PTY width-lock: hiding releases it (WITHOUT tearing the stream down), showing re-takes
-        /// it at the current grid. Ordering is guaranteed two ways so the VISIBLE pane is never
-        /// left unlocked: (1) bumping `geometryGeneration` makes a not-yet-sent background
-        /// `lock:false` bail on its generation guard; (2) if the release ALREADY committed to its
-        /// send, the re-lock below AWAITS that release task before issuing `lock:true`, so the
-        /// lock can't be overtaken by a reordered release. Different panes own different PTYs +
-        /// generation keys, so a background-release on one and a foreground-retake on another
-        /// never order against each other.
+        /// it. The VISIBLE pane is never left unlocked because the re-lock's `lock:true` is
+        /// guaranteed to be the LAST geometry op: (1) bumping `geometryGeneration` makes a
+        /// not-yet-sent background `lock:false` bail on its generation guard; (2) `relockPending`
+        /// makes EVERY `sendPTYSize` caller (the re-lock itself AND any `sizeChanged` in the
+        /// window) defer while we await the in-flight release, so no `lock:true` can race the
+        /// `lock:false`; the deferred re-lock then drives toward the LIVE grid. Different panes own
+        /// different PTYs + generation keys, so releases/retakes across panes never contend.
         func setForeground(_ f: Bool) {
             guard !stopped, f != foreground else { return }
             foreground = f
@@ -320,17 +332,18 @@ struct LiveTerminalView: UIViewRepresentable {
                 myGeometryGeneration = gen
                 lastSentCols = 0                // defeat sendPTYSize's dedup so the re-lock re-sends
                 lastSentRows = 0
-                guard desiredCols >= 4, desiredRows >= 2 else { return }
-                let cols = desiredCols, rows = desiredRows
+                relockPending = true            // hold off ALL sendPTYSize until the release lands
                 let pending = Self.geometryReleaseTask[paneID]
                 Task { @MainActor [weak self] in
                     await pending?.value        // let any committed lock:false land FIRST
                     guard let self, self.foreground, !self.stopped,
                           self.myGeometryGeneration == gen else { return }   // a newer hide/show superseded us
-                    self.sendPTYSize(cols: cols, rows: rows)   // re-take lock:true, now guaranteed last
+                    self.relockPending = false
+                    self.sendPTYSize(cols: self.desiredCols, rows: self.desiredRows)   // re-take lock:true at the LIVE grid, now last
                 }
             } else {
-                releaseGeometryOwnership()   // release lock:false, keep the stream + emulator warm
+                relockPending = false           // a hide cancels any pending re-lock intent
+                releaseGeometryOwnership()       // release lock:false, keep the stream + emulator warm
             }
         }
 
@@ -463,11 +476,12 @@ struct LiveTerminalView: UIViewRepresentable {
             desiredCols = cols
             desiredRows = rows
             resizeRetries = 0        // a new target gets a fresh retry budget
-            // A backgrounded (keep-mounted) pane TRACKS the latest grid above but does not
-            // send `lock:true` while hidden — it would re-pin a co-viewing desktop to the
-            // phone's width with nobody looking. `setForeground(true)` re-locks at the
-            // tracked size when the pane returns to screen.
-            guard foreground else { return }
+            // A backgrounded pane (or one whose re-lock is still awaiting the in-flight release,
+            // `relockPending`) TRACKS the latest grid above but does not start a drain: a hidden
+            // pane would re-pin a co-viewing desktop, and a `lock:true` sent during the release
+            // window could race the `lock:false` and strand the visible pane unlocked. The
+            // deferred re-lock re-sends at the LIVE grid once the release lands.
+            guard foreground, !relockPending else { return }
             guard resizeTask == nil else { return }   // a drain is running; it re-reads `desired`
             let cell = Self.cellPixels()
             resizeTask = Task { @MainActor [weak self] in

--- a/App/LiveTerminalView.swift
+++ b/App/LiveTerminalView.swift
@@ -179,6 +179,22 @@ struct LiveTerminalView: UIViewRepresentable {
             let gen = (Self.geometryGeneration[paneID] ?? 0) + 1
             Self.geometryGeneration[paneID] = gen
             myGeometryGeneration = gen
+            // Symmetric with setForeground(true): on a fast evict→reopen (or a transient
+            // double-mount) of the SAME pane id, a prior coordinator's ALREADY-committed
+            // lock:false could otherwise overtake this fresh mount's first lock:true and strand
+            // the visible pane unlocked. Defer this mount's first lock (relockPending) until any
+            // pending release for this pane has landed. A fresh pane id has no entry → awaits nil
+            // → clears at once.
+            relockPending = true
+            let pane = paneID
+            Task { @MainActor [weak self] in
+                await Self.geometryReleaseTask[pane]?.value
+                guard let self, !self.stopped, self.myGeometryGeneration == gen else { return }
+                self.relockPending = false
+                if self.desiredCols >= 4, self.desiredRows >= 2 {
+                    self.sendPTYSize(cols: self.desiredCols, rows: self.desiredRows)
+                }
+            }
             // A dedicated pan that scrolls the AGENT (see handleScrollPan) — for the
             // alt screen OR any mouse-reporting program (Claude Code). It recognizes
             // SIMULTANEOUSLY with SwiftTerm's own gestures: `gestureRecognizer(_:should
@@ -293,11 +309,21 @@ struct LiveTerminalView: UIViewRepresentable {
             let rows = lastSentRows > 0 ? lastSentRows : desiredRows
             let inflight = resizeTask
             resizeTask = nil
-            guard cols >= 4, rows >= 2 else { Self.geometryReleaseTask[paneID] = nil; return }
+            // Leave any existing registry entry in place on this early bail (a pane that never
+            // laid out): an older release may still be in flight, and its entry is the only handle
+            // a future re-lock has to await it.
+            guard cols >= 4, rows >= 2 else { return }
             let client = self.client
             let pane = self.paneID
             let myGen = self.myGeometryGeneration
+            // CHAIN releases: await the PREVIOUS entry first, so awaiting the newest release
+            // transitively awaits every older one. Without this, overwriting the map here would
+            // orphan an older ALREADY-committed lock:false (past its generation guard), and a later
+            // re-lock — which awaits only the newest entry — could send lock:true before that older
+            // lock:false lands, leaving the visible pane unlocked.
+            let previous = Self.geometryReleaseTask[pane]
             Self.geometryReleaseTask[pane] = Task.detached {
+                await previous?.value        // an older release's lock:false must land BEFORE ours
                 _ = await inflight?.value    // let the in-flight lock:true finish its round-trip
                 // If a newer coordinator OR a re-show claimed this pane while we awaited, it owns
                 // the lock now — releasing would unlock a pane still on screen. Bail so its

--- a/App/PaneKeepAlive.swift
+++ b/App/PaneKeepAlive.swift
@@ -1,0 +1,62 @@
+import SwiftUI
+import HerdrKit
+
+/// One open terminal in the keep-alive container. This is the OPEN CONTEXT captured when a
+/// pane is opened — NOT a cached object: the live stream, SwiftTerm emulator, and per-pane
+/// `@State` all live inside the mounted `TerminalPaneContent`, which is never torn down while
+/// its slot exists. Identity is the pane id, so `ForEach` never remounts a slot when the LRU
+/// list is reordered or another pane is fronted.
+struct PaneSlot: Identifiable {
+    let paneID: String
+    let title: String
+    let agent: AgentInfo?
+    /// A spawn pre-fill (the new-agent task) for the pane it opened; "" for list/Terminal-tab
+    /// opens. Siblings carry "" too, so a pre-fill never leaks to a neighbour.
+    let initialReply: String
+    /// The ordered agents this pane can swipe-page through (snapshot at open time).
+    let siblings: [AgentInfo]
+    var id: String { paneID }
+}
+
+/// Hosts the recently-opened terminal panes MOUNTED but hidden, so reopening — and swiping
+/// between them — is instant: nothing is torn down or re-streamed. Exactly one slot is the
+/// FRONT (visible, interactive, holding the PTY width-lock); the rest sit at opacity 0 with
+/// hit-testing disabled, their stream still warm and their lock released. Opening/paging just
+/// changes which slot is front.
+///
+/// It lives INSIDE `TerminalHomeView`, which is the point: a reconnect bumps the view's
+/// `.id(session)` and dismantles every mounted pane (each `Coordinator.stop()` closing its
+/// stream) for free — no manual "drop panes on reconnect" bookkeeping.
+struct PaneKeepAliveContainer: View {
+    let client: HerdrClient
+    let slots: [PaneSlot]
+    let frontID: String?
+    /// Back out of the fronted pane to the list (header chevron / left-edge swipe).
+    let onClose: () -> Void
+    /// Swipe to the prev/next agent: (the slot the swipe came from, ±1).
+    let onNavigate: (PaneSlot, Int) -> Void
+
+    var body: some View {
+        ZStack {
+            ForEach(slots) { slot in
+                let isFront = slot.paneID == frontID
+                TerminalPaneContent(
+                    client: client,
+                    paneID: slot.paneID,
+                    title: slot.title,
+                    agent: slot.agent,
+                    initialReply: slot.initialReply,
+                    isForeground: isFront,
+                    onNavigate: { onNavigate(slot, $0) },
+                    onClose: onClose)
+                    // STABLE identity — the pane id, NEVER a swipe-varying `currentID`. So a
+                    // swipe or an LRU reorder flips visibility without giving the subtree a new
+                    // identity (which would dismantle it and re-stream from a cold handshake).
+                    .id(slot.paneID)
+                    .opacity(isFront ? 1 : 0)
+                    .allowsHitTesting(isFront)
+                    .zIndex(isFront ? 1 : 0)
+            }
+        }
+    }
+}

--- a/App/PaneKeepAlive.swift
+++ b/App/PaneKeepAlive.swift
@@ -56,6 +56,10 @@ struct PaneKeepAliveContainer: View {
                     .opacity(isFront ? 1 : 0)
                     .allowsHitTesting(isFront)
                     .zIndex(isFront ? 1 : 0)
+                    // A hidden warm pane is invisible AND inert — keep it out of the
+                    // accessibility tree too (VoiceOver shouldn't read an offscreen pane; it
+                    // also makes the paging XCUITest's assertions unambiguous).
+                    .accessibilityHidden(!isFront)
             }
         }
     }

--- a/HerdrUITests/PagingTests.swift
+++ b/HerdrUITests/PagingTests.swift
@@ -22,33 +22,41 @@ final class PagingTests: XCTestCase {
         app.launch()
         Thread.sleep(forTimeInterval: 2.0)   // let the first pane mount + its stream seed
 
-        // Opens on ALFA (heading "ALFA · ALFA").
-        XCTAssertTrue(frontHeader(app, contains: "ALFA"),
+        // Opens on ALFA (heading "ALFA · ALFA") — front, hittable.
+        XCTAssertTrue(frontIs(app, "ALFA"),
             "Paging harness did not open on the first agent (ALFA).")
         attach(app, "01-alfa")
 
-        // Swipe LEFT → next agent (BRAVO). ALFA leaves the a11y tree; BRAVO enters.
+        // Swipe LEFT → next agent (BRAVO) is now the FRONT (hittable) pane. If the swipe never
+        // paged, BRAVO would be absent and ALFA would still be the hittable front → fail.
         swipe(app, .left)
-        XCTAssertTrue(frontHeader(app, contains: "BRAVO"),
+        XCTAssertTrue(frontIs(app, "BRAVO"),
             "Swipe-left did not page to the next agent (BRAVO).")
-        XCTAssertFalse(frontHeader(app, contains: "ALFA", timeout: 1),
-            "ALFA is still on screen after paging to BRAVO — the swap did not front BRAVO.")
+        XCTAssertFalse(frontIs(app, "ALFA", timeout: 1),
+            "ALFA is still the front pane after paging to BRAVO — the swap did not front BRAVO.")
         attach(app, "02-bravo")
 
-        // Swipe RIGHT → previous agent (back to ALFA), a warm keep-mounted hit.
+        // Swipe RIGHT → previous agent (back to ALFA), a warm keep-mounted hit that re-fronts it.
         swipe(app, .right)
-        XCTAssertTrue(frontHeader(app, contains: "ALFA"),
+        XCTAssertTrue(frontIs(app, "ALFA"),
             "Swipe-right did not page back to the previous agent (ALFA).")
         attach(app, "03-alfa-again")
     }
 
     // MARK: helpers
 
-    /// The front pane's header heading rendered as a SwiftUI Text (staticText). Non-front panes
-    /// are `.accessibilityHidden`, so a match means that pane is the one on screen.
-    private func frontHeader(_ app: XCUIApplication, contains name: String, timeout: TimeInterval = 6) -> Bool {
-        let pred = NSPredicate(format: "label CONTAINS[c] %@", name)
-        return app.staticTexts.containing(pred).firstMatch.waitForExistence(timeout: timeout)
+    /// True when the named agent's header heading belongs to the FRONT pane — present AND
+    /// HITTABLE. A backgrounded keep-mounted pane sits at opacity 0 with hit-testing off, so its
+    /// header is not hittable; only the fronted pane's header is. This distinguishes "on screen"
+    /// from "merely still mounted", without relying on accessibility hiding.
+    private func frontIs(_ app: XCUIApplication, _ name: String, timeout: TimeInterval = 6) -> Bool {
+        let el = app.staticTexts.containing(NSPredicate(format: "label CONTAINS[c] %@", name)).firstMatch
+        let deadline = Date(timeIntervalSinceNow: timeout)
+        repeat {
+            if el.exists && el.isHittable { return true }
+            Thread.sleep(forTimeInterval: 0.2)
+        } while Date() < deadline
+        return el.exists && el.isHittable
     }
 
     private enum Dir { case left, right }

--- a/HerdrUITests/PagingTests.swift
+++ b/HerdrUITests/PagingTests.swift
@@ -1,0 +1,75 @@
+import XCTest
+
+/// The SWIPE-BETWEEN-AGENTS receipt (JARVIS-commissioned under standing rule 47814/47874:
+/// a gesture change ships with an on-simulator gesture proof, not static review alone).
+///
+/// Launches the keep-mounted paging harness (`HERDR_SCREENSHOT_MOCK=paging`) — three
+/// distinctively-named agents (ALFA / BRAVO / CHARLIE) in the real `PaneKeepAliveContainer`.
+/// A horizontal swipe fronts the neighbour, and the header heading changes accordingly. Only
+/// the FRONT pane is in the accessibility tree (`.accessibilityHidden(!isFront)`), so an
+/// existence assertion genuinely proves which pane is on screen: after swiping to BRAVO the
+/// ALFA header is GONE, and swiping back makes it reappear (a warm keep-mounted hit).
+///
+/// If the swipe never registered, the front pane would not change and the target header would
+/// never appear → this fails. So a PASS proves the discrete swipe recognizers page the panes.
+final class PagingTests: XCTestCase {
+
+    override func setUp() { continueAfterFailure = false }
+
+    func testSwipeBetweenAgents() {
+        let app = XCUIApplication()
+        app.launchEnvironment["HERDR_SCREENSHOT_MOCK"] = "paging"
+        app.launch()
+        Thread.sleep(forTimeInterval: 2.0)   // let the first pane mount + its stream seed
+
+        // Opens on ALFA (heading "ALFA · ALFA").
+        XCTAssertTrue(frontHeader(app, contains: "ALFA"),
+            "Paging harness did not open on the first agent (ALFA).")
+        attach(app, "01-alfa")
+
+        // Swipe LEFT → next agent (BRAVO). ALFA leaves the a11y tree; BRAVO enters.
+        swipe(app, .left)
+        XCTAssertTrue(frontHeader(app, contains: "BRAVO"),
+            "Swipe-left did not page to the next agent (BRAVO).")
+        XCTAssertFalse(frontHeader(app, contains: "ALFA", timeout: 1),
+            "ALFA is still on screen after paging to BRAVO — the swap did not front BRAVO.")
+        attach(app, "02-bravo")
+
+        // Swipe RIGHT → previous agent (back to ALFA), a warm keep-mounted hit.
+        swipe(app, .right)
+        XCTAssertTrue(frontHeader(app, contains: "ALFA"),
+            "Swipe-right did not page back to the previous agent (ALFA).")
+        attach(app, "03-alfa-again")
+    }
+
+    // MARK: helpers
+
+    /// The front pane's header heading rendered as a SwiftUI Text (staticText). Non-front panes
+    /// are `.accessibilityHidden`, so a match means that pane is the one on screen.
+    private func frontHeader(_ app: XCUIApplication, contains name: String, timeout: TimeInterval = 6) -> Bool {
+        let pred = NSPredicate(format: "label CONTAINS[c] %@", name)
+        return app.staticTexts.containing(pred).firstMatch.waitForExistence(timeout: timeout)
+    }
+
+    private enum Dir { case left, right }
+
+    /// A firm, fast horizontal flick on the terminal body at mid-height. Both directions start
+    /// well clear of the left screen edge (dx ≥ 0.45 ≫ the ~44pt edge-back zone), so the
+    /// previous-agent (rightward) swipe is never ceded to the edge-back gesture. A short press
+    /// before the drag gives the discrete `UISwipeGestureRecognizer` the velocity it needs.
+    private func swipe(_ app: XCUIApplication, _ dir: Dir) {
+        let startX: CGFloat = dir == .left ? 0.85 : 0.45
+        let endX:   CGFloat = dir == .left ? 0.15 : 0.95
+        let start = app.coordinate(withNormalizedOffset: CGVector(dx: startX, dy: 0.5))
+        let end   = app.coordinate(withNormalizedOffset: CGVector(dx: endX, dy: 0.5))
+        start.press(forDuration: 0.03, thenDragTo: end)
+        Thread.sleep(forTimeInterval: 1.2)   // let the front swap + repaint
+    }
+
+    private func attach(_ app: XCUIApplication, _ name: String) {
+        let shot = XCTAttachment(screenshot: app.screenshot())
+        shot.name = name
+        shot.lifetime = .keepAlways
+        add(shot)
+    }
+}

--- a/HerdrUITests/PagingTests.swift
+++ b/HerdrUITests/PagingTests.swift
@@ -27,20 +27,35 @@ final class PagingTests: XCTestCase {
             "Paging harness did not open on the first agent (ALFA).")
         attach(app, "01-alfa")
 
-        // Swipe LEFT → next agent (BRAVO) is now the FRONT (hittable) pane. If the swipe never
-        // paged, BRAVO would be absent and ALFA would still be the hittable front → fail.
-        swipe(app, .left)
-        XCTAssertTrue(frontIs(app, "BRAVO"),
+        // Swipe LEFT → next agent (BRAVO) becomes the FRONT (hittable) pane. The discrete swipe
+        // recognizer is velocity-sensitive, so retry the flick until it lands (a swipe that never
+        // fires leaves ALFA fronted; a swipe that pages makes BRAVO the hittable front). Retrying
+        // can only ADVANCE when it actually fires, and stops the instant BRAVO is front, so it
+        // cannot overshoot.
+        XCTAssertTrue(pageUntilFront(app, .left, to: "BRAVO"),
             "Swipe-left did not page to the next agent (BRAVO).")
         XCTAssertFalse(frontIs(app, "ALFA", timeout: 1),
             "ALFA is still the front pane after paging to BRAVO — the swap did not front BRAVO.")
         attach(app, "02-bravo")
 
         // Swipe RIGHT → previous agent (back to ALFA), a warm keep-mounted hit that re-fronts it.
-        swipe(app, .right)
-        XCTAssertTrue(frontIs(app, "ALFA"),
+        XCTAssertTrue(pageUntilFront(app, .right, to: "ALFA"),
             "Swipe-right did not page back to the previous agent (ALFA).")
         attach(app, "03-alfa-again")
+    }
+
+    /// Flick in `dir` until the named agent is the hittable front pane, or give up after a few
+    /// tries. Each attempt only pages when the discrete recognizer actually fires, and returns as
+    /// soon as `to` is front — so it recovers a dropped flick without overshooting past the target.
+    private func pageUntilFront(_ app: XCUIApplication, _ dir: Dir, to name: String) -> Bool {
+        // A generous per-attempt wait (the neighbour's header renders within ~1s of a fired
+        // flick), so a retry fires only when the flick genuinely dropped — never overshooting a
+        // target that just hadn't rendered yet.
+        for _ in 0..<3 {
+            swipe(app, dir)
+            if frontIs(app, name, timeout: 4) { return true }
+        }
+        return false
     }
 
     // MARK: helpers

--- a/HerdrUITests/PagingTests.swift
+++ b/HerdrUITests/PagingTests.swift
@@ -53,16 +53,17 @@ final class PagingTests: XCTestCase {
 
     private enum Dir { case left, right }
 
-    /// A firm, fast horizontal flick on the terminal body at mid-height. Both directions start
-    /// well clear of the left screen edge (dx ≥ 0.45 ≫ the ~44pt edge-back zone), so the
-    /// previous-agent (rightward) swipe is never ceded to the edge-back gesture. A short press
-    /// before the drag gives the discrete `UISwipeGestureRecognizer` the velocity it needs.
+    /// A firm, FAST horizontal flick on the terminal body at mid-height. The discrete
+    /// `UISwipeGestureRecognizer` fires only on real velocity — a plain drag is read as the
+    /// scroll pan and never pages — so we drive the drag at `.fast` velocity explicitly. Both
+    /// directions start well clear of the left screen edge (dx ≥ 0.45 ≫ the ~44pt edge-back
+    /// zone), so the previous-agent (rightward) swipe is never ceded to the edge-back gesture.
     private func swipe(_ app: XCUIApplication, _ dir: Dir) {
         let startX: CGFloat = dir == .left ? 0.85 : 0.45
         let endX:   CGFloat = dir == .left ? 0.15 : 0.95
         let start = app.coordinate(withNormalizedOffset: CGVector(dx: startX, dy: 0.5))
         let end   = app.coordinate(withNormalizedOffset: CGVector(dx: endX, dy: 0.5))
-        start.press(forDuration: 0.03, thenDragTo: end)
+        start.press(forDuration: 0.0, thenDragTo: end, withVelocity: .fast, thenHoldForDuration: 0.0)
         Thread.sleep(forTimeInterval: 1.2)   // let the front swap + repaint
     }
 

--- a/project.yml
+++ b/project.yml
@@ -73,7 +73,7 @@ targets:
       - package: HerdrKit
         product: HerdrKit
       # SwiftTerm rides on the APP target only (it is UIKit/AppKit) — it renders
-      # the live terminal in TerminalPaneView. HerdrKit deliberately does NOT
+      # the live terminal in TerminalPaneContent. HerdrKit deliberately does NOT
       # depend on it so the Linux build/test of the protocol layer stays intact.
       - package: SwiftTerm
         product: SwiftTerm


### PR DESCRIPTION
## What (owner-requested, design-panel plan approved)
Owner on v0.1.15: opening/closing an agent terminal is **too slow**, recently-opened panes should **stay open like a cache**, and the **agents list reloads slowly**. A 3-approach design panel ran; owner chose **keep-mounted**.

**Root cause:** `pane.stream` opens a **full new SSH handshake per open** (RPCs reuse a warm client); `NavigationStack` pop + the `.id(currentID)` swipe-rebuild throw the stream/view away every time. The list just blanks its still-valid `@State` to a spinner.

## Changes
- **List (Phase 1):** `load()` shows the spinner only when `agents.isEmpty`; otherwise refreshes silently (stale-while-revalidate). A background refresh failure keeps the good list (host-key rejections still always surface).
- **Panes (Phase 2):** recently-opened terminals are kept **MOUNTED (hidden)** in a new `PaneKeepAliveContainer` (LRU, N=3) instead of pushed onto the `NavigationStack` — reopening + swiping between them is instant, nothing torn down/re-streamed, scroll position + typed drafts preserved. The swipe `.id` is now the **stable paneID** (not `currentID`), so paging flips visibility without remounting. Deletes the `TerminalPaneView` wrapper + the "send/clear reply first" veto (drafts now survive paging). `@Environment(dismiss)` → injected `onClose`; `EdgeSwipeBack` rendered only for the front pane (it attaches to the window).
- **Lock hand-off (Phase 2b — the one `LiveTerminalView` change, lock only, NOT scroll):** only the front pane holds the PTY width-lock. `isForeground` drives `Coordinator.setForeground` — background releases `lock:false` (keeping the stream warm), foreground re-takes `lock:true` at the tracked grid, arbitrated by the existing `geometryGeneration` guard. A hidden pane tracks size changes but never re-locks offscreen.
- Reconnect invalidation is **free**: the container lives in `TerminalHomeView`, whose `.id(session)` dismantles every mounted pane.

## Verification
- **ScrollTests GREEN** on the pre-paging sha (69741a8): `testTerminalScrollsWhenSwiped` + `testClaudeCodeScrollsViaWheel`, 0 failures — proves scroll not regressed by the restructure + lock handoff.
- **New `PagingTests.testSwipeBetweenAgents`** (JARVIS-commissioned gesture receipt): a `HERDR_SCREENSHOT_MOCK=paging` harness; swipe fronts the neighbour and the header changes (ALFA→BRAVO→ALFA); non-front panes are `.accessibilityHidden` so the assertion proves front-ness.
- Buildbox BUILD SUCCEEDED; app renders.
- Ship as v0.1.16 after 2 distinct-runtime reviews + owner on-device (reopen instant, swipe instant, scroll intact, draft survives paging, co-viewing desktop reclaims width on background).

## Known / accepted
- N=3 background panes keep live streams + VT parsers (bounded main-actor CPU) — the accepted cost of "stays open".
- Phase 3 (a pre-warmed spare SSH connection for cold FIRST opens) is a deliberate low-risk follow-up, not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)