### PR TITLE
feat(gram): file attachments + delete-on-hold on the Gram page

### DIFF
--- a/App/GramView.swift
+++ b/App/GramView.swift
@@ -1,12 +1,16 @@
 import HerdrKit
 import SwiftUI
+import UniformTypeIdentifiers
 
 /// The Gram page: the owner's side of the owner<->agent message channel.
 ///
 /// The app is the OWNER. This shows the inbox (agent->owner messages the fleet
 /// sent, plus the owner's own posts and their claim state) newest-first, and a
-/// composer to post to the shared grab-queue or one agent directly. Text only;
-/// file attachments are a later phase.
+/// composer to post to the shared grab-queue or one agent directly, with an
+/// optional file attachment. A received file shows a chip that downloads and
+/// previews it (QuickLook); long-pressing a message deletes it — and its file
+/// bytes — for good, which is what makes gram safe for a short-lived secret like
+/// a temporary API key.
 ///
 /// Nav-agnostic: it renders its own content and takes an optional `onClose` — a
 /// modal cover passes one (a close button appears); a persistent tab passes nil.
@@ -36,6 +40,27 @@ struct GramView: View {
     /// Messages with a mark-read in flight, so a re-`onAppear` (scroll) does not fire
     /// a duplicate `gram.mark_read`.
     @State private var markingRead: Set<String> = []
+
+    /// A file the owner picked to attach to the next post (read into memory at pick
+    /// time), nil when none is staged.
+    @State private var attachedFile: PickedAttachment?
+    @State private var showFileImporter = false
+    /// True while a picked file is uploading (many small chunks over SSH).
+    @State private var uploading = false
+    /// A downloaded file written to a temp URL, presented via QuickLook when set.
+    @State private var previewURL: URL?
+    /// The message id whose file is currently downloading, to show a spinner on it.
+    @State private var downloadingFileFor: String?
+
+    /// A file staged for sending: read into memory so the send is one atomic action.
+    private struct PickedAttachment {
+        let name: String
+        let mime: String
+        let data: Data
+    }
+
+    /// Client-side attachment cap, mirroring the server's `MAX_FILE_BYTES`.
+    private static let maxFileBytes = 10 * 1024 * 1024
 
     /// The list the page renders: optimistic posts first, then the server snapshot
     /// with those posts de-duped out once the server reflects them.
@@ -94,6 +119,16 @@ struct GramView: View {
         // refresh (the gram store has no event stream); the loop ends when the view
         // goes away (task cancellation).
         .task { await pollLoop() }
+        .fileImporter(
+            isPresented: $showFileImporter,
+            allowedContentTypes: [.item],
+            allowsMultipleSelection: false
+        ) { result in
+            handlePickedFile(result)
+        }
+        // A tapped file chip downloads the bytes to a temp URL; QuickLook previews
+        // it and offers the system share action (save to Files, etc.).
+        .quickLookPreview($previewURL)
     }
 
     /// A load error / send error, shown ABOVE the composer in every phase — the
@@ -197,8 +232,13 @@ struct GramView: View {
             ScrollView {
                 LazyVStack(spacing: 10) {
                     ForEach(messages) { message in
-                        GramRow(message: message)
-                            .onAppear { markReadIfNeeded(message) }
+                        GramRow(
+                            message: message,
+                            isDownloadingFile: downloadingFileFor == message.id,
+                            onOpenFile: { openFile(message) },
+                            onDelete: { delete(message) }
+                        )
+                        .onAppear { markReadIfNeeded(message) }
                     }
                 }
                 .padding(16)
@@ -246,7 +286,18 @@ struct GramView: View {
                 }
                 Spacer(minLength: 0)
             }
+            if let attachedFile { attachmentChip(attachedFile) }
             HStack(alignment: .bottom, spacing: 8) {
+                Button {
+                    showFileImporter = true
+                } label: {
+                    Image(systemName: "paperclip")
+                        .font(.system(size: 16, weight: .semibold))
+                        .foregroundStyle(Palette.textDim)
+                        .frame(width: 38, height: 38)
+                        .background(Circle().fill(Palette.surface))
+                }
+                .disabled(sending)
                 TextField("Message an agent…", text: $draft, axis: .vertical)
                     .font(Typography.app(15))
                     .foregroundStyle(Palette.text)
@@ -258,11 +309,16 @@ struct GramView: View {
                 Button {
                     Task { await send() }
                 } label: {
-                    Image(systemName: "arrow.up")
-                        .font(.system(size: 16, weight: .bold))
-                        .foregroundStyle(canSend ? Palette.ground : Palette.textFaint)
-                        .frame(width: 38, height: 38)
-                        .background(Circle().fill(canSend ? Palette.text : Palette.surface))
+                    Group {
+                        if uploading {
+                            ProgressView().tint(Palette.ground)
+                        } else {
+                            Image(systemName: "arrow.up").font(.system(size: 16, weight: .bold))
+                        }
+                    }
+                    .foregroundStyle(canSend ? Palette.ground : Palette.textFaint)
+                    .frame(width: 38, height: 38)
+                    .background(Circle().fill(canSend ? Palette.text : Palette.surface))
                 }
                 .disabled(!canSend)
             }
@@ -274,7 +330,38 @@ struct GramView: View {
     }
 
     private var canSend: Bool {
-        !sending && !draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        guard !sending else { return false }
+        return attachedFile != nil
+            || !draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    /// The staged attachment shown above the composer, with a remove button.
+    private func attachmentChip(_ file: PickedAttachment) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: FileGlyph.name(for: file.mime, fileName: file.name))
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(Palette.textDim)
+            Text(file.name)
+                .font(Typography.app(13, .medium))
+                .foregroundStyle(Palette.text)
+                .lineLimit(1)
+                .truncationMode(.middle)
+            Text(GramFile.displaySize(of: UInt64(file.data.count)))
+                .font(Typography.machine(11))
+                .foregroundStyle(Palette.textFaint)
+            Spacer(minLength: 0)
+            Button {
+                attachedFile = nil
+            } label: {
+                Image(systemName: "xmark.circle.fill")
+                    .font(.system(size: 15))
+                    .foregroundStyle(Palette.textFaint)
+            }
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 7)
+        .background(RoundedRectangle(cornerRadius: 8).fill(Palette.surface))
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     // MARK: - Actions
@@ -333,13 +420,31 @@ struct GramView: View {
 
     private func send() async {
         let text = draft.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !text.isEmpty, !sending else { return }
+        let attachment = attachedFile
+        // A file with no caption is fine; an empty text-only message is not.
+        guard (!text.isEmpty || attachment != nil), !sending else { return }
         sending = true
-        defer { sending = false }
+        defer {
+            sending = false
+            uploading = false
+        }
         sendError = nil
         do {
-            let posted = try await client.gramPost(text: text, to: recipient.wireTo)
+            let posted: GramMessage
+            if let attachment {
+                // Upload the bytes in chunks, then post the message referencing them.
+                uploading = true
+                let uploadID = try await client.gramUploadFile(attachment.data)
+                uploading = false
+                posted = try await client.gramPost(
+                    text: text, to: recipient.wireTo,
+                    attachment: .init(
+                        uploadID: uploadID, name: attachment.name, mime: attachment.mime))
+            } else {
+                posted = try await client.gramPost(text: text, to: recipient.wireTo)
+            }
             draft = ""
+            attachedFile = nil
             // Optimistic: kept in `pendingPosts`, so a concurrent poll's snapshot
             // cannot drop it; de-duped by id, reconciled once the server reflects it.
             pendingPosts.removeAll { $0.id == posted.id }
@@ -348,6 +453,76 @@ struct GramView: View {
             sendError = error.message
         } catch {
             sendError = "Couldn't send. Try again."
+        }
+    }
+
+    /// Read a picked file into memory (bounded by the server's size cap) so the
+    /// send is one atomic action. A file URL from the importer is security-scoped.
+    private func handlePickedFile(_ result: Result<[URL], Error>) {
+        guard case .success(let urls) = result, let url = urls.first else { return }
+        let scoped = url.startAccessingSecurityScopedResource()
+        defer { if scoped { url.stopAccessingSecurityScopedResource() } }
+        do {
+            let data = try Data(contentsOf: url)
+            guard !data.isEmpty else {
+                sendError = "That file is empty."
+                return
+            }
+            guard data.count <= Self.maxFileBytes else {
+                sendError = "That file is too large (max 10 MB)."
+                return
+            }
+            attachedFile = PickedAttachment(
+                name: url.lastPathComponent, mime: Self.mimeType(for: url), data: data)
+            sendError = nil
+        } catch {
+            sendError = "Couldn't read that file."
+        }
+    }
+
+    private static func mimeType(for url: URL) -> String {
+        if let type = UTType(filenameExtension: url.pathExtension),
+            let mime = type.preferredMIMEType
+        {
+            return mime
+        }
+        return "application/octet-stream"
+    }
+
+    /// Download a message's file to a temp URL and present it in QuickLook (which
+    /// offers the system share action to save it).
+    private func openFile(_ message: GramMessage) {
+        guard downloadingFileFor == nil else { return }
+        downloadingFileFor = message.id
+        Task {
+            defer { downloadingFileFor = nil }
+            do {
+                let (name, _, data) = try await client.gramGetFile(id: message.id)
+                let url = FileManager.default.temporaryDirectory
+                    .appendingPathComponent(name.isEmpty ? "file" : name)
+                try data.write(to: url, options: .atomic)
+                previewURL = url
+            } catch let error as APIError {
+                sendError = "Couldn't open the file: \(error.message)"
+            } catch {
+                sendError = "Couldn't open the file."
+            }
+        }
+    }
+
+    /// Delete a message (and its file bytes) after the server confirms — so a
+    /// failed delete leaves the row in place rather than lying that it's gone.
+    private func delete(_ message: GramMessage) {
+        Task {
+            do {
+                try await client.gramDelete(id: message.id)
+                serverMessages.removeAll { $0.id == message.id }
+                pendingPosts.removeAll { $0.id == message.id }
+            } catch let error as APIError {
+                sendError = "Couldn't delete: \(error.message)"
+            } catch {
+                sendError = "Couldn't delete. Try again."
+            }
         }
     }
 
@@ -376,6 +551,9 @@ struct GramView: View {
 /// shows the recipient and the claim state of a queued item.
 private struct GramRow: View {
     let message: GramMessage
+    var isDownloadingFile: Bool
+    var onOpenFile: () -> Void
+    var onDelete: () -> Void
 
     var body: some View {
         HStack(alignment: .top, spacing: 10) {
@@ -393,10 +571,15 @@ private struct GramRow: View {
                         .font(Typography.machine(11))
                         .foregroundStyle(Palette.textFaint)
                 }
-                Text(message.text)
-                    .font(Typography.app(14))
-                    .foregroundStyle(Palette.textDim)
-                    .fixedSize(horizontal: false, vertical: true)
+                if !message.text.isEmpty {
+                    Text(message.text)
+                        .font(Typography.app(14))
+                        .foregroundStyle(Palette.textDim)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                if let file = message.file {
+                    fileChip(file)
+                }
                 if let status = statusLine {
                     Text(status)
                         .font(Typography.machine(11))
@@ -408,6 +591,47 @@ private struct GramRow: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(RoundedRectangle(cornerRadius: 12).fill(Palette.card))
         .overlay(RoundedRectangle(cornerRadius: 12).stroke(Palette.hairlineQuiet, lineWidth: 1))
+        // Long-press to delete a message (and its file bytes) for good.
+        .contextMenu {
+            Button(role: .destructive, action: onDelete) {
+                Label("Delete", systemImage: "trash")
+            }
+        }
+    }
+
+    /// A tappable chip for an attached file: tap to download + preview it.
+    private func fileChip(_ file: GramFile) -> some View {
+        Button(action: onOpenFile) {
+            HStack(spacing: 8) {
+                Image(systemName: FileGlyph.name(for: file.mime, fileName: file.name))
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(Palette.text)
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(file.name)
+                        .font(Typography.app(13, .medium))
+                        .foregroundStyle(Palette.text)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                    Text(file.displaySize)
+                        .font(Typography.machine(11))
+                        .foregroundStyle(Palette.textFaint)
+                }
+                Spacer(minLength: 0)
+                if isDownloadingFile {
+                    ProgressView().tint(Palette.textDim)
+                } else {
+                    Image(systemName: "arrow.down.circle")
+                        .font(.system(size: 15, weight: .semibold))
+                        .foregroundStyle(Palette.textDim)
+                }
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 8)
+            .background(RoundedRectangle(cornerRadius: 9).fill(Palette.surface))
+        }
+        .buttonStyle(.plain)
+        .disabled(isDownloadingFile)
+        .padding(.top, 2)
     }
 
     @ViewBuilder
@@ -463,5 +687,21 @@ private struct GramRow: View {
         case ..<86400: return "\(Int(seconds / 3600))h"
         default: return "\(Int(seconds / 86400))d"
         }
+    }
+}
+
+/// Picks an SF Symbol for a file from its MIME type. Shared by the composer's
+/// staged-attachment chip and a received message's file chip.
+private enum FileGlyph {
+    static func name(for mime: String, fileName: String) -> String {
+        let mime = mime.lowercased()
+        if mime.hasPrefix("image/") { return "photo" }
+        if mime.hasPrefix("video/") { return "film" }
+        if mime.hasPrefix("audio/") { return "waveform" }
+        if mime == "application/pdf" { return "doc.richtext" }
+        if mime == "application/zip" || mime.contains("compressed") { return "doc.zipper" }
+        if mime == "application/json" { return "curlybraces" }
+        if mime.hasPrefix("text/") { return "doc.text" }
+        return "doc"
     }
 }

--- a/App/GramView.swift
+++ b/App/GramView.swift
@@ -51,6 +51,10 @@ struct GramView: View {
     @State private var previewURL: URL?
     /// The message id whose file is currently downloading, to show a spinner on it.
     @State private var downloadingFileFor: String?
+    /// Ids the server has confirmed deleted, kept as tombstones so an in-flight poll
+    /// (whose snapshot predates the delete) cannot resurrect the row for a few
+    /// seconds. Cleared once the server's own snapshot also omits the id.
+    @State private var deletedIDs: Set<String> = []
 
     /// A file staged for sending: read into memory so the send is one atomic action.
     private struct PickedAttachment {
@@ -66,7 +70,8 @@ struct GramView: View {
     /// with those posts de-duped out once the server reflects them.
     private var messages: [GramMessage] {
         let pendingIDs = Set(pendingPosts.map(\.id))
-        return pendingPosts + serverMessages.filter { !pendingIDs.contains($0.id) }
+        return (pendingPosts + serverMessages.filter { !pendingIDs.contains($0.id) })
+            .filter { !deletedIDs.contains($0.id) }
     }
 
     private enum LoadPhase: Equatable {
@@ -129,6 +134,17 @@ struct GramView: View {
         // A tapped file chip downloads the bytes to a temp URL; QuickLook previews
         // it and offers the system share action (save to Files, etc.).
         .quickLookPreview($previewURL)
+        // Delete the previewed temp file when QuickLook dismisses (it nils the
+        // binding) or when it is replaced — so a previewed secret does not linger.
+        .onChange(of: previewURL) { oldValue, newValue in
+            if let oldValue, oldValue != newValue {
+                try? FileManager.default.removeItem(at: oldValue)
+            }
+        }
+        // Backstop: remove any lingering preview file when the page goes away.
+        .onDisappear {
+            if let previewURL { try? FileManager.default.removeItem(at: previewURL) }
+        }
     }
 
     /// A load error / send error, shown ABOVE the composer in every phase — the
@@ -284,6 +300,7 @@ struct GramView: View {
                     .padding(.vertical, 5)
                     .background(RoundedRectangle(cornerRadius: 7).fill(Palette.surface))
                 }
+                .disabled(sending)
                 Spacer(minLength: 0)
             }
             if let attachedFile { attachmentChip(attachedFile) }
@@ -311,7 +328,10 @@ struct GramView: View {
                 } label: {
                     Group {
                         if uploading {
-                            ProgressView().tint(Palette.ground)
+                            // Over the dark `surface` fill (canSend is false while
+                            // sending), tint the spinner light so it is visible —
+                            // it is the only feedback during a many-chunk upload.
+                            ProgressView().tint(Palette.text)
                         } else {
                             Image(systemName: "arrow.up").font(.system(size: 16, weight: .bold))
                         }
@@ -397,6 +417,9 @@ struct GramView: View {
             // load started BEFORE a post can no longer discard it).
             let serverIDs = Set(fetched.map(\.id))
             pendingPosts.removeAll { serverIDs.contains($0.id) }
+            // Retire delete-tombstones the server has confirmed gone; keep only those
+            // it still returns (a poll that raced the delete), which stay suppressed.
+            deletedIDs.formIntersection(serverIDs)
             phase = .loaded
             refreshNote = nil
         } catch let error as APIError where error.code == "gram_unavailable" {
@@ -421,6 +444,11 @@ struct GramView: View {
     private func send() async {
         let text = draft.trimmingCharacters(in: .whitespacesAndNewlines)
         let attachment = attachedFile
+        // Capture the destination BEFORE any await. Otherwise the recipient picker
+        // could change mid-upload and the file (possibly a secret) would post to a
+        // different agent than the one chosen when Send was tapped. The picker is
+        // also disabled while sending, but capturing is the real guarantee.
+        let to = recipient.wireTo
         // A file with no caption is fine; an empty text-only message is not.
         guard (!text.isEmpty || attachment != nil), !sending else { return }
         sending = true
@@ -437,11 +465,11 @@ struct GramView: View {
                 let uploadID = try await client.gramUploadFile(attachment.data)
                 uploading = false
                 posted = try await client.gramPost(
-                    text: text, to: recipient.wireTo,
+                    text: text, to: to,
                     attachment: .init(
                         uploadID: uploadID, name: attachment.name, mime: attachment.mime))
             } else {
-                posted = try await client.gramPost(text: text, to: recipient.wireTo)
+                posted = try await client.gramPost(text: text, to: to)
             }
             draft = ""
             attachedFile = nil
@@ -462,12 +490,22 @@ struct GramView: View {
         guard case .success(let urls) = result, let url = urls.first else { return }
         let scoped = url.startAccessingSecurityScopedResource()
         defer { if scoped { url.stopAccessingSecurityScopedResource() } }
+        // Reject an over-cap file BEFORE reading it into memory, so picking a
+        // multi-gigabyte file can't allocate/read it all (and risk a jetsam) before
+        // the size check ever runs.
+        if let size = try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize,
+            size > Self.maxFileBytes
+        {
+            sendError = "That file is too large (max 10 MB)."
+            return
+        }
         do {
             let data = try Data(contentsOf: url)
             guard !data.isEmpty else {
                 sendError = "That file is empty."
                 return
             }
+            // Fallback for a URL whose size wasn't reported up front.
             guard data.count <= Self.maxFileBytes else {
                 sendError = "That file is too large (max 10 MB)."
                 return
@@ -498,9 +536,16 @@ struct GramView: View {
             defer { downloadingFileFor = nil }
             do {
                 let (name, _, data) = try await client.gramGetFile(id: message.id)
+                // Never trust the server name to be a safe path component; reduce it
+                // to a bare basename before joining it to the temp directory.
                 let url = FileManager.default.temporaryDirectory
-                    .appendingPathComponent(name.isEmpty ? "file" : name)
-                try data.write(to: url, options: .atomic)
+                    .appendingPathComponent(Self.safeTempFileName(name))
+                // Remove any previously-previewed file so a viewed secret does not
+                // accumulate in tmp; write encrypted-at-rest.
+                if let previous = previewURL {
+                    try? FileManager.default.removeItem(at: previous)
+                }
+                try data.write(to: url, options: [.atomic, .completeFileProtection])
                 previewURL = url
             } catch let error as APIError {
                 sendError = "Couldn't open the file: \(error.message)"
@@ -510,12 +555,27 @@ struct GramView: View {
         }
     }
 
+    /// Reduce a server-supplied file name to a safe single path component for the
+    /// temp directory: strip any directory parts and reject `.`/`..`.
+    private static func safeTempFileName(_ name: String) -> String {
+        let base = (name as NSString).lastPathComponent
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "\\", with: "_")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        if base.isEmpty || base == "." || base == ".." { return "file" }
+        return base
+    }
+
     /// Delete a message (and its file bytes) after the server confirms — so a
     /// failed delete leaves the row in place rather than lying that it's gone.
     private func delete(_ message: GramMessage) {
         Task {
             do {
                 try await client.gramDelete(id: message.id)
+                // Tombstone it so an in-flight poll (snapshot predating the delete)
+                // can't briefly resurrect the row; cleared in `load` once the server
+                // no longer returns it.
+                deletedIDs.insert(message.id)
                 serverMessages.removeAll { $0.id == message.id }
                 pendingPosts.removeAll { $0.id == message.id }
             } catch let error as APIError {

--- a/App/GramView.swift
+++ b/App/GramView.swift
@@ -1,4 +1,5 @@
 import HerdrKit
+import QuickLook
 import SwiftUI
 import UniformTypeIdentifiers
 
@@ -558,7 +559,7 @@ struct GramView: View {
     /// Reduce a server-supplied file name to a safe single path component for the
     /// temp directory: strip any directory parts and reject `.`/`..`.
     private static func safeTempFileName(_ name: String) -> String {
-        let base = (name as NSString).lastPathComponent
+        let base = URL(fileURLWithPath: name).lastPathComponent
             .replacingOccurrences(of: "/", with: "_")
             .replacingOccurrences(of: "\\", with: "_")
             .trimmingCharacters(in: .whitespacesAndNewlines)

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -2428,6 +2428,9 @@ struct MockTransport: HerdrTransport {
         if requestLine.contains("agent.read") { return backfill ? Self.backfillRead() : Self.agentRead }
         if requestLine.contains("gram.list") { return Self.gramList }
         if requestLine.contains("gram.post") { return Self.gramPosted }
+        if requestLine.contains("gram.get_file") { return Self.gramFileContent }
+        if requestLine.contains("gram.upload_chunk") { return Self.gramOk }
+        if requestLine.contains("gram.delete") { return Self.gramOk }
         if requestLine.contains("pane.set_pty_size") { return Self.panePtySize }
         return #"{"id":"mock","result":{}}"#
     }
@@ -2526,13 +2529,21 @@ struct MockTransport: HerdrTransport {
       {"id":"g2","direction":"owner_to_agent","from":"owner","text":"Anyone free to triage the failing CI?","created_unix_ms":1723000004000,"read_by_owner":true},
       {"id":"g3","direction":"owner_to_agent","from":"owner","text":"Rebase the vetrina branch onto main.","grabbed_by":"herdr-app","grabbed_unix_ms":1723000004500,"created_unix_ms":1723000003000,"read_by_owner":true},
       {"id":"g4","direction":"owner_to_agent","from":"owner","to":"clientloop","text":"Ship the Amigo POC scaffold today.","created_unix_ms":1723000002000,"read_by_owner":true},
-      {"id":"g5","direction":"agent_to_owner","from":"vetrina","text":"Deployed vetrina.dev — it is live.","created_unix_ms":1723000001000,"read_by_owner":true}
+      {"id":"g5","direction":"agent_to_owner","from":"vetrina","text":"Deployed vetrina.dev — it is live.","created_unix_ms":1723000001000,"read_by_owner":true,"file":{"name":"vetrina-live.png","size":48213,"mime":"image/png","sha256":"9f2c0a1b7d3e4f5061728394a5b6c7d8e9f0a1b2c3d4e5f60718293a4b5c6d7e"}}
     ]}}
     """#
 
     /// A canned `gram.post` echo, so the mock composer's send path resolves.
     static let gramPosted =
         #"{"id":"mock","result":{"type":"gram_sent","message":{"id":"gp1","direction":"owner_to_agent","from":"owner","text":"(sent)","created_unix_ms":1723000006000,"read_by_owner":true}}}"#
+
+    /// A canned `gram.get_file` reply; the bytes decode to "hello world".
+    /// Byte-identical to MockWireFixtures.gramFileContent.
+    static let gramFileContent =
+        #"{"id":"mock","result":{"type":"gram_file_content","name":"vetrina-live.png","mime":"image/png","size":11,"data_base64":"aGVsbG8gd29ybGQ="}}"#
+
+    /// A canned `type: ok` reply for `gram.upload_chunk` and `gram.delete`.
+    static let gramOk = #"{"id":"mock","result":{"type":"ok"}}"#
 
     // pane.stream / pane.set_pty_size fixtures for the live terminal. Byte-identical
     // to MockWireFixtures in Tests/HerdrKitTests/MockWireFixtureTests.swift, which is

--- a/Sources/HerdrKit/Gram.swift
+++ b/Sources/HerdrKit/Gram.swift
@@ -13,6 +13,40 @@ public enum GramDirection: String, Decodable, Sendable, Equatable {
     case ownerToAgent = "owner_to_agent"
 }
 
+/// A gram-specific client failure that isn't a server `APIError`.
+public enum GramError: Error, CustomStringConvertible {
+    /// `gram.get_file` returned data that was not valid base64 (should not happen).
+    case invalidFileData
+    public var description: String {
+        switch self {
+        case .invalidFileData:
+            return "the server returned file data that could not be decoded"
+        }
+    }
+}
+
+/// Metadata for a file attached to a gram message. The bytes are fetched
+/// separately with `gramGetFile`; this is only what's needed to show and verify
+/// it. Mirrors src/api/schema/gram.rs::GramFileInfo.
+public struct GramFile: Decodable, Sendable, Equatable {
+    public let name: String
+    public let size: UInt64
+    public let mime: String
+    public let sha256: String
+
+    /// A human-readable size, e.g. "12 KB" or "1.3 MB".
+    public var displaySize: String { Self.displaySize(of: size) }
+
+    /// Format a byte count for display. Static so a not-yet-uploaded local file
+    /// (which has no `GramFile` yet) can use the same rendering.
+    public static func displaySize(of size: UInt64) -> String {
+        let bytes = Double(size)
+        if bytes < 1024 { return "\(size) B" }
+        if bytes < 1024 * 1024 { return String(format: "%.0f KB", bytes / 1024) }
+        return String(format: "%.1f MB", bytes / (1024 * 1024))
+    }
+}
+
 /// One gram message as returned by the server.
 public struct GramMessage: Decodable, Identifiable, Sendable, Equatable {
     public let id: String
@@ -31,9 +65,11 @@ public struct GramMessage: Decodable, Identifiable, Sendable, Equatable {
     /// it locally for an optimistic update after `gram.mark_read` (the rest of the
     /// message is immutable / decode-only).
     public var readByOwner: Bool
+    /// A file attached to this message, or nil. Fetch its bytes with `gramGetFile`.
+    public let file: GramFile?
 
     enum CodingKeys: String, CodingKey {
-        case id, direction, from, to, text
+        case id, direction, from, to, text, file
         case grabbedBy = "grabbed_by"
         case grabbedUnixMs = "grabbed_unix_ms"
         case createdUnixMs = "created_unix_ms"
@@ -63,4 +99,16 @@ struct GramListResult: Decodable {
 /// `message` is decoded — the type discriminator is ignored.
 struct GramMessageResult: Decodable {
     let message: GramMessage
+}
+
+/// `gram.get_file` result (`type: "gram_file_content"`): the file's bytes inline.
+struct GramFileContentResult: Decodable {
+    let name: String
+    let mime: String
+    let size: UInt64
+    let dataBase64: String
+    enum CodingKeys: String, CodingKey {
+        case name, mime, size
+        case dataBase64 = "data_base64"
+    }
 }

--- a/Sources/HerdrKit/HerdrClient.swift
+++ b/Sources/HerdrKit/HerdrClient.swift
@@ -6,7 +6,16 @@ import Foundation
 /// single-shot (see `HerdrTransport`). Only `subscribe` holds a connection open.
 public actor HerdrClient {
     private let transport: HerdrTransport
-    private let encoder = JSONEncoder()
+    private let encoder: JSONEncoder = {
+        let encoder = JSONEncoder()
+        // Do NOT escape "/" as "\/". A base64 gram file chunk is slash-heavy (an
+        // all-0xFF chunk is ALL "/"), and the default escaping would nearly double
+        // those bytes — enough to push an otherwise in-budget chunk past the SSH
+        // transport's command-size cap. Unescaped "/" is valid JSON and the server
+        // parses it identically.
+        encoder.outputFormatting = [.withoutEscapingSlashes]
+        return encoder
+    }()
     private let decoder = JSONDecoder()
     private var sequence: UInt64 = 0
 

--- a/Sources/HerdrKit/HerdrClient.swift
+++ b/Sources/HerdrKit/HerdrClient.swift
@@ -215,19 +215,48 @@ public actor HerdrClient {
                        as: GramListResult.self).messages
     }
 
+    /// A file already uploaded via `gramUploadFile`, ready to attach to a post.
+    public struct GramFileAttachment: Sendable {
+        public let uploadID: String
+        public let name: String
+        public let mime: String
+        public init(uploadID: String, name: String, mime: String) {
+            self.uploadID = uploadID
+            self.name = name
+            self.mime = mime
+        }
+    }
+
+    struct GramFileUploadParams: Encodable {
+        let uploadID: String
+        let name: String
+        let mime: String
+        enum CodingKeys: String, CodingKey {
+            case uploadID = "upload_id"
+            case name, mime
+        }
+    }
+
     struct GramPostParams: Encodable {
         let text: String
         let to: String?
+        let file: GramFileUploadParams?
     }
 
     /// The owner posts a message to agents. `to == nil` posts to the shared
     /// grab-queue any agent can claim; `to == <agentName>` addresses one live
     /// agent directly (the server rejects a name that is not a live agent).
-    /// Returns the stored message.
+    /// `attachment` attaches a file previously uploaded with `gramUploadFile`; the
+    /// text may be empty when a file is attached. Returns the stored message.
     @discardableResult
-    public func gramPost(text: String, to: String? = nil) async throws -> GramMessage {
-        try await call("gram.post", GramPostParams(text: text, to: to),
-                       as: GramMessageResult.self).message
+    public func gramPost(
+        text: String, to: String? = nil, attachment: GramFileAttachment? = nil
+    ) async throws -> GramMessage {
+        let file = attachment.map {
+            GramFileUploadParams(uploadID: $0.uploadID, name: $0.name, mime: $0.mime)
+        }
+        return try await call("gram.post", GramPostParams(text: text, to: to, file: file),
+                              as: GramMessageResult.self).message
     }
 
     struct GramMarkReadParams: Encodable { let id: String }
@@ -235,6 +264,66 @@ public actor HerdrClient {
     /// The owner marks an agent->owner message read (clears its unread badge).
     public func gramMarkRead(id: String) async throws {
         _ = try await call("gram.mark_read", GramMarkReadParams(id: id), as: JSONNull.self)
+    }
+
+    struct GramDeleteParams: Encodable { let id: String }
+
+    /// The owner deletes a gram message and any file attached to it, for good. As
+    /// the owner the app sends no caller pane, so it may delete any message.
+    public func gramDelete(id: String) async throws {
+        _ = try await call("gram.delete", GramDeleteParams(id: id), as: JSONNull.self)
+    }
+
+    struct GramUploadChunkParams: Encodable {
+        let uploadID: String
+        let offset: UInt64
+        let dataBase64: String
+        enum CodingKeys: String, CodingKey {
+            case uploadID = "upload_id"
+            case offset
+            case dataBase64 = "data_base64"
+        }
+    }
+
+    /// Raw bytes per upload chunk. The SSH transport caps a whole request command
+    /// near 120 KB, and the request JSON is base64'd twice on the way out (the
+    /// inner `data_base64`, then the argv itself), a ~1.78x expansion. 48 KiB raw
+    /// lands around 87 KB of command — safely under the cap with headroom.
+    static let gramUploadChunkBytes = 48 * 1024
+
+    /// Uploads a file's bytes in chunks and returns the `upload_id` to attach to a
+    /// `gramPost`. Chunks are sent in order; the server validates each against the
+    /// running offset. A single request per chunk keeps every one under the SSH
+    /// command-size cap.
+    public func gramUploadFile(_ data: Data) async throws -> String {
+        let uploadID = "app-" + UUID().uuidString.replacingOccurrences(of: "-", with: "")
+        var offset = 0
+        while offset < data.count {
+            let end = min(offset + Self.gramUploadChunkBytes, data.count)
+            let chunk = data.subdata(in: offset..<end)
+            _ = try await call(
+                "gram.upload_chunk",
+                GramUploadChunkParams(
+                    uploadID: uploadID, offset: UInt64(offset),
+                    dataBase64: chunk.base64EncodedString()),
+                as: JSONNull.self)
+            offset = end
+        }
+        return uploadID
+    }
+
+    struct GramGetFileParams: Encodable { let id: String }
+
+    /// Downloads the file attached to a message and returns its name, mime, and
+    /// bytes. As the owner the app sends no caller pane and may download any file.
+    /// The bytes come back inline (base64) in one reply.
+    public func gramGetFile(id: String) async throws -> (name: String, mime: String, data: Data) {
+        let result = try await call("gram.get_file", GramGetFileParams(id: id),
+                                    as: GramFileContentResult.self)
+        guard let data = Data(base64Encoded: result.dataBase64) else {
+            throw GramError.invalidFileData
+        }
+        return (result.name, result.mime, data)
     }
 
     struct SendKeysParams: Encodable {

--- a/Tests/HerdrKitTests/MockWireFixtureTests.swift
+++ b/Tests/HerdrKitTests/MockWireFixtureTests.swift
@@ -15,6 +15,9 @@ final class MockWireFixtureTests: XCTestCase {
             if requestLine.contains("agent.read") { return MockWireFixtures.agentRead }
             if requestLine.contains("gram.list") { return MockWireFixtures.gramList }
             if requestLine.contains("gram.post") { return MockWireFixtures.gramPosted }
+            if requestLine.contains("gram.get_file") { return MockWireFixtures.gramFileContent }
+            if requestLine.contains("gram.upload_chunk") { return MockWireFixtures.okResult }
+            if requestLine.contains("gram.delete") { return MockWireFixtures.okResult }
             if requestLine.contains("pane.set_pty_size") { return MockWireFixtures.panePtySize }
             return #"{"id":"x","result":{}}"#
         }
@@ -249,6 +252,40 @@ final class MockWireFixtureTests: XCTestCase {
         XCTAssertEqual(posted.direction, .ownerToAgent)
         XCTAssertEqual(posted.from, "owner")
     }
+
+    /// A message may carry a file (`file` object); one without it decodes to nil,
+    /// not a failure — so the row shows a chip only when there is one.
+    func testMockGramListDecodesFileAttachment() async throws {
+        let client = HerdrClient(transport: FixtureTransport())
+        let messages = try await client.gramList()
+
+        let withFile = try XCTUnwrap(messages.first { $0.id == "g5" })
+        let file = try XCTUnwrap(withFile.file, "g5 should carry a file")
+        XCTAssertEqual(file.name, "vetrina-live.png")
+        XCTAssertEqual(file.mime, "image/png")
+        XCTAssertEqual(file.size, 48213)
+
+        let noFile = try XCTUnwrap(messages.first { $0.id == "g1" })
+        XCTAssertNil(noFile.file, "a message without a file must decode to nil")
+    }
+
+    /// `gram.get_file` returns the bytes inline (base64); the client decodes them.
+    func testMockGramGetFileDecodes() async throws {
+        let client = HerdrClient(transport: FixtureTransport())
+        let (name, mime, data) = try await client.gramGetFile(id: "g5")
+        XCTAssertEqual(name, "vetrina-live.png")
+        XCTAssertEqual(mime, "image/png")
+        XCTAssertEqual(String(decoding: data, as: UTF8.self), "hello world")
+    }
+
+    /// The upload + delete round-trips decode their `type: ok` replies without
+    /// throwing, and the upload mints a safe `app-` id.
+    func testMockGramUploadAndDeleteSucceed() async throws {
+        let client = HerdrClient(transport: FixtureTransport())
+        let uploadID = try await client.gramUploadFile(Data("hello".utf8))
+        XCTAssertTrue(uploadID.hasPrefix("app-"), "upload id should be a safe app- token")
+        try await client.gramDelete(id: "g5")
+    }
 }
 
 /// THE FIXTURES. Duplicated verbatim in App/HerdrApp.swift's MockTransport (the
@@ -287,7 +324,7 @@ enum MockWireFixtures {
       {"id":"g2","direction":"owner_to_agent","from":"owner","text":"Anyone free to triage the failing CI?","created_unix_ms":1723000004000,"read_by_owner":true},
       {"id":"g3","direction":"owner_to_agent","from":"owner","text":"Rebase the vetrina branch onto main.","grabbed_by":"herdr-app","grabbed_unix_ms":1723000004500,"created_unix_ms":1723000003000,"read_by_owner":true},
       {"id":"g4","direction":"owner_to_agent","from":"owner","to":"clientloop","text":"Ship the Amigo POC scaffold today.","created_unix_ms":1723000002000,"read_by_owner":true},
-      {"id":"g5","direction":"agent_to_owner","from":"vetrina","text":"Deployed vetrina.dev — it is live.","created_unix_ms":1723000001000,"read_by_owner":true}
+      {"id":"g5","direction":"agent_to_owner","from":"vetrina","text":"Deployed vetrina.dev — it is live.","created_unix_ms":1723000001000,"read_by_owner":true,"file":{"name":"vetrina-live.png","size":48213,"mime":"image/png","sha256":"9f2c0a1b7d3e4f5061728394a5b6c7d8e9f0a1b2c3d4e5f60718293a4b5c6d7e"}}
     ]}}
     """#
 
@@ -295,6 +332,14 @@ enum MockWireFixtures {
     /// MockTransport.gramPosted.
     static let gramPosted =
         #"{"id":"mock","result":{"type":"gram_sent","message":{"id":"gp1","direction":"owner_to_agent","from":"owner","text":"(sent)","created_unix_ms":1723000006000,"read_by_owner":true}}}"#
+
+    /// A canned `gram.get_file` reply (`type: gram_file_content`); the bytes decode
+    /// to "hello world". Keep in sync with the App's MockTransport.gramFileContent.
+    static let gramFileContent =
+        #"{"id":"mock","result":{"type":"gram_file_content","name":"vetrina-live.png","mime":"image/png","size":11,"data_base64":"aGVsbG8gd29ybGQ="}}"#
+
+    /// A canned `type: ok` reply, for `gram.upload_chunk` and `gram.delete`.
+    static let okResult = #"{"id":"mock","result":{"type":"ok"}}"#
 
     // MARK: pane.stream / pane.set_pty_size fixtures (mirrored in App MockTransport)
 

--- a/Tests/HerdrKitTests/MockWireFixtureTests.swift
+++ b/Tests/HerdrKitTests/MockWireFixtureTests.swift
@@ -286,6 +286,32 @@ final class MockWireFixtureTests: XCTestCase {
         XCTAssertTrue(uploadID.hasPrefix("app-"), "upload id should be a safe app- token")
         try await client.gramDelete(id: "g5")
     }
+
+    /// A worst-case slash-heavy chunk (all 0xFF → base64 is entirely "/") must not
+    /// inflate the request line: the request encoder must emit unescaped "/", or a
+    /// binary chunk would blow the SSH command-size cap. Guards the chunk-size math.
+    func testGramUploadChunkRequestStaysCompactForSlashHeavyData() async throws {
+        final class Capture: HerdrTransport, @unchecked Sendable {
+            var maxLen = 0
+            func roundTrip(_ requestLine: String) async throws -> String {
+                maxLen = max(maxLen, requestLine.utf8.count)
+                return #"{"id":"x","result":{"type":"ok"}}"#
+            }
+            func stream(_ requestLine: String) -> AsyncThrowingStream<String, Error> {
+                AsyncThrowingStream { $0.finish() }
+            }
+        }
+        let capture = Capture()
+        let client = HerdrClient(transport: capture)
+        let data = Data(repeating: 0xFF, count: HerdrClient.gramUploadChunkBytes)
+        _ = try await client.gramUploadFile(data)
+        // ~49 KiB raw → ~65.5 KB unescaped base64 + envelope. Escaping every "/"
+        // would nearly double it; assert it stays well under the point where the
+        // outer argv base64 (~1.33x) would breach the 120 KB command cap.
+        XCTAssertLessThan(
+            capture.maxLen, 80_000,
+            "slash escaping inflated the upload request line to \(capture.maxLen) bytes")
+    }
 }
 
 /// THE FIXTURES. Duplicated verbatim in App/HerdrApp.swift's MockTransport (the

--- a/project.yml
+++ b/project.yml
@@ -77,6 +77,9 @@ targets:
       # depend on it so the Linux build/test of the protocol layer stays intact.
       - package: SwiftTerm
         product: SwiftTerm
+      # QuickLook backs the Gram page's file preview (`.quickLookPreview`). Linked
+      # explicitly so the SwiftUI modifier resolves regardless of auto-linking.
+      - sdk: QuickLook.framework
     # Add the UI-test bundle to the auto-generated `Herdr` scheme's TEST action, so
     # `xcodebuild test -scheme Herdr -only-testing:HerdrUITests` runs it. This does NOT
     # touch the scheme's build/archive action, so the TestFlight lane (`-scheme Herdr`


### PR DESCRIPTION
## What

The owner side of gram **P3**: attach and preview files, and delete a message by long-pressing it. Pairs with jerryfane/herdr **PR #50** (the backend: `gram.upload_chunk` / `gram.get_file` / `gram.delete` + file attach).

### HerdrKit (Linux-tested)
- `GramMessage` gains an optional `file: GramFile?` (name/size/mime/sha256).
- New client methods: `gramUploadFile(_:)` (chunks at ~48 KiB raw to stay under the SSH transport's ~120 KB command cap after double-base64), `gramPost(text:to:attachment:)`, `gramGetFile(id:)`, `gramDelete(id:)`.

### GramView
- **Attach:** a paperclip in the composer picks a file (`.fileImporter`, capped at 10 MB), staged as a chip, sent with an optional caption. Empty caption is allowed when a file is attached.
- **Receive:** a message with a file shows a tappable chip → downloads the bytes → previews via `.quickLookPreview` (QuickLook's own share action saves to Files/Photos).
- **Delete:** long-press a message → **Delete** (`.contextMenu`). The row is removed only *after* the server confirms the purge, so a failed delete doesn't lie. This is the motivating use case: send a temporary API key, use it, delete it — bytes and record gone.
- `project.yml` links `QuickLook.framework` for the preview modifier.

### Mock / tests
- `MockTransport` answers `gram.get_file` / `gram.upload_chunk` / `gram.delete` and carries a file on one demo message (so the `HERDR_SCREENSHOT_MOCK=gram` render shows a file chip).
- `MockWireFixtureTests` (Linux-runnable) prove the new `file` field, `gram_file_content`, and `ok` replies decode through the real `HerdrClient` — fixtures kept byte-identical with the app's `MockTransport`.

## Notes for review
- The `.contextMenu` is on the **plain SwiftUI gram-list ScrollView**, not the SwiftTerm terminal — so the terminal-scroll device-receipt rule does not apply here; long-press vs. scroll is SwiftUI-native disambiguation.
- HerdrKit builds + all HerdrKit tests pass on Linux (`/opt/swift`, 6.1.2). The App SwiftUI target compiles on the macOS CI matrix.