### PR TITLE
terminal: backfill recent scrollback on connect (scroll-up shows history)

### DIFF
--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -283,6 +283,16 @@ struct RootView: View {
                                  paneID: "w1:p1", title: "claude",
                                  agent: MockTransport.demoPaneAgent)
             }
+        case .backfill:
+            // A REAL SwiftTerm pane whose LIVE stream carries only the short one-screen seed,
+            // while agent.read (source=recent, ansi) returns ~1000 numbered lines of history —
+            // so the scrollback a swipe-up reveals can ONLY have come from the connect-time
+            // backfill (the scrollback receipt for open/refresh history).
+            NavigationStack {
+                TerminalPaneContent(client: HerdrClient(transport: MockTransport(backfill: true)),
+                                 paneID: "w1:p1", title: "backfill",
+                                 agent: MockTransport.demoPaneAgent)
+            }
         case .paging:
             // Three distinctively-named agents in the real keep-mounted container. A swipe
             // fronts the neighbour and the header heading changes (ALFA→BRAVO→ALFA) — the
@@ -2315,7 +2325,7 @@ struct PagingTestHarness: View {
 #endif
 
 enum ScreenshotMock {
-    case list, pane, settings, newAgent, scroll, ccscroll, paging
+    case list, pane, settings, newAgent, scroll, ccscroll, paging, backfill
 
     static var mode: ScreenshotMock? {
         let env = ProcessInfo.processInfo.environment["HERDR_SCREENSHOT_MOCK"]?.lowercased()
@@ -2336,6 +2346,10 @@ enum ScreenshotMock {
         // `paging` drives the swipe-between-agents receipt: three distinctively-named agents
         // in the keep-mounted container; a swipe fronts the neighbour and the header changes.
         case "paging": return .paging
+        // `backfill` drives the scrollback-backfill receipt: the LIVE stream carries only a
+        // short one-screen seed, while agent.read (recent, ansi) returns ~1000 lines of history
+        // — so scrollback the swipe reveals can ONLY have come from the connect-time backfill.
+        case "backfill": return .backfill
         default: return .list
         }
     }
@@ -2352,13 +2366,17 @@ struct MockTransport: HerdrTransport {
     /// When set, this pane is a Claude-Code stand-in (alt-screen + mouse-mode) that
     /// scrolls in RESPONSE to SGR wheel events the app sends — for the ccscroll receipt.
     var ccDriver: CCScrollDriver?
+    /// When true, `agent.read` (source=recent, ansi) returns MANY numbered lines of history
+    /// while `pane.stream` seeds only the SHORT one-screen reset — so the scrollback a swipe
+    /// reveals can ONLY come from the connect-time backfill path. For the backfill receipt.
+    var backfill = false
 
     func roundTrip(_ requestLine: String) async throws -> String {
         // ccscroll receipt: any request may carry an SGR wheel event the app sent
         // (via sendText); the driver scrolls the stand-in Claude Code if so.
         ccDriver?.received(requestLine)
         if requestLine.contains("agent.list") { return Self.agentList }
-        if requestLine.contains("agent.read") { return Self.agentRead }
+        if requestLine.contains("agent.read") { return backfill ? Self.backfillRead() : Self.agentRead }
         if requestLine.contains("pane.set_pty_size") { return Self.panePtySize }
         return #"{"id":"mock","result":{}}"#
     }
@@ -2401,6 +2419,24 @@ struct MockTransport: HerdrTransport {
         body += "SCROLLTEST end — swipe down to reveal earlier lines"
         let b64 = Data(body.utf8).base64EncodedString()
         return "{\"stream\":\"pane.bytes\",\"frame\":\"reset\",\"seq\":0,\"epoch\":7,\"cols\":80,\"rows\":24,\"data_b64\":\"\(b64)\"}"
+    }
+
+    /// An `agent.read` response (source=recent, format=ansi) carrying ~1000 DISTINCT numbered
+    /// lines as ANSI — the history the app's connect-time backfill prepends into SwiftTerm's
+    /// scrollback. `\r\n` endings (no staircase), cursor hidden (ESC[?25l) so static frames stay
+    /// byte-identical for the before/after image compare. Built at runtime (DEBUG/UI-test only);
+    /// JSONSerialization escapes the ESC + control bytes in the `text` field.
+    static func backfillRead() -> String {
+        var body = "\u{1b}[?25l"   // hide cursor: static frames stay byte-identical
+        for i in 1...1000 {
+            body += String(format: "BACKFILL line %04d  the quick brown fox jumps over the lazy dog\r\n", i)
+        }
+        body += "BACKFILL end — swipe down to reveal earlier lines"
+        let payload: [String: Any] = ["id": "mock", "result": ["read": [
+            "pane_id": "w1:p1", "text": body, "truncated": false,
+            "source": "recent", "format": "ansi"]]]
+        let data = (try? JSONSerialization.data(withJSONObject: payload)) ?? Data()
+        return String(data: data, encoding: .utf8) ?? Self.agentRead
     }
 
     // Realistic herdr statuses only (idle|working|blocked|done|unknown). "needs

--- a/App/LiveTerminalView.swift
+++ b/App/LiveTerminalView.swift
@@ -122,6 +122,13 @@ struct LiveTerminalView: UIViewRepresentable {
         /// defeat the release (review HIGH). Once stopped, `sendPTYSize` is inert.
         private var stopped = false
 
+        /// Scrollback backfill: the in-flight `read` (source=.recent, ANSI) fetching history
+        /// produced BEFORE the live stream connected, resolved to ANSI bytes (nil on empty /
+        /// error / timeout). The FIRST reset awaits it once, to prepend history above the seed.
+        private var backfillTask: Task<[UInt8]?, Never>?
+        /// Guards the one-time scrollback-cap raise + history prepend to the FIRST reset only.
+        private var didSeedOnce = false
+
         /// Page-between-agents callback (see `LiveTerminalView.onNavigate`), refreshed
         /// by `updateUIView`. +1 = next agent, -1 = previous.
         var onNavigate: ((Int) -> Void)?
@@ -172,6 +179,18 @@ struct LiveTerminalView: UIViewRepresentable {
         static let paneFont: UIFont =
             UIFont(name: "IBMPlexMono", size: paneFontSize)
             ?? UIFont.monospacedSystemFont(ofSize: paneFontSize, weight: .regular)
+
+        /// Scrollback backfill — so scrolling up shows output produced BEFORE this connection
+        /// (open/refresh only seeds the current screen otherwise). On each connect we fetch the
+        /// last `backfillLines` rendered rows (server `recent`, incl. scrollback, as ANSI) and
+        /// feed them into SwiftTerm's scrollback ABOVE the live seed. `0` disables the feature.
+        static let backfillLines: UInt32 = 1000            // server clamps `recent` to 1000 rows
+        /// SwiftTerm scrollback ring, raised once per connect from its ~500 default. MUST stay
+        /// >= backfillLines + live tail so a full backfill is retained (not truncated).
+        static let scrollbackCap = 4000
+        /// Bound the wait so a slow/hung `read` can never stall the live seed — on timeout we
+        /// skip history and paint the seed (today's behaviour).
+        static let backfillTimeoutNanos: UInt64 = 1_200_000_000
 
         init(client: HerdrClient, paneID: String) {
             self.client = client
@@ -246,6 +265,7 @@ struct LiveTerminalView: UIViewRepresentable {
             view.addGestureRecognizer(swipePrev)
             swipeAgentPrev = swipePrev
             style(view)
+            startBackfill()   // fetch history CONCURRENTLY with the stream; the first reset awaits it
             start()
         }
 
@@ -294,6 +314,8 @@ struct LiveTerminalView: UIViewRepresentable {
             scrollSendTask = nil
             streamTask?.cancel()
             streamTask = nil
+            backfillTask?.cancel()
+            backfillTask = nil
             releaseGeometryOwnership()
         }
 
@@ -410,6 +432,28 @@ struct LiveTerminalView: UIViewRepresentable {
 
         // MARK: streaming
 
+        /// Fetch recent rendered history (incl. scrollback) as ANSI, bounded by a timeout so it
+        /// can never stall the live seed. Runs concurrently with the stream; the FIRST reset
+        /// awaits this at the single point where the bytes must land above the seed.
+        private func startBackfill() {
+            guard Self.backfillLines > 0 else { backfillTask = nil; return }
+            let client = self.client, pane = self.paneID
+            backfillTask = Task { () -> [UInt8]? in
+                let read = Task {
+                    try? await client.read(pane: pane, source: .recent, format: .ansi,
+                                           lines: Self.backfillLines)
+                }
+                let timeout = Task {
+                    try? await Task.sleep(nanoseconds: Self.backfillTimeoutNanos)
+                    read.cancel()   // a slow/hung read must never stall the seed
+                }
+                let result = await read.value
+                timeout.cancel()
+                guard let text = result?.text, !text.isEmpty else { return nil }
+                return [UInt8](text.utf8)
+            }
+        }
+
         private func start() {
             streamTask?.cancel()
             sawExited = false
@@ -428,7 +472,7 @@ struct LiveTerminalView: UIViewRepresentable {
         }
 
         @MainActor
-        private func handle(_ event: TerminalStreamEvent) {
+        private func handle(_ event: TerminalStreamEvent) async {
             guard let view else { return }
             switch event {
             case .started(let started):
@@ -437,6 +481,23 @@ struct LiveTerminalView: UIViewRepresentable {
             case .frame(let frame):
                 switch frame {
                 case .reset(_, _, let cols, let rows, let data, _):
+                    if !didSeedOnce {
+                        didSeedOnce = true
+                        // Raise SwiftTerm's scrollback ring ONCE (its ~500 default) so it can hold
+                        // the full backfill plus the live tail. Durable: layout resizes go through
+                        // terminal.resize(), which preserves scrollback (setupOptions runs only at
+                        // construction).
+                        view.getTerminal().changeHistorySize(Self.scrollbackCap)
+                        // History ABOVE the seed: feed it BEFORE the clear so its lines scroll into
+                        // SwiftTerm's scrollback; the ESC[2J below then erases only the overlapping
+                        // VISIBLE rows (recent's bottom ≈ the current screen) in place — scrollback
+                        // untouched — and the seed repaints them, so nothing is duplicated. Bounded
+                        // await; re-check teardown before feeding a possibly-dismantled view.
+                        let history = await backfillTask?.value ?? nil
+                        if let history, !history.isEmpty, !stopped {
+                            view.feed(byteArray: history[...])
+                        }
+                    }
                     // Clear the VISIBLE screen + home (NOT scrollback — see
                     // clearSequence, Fix B), then paint the full-screen seed.
                     // `lagged` resets seed identically (the server already collapsed

--- a/App/LiveTerminalView.swift
+++ b/App/LiveTerminalView.swift
@@ -4,6 +4,21 @@ import UIKit
 import SwiftTerm
 import HerdrKit
 
+/// One-shot claim gate: `claim()` returns true to EXACTLY ONE caller, so a
+/// `CheckedContinuation` raced between two tasks (a read vs a timeout) is resumed at
+/// most once. Used by the scrollback backfill to bound a read that the transport won't
+/// cancel — the loser is abandoned rather than awaited.
+private final class ResumeGate: @unchecked Sendable {
+    private let lock = NSLock()
+    private var claimed = false
+    func claim() -> Bool {
+        lock.lock(); defer { lock.unlock() }
+        if claimed { return false }
+        claimed = true
+        return true
+    }
+}
+
 /// A read-only, LIVE SwiftTerm terminal for a herdr pane (#40). It consumes
 /// `client.streamTerminal(pane:)` — herdr's raw PTY byte firehose — and feeds the
 /// bytes to a real VT emulator, so the phone renders a grid-faithful terminal
@@ -439,18 +454,26 @@ struct LiveTerminalView: UIViewRepresentable {
             guard Self.backfillLines > 0 else { backfillTask = nil; return }
             let client = self.client, pane = self.paneID
             backfillTask = Task { () -> [UInt8]? in
-                let read = Task {
-                    try? await client.read(pane: pane, source: .recent, format: .ansi,
-                                           lines: Self.backfillLines)
+                // Race the read against the timeout and take whichever finishes FIRST, ABANDONING
+                // the loser. The shipped HerdrTransports do NOT honour Task cancellation on the read
+                // path, so we must never `await` a hung read — that would leave the first .reset (and
+                // every frame queued behind it) suspended forever, a blank terminal. Instead a
+                // one-shot gate resumes the continuation exactly once: whichever of the read / the
+                // 1.2s sleep fires first wins; a hung read just leaks its background task and we paint
+                // the seed with no history, exactly as before the feature.
+                let gate = ResumeGate()
+                return await withCheckedContinuation { (cont: CheckedContinuation<[UInt8]?, Never>) in
+                    let read = Task {
+                        let r = try? await client.read(pane: pane, source: .recent,
+                                                       format: .ansi, lines: Self.backfillLines)
+                        let bytes = (r?.text).flatMap { $0.isEmpty ? nil : [UInt8]($0.utf8) }
+                        if gate.claim() { cont.resume(returning: bytes) }
+                    }
+                    Task {
+                        try? await Task.sleep(nanoseconds: Self.backfillTimeoutNanos)
+                        if gate.claim() { read.cancel(); cont.resume(returning: nil) }
+                    }
                 }
-                let timeout = Task {
-                    try? await Task.sleep(nanoseconds: Self.backfillTimeoutNanos)
-                    read.cancel()   // a slow/hung read must never stall the seed
-                }
-                let result = await read.value
-                timeout.cancel()
-                guard let text = result?.text, !text.isEmpty else { return nil }
-                return [UInt8](text.utf8)
             }
         }
 
@@ -481,29 +504,39 @@ struct LiveTerminalView: UIViewRepresentable {
             case .frame(let frame):
                 switch frame {
                 case .reset(_, _, let cols, let rows, let data, _):
-                    if !didSeedOnce {
+                    let firstReset = !didSeedOnce
+                    if firstReset {
                         didSeedOnce = true
-                        // Raise SwiftTerm's scrollback ring ONCE (its ~500 default) so it can hold
-                        // the full backfill plus the live tail. Durable: layout resizes go through
-                        // terminal.resize(), which preserves scrollback (setupOptions runs only at
-                        // construction).
+                        // Raise SwiftTerm's scrollback ring ONCE (its ~500 default) so it can hold the
+                        // full backfill plus the live tail — BEFORE the resize below so a resize can't
+                        // reclamp the ring while history is being fed. Whether the raise then survives
+                        // the LAYOUT-driven terminal.resize() (SwiftTerm's Buffer.resize must not
+                        // recompute maxLength down from options.scrollback) is an SPM-dependency
+                        // internal not visible here; the swipe-up XCUITest, which resizes to the real
+                        // sim grid, is the actual proof that history survives.
                         view.getTerminal().changeHistorySize(Self.scrollbackCap)
-                        // History ABOVE the seed: feed it BEFORE the clear so its lines scroll into
-                        // SwiftTerm's scrollback; the ESC[2J below then erases only the overlapping
-                        // VISIBLE rows (recent's bottom ≈ the current screen) in place — scrollback
-                        // untouched — and the seed repaints them, so nothing is duplicated. Bounded
-                        // await; re-check teardown before feeding a possibly-dismantled view.
+                    }
+                    // Size the grid to the reset's geometry FIRST (was previously between clear+seed),
+                    // so nothing later in THIS reset can truncate freshly-fed history.
+                    resizeEmulator(cols: cols, rows: rows, in: view)
+                    if firstReset {
+                        // History ABOVE the seed: feed it now so its lines scroll into SwiftTerm's
+                        // scrollback; the ESC[2J below then erases only the overlapping VISIBLE rows
+                        // (recent's bottom ≈ the current screen) in place — scrollback untouched — and
+                        // the seed repaints them, so nothing is duplicated. Bounded (raced) await;
+                        // re-check teardown before feeding a possibly-dismantled view. The trailing
+                        // ESC[0m resets any SGR the history left active, so ESC[2J's background-colour
+                        // erase can't tint the rows the seed does not repaint.
                         let history = await backfillTask?.value ?? nil
                         if let history, !history.isEmpty, !stopped {
                             view.feed(byteArray: history[...])
+                            view.feed(byteArray: [UInt8]("\u{1b}[0m".utf8)[...])
                         }
                     }
-                    // Clear the VISIBLE screen + home (NOT scrollback — see
-                    // clearSequence, Fix B), then paint the full-screen seed.
-                    // `lagged` resets seed identically (the server already collapsed
-                    // the backlog into this keyframe).
+                    // Clear the VISIBLE screen + home (NOT scrollback — see clearSequence, Fix B),
+                    // then paint the full-screen seed. `lagged` resets seed identically (the server
+                    // already collapsed the backlog into this keyframe).
                     view.feed(byteArray: Self.clearSequence[...])
-                    resizeEmulator(cols: cols, rows: rows, in: view)
                     if !data.isEmpty { view.feed(byteArray: [UInt8](data)[...]) }
                 case .data(_, _, let data):
                     if !data.isEmpty { view.feed(byteArray: [UInt8](data)[...]) }

--- a/HerdrUITests/ScrollTests.swift
+++ b/HerdrUITests/ScrollTests.swift
@@ -92,6 +92,45 @@ final class ScrollTests: XCTestCase {
             "Claude Code pane did NOT scroll: content unchanged after swipe (diff=\(movedDiff)). The drag was not translated into an SGR wheel event for the mouse-mode agent.")
     }
 
+    /// The SCROLLBACK-BACKFILL receipt (open/refresh history). On connect the live stream seeds
+    /// only the CURRENT screen; this proves the connect-time backfill (agent.read source=recent,
+    /// ansi) supplies earlier output so a swipe-up reveals it. The `backfill` mock's LIVE stream
+    /// carries ONLY the short one-screen seed while agent.read returns ~1000 numbered lines — so
+    /// any scrollback the swipe reveals came from the backfill path, not the stream. RED without
+    /// the feature (nothing above the seed to scroll into); GREEN once the backfill fills
+    /// SwiftTerm's scrollback.
+    func testBackfillMakesHistoryScrollable() {
+        let app = XCUIApplication()
+        app.launchEnvironment["HERDR_SCREENSHOT_MOCK"] = "backfill"
+        app.launch()
+        Thread.sleep(forTimeInterval: 3.0)   // launch + backfill read + reset seed feed
+
+        // Static baseline (cursor hidden by the fixture): untouched frames ~identical.
+        let before = app.screenshot()
+        Thread.sleep(forTimeInterval: 1.0)
+        let beforeAgain = app.screenshot()
+        let idleDiff = pixelDiffFraction(before, beforeAgain)
+        attach(before, name: "bf-01-before")
+        XCTAssertLessThan(idleDiff, 0.02,
+            "Backfill mock not static when untouched (diff=\(idleDiff)); would invalidate the scroll check.")
+
+        // Swipe DOWN on the terminal body to reveal the backfilled history above the current
+        // screen (same gesture the omp scroll receipt uses).
+        let high = app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.35))
+        let low  = app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.82))
+        for _ in 0..<3 {
+            high.press(forDuration: 0.05, thenDragTo: low)
+            Thread.sleep(forTimeInterval: 0.2)
+        }
+        Thread.sleep(forTimeInterval: 1.0)
+
+        let after = app.screenshot()
+        attach(after, name: "bf-02-after-swipe")
+        let movedDiff = pixelDiffFraction(before, after)
+        XCTAssertGreaterThan(movedDiff, 0.10,
+            "No backfilled history to scroll into: content unchanged after swiping (diff=\(movedDiff)). The connect-time scrollback backfill did not populate SwiftTerm's scrollback.")
+    }
+
     // MARK: - helpers
 
     private func attach(_ shot: XCUIScreenshot, name: String) {


### PR DESCRIPTION
**Owner request:** "when I open an agent or refresh its terminal, we only load the most recent output and I can't scroll on historical output — if I scroll up, also show the previous outputs from before the refresh/open."

**Root cause:** the live terminal is fed only by `pane.stream`, whose `reset` seed is the current visible screen only; nothing above it to scroll to. Refresh (`.id(streamGen)`) recreates the view, discarding accumulated scrollback.

**Fix (app-only, no server/HerdrKit change):** on each connect, fetch the last 1000 rendered rows via the existing `HerdrClient.read(source:.recent, format:.ansi, lines:)` (the server already retains ~10 MB scrollback per pane) **concurrently** with the live stream, and feed that ANSI history into SwiftTerm's scrollback inside the FIRST `.reset`, just before the existing clear+seed. `ESC[2J` erases the overlapping visible rows in place (scrollback untouched) and the seed repaints the current screen — no duplication. Raises SwiftTerm's scrollback ring from ~500 → 4000 (`Terminal.changeHistorySize`) so the full backfill is retained. Bounded by a 1.2s timeout so a slow read never stalls the seed; live `.data` frames queue in order behind the reset and are never lost. Fed unconditionally (safe for alt-screen: history lands in the normal buffer's scrollback, invisible during fullscreen, present on exit).

**Limit (acceptable):** up to ~1000 rendered lines of history per connect (server `recent` clamp), reflowed to the current width. Plenty for "see output from before the refresh"; more would need server work.

**Receipt (rule 47874):** new `HERDR_SCREENSHOT_MOCK=backfill` — the live stream seeds only one screen while `agent.read` returns 1000 numbered lines, so scrollback can ONLY come from the backfill path — and `HerdrUITests.testBackfillMakesHistoryScrollable` swipes up and asserts content moved (RED without the feature, GREEN with). Existing scroll/paging receipts still green.

Files: `App/LiveTerminalView.swift` (the feature), `App/HerdrApp.swift` (DEBUG mock), `HerdrUITests/ScrollTests.swift` (receipt). `Sources/HerdrKit/HerdrClient.swift` `read(...)` used as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)