### PR TITLE
feat(gram): Gram page — owner<->agent messages (P2)

### DIFF
--- a/App/AppDelegate.swift
+++ b/App/AppDelegate.swift
@@ -85,10 +85,15 @@ final class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCent
         [.banner, .list, .sound]
     }
 
-    // A tap on the notification → deep-link to the agent's pane.
+    // A tap on the notification → deep-link. A gram alert carries `gram: true` and an
+    // empty `pane_id`, so it MUST be checked before the pane branch (an empty pane id
+    // is a non-nil String that would otherwise deep-link to a nonexistent pane).
     func userNotificationCenter(_ center: UNUserNotificationCenter,
                                 didReceive response: UNNotificationResponse) async {
-        if let paneID = response.notification.request.content.userInfo["pane_id"] as? String {
+        let userInfo = response.notification.request.content.userInfo
+        if userInfo["gram"] as? Bool == true {
+            await MainActor.run { PushCenter.shared.tappedGram() }
+        } else if let paneID = userInfo["pane_id"] as? String, !paneID.isEmpty {
             await MainActor.run { PushCenter.shared.tapped(paneID: paneID) }
         }
     }

--- a/App/GramView.swift
+++ b/App/GramView.swift
@@ -18,13 +18,31 @@ struct GramView: View {
     let agents: [AgentInfo]
     var onClose: (() -> Void)?
 
-    @State private var messages: [GramMessage] = []
+    /// The last server snapshot (newest first) and the owner's just-posted messages
+    /// not yet reflected in a snapshot. `messages` composes them so a background poll
+    /// can never drop an optimistic post it hasn't caught up to.
+    @State private var serverMessages: [GramMessage] = []
+    @State private var pendingPosts: [GramMessage] = []
     @State private var phase: LoadPhase = .loading
     @State private var recipient: Recipient = .queue
     @State private var draft: String = ""
     @State private var sending = false
-    @State private var banner: String?
+    /// A send failure. Kept SEPARATE from load state so a successful background poll
+    /// never clears it before the owner sees it.
+    @State private var sendError: String?
+    /// A non-fatal refresh failure while messages are already shown.
+    @State private var refreshNote: String?
     @State private var isLoading = false
+    /// Messages with a mark-read in flight, so a re-`onAppear` (scroll) does not fire
+    /// a duplicate `gram.mark_read`.
+    @State private var markingRead: Set<String> = []
+
+    /// The list the page renders: optimistic posts first, then the server snapshot
+    /// with those posts de-duped out once the server reflects them.
+    private var messages: [GramMessage] {
+        let pendingIDs = Set(pendingPosts.map(\.id))
+        return pendingPosts + serverMessages.filter { !pendingIDs.contains($0.id) }
+    }
 
     private enum LoadPhase: Equatable {
         case loading
@@ -83,8 +101,8 @@ struct GramView: View {
     /// (empty inbox, pre-deploy daemon, or a loaded list alike).
     @ViewBuilder
     private var bannerView: some View {
-        if let banner {
-            Text(banner)
+        if let text = sendError ?? refreshNote {
+            Text(text)
                 .font(Typography.app(12))
                 .foregroundStyle(Palette.died)
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -261,21 +279,23 @@ struct GramView: View {
 
     // MARK: - Actions
 
-    /// Load once, then poll every few seconds while the page is visible so a new
-    /// agent message appears without a manual refresh (the gram store has no event
-    /// stream). Ends when the view goes away (the task is cancelled).
+    /// Load once, then poll while the page is visible so a new agent message appears
+    /// without a manual refresh (the gram store has no event stream). Backs off when
+    /// the server can't serve gram (a pre-deploy daemon), so a failing `gram.list`
+    /// isn't hit every few seconds. Ends when the view goes away (task cancelled).
     private func pollLoop() async {
         await load(initial: true)
         while !Task.isCancelled {
-            try? await Task.sleep(nanoseconds: 6_000_000_000)
+            let interval: UInt64
+            if case .unavailable = phase { interval = 30_000_000_000 } else { interval = 6_000_000_000 }
+            try? await Task.sleep(nanoseconds: interval)
             if Task.isCancelled { break }
             await load(initial: false)
         }
     }
 
     private func load(initial: Bool) async {
-        // One load at a time: overlapping polls/refreshes race, and a load in flight
-        // during a send could overwrite the optimistic insert.
+        // One load at a time: overlapping loads would race each other.
         guard !isLoading else { return }
         isLoading = true
         defer { isLoading = false }
@@ -283,14 +303,20 @@ struct GramView: View {
         // the current messages visible.
         if initial && messages.isEmpty { phase = .loading }
         do {
-            messages = try await client.gramList()
+            let fetched = try await client.gramList()
+            serverMessages = fetched
+            // Drop optimistic posts the server now reflects; unconfirmed ones stay
+            // visible via `messages` (gram.post writes synchronously, so any in-flight
+            // load started BEFORE a post can no longer discard it).
+            let serverIDs = Set(fetched.map(\.id))
+            pendingPosts.removeAll { serverIDs.contains($0.id) }
             phase = .loaded
-            banner = nil
+            refreshNote = nil
         } catch let error as APIError where error.code == "gram_unavailable" {
             if messages.isEmpty {
                 phase = .unavailable("Gram isn't available on this server yet.")
             } else {
-                banner = "Gram is unavailable right now."
+                refreshNote = "Gram is unavailable right now."
             }
         } catch {
             // A daemon predating the gram build answers an unknown-method error, NOT
@@ -300,7 +326,7 @@ struct GramView: View {
                 phase = .unavailable(
                     "Gram isn't available on this server yet, or the messages couldn't load.")
             } else {
-                banner = "Refresh failed — showing the last loaded messages."
+                refreshNote = "Refresh failed — showing the last loaded messages."
             }
         }
     }
@@ -310,30 +336,34 @@ struct GramView: View {
         guard !text.isEmpty, !sending else { return }
         sending = true
         defer { sending = false }
+        sendError = nil
         do {
             let posted = try await client.gramPost(text: text, to: recipient.wireTo)
             draft = ""
-            // Optimistically show it immediately, de-duped by id so a repeat never
-            // collides in the ForEach; the next poll reconciles.
-            messages.removeAll { $0.id == posted.id }
-            messages.insert(posted, at: 0)
-            banner = nil
+            // Optimistic: kept in `pendingPosts`, so a concurrent poll's snapshot
+            // cannot drop it; de-duped by id, reconciled once the server reflects it.
+            pendingPosts.removeAll { $0.id == posted.id }
+            pendingPosts.insert(posted, at: 0)
         } catch let error as APIError {
-            banner = error.message
+            sendError = error.message
         } catch {
-            banner = "Couldn't send. Try again."
+            sendError = "Couldn't send. Try again."
         }
     }
 
     private func markReadIfNeeded(_ message: GramMessage) {
-        guard message.isUnread else { return }
+        // Skip if already read or a mark-read is already in flight for it (onAppear
+        // re-fires on scroll).
+        guard message.isUnread, !markingRead.contains(message.id) else { return }
+        markingRead.insert(message.id)
         Task {
+            defer { markingRead.remove(message.id) }
             do {
                 try await client.gramMarkRead(id: message.id)
-                // Flip the local copy only after the server confirms, so a failed
-                // mark-read doesn't clear the unread dot until it actually took.
-                if let index = messages.firstIndex(where: { $0.id == message.id }) {
-                    messages[index].readByOwner = true
+                // Flip the local copy only after the server confirms — an unread
+                // agent->owner message always lives in the server snapshot.
+                if let index = serverMessages.firstIndex(where: { $0.id == message.id }) {
+                    serverMessages[index].readByOwner = true
                 }
             } catch {
                 // Leave it unread; the next poll re-surfaces it.

--- a/App/GramView.swift
+++ b/App/GramView.swift
@@ -1,0 +1,384 @@
+import HerdrKit
+import SwiftUI
+
+/// The Gram page: the owner's side of the owner<->agent message channel.
+///
+/// The app is the OWNER. This shows the inbox (agent->owner messages the fleet
+/// sent, plus the owner's own posts and their claim state) newest-first, and a
+/// composer to post to the shared grab-queue or one agent directly. Text only;
+/// file attachments are a later phase.
+///
+/// Nav-agnostic: it renders its own content and takes an optional `onClose` — a
+/// modal cover passes one (a close button appears); a persistent tab passes nil.
+/// It owns its polling and never blocks the caller.
+struct GramView: View {
+    let client: HerdrClient
+    /// Live agents, for the direct-recipient picker. Only named agents can be
+    /// addressed directly (the server validates `to` against a live agent name).
+    let agents: [AgentInfo]
+    var onClose: (() -> Void)?
+
+    @State private var messages: [GramMessage] = []
+    @State private var phase: LoadPhase = .loading
+    @State private var recipient: Recipient = .queue
+    @State private var draft: String = ""
+    @State private var sending = false
+    @State private var banner: String?
+
+    private enum LoadPhase: Equatable {
+        case loading
+        case loaded
+        /// The server does not offer gram yet (older daemon), or another load error.
+        case unavailable(String)
+    }
+
+    /// Where a composed message goes.
+    private enum Recipient: Hashable {
+        case queue
+        case agent(String)
+
+        var wireTo: String? {
+            switch self {
+            case .queue: return nil
+            case .agent(let name): return name
+            }
+        }
+        var label: String {
+            switch self {
+            case .queue: return "Shared queue"
+            case .agent(let name): return name
+            }
+        }
+    }
+
+    /// Named agents, de-duplicated, sorted — the addressable direct recipients.
+    private var addressableAgents: [String] {
+        var seen = Set<String>()
+        var names: [String] = []
+        for agent in agents {
+            guard let name = agent.name, !name.isEmpty, seen.insert(name).inserted else { continue }
+            names.append(name)
+        }
+        return names.sorted()
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider().overlay(Palette.hairlineQuiet)
+            content
+            composer
+        }
+        .background(Palette.ground.ignoresSafeArea())
+        .task { await load(initial: true) }
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack(spacing: 10) {
+            Text("Gram")
+                .font(Typography.app(20, .semibold))
+                .foregroundStyle(Palette.text)
+            if unreadCount > 0 {
+                Text("\(unreadCount)")
+                    .font(Typography.machine(11, .semibold))
+                    .foregroundStyle(Palette.ground)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(Capsule().fill(Palette.waiting))
+            }
+            Spacer()
+            Button {
+                Task { await load(initial: false) }
+            } label: {
+                Image(systemName: "arrow.clockwise")
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundStyle(Palette.textDim)
+            }
+            if let onClose {
+                Button(action: onClose) {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 15, weight: .semibold))
+                        .foregroundStyle(Palette.textDim)
+                }
+                .padding(.leading, 4)
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+    }
+
+    private var unreadCount: Int { messages.filter { $0.isUnread }.count }
+
+    // MARK: - Content
+
+    @ViewBuilder
+    private var content: some View {
+        switch phase {
+        case .loading:
+            centered { ProgressView().tint(Palette.textDim) }
+        case .unavailable(let message):
+            centered {
+                VStack(spacing: 8) {
+                    Image(systemName: "bubble.left.and.exclamationmark.bubble.right")
+                        .font(.system(size: 28))
+                        .foregroundStyle(Palette.textFaint)
+                    Text(message)
+                        .font(Typography.app(14))
+                        .foregroundStyle(Palette.textDim)
+                        .multilineTextAlignment(.center)
+                }
+                .padding(.horizontal, 32)
+            }
+        case .loaded where messages.isEmpty:
+            centered {
+                VStack(spacing: 8) {
+                    Image(systemName: "tray")
+                        .font(.system(size: 28))
+                        .foregroundStyle(Palette.textFaint)
+                    Text("No messages yet")
+                        .font(Typography.app(15, .medium))
+                        .foregroundStyle(Palette.textDim)
+                    Text("Agents you message, and their replies, appear here.")
+                        .font(Typography.app(13))
+                        .foregroundStyle(Palette.textFaint)
+                        .multilineTextAlignment(.center)
+                }
+                .padding(.horizontal, 32)
+            }
+        case .loaded:
+            ScrollView {
+                LazyVStack(spacing: 10) {
+                    if let banner {
+                        Text(banner)
+                            .font(Typography.app(12))
+                            .foregroundStyle(Palette.died)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                    ForEach(messages) { message in
+                        GramRow(message: message)
+                            .onAppear { markReadIfNeeded(message) }
+                    }
+                }
+                .padding(16)
+            }
+            .refreshable { await load(initial: false) }
+        }
+    }
+
+    private func centered<V: View>(@ViewBuilder _ inner: () -> V) -> some View {
+        VStack { Spacer(); inner(); Spacer() }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    // MARK: - Composer
+
+    private var composer: some View {
+        VStack(spacing: 8) {
+            Divider().overlay(Palette.hairlineQuiet)
+            HStack(spacing: 8) {
+                Text("To")
+                    .font(Typography.machine(11, .semibold))
+                    .foregroundStyle(Palette.textFaint)
+                Menu {
+                    Button { recipient = .queue } label: {
+                        Label("Shared queue (any agent)", systemImage: "tray.and.arrow.down")
+                    }
+                    if !addressableAgents.isEmpty {
+                        Divider()
+                        ForEach(addressableAgents, id: \.self) { name in
+                            Button { recipient = .agent(name) } label: { Text(name) }
+                        }
+                    }
+                } label: {
+                    HStack(spacing: 4) {
+                        Text(recipient.label)
+                            .font(Typography.app(13, .medium))
+                            .foregroundStyle(Palette.text)
+                        Image(systemName: "chevron.up.chevron.down")
+                            .font(.system(size: 10, weight: .semibold))
+                            .foregroundStyle(Palette.textFaint)
+                    }
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 5)
+                    .background(RoundedRectangle(cornerRadius: 7).fill(Palette.surface))
+                }
+                Spacer(minLength: 0)
+            }
+            HStack(alignment: .bottom, spacing: 8) {
+                TextField("Message an agent…", text: $draft, axis: .vertical)
+                    .font(Typography.app(15))
+                    .foregroundStyle(Palette.text)
+                    .tint(Palette.text)
+                    .lineLimit(1...5)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 9)
+                    .background(RoundedRectangle(cornerRadius: 10).fill(Palette.surface))
+                Button {
+                    Task { await send() }
+                } label: {
+                    Image(systemName: "arrow.up")
+                        .font(.system(size: 16, weight: .bold))
+                        .foregroundStyle(canSend ? Palette.ground : Palette.textFaint)
+                        .frame(width: 38, height: 38)
+                        .background(Circle().fill(canSend ? Palette.text : Palette.surface))
+                }
+                .disabled(!canSend)
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.top, 8)
+        .padding(.bottom, 12)
+        .background(Palette.ground)
+    }
+
+    private var canSend: Bool {
+        !sending && !draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    // MARK: - Actions
+
+    private func load(initial: Bool) async {
+        // Show the spinner only on the first load with nothing to show yet; a
+        // refresh keeps the current messages visible.
+        if initial && messages.isEmpty { phase = .loading }
+        do {
+            let fetched = try await client.gramList()
+            messages = fetched
+            phase = .loaded
+            banner = nil
+        } catch let error as APIError where error.code == "gram_unavailable" {
+            phase = .unavailable("Gram isn't available on this server yet.")
+        } catch {
+            if messages.isEmpty {
+                phase = .unavailable("Couldn't load messages. Pull to retry.")
+            } else {
+                banner = "Refresh failed — showing the last loaded messages."
+            }
+        }
+    }
+
+    private func send() async {
+        let text = draft.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty, !sending else { return }
+        sending = true
+        defer { sending = false }
+        do {
+            let posted = try await client.gramPost(text: text, to: recipient.wireTo)
+            draft = ""
+            // Optimistically show it immediately, then reconcile on the next load.
+            messages.insert(posted, at: 0)
+            banner = nil
+        } catch let error as APIError {
+            banner = error.message
+        } catch {
+            banner = "Couldn't send. Try again."
+        }
+    }
+
+    private func markReadIfNeeded(_ message: GramMessage) {
+        guard message.isUnread else { return }
+        Task {
+            try? await client.gramMarkRead(id: message.id)
+            // Optimistically flip the local copy so the unread dot/badge clears.
+            if let index = messages.firstIndex(where: { $0.id == message.id }) {
+                messages[index].readByOwner = true
+            }
+        }
+    }
+}
+
+/// One message row. Agent->owner shows the sender's identity chip; owner->agent
+/// shows the recipient and the claim state of a queued item.
+private struct GramRow: View {
+    let message: GramMessage
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 10) {
+            avatar
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(spacing: 6) {
+                    Text(title)
+                        .font(Typography.app(13, .semibold))
+                        .foregroundStyle(Palette.text)
+                    if message.isUnread {
+                        Circle().fill(Palette.waiting).frame(width: 7, height: 7)
+                    }
+                    Spacer(minLength: 0)
+                    Text(age)
+                        .font(Typography.machine(11))
+                        .foregroundStyle(Palette.textFaint)
+                }
+                Text(message.text)
+                    .font(Typography.app(14))
+                    .foregroundStyle(Palette.textDim)
+                    .fixedSize(horizontal: false, vertical: true)
+                if let status = statusLine {
+                    Text(status)
+                        .font(Typography.machine(11))
+                        .foregroundStyle(statusColor)
+                }
+            }
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(RoundedRectangle(cornerRadius: 12).fill(Palette.card))
+        .overlay(RoundedRectangle(cornerRadius: 12).stroke(Palette.hairlineQuiet, lineWidth: 1))
+    }
+
+    @ViewBuilder
+    private var avatar: some View {
+        if message.isFromAgent {
+            Text(AgentIdentity.glyph(for: message.from))
+                .font(Typography.app(14, .bold))
+                .foregroundStyle(Palette.text)
+                .frame(width: 30, height: 30)
+                .background(AgentIdentity.gradient(for: message.from), in: RoundedRectangle(cornerRadius: 8))
+        } else {
+            Image(systemName: "arrow.up.forward")
+                .font(.system(size: 13, weight: .bold))
+                .foregroundStyle(Palette.textDim)
+                .frame(width: 30, height: 30)
+                .background(RoundedRectangle(cornerRadius: 8).fill(Palette.surfaceRaised))
+        }
+    }
+
+    private var title: String {
+        if message.isFromAgent {
+            return message.from
+        }
+        if let to = message.to {
+            return "You → \(to)"
+        }
+        return "You → queue"
+    }
+
+    /// Claim state for the owner's queue posts.
+    private var statusLine: String? {
+        guard !message.isFromAgent else { return nil }
+        if let grabber = message.grabbedBy {
+            return "grabbed by \(grabber)"
+        }
+        if message.to == nil {
+            return "unclaimed"
+        }
+        return nil
+    }
+
+    private var statusColor: Color {
+        message.grabbedBy != nil ? Palette.done : Palette.textFaint
+    }
+
+    private var age: String { Self.age(from: message.createdAt) }
+
+    static func age(from date: Date) -> String {
+        let seconds = max(0, Date().timeIntervalSince(date))
+        switch seconds {
+        case ..<60: return "now"
+        case ..<3600: return "\(Int(seconds / 60))m"
+        case ..<86400: return "\(Int(seconds / 3600))h"
+        default: return "\(Int(seconds / 86400))d"
+        }
+    }
+}

--- a/App/GramView.swift
+++ b/App/GramView.swift
@@ -24,6 +24,7 @@ struct GramView: View {
     @State private var draft: String = ""
     @State private var sending = false
     @State private var banner: String?
+    @State private var isLoading = false
 
     private enum LoadPhase: Equatable {
         case loading
@@ -67,10 +68,29 @@ struct GramView: View {
             header
             Divider().overlay(Palette.hairlineQuiet)
             content
+            bannerView
             composer
         }
         .background(Palette.ground.ignoresSafeArea())
-        .task { await load(initial: true) }
+        // Poll while the page is open so new agent messages appear without a manual
+        // refresh (the gram store has no event stream); the loop ends when the view
+        // goes away (task cancellation).
+        .task { await pollLoop() }
+    }
+
+    /// A load error / send error, shown ABOVE the composer in every phase — the
+    /// composer is enabled in all states, so a failure must be visible in all states
+    /// (empty inbox, pre-deploy daemon, or a loaded list alike).
+    @ViewBuilder
+    private var bannerView: some View {
+        if let banner {
+            Text(banner)
+                .font(Typography.app(12))
+                .foregroundStyle(Palette.died)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 16)
+                .padding(.top, 8)
+        }
     }
 
     // MARK: - Header
@@ -120,7 +140,7 @@ struct GramView: View {
             centered { ProgressView().tint(Palette.textDim) }
         case .unavailable(let message):
             centered {
-                VStack(spacing: 8) {
+                VStack(spacing: 12) {
                     Image(systemName: "bubble.left.and.exclamationmark.bubble.right")
                         .font(.system(size: 28))
                         .foregroundStyle(Palette.textFaint)
@@ -128,6 +148,14 @@ struct GramView: View {
                         .font(Typography.app(14))
                         .foregroundStyle(Palette.textDim)
                         .multilineTextAlignment(.center)
+                    Button { Task { await load(initial: true) } } label: {
+                        Text("Retry")
+                            .font(Typography.app(14, .semibold))
+                            .foregroundStyle(Palette.ground)
+                            .padding(.horizontal, 20)
+                            .padding(.vertical, 8)
+                            .background(Capsule().fill(Palette.text))
+                    }
                 }
                 .padding(.horizontal, 32)
             }
@@ -150,12 +178,6 @@ struct GramView: View {
         case .loaded:
             ScrollView {
                 LazyVStack(spacing: 10) {
-                    if let banner {
-                        Text(banner)
-                            .font(Typography.app(12))
-                            .foregroundStyle(Palette.died)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                    }
                     ForEach(messages) { message in
                         GramRow(message: message)
                             .onAppear { markReadIfNeeded(message) }
@@ -239,20 +261,44 @@ struct GramView: View {
 
     // MARK: - Actions
 
+    /// Load once, then poll every few seconds while the page is visible so a new
+    /// agent message appears without a manual refresh (the gram store has no event
+    /// stream). Ends when the view goes away (the task is cancelled).
+    private func pollLoop() async {
+        await load(initial: true)
+        while !Task.isCancelled {
+            try? await Task.sleep(nanoseconds: 6_000_000_000)
+            if Task.isCancelled { break }
+            await load(initial: false)
+        }
+    }
+
     private func load(initial: Bool) async {
-        // Show the spinner only on the first load with nothing to show yet; a
-        // refresh keeps the current messages visible.
+        // One load at a time: overlapping polls/refreshes race, and a load in flight
+        // during a send could overwrite the optimistic insert.
+        guard !isLoading else { return }
+        isLoading = true
+        defer { isLoading = false }
+        // Spinner only on the first load with nothing to show yet; a refresh keeps
+        // the current messages visible.
         if initial && messages.isEmpty { phase = .loading }
         do {
-            let fetched = try await client.gramList()
-            messages = fetched
+            messages = try await client.gramList()
             phase = .loaded
             banner = nil
         } catch let error as APIError where error.code == "gram_unavailable" {
-            phase = .unavailable("Gram isn't available on this server yet.")
-        } catch {
             if messages.isEmpty {
-                phase = .unavailable("Couldn't load messages. Pull to retry.")
+                phase = .unavailable("Gram isn't available on this server yet.")
+            } else {
+                banner = "Gram is unavailable right now."
+            }
+        } catch {
+            // A daemon predating the gram build answers an unknown-method error, NOT
+            // `gram_unavailable`, so a first-load failure gets one honest message
+            // covering both "not deployed yet" and "couldn't reach it", plus a Retry.
+            if messages.isEmpty {
+                phase = .unavailable(
+                    "Gram isn't available on this server yet, or the messages couldn't load.")
             } else {
                 banner = "Refresh failed — showing the last loaded messages."
             }
@@ -267,7 +313,9 @@ struct GramView: View {
         do {
             let posted = try await client.gramPost(text: text, to: recipient.wireTo)
             draft = ""
-            // Optimistically show it immediately, then reconcile on the next load.
+            // Optimistically show it immediately, de-duped by id so a repeat never
+            // collides in the ForEach; the next poll reconciles.
+            messages.removeAll { $0.id == posted.id }
             messages.insert(posted, at: 0)
             banner = nil
         } catch let error as APIError {
@@ -280,10 +328,15 @@ struct GramView: View {
     private func markReadIfNeeded(_ message: GramMessage) {
         guard message.isUnread else { return }
         Task {
-            try? await client.gramMarkRead(id: message.id)
-            // Optimistically flip the local copy so the unread dot/badge clears.
-            if let index = messages.firstIndex(where: { $0.id == message.id }) {
-                messages[index].readByOwner = true
+            do {
+                try await client.gramMarkRead(id: message.id)
+                // Flip the local copy only after the server confirms, so a failed
+                // mark-read doesn't clear the unread dot until it actually took.
+                if let index = messages.firstIndex(where: { $0.id == message.id }) {
+                    messages[index].readByOwner = true
+                }
+            } catch {
+                // Leave it unread; the next poll re-surfaces it.
             }
         }
     }

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -306,9 +306,10 @@ struct RootView: View {
             PagingTestHarness(client: mockClient)
         case .gram:
             // The Gram page over a mock that answers gram.list with a canned owner
-            // view. Empty `agents` keeps the recipient picker to the shared queue —
-            // the messages + claim states are what this FYI shows.
-            GramView(client: mockClient, agents: [], onClose: {})
+            // view. Empty `agents` keeps the recipient picker to the shared queue;
+            // onClose nil hides the close X (there is nothing to dismiss to in the
+            // standalone screenshot render). The messages + claim states are the FYI.
+            GramView(client: mockClient, agents: [], onClose: nil)
         }
     }
     #endif
@@ -969,6 +970,14 @@ struct TerminalHomeView: View {
     /// flag before this view existed). Clearing it lets a later tap re-trigger.
     private func openGramIfPending() {
         guard push.pendingGram else { return }
+        // Another cover is already presented: `fullScreenCover(item:)` does not
+        // reliably swap to a new item while up, so dismiss it first (keeping the flag
+        // armed). The cover's onDismiss re-invokes this, and with none presented it
+        // opens the Gram page.
+        if let current = activeCover, current != .gram {
+            activeCover = nil
+            return
+        }
         push.pendingGram = false
         activeCover = .gram
     }
@@ -1037,6 +1046,7 @@ struct TerminalHomeView: View {
         // onDismiss applies a queued open AFTER the cover is fully gone.
         .fullScreenCover(item: $activeCover, onDismiss: {
             if let slot = pendingOpenSlot { pendingOpenSlot = nil; open(slot) }
+            openGramIfPending()   // a gram tap deferred while another cover was up
         }) { cover in
             switch cover {
             case .settings:

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -185,6 +185,7 @@ struct RootView: View {
     @AppStorage("notify.needsInput") private var notifyNeedsInput = true
     @AppStorage("notify.dies") private var notifyDies = true
     @AppStorage("notify.finishes") private var notifyFinishes = false
+    @AppStorage("notify.gram") private var notifyGram = true
 
     var body: some View {
         Group {
@@ -220,6 +221,7 @@ struct RootView: View {
             .onChange(of: notifyNeedsInput) { _, _ in pushPrefsChanged() }
             .onChange(of: notifyDies) { _, _ in pushPrefsChanged() }
             .onChange(of: notifyFinishes) { _, _ in pushPrefsChanged() }
+            .onChange(of: notifyGram) { _, _ in pushPrefsChanged() }
         } else {
             ConnectView { connect($0) }
         }
@@ -232,7 +234,7 @@ struct RootView: View {
         // `client`, which the SwiftUI setter may not have published through yet on the same tick.
         guard let client = explicitClient ?? self.client, let token = push.deviceToken else { return }
         let p = PushCenter.Prefs.current
-        Task { try? await client.registerDevice(token: token, needsInput: p.needsInput, dies: p.dies, finishes: p.finishes) }
+        Task { try? await client.registerDevice(token: token, needsInput: p.needsInput, dies: p.dies, finishes: p.finishes, gram: p.gram) }
     }
 
     /// A push-category toggle changed while connected: re-register the current prefs with the server so the
@@ -302,6 +304,11 @@ struct RootView: View {
             // swipe-between-agents receipt. The pane ids are NOT in the mock agent.list, so
             // reresolveAgent leaves the seeded identity in place and the header stays stable.
             PagingTestHarness(client: mockClient)
+        case .gram:
+            // The Gram page over a mock that answers gram.list with a canned owner
+            // view. Empty `agents` keeps the recipient picker to the shared queue —
+            // the messages + claim states are what this FYI shows.
+            GramView(client: mockClient, agents: [], onClose: {})
         }
     }
     #endif
@@ -858,7 +865,7 @@ struct TerminalHomeView: View {
     @State private var activeCover: ActiveCover?
 
     private enum ActiveCover: Int, Identifiable {
-        case settings, newAgent
+        case settings, newAgent, gram
         var id: Int { rawValue }
     }
 
@@ -957,6 +964,15 @@ struct TerminalHomeView: View {
                       initialReply: "", siblings: orderedSiblings))
     }
 
+    /// A tapped gram push opens the Gram cover. Like `applyDeepLink`, it is consumed
+    /// on the onChange path (app already up) AND post-load (a cold-launch tap set the
+    /// flag before this view existed). Clearing it lets a later tap re-trigger.
+    private func openGramIfPending() {
+        guard push.pendingGram else { return }
+        push.pendingGram = false
+        activeCover = .gram
+    }
+
     /// Swipe-page from the fronted pane to its prev/next sibling (clamped). `open()`s the
     /// neighbour — instant if it is already mounted.
     private func navigate(from slot: PaneSlot, delta: Int) {
@@ -1004,6 +1020,7 @@ struct TerminalHomeView: View {
                 // on the list) deep-links immediately; the cold-launch / just-loaded case is handled
                 // at the end of load().
                 .onChange(of: push.pendingPaneID) { _, newValue in if newValue != nil { applyDeepLink() } }
+                .onChange(of: push.pendingGram) { _, newValue in if newValue { openGramIfPending() } }
             }
             // Recently-opened terminals kept MOUNTED so reopening + swiping between them is
             // instant (nothing torn down or re-streamed). Overlays the list: a fronted pane
@@ -1043,6 +1060,11 @@ struct TerminalHomeView: View {
                         activeCover = nil
                     },
                     onCancel: { activeCover = nil })
+            case .gram:
+                GramView(
+                    client: client,
+                    agents: agents,
+                    onClose: { activeCover = nil })
             }
         }
     }
@@ -1115,6 +1137,10 @@ struct TerminalHomeView: View {
             }
             .buttonStyle(.plain)
             .disabled(terminalTarget == nil)
+            Button { activeCover = .gram } label: {
+                tabItem("bubble.left.and.bubble.right", "Gram", active: false)
+            }
+            .buttonStyle(.plain)
             Button { activeCover = .settings } label: {
                 tabItem("gearshape", "Settings", active: false)
             }
@@ -1371,6 +1397,7 @@ struct TerminalHomeView: View {
             everLive.formUnion(live)
             slots.removeAll { $0.paneID != frontID && everLive.contains($0.paneID) && !live.contains($0.paneID) }
             applyDeepLink(afterLoad: true)   // agents + roster loaded — front any pending push target
+            openGramIfPending()              // a cold-launch gram tap opens the Gram page once loaded
         } catch {
             let rejected: String?
             if let transportError = error as? TransportError,
@@ -2113,6 +2140,7 @@ struct SettingsView: View {
     @AppStorage("notify.needsInput") private var notifyNeedsInput = true
     @AppStorage("notify.dies") private var notifyDies = true
     @AppStorage("notify.finishes") private var notifyFinishes = false
+    @AppStorage("notify.gram") private var notifyGram = true
     @State private var copied = false
 
     var body: some View {
@@ -2173,6 +2201,7 @@ struct SettingsView: View {
             toggleRow("An agent needs input", $notifyNeedsInput)
             toggleRow("An agent dies", $notifyDies)
             toggleRow("An agent finishes", $notifyFinishes)
+            toggleRow("A gram message arrives", $notifyGram)
             // Honest about delivery: the toggles persist the choice, but push
             // delivery is not wired yet — do not imply live notifications.
             Text("Delivery is coming soon — these save your preference.")
@@ -2328,7 +2357,7 @@ struct PagingTestHarness: View {
 #endif
 
 enum ScreenshotMock {
-    case list, pane, settings, newAgent, scroll, ccscroll, paging, backfill
+    case list, pane, settings, newAgent, scroll, ccscroll, paging, backfill, gram
 
     static var mode: ScreenshotMock? {
         let env = ProcessInfo.processInfo.environment["HERDR_SCREENSHOT_MOCK"]?.lowercased()
@@ -2353,6 +2382,9 @@ enum ScreenshotMock {
         // short one-screen seed, while agent.read (recent, ansi) returns ~1000 lines of history
         // — so scrollback the swipe reveals can ONLY have come from the connect-time backfill.
         case "backfill": return .backfill
+        // `gram` renders the Gram page from a canned owner-view gram.list — the
+        // messages, unread badge, claim states, and composer, for a layout FYI.
+        case "gram": return .gram
         default: return .list
         }
     }
@@ -2380,6 +2412,8 @@ struct MockTransport: HerdrTransport {
         ccDriver?.received(requestLine)
         if requestLine.contains("agent.list") { return Self.agentList }
         if requestLine.contains("agent.read") { return backfill ? Self.backfillRead() : Self.agentRead }
+        if requestLine.contains("gram.list") { return Self.gramList }
+        if requestLine.contains("gram.post") { return Self.gramPosted }
         if requestLine.contains("pane.set_pty_size") { return Self.panePtySize }
         return #"{"id":"mock","result":{}}"#
     }
@@ -2469,6 +2503,22 @@ struct MockTransport: HerdrTransport {
     static let agentRead = #"""
     {"id":"mock","result":{"read":{"pane_id":"w1:p1","text":"$ herdr agent attach jarvis\n\n> Ran 146 tests, 0 failures\n> Edited SessionRecoveryTests.swift  +18 -4\n\nRun `swift test` with -Xswiftc -warnings-as-errors?\n  1. yes\n  2. no, skip it\n>\n\n[demo data - mock render mode, no live connection]","truncated":false,"source":"recent_unwrapped","format":"text"}}}
     """#
+
+    /// `gram.list` owner view for the Gram-page mock render. Byte-identical to
+    /// MockWireFixtures.gramList in the tests, where it is machine-checked to decode.
+    static let gramList = #"""
+    {"id":"mock","result":{"type":"gram_list","messages":[
+      {"id":"g1","direction":"agent_to_owner","from":"trend-scout","text":"Digest ready: 7 trends, 2 need your call.","created_unix_ms":1723000005000,"read_by_owner":false},
+      {"id":"g2","direction":"owner_to_agent","from":"owner","text":"Anyone free to triage the failing CI?","created_unix_ms":1723000004000,"read_by_owner":true},
+      {"id":"g3","direction":"owner_to_agent","from":"owner","text":"Rebase the vetrina branch onto main.","grabbed_by":"herdr-app","grabbed_unix_ms":1723000004500,"created_unix_ms":1723000003000,"read_by_owner":true},
+      {"id":"g4","direction":"owner_to_agent","from":"owner","to":"clientloop","text":"Ship the Amigo POC scaffold today.","created_unix_ms":1723000002000,"read_by_owner":true},
+      {"id":"g5","direction":"agent_to_owner","from":"vetrina","text":"Deployed vetrina.dev — it is live.","created_unix_ms":1723000001000,"read_by_owner":true}
+    ]}}
+    """#
+
+    /// A canned `gram.post` echo, so the mock composer's send path resolves.
+    static let gramPosted =
+        #"{"id":"mock","result":{"type":"gram_sent","message":{"id":"gp1","direction":"owner_to_agent","from":"owner","text":"(sent)","created_unix_ms":1723000006000,"read_by_owner":true}}}"#
 
     // pane.stream / pane.set_pty_size fixtures for the live terminal. Byte-identical
     // to MockWireFixtures in Tests/HerdrKitTests/MockWireFixtureTests.swift, which is

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -1419,6 +1419,10 @@ struct TerminalHomeView: View {
             // yank the reader into a stale pane (an agent that may have finished long ago). If it was
             // already opened by the onChange path, this is nil already. They can reopen from the list.
             push.pendingPaneID = nil
+            // Same for a pending gram tap: a message does not go stale like a pane,
+            // but popping the Gram cover on some much-later successful load is a
+            // surprise; drop it for the same reason and consistency.
+            push.pendingGram = false
         }
     }
 }

--- a/App/PushCenter.swift
+++ b/App/PushCenter.swift
@@ -18,6 +18,10 @@ final class PushCenter: ObservableObject {
     /// its agent list has loaded, then clears it. Held here so a cold-launch tap (app was closed)
     /// and a tap during a reconnect both survive until the view can act on it.
     @Published var pendingPaneID: String?
+    /// Set when the user taps a gram push (the payload carries `gram: true`, no pane). The home view
+    /// opens the Gram page then clears it. Held here so a cold-launch tap (app was closed) survives
+    /// until the view can act, exactly like `pendingPaneID`.
+    @Published var pendingGram: Bool = false
 
     private static let tokenKey = "push.deviceToken"
 
@@ -37,19 +41,26 @@ final class PushCenter: ObservableObject {
         pendingPaneID = paneID
     }
 
+    /// A gram push was tapped — open the Gram page when the view is ready.
+    func tappedGram() {
+        pendingGram = true
+    }
+
     /// The user's per-category push preferences (the existing Settings toggles), sent to the server
     /// alongside the token so it only pushes the kinds they want. Defaults match SettingsView.
     struct Prefs: Equatable {
         var needsInput: Bool
         var dies: Bool
         var finishes: Bool
+        var gram: Bool
         static var current: Prefs {
             let d = UserDefaults.standard
             return Prefs(
                 needsInput: d.object(forKey: "notify.needsInput") as? Bool ?? true,
                 dies:       d.object(forKey: "notify.dies") as? Bool ?? true,
-                finishes:   d.object(forKey: "notify.finishes") as? Bool ?? false)
+                finishes:   d.object(forKey: "notify.finishes") as? Bool ?? false,
+                gram:       d.object(forKey: "notify.gram") as? Bool ?? true)
         }
-        var anyEnabled: Bool { needsInput || dies || finishes }
+        var anyEnabled: Bool { needsInput || dies || finishes || gram }
     }
 }

--- a/HerdrUITests/GramTests.swift
+++ b/HerdrUITests/GramTests.swift
@@ -1,0 +1,35 @@
+import XCTest
+
+/// Smoke test for the Gram page. Launches into the `gram` screenshot mock — a
+/// canned owner-view `gram.list` (agent->owner messages, owner posts, an
+/// unclaimed queue item, a grabbed one, a direct message) — and asserts the page
+/// renders its title and a message, then attaches a screenshot for the CI
+/// artifact / layout FYI. Unlike the scroll receipts this exercises no gesture;
+/// it just proves GramView builds and renders the mock owner view.
+final class GramTests: XCTestCase {
+
+    override func setUp() { continueAfterFailure = false }
+
+    func testGramPageRenders() {
+        let app = XCUIApplication()
+        app.launchEnvironment["HERDR_SCREENSHOT_MOCK"] = "gram"
+        app.launch()
+
+        // The title renders once the view is up.
+        XCTAssertTrue(app.staticTexts["Gram"].waitForExistence(timeout: 8),
+                      "the Gram page title should render")
+
+        // Give the mock gram.list a moment to load + lay out the rows.
+        Thread.sleep(forTimeInterval: 2.0)
+
+        // A canned agent->owner message's sender label should appear.
+        XCTAssertTrue(app.staticTexts["trend-scout"].waitForExistence(timeout: 5),
+                      "an agent->owner message should render its sender")
+
+        let shot = app.screenshot()
+        let attachment = XCTAttachment(screenshot: shot)
+        attachment.name = "gram-page"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+}

--- a/Sources/HerdrKit/Gram.swift
+++ b/Sources/HerdrKit/Gram.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+// Wire types for herdr's `gram.*` methods — the owner<->agent message channel.
+// Field names mirror the server schema (src/api/schema/gram.rs::GramMessageInfo)
+// so the app decodes it byte-for-byte. The app is the OWNER: it reads the owner
+// view (`gram.list` with no caller pane), posts to agents (`gram.post`), and
+// marks messages read (`gram.mark_read`). `gram.send`/`gram.grab` are agent-side
+// (the `herdr gram` CLI) and are intentionally not modelled here.
+
+/// Which way a gram message flows.
+public enum GramDirection: String, Decodable, Sendable, Equatable {
+    case agentToOwner = "agent_to_owner"
+    case ownerToAgent = "owner_to_agent"
+}
+
+/// One gram message as returned by the server.
+public struct GramMessage: Decodable, Identifiable, Sendable, Equatable {
+    public let id: String
+    public let direction: GramDirection
+    /// Sender identity: an agent's name/identity for `agentToOwner`, or "owner".
+    public let from: String
+    /// For `ownerToAgent`: the addressed agent (direct), or nil for the shared
+    /// grab-queue. Always nil for `agentToOwner`.
+    public let to: String?
+    public let text: String
+    /// The agent that claimed a shared-queue item; nil while unclaimed.
+    public let grabbedBy: String?
+    public let grabbedUnixMs: UInt64?
+    public let createdUnixMs: UInt64
+    /// The owner has viewed this `agentToOwner` message. `var` so the app can flip
+    /// it locally for an optimistic update after `gram.mark_read` (the rest of the
+    /// message is immutable / decode-only).
+    public var readByOwner: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case id, direction, from, to, text
+        case grabbedBy = "grabbed_by"
+        case grabbedUnixMs = "grabbed_unix_ms"
+        case createdUnixMs = "created_unix_ms"
+        case readByOwner = "read_by_owner"
+    }
+
+    /// A message an agent sent the owner (vs one the owner posted).
+    public var isFromAgent: Bool { direction == .agentToOwner }
+
+    /// A shared, still-open queue item the owner posted (any agent may claim).
+    public var isOpenQueueItem: Bool {
+        direction == .ownerToAgent && to == nil && grabbedBy == nil
+    }
+
+    /// An agent->owner message the owner has not yet read.
+    public var isUnread: Bool { isFromAgent && !readByOwner }
+
+    public var createdAt: Date { Date(timeIntervalSince1970: Double(createdUnixMs) / 1000.0) }
+}
+
+/// `gram.list` result (`type: "gram_list"`). Only `messages` is decoded.
+struct GramListResult: Decodable {
+    let messages: [GramMessage]
+}
+
+/// `gram.post` / `gram.send` / `gram.grab` result (`type` varies). Only the echoed
+/// `message` is decoded — the type discriminator is ignored.
+struct GramMessageResult: Decodable {
+    let message: GramMessage
+}

--- a/Sources/HerdrKit/HerdrClient.swift
+++ b/Sources/HerdrKit/HerdrClient.swift
@@ -166,25 +166,75 @@ public actor HerdrClient {
         let notifyNeedsInput: Bool
         let notifyDies: Bool
         let notifyFinishes: Bool
+        let notifyGram: Bool
         enum CodingKeys: String, CodingKey {
             case deviceToken = "device_token"
             case platform
             case notifyNeedsInput = "notify_needs_input"
             case notifyDies = "notify_dies"
             case notifyFinishes = "notify_finishes"
+            case notifyGram = "notify_gram"
         }
     }
 
     /// Register this device's APNs token so the server can push agent transitions (needs-you /
-    /// finished / stopped) even while the app is closed, filtered by the user's category prefs.
-    /// Idempotent — safe to re-send on every (re)connect and whenever a token or pref changes. A
-    /// server that does not yet implement the method just throws, which the caller ignores.
-    public func registerDevice(token: String, needsInput: Bool, dies: Bool, finishes: Bool) async throws {
+    /// finished / stopped) and gram messages even while the app is closed, filtered by the user's
+    /// category prefs. Idempotent — safe to re-send on every (re)connect and whenever a token or
+    /// pref changes. A server that does not yet implement the method (or the `notify_gram` field)
+    /// just ignores what it does not know, and an older server throws, which the caller ignores.
+    public func registerDevice(
+        token: String, needsInput: Bool, dies: Bool, finishes: Bool, gram: Bool
+    ) async throws {
         _ = try await call("notifications.register_device",
                            RegisterDeviceParams(deviceToken: token, platform: "apns",
                                                 notifyNeedsInput: needsInput, notifyDies: dies,
-                                                notifyFinishes: finishes),
+                                                notifyFinishes: finishes, notifyGram: gram),
                            as: JSONNull.self)
+    }
+
+    // MARK: - Gram (owner<->agent messages)
+
+    struct GramListParams: Encodable {
+        let callerPaneID: String?
+        let onlyQueue: Bool
+        let unreadOnly: Bool
+        enum CodingKeys: String, CodingKey {
+            case callerPaneID = "caller_pane_id"
+            case onlyQueue = "only_queue"
+            case unreadOnly = "unread_only"
+        }
+    }
+
+    /// The owner view of the gram store: every message, both directions, newest
+    /// first. The app is the owner, so it omits `caller_pane_id` (supplying one
+    /// would select an agent view). `unreadOnly` narrows to unread agent->owner
+    /// messages. Throws the server's `APIError` on an older server that lacks gram.
+    public func gramList(unreadOnly: Bool = false) async throws -> [GramMessage] {
+        try await call("gram.list",
+                       GramListParams(callerPaneID: nil, onlyQueue: false, unreadOnly: unreadOnly),
+                       as: GramListResult.self).messages
+    }
+
+    struct GramPostParams: Encodable {
+        let text: String
+        let to: String?
+    }
+
+    /// The owner posts a message to agents. `to == nil` posts to the shared
+    /// grab-queue any agent can claim; `to == <agentName>` addresses one live
+    /// agent directly (the server rejects a name that is not a live agent).
+    /// Returns the stored message.
+    @discardableResult
+    public func gramPost(text: String, to: String? = nil) async throws -> GramMessage {
+        try await call("gram.post", GramPostParams(text: text, to: to),
+                       as: GramMessageResult.self).message
+    }
+
+    struct GramMarkReadParams: Encodable { let id: String }
+
+    /// The owner marks an agent->owner message read (clears its unread badge).
+    public func gramMarkRead(id: String) async throws {
+        _ = try await call("gram.mark_read", GramMarkReadParams(id: id), as: JSONNull.self)
     }
 
     struct SendKeysParams: Encodable {

--- a/Tests/HerdrKitTests/MockWireFixtureTests.swift
+++ b/Tests/HerdrKitTests/MockWireFixtureTests.swift
@@ -13,6 +13,8 @@ final class MockWireFixtureTests: XCTestCase {
         func roundTrip(_ requestLine: String) async throws -> String {
             if requestLine.contains("agent.list") { return MockWireFixtures.agentList }
             if requestLine.contains("agent.read") { return MockWireFixtures.agentRead }
+            if requestLine.contains("gram.list") { return MockWireFixtures.gramList }
+            if requestLine.contains("gram.post") { return MockWireFixtures.gramPosted }
             if requestLine.contains("pane.set_pty_size") { return MockWireFixtures.panePtySize }
             return #"{"id":"x","result":{}}"#
         }
@@ -197,6 +199,56 @@ final class MockWireFixtureTests: XCTestCase {
         XCTAssertThrowsError(try frame(#"{"stream":"pane.bytes","frame":"data","seq":1,"epoch":7,"data_b64":"@@not base64@@"}"#),
                              "an invalid base64 payload must be rejected")
     }
+
+    /// The `gram.list` fixture must decode through the real client path, and the
+    /// GramMessage flags the Gram page renders on (unread, open-queue, grabbed,
+    /// direct) must resolve correctly. Optional fields (`to`, `grabbed_by`) are
+    /// omitted in JSON when absent — decoding must yield nil, not fail.
+    func testMockGramListDecodes() async throws {
+        let client = HerdrClient(transport: FixtureTransport())
+        let messages = try await client.gramList()
+        XCTAssertEqual(messages.count, 5, "gram.list fixture did not decode to 5 messages")
+
+        // Newest first: the unread agent->owner digest leads.
+        let first = try XCTUnwrap(messages.first)
+        XCTAssertEqual(first.id, "g1")
+        XCTAssertEqual(first.direction, .agentToOwner)
+        XCTAssertEqual(first.from, "trend-scout")
+        XCTAssertTrue(first.isFromAgent)
+        XCTAssertTrue(first.isUnread, "an agent->owner message with read_by_owner:false is unread")
+        XCTAssertNil(first.to)
+        XCTAssertNil(first.grabbedBy)
+
+        // An unclaimed shared queue post (no `to`, no `grabbed_by`).
+        let queue = try XCTUnwrap(messages.first { $0.id == "g2" })
+        XCTAssertEqual(queue.direction, .ownerToAgent)
+        XCTAssertNil(queue.to)
+        XCTAssertNil(queue.grabbedBy)
+        XCTAssertTrue(queue.isOpenQueueItem)
+
+        // A grabbed queue item is no longer open.
+        let grabbed = try XCTUnwrap(messages.first { $0.id == "g3" })
+        XCTAssertEqual(grabbed.grabbedBy, "herdr-app")
+        XCTAssertFalse(grabbed.isOpenQueueItem)
+
+        // A direct message carries `to`.
+        let direct = try XCTUnwrap(messages.first { $0.id == "g4" })
+        XCTAssertEqual(direct.to, "clientloop")
+        XCTAssertNil(direct.grabbedBy)
+
+        // Exactly one unread → the header badge shows 1.
+        XCTAssertEqual(messages.filter { $0.isUnread }.count, 1)
+    }
+
+    /// `gram.post` echoes the stored message (`type: gram_sent`) — the composer
+    /// inserts it optimistically, so it must decode through the client path.
+    func testMockGramPostDecodes() async throws {
+        let client = HerdrClient(transport: FixtureTransport())
+        let posted = try await client.gramPost(text: "hello", to: nil)
+        XCTAssertEqual(posted.id, "gp1")
+        XCTAssertEqual(posted.direction, .ownerToAgent)
+        XCTAssertEqual(posted.from, "owner")
+    }
 }
 
 /// THE FIXTURES. Duplicated verbatim in App/HerdrApp.swift's MockTransport (the
@@ -225,6 +277,24 @@ enum MockWireFixtures {
     static let agentRead = #"""
     {"id":"mock","result":{"read":{"pane_id":"w1:p1","text":"$ herdr agent attach jarvis\n\n> Ran 146 tests, 0 failures\n> Edited SessionRecoveryTests.swift  +18 -4\n\nRun `swift test` with -Xswiftc -warnings-as-errors?\n  1. yes\n  2. no, skip it\n>\n\n[demo data - mock render mode, no live connection]","truncated":false,"source":"recent_unwrapped","format":"text"}}}
     """#
+
+    /// A `gram.list` owner view: unread + read agent->owner messages, an unclaimed
+    /// shared queue post, a grabbed one, and a direct message — newest first. Keep in
+    /// sync with the App's MockTransport.gramList.
+    static let gramList = #"""
+    {"id":"mock","result":{"type":"gram_list","messages":[
+      {"id":"g1","direction":"agent_to_owner","from":"trend-scout","text":"Digest ready: 7 trends, 2 need your call.","created_unix_ms":1723000005000,"read_by_owner":false},
+      {"id":"g2","direction":"owner_to_agent","from":"owner","text":"Anyone free to triage the failing CI?","created_unix_ms":1723000004000,"read_by_owner":true},
+      {"id":"g3","direction":"owner_to_agent","from":"owner","text":"Rebase the vetrina branch onto main.","grabbed_by":"herdr-app","grabbed_unix_ms":1723000004500,"created_unix_ms":1723000003000,"read_by_owner":true},
+      {"id":"g4","direction":"owner_to_agent","from":"owner","to":"clientloop","text":"Ship the Amigo POC scaffold today.","created_unix_ms":1723000002000,"read_by_owner":true},
+      {"id":"g5","direction":"agent_to_owner","from":"vetrina","text":"Deployed vetrina.dev — it is live.","created_unix_ms":1723000001000,"read_by_owner":true}
+    ]}}
+    """#
+
+    /// A canned `gram.post` echo (`type: gram_sent`). Keep in sync with the App's
+    /// MockTransport.gramPosted.
+    static let gramPosted =
+        #"{"id":"mock","result":{"type":"gram_sent","message":{"id":"gp1","direction":"owner_to_agent","from":"owner","text":"(sent)","created_unix_ms":1723000006000,"read_by_owner":true}}}"#
 
     // MARK: pane.stream / pane.set_pty_size fixtures (mirrored in App MockTransport)
 


### PR DESCRIPTION
## What

**Phase 2** of gram: the app's Gram page — the owner's side of the owner↔agent message channel whose backend merged in the herdr fork (jerryfane/herdr #48). A 4th tab opens **GramView** (a Settings-pattern `fullScreenCover`): an inbox of agent→owner messages and the owner's own posts (with claim state), plus a composer that posts to the **shared grab-queue** or **one agent** directly. Text only; file attachments are P3.

## Changes

**HerdrKit** (`Gram.swift`, `HerdrClient.swift`)
- `GramMessage` wire type + `gramList` (owner view — omits `caller_pane_id`), `gramPost`, `gramMarkRead`.
- `notify_gram` added to `registerDevice`.
- **Decoding is machine-checked on Linux** — `MockWireFixtureTests` gains `gram.list` + `gram.post` fixtures + decode tests (unread / open-queue / grabbed / direct all resolve). All 222+ HerdrKit tests pass locally.

**App**
- `GramView.swift` — kit-styled (navy ground, cards, `AgentIdentity` chips, Geist/IBM Plex Mono), loads/refreshes the owner view, marks messages read on view, composes to queue or a picked agent, and degrades gracefully to "gram isn't available on this server yet" against a pre-deploy daemon.
- Nav: `ActiveCover.gram` + the `.gram` cover builder + a "Gram" tab button.
- Push: a "gram received" toggle wired through all four pref sites (`PushCenter.Prefs`, both `@AppStorage` mirrors, `registerPush`), and a gram push-tap deep-link (`pendingGram`) that opens the page on both cold-launch and foreground (`AppDelegate` branches on the payload's `gram` marker before `pane_id`, since gram alerts carry an empty pane id).

**Mock / test**
- `HERDR_SCREENSHOT_MOCK=gram` renders the page from a canned owner view (mirrored, decode-checked fixtures); `GramTests` smoke-asserts it renders and attaches a screenshot.

## Notes
- The page shows "gram unavailable" until the herdr fork's gram build is deployed to the daemon (that deploy ships with the push 2c binary in one owner swap).
- No gesture surface changed, so rule-47874 (on-device gesture receipt) does not apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)