### PR TITLE
push: request the permission prompt when a category is toggled on (#67)

### DIFF
--- a/App/AppDelegate.swift
+++ b/App/AppDelegate.swift
@@ -45,9 +45,10 @@ final class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCent
     }
 
     /// Ask for notification permission (and register for APNs) only if the user has at least one push
-    /// category enabled in Settings — mirrors the notify.* toggles so we never prompt for something
-    /// they turned off. NOT called in 2b (the prompt is deferred until push can actually deliver — see
-    /// RootView.connect()); the 2a/2c PR wires the call, once the entitlement + server exist. Static so
+    /// category enabled in Settings — mirrors the notify.* toggles so we never prompt for something they
+    /// turned off. Called from RootView.connect() (now that the entitlement + 2c server exist, push can
+    /// deliver) AND from pushPrefsChanged() (so enabling a category AFTER connect also prompts). iOS shows
+    /// the alert at most once per install; later calls return the existing status silently. Static so
     /// RootView can call it without a reference to the delegate instance.
     static func requestAuthorizationIfWanted() {
         // Never prompt during a buildbox screenshot or an XCUITest run. ScreenshotMock covers the env

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -235,12 +235,15 @@ struct RootView: View {
         Task { try? await client.registerDevice(token: token, needsInput: p.needsInput, dies: p.dies, finishes: p.finishes) }
     }
 
-    /// A push-category toggle changed while connected: re-register the current prefs with the server so
-    /// the change takes effect immediately (no-op until a device token exists — i.e. until push is
-    /// activated in 2a/2c). The permission PROMPT is intentionally NOT triggered here in 2b, for the
-    /// same one-shot-grant reason as connect() — it lands with the entitlement + server in 2a/2c.
+    /// A push-category toggle changed while connected: re-register the current prefs with the server so the
+    /// change takes effect immediately (registerPush is a no-op until a device token exists), AND request the
+    /// permission prompt — so a user who connected with every category OFF (nothing to prompt for then) and
+    /// later enables one gets asked NOW, instead of never. requestAuthorizationIfWanted self-guards on
+    /// `anyEnabled` and skips under ScreenshotMock, and iOS shows the alert at most once per install (later
+    /// calls return the existing status silently), so this is safe + idempotent to call on every toggle.
     private func pushPrefsChanged() {
         registerPush()
+        AppDelegate.requestAuthorizationIfWanted()
     }
 
     #if DEBUG


### PR DESCRIPTION
Closes #67 (the fast-follow from #66's review).

**Gap:** the notification permission prompt fired only on `RootView.connect()` and only if a notify category was already enabled. A user who connected with all categories OFF (no prompt) then enabled one later never got asked → never received push. (Doesn't affect the owner — his defaults are on.)

**Fix:** `pushPrefsChanged()` (the .onChange handler for the three notify toggles) now also calls `AppDelegate.requestAuthorizationIfWanted()` alongside `registerPush()`. The helper already self-guards on `anyEnabled` + skips under ScreenshotMock, and iOS shows the alert once per install (later calls return the existing status silently), so it's safe + idempotent per toggle. On grant → registerForRemoteNotifications → token → registerPush.

Also de-stales two doc comments that still claimed the prompt was 'deferred to the 2a/2c PR' (shipped in v0.1.19). Two-file, +N/-N; not a scroll/gesture change (no rule-47874 receipt). The permission flow isn't unit/UITestable — verified by review + compile + on-device (all categories off → connect → toggle one on → the alert appears).

🤖 Generated with [Claude Code](https://claude.com/claude-code)