### PR TITLE
feat(gram): render received Markdown files as formatted HTML in preview

### DIFF
--- a/App/GramView.swift
+++ b/App/GramView.swift
@@ -536,17 +536,28 @@ struct GramView: View {
         Task {
             defer { downloadingFileFor = nil }
             do {
-                let (name, _, data) = try await client.gramGetFile(id: message.id)
-                // Never trust the server name to be a safe path component; reduce it
-                // to a bare basename before joining it to the temp directory.
-                let url = FileManager.default.temporaryDirectory
-                    .appendingPathComponent(Self.safeTempFileName(name))
+                let (name, mime, data) = try await client.gramGetFile(id: message.id)
                 // Remove any previously-previewed file so a viewed secret does not
-                // accumulate in tmp; write encrypted-at-rest.
+                // accumulate in tmp.
                 if let previous = previewURL {
                     try? FileManager.default.removeItem(at: previous)
                 }
-                try data.write(to: url, options: [.atomic, .completeFileProtection])
+                let tmp = FileManager.default.temporaryDirectory
+                let url: URL
+                if Self.isMarkdown(name: name, mime: mime),
+                    let text = String(data: data, encoding: .utf8)
+                {
+                    // Render markdown to styled HTML so it previews FORMATTED —
+                    // QuickLook shows a raw .md file as plain source otherwise.
+                    let html = Markdown.toStyledHTML(text, title: Self.displayTitle(name))
+                    url = tmp.appendingPathComponent(Self.previewHTMLName(for: name))
+                    try Data(html.utf8).write(to: url, options: [.atomic, .completeFileProtection])
+                } else {
+                    // Never trust the server name to be a safe path component; reduce
+                    // it to a bare basename. Write encrypted-at-rest.
+                    url = tmp.appendingPathComponent(Self.safeTempFileName(name))
+                    try data.write(to: url, options: [.atomic, .completeFileProtection])
+                }
                 previewURL = url
             } catch let error as APIError {
                 sendError = "Couldn't open the file: \(error.message)"
@@ -565,6 +576,30 @@ struct GramView: View {
             .trimmingCharacters(in: .whitespacesAndNewlines)
         if base.isEmpty || base == "." || base == ".." { return "file" }
         return base
+    }
+
+    /// A file we should render as formatted HTML (a markdown source), by extension
+    /// or advisory mime.
+    private static func isMarkdown(name: String, mime: String) -> Bool {
+        let lower = name.lowercased()
+        return lower.hasSuffix(".md") || lower.hasSuffix(".markdown")
+            || mime.lowercased() == "text/markdown"
+    }
+
+    /// The markdown file's name without its `.md`/`.markdown` extension, for the
+    /// preview title.
+    private static func displayTitle(_ name: String) -> String {
+        let base = safeTempFileName(name)
+        for ext in [".markdown", ".md"] where base.lowercased().hasSuffix(ext) {
+            return String(base.dropLast(ext.count))
+        }
+        return base
+    }
+
+    /// The temp file name for a rendered markdown preview — a `.html` extension so
+    /// QuickLook renders it as a web page, not source.
+    private static func previewHTMLName(for name: String) -> String {
+        displayTitle(name) + ".html"
     }
 
     /// Delete a message (and its file bytes) after the server confirms — so a

--- a/Sources/HerdrKit/Markdown.swift
+++ b/Sources/HerdrKit/Markdown.swift
@@ -1,0 +1,299 @@
+import Foundation
+
+/// A small, dependency-free Markdown → styled-HTML converter for previewing
+/// received `.md` files as formatted pages instead of raw source. It covers the
+/// common subset agent- and human-written markdown uses: ATX headings, bold /
+/// italic, inline and fenced code, unordered / ordered lists, GitHub tables,
+/// blockquotes, horizontal rules, links, and paragraphs. Anything it doesn't
+/// recognize falls through as escaped text, so output is always safe HTML.
+///
+/// It lives in HerdrKit (not the app) so the parsing — the part with real logic —
+/// is unit-tested on Linux; the app only decides when to call it.
+public enum Markdown {
+
+    /// Convert markdown to a self-contained, theme-aware HTML document suitable for
+    /// QuickLook. `title` names the browser/preview tab.
+    public static func toStyledHTML(_ markdown: String, title: String = "Preview") -> String {
+        document(title: escape(title), body: renderBlocks(markdown))
+    }
+
+    // MARK: - Block parsing
+
+    private static func renderBlocks(_ markdown: String) -> String {
+        // Normalize newlines; keep blank lines (they separate blocks).
+        let lines = markdown
+            .replacingOccurrences(of: "\r\n", with: "\n")
+            .replacingOccurrences(of: "\r", with: "\n")
+            .components(separatedBy: "\n")
+
+        var html = ""
+        var i = 0
+        while i < lines.count {
+            let line = lines[i]
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+
+            // Blank line — nothing to emit (blocks handle their own spacing).
+            if trimmed.isEmpty { i += 1; continue }
+
+            // Fenced code block: ``` ... ```
+            if trimmed.hasPrefix("```") {
+                var code: [String] = []
+                i += 1
+                while i < lines.count, !lines[i].trimmingCharacters(in: .whitespaces).hasPrefix("```") {
+                    code.append(lines[i]); i += 1
+                }
+                i += 1  // consume the closing fence (or run off the end)
+                html += "<pre><code>\(escape(code.joined(separator: "\n")))</code></pre>\n"
+                continue
+            }
+
+            // Horizontal rule: ---, ***, ___
+            if isHorizontalRule(trimmed) {
+                html += "<hr>\n"; i += 1; continue
+            }
+
+            // ATX heading: #..###### followed by a space
+            if let heading = heading(trimmed) {
+                html += heading + "\n"; i += 1; continue
+            }
+
+            // GitHub table: a header row then a |---|---| separator row.
+            if trimmed.contains("|"), i + 1 < lines.count,
+                isTableSeparator(lines[i + 1].trimmingCharacters(in: .whitespaces))
+            {
+                var rows: [String] = [line]
+                i += 2  // header + separator
+                rows.append(lines[i - 1])  // keep separator marker slot; rebuilt below
+                var bodyRows: [String] = []
+                while i < lines.count, lines[i].contains("|"),
+                    !lines[i].trimmingCharacters(in: .whitespaces).isEmpty
+                {
+                    bodyRows.append(lines[i]); i += 1
+                }
+                html += renderTable(header: rows[0], bodyRows: bodyRows) + "\n"
+                continue
+            }
+
+            // Blockquote: one or more lines starting with >
+            if trimmed.hasPrefix(">") {
+                var quote: [String] = []
+                while i < lines.count, lines[i].trimmingCharacters(in: .whitespaces).hasPrefix(">") {
+                    var q = lines[i].trimmingCharacters(in: .whitespaces)
+                    q.removeFirst()  // drop '>'
+                    quote.append(q.trimmingCharacters(in: .whitespaces))
+                    i += 1
+                }
+                html += "<blockquote>\(renderBlocks(quote.joined(separator: "\n")))</blockquote>\n"
+                continue
+            }
+
+            // Unordered list: -, *, + markers
+            if isUnorderedItem(trimmed) {
+                var items: [String] = []
+                while i < lines.count, isUnorderedItem(lines[i].trimmingCharacters(in: .whitespaces)) {
+                    items.append(listItemText(lines[i].trimmingCharacters(in: .whitespaces), ordered: false))
+                    i += 1
+                }
+                html += "<ul>\(items.map { "<li>\(inline($0))</li>" }.joined())</ul>\n"
+                continue
+            }
+
+            // Ordered list: 1. 2. ...
+            if isOrderedItem(trimmed) {
+                var items: [String] = []
+                while i < lines.count, isOrderedItem(lines[i].trimmingCharacters(in: .whitespaces)) {
+                    items.append(listItemText(lines[i].trimmingCharacters(in: .whitespaces), ordered: true))
+                    i += 1
+                }
+                html += "<ol>\(items.map { "<li>\(inline($0))</li>" }.joined())</ol>\n"
+                continue
+            }
+
+            // Paragraph: gather consecutive "plain" lines until a blank or a block start.
+            var para: [String] = []
+            while i < lines.count {
+                let l = lines[i]
+                let t = l.trimmingCharacters(in: .whitespaces)
+                if t.isEmpty || t.hasPrefix("```") || t.hasPrefix(">") || isHorizontalRule(t)
+                    || heading(t) != nil || isUnorderedItem(t) || isOrderedItem(t)
+                {
+                    break
+                }
+                para.append(t); i += 1
+            }
+            if !para.isEmpty {
+                html += "<p>\(inline(para.joined(separator: " ")))</p>\n"
+            }
+        }
+        return html
+    }
+
+    // MARK: - Block helpers
+
+    private static func isHorizontalRule(_ s: String) -> Bool {
+        let compact = s.replacingOccurrences(of: " ", with: "")
+        return compact.count >= 3
+            && (compact.allSatisfy { $0 == "-" } || compact.allSatisfy { $0 == "*" }
+                || compact.allSatisfy { $0 == "_" })
+    }
+
+    private static func heading(_ s: String) -> String? {
+        var level = 0
+        var rest = Substring(s)
+        while rest.first == "#" { level += 1; rest = rest.dropFirst() }
+        guard level >= 1, level <= 6, rest.first == " " else { return nil }
+        let text = rest.trimmingCharacters(in: .whitespaces)
+        return "<h\(level)>\(inline(text))</h\(level)>"
+    }
+
+    private static func isUnorderedItem(_ s: String) -> Bool {
+        s.hasPrefix("- ") || s.hasPrefix("* ") || s.hasPrefix("+ ")
+    }
+
+    private static func isOrderedItem(_ s: String) -> Bool {
+        guard let dot = s.firstIndex(of: ".") else { return false }
+        let num = s[s.startIndex..<dot]
+        return !num.isEmpty && num.allSatisfy(\.isNumber) && s[s.index(after: dot)...].hasPrefix(" ")
+    }
+
+    private static func listItemText(_ s: String, ordered: Bool) -> String {
+        if ordered, let dot = s.firstIndex(of: ".") {
+            return String(s[s.index(after: dot)...]).trimmingCharacters(in: .whitespaces)
+        }
+        return String(s.dropFirst(2))  // drop the marker + space
+    }
+
+    private static func isTableSeparator(_ s: String) -> Bool {
+        guard s.contains("-"), s.contains("|") else { return false }
+        return s.allSatisfy { $0 == "|" || $0 == "-" || $0 == ":" || $0 == " " }
+    }
+
+    private static func tableCells(_ row: String) -> [String] {
+        var s = row.trimmingCharacters(in: .whitespaces)
+        if s.hasPrefix("|") { s.removeFirst() }
+        if s.hasSuffix("|") { s.removeLast() }
+        return s.components(separatedBy: "|").map { $0.trimmingCharacters(in: .whitespaces) }
+    }
+
+    private static func renderTable(header: String, bodyRows: [String]) -> String {
+        let head = tableCells(header).map { "<th>\(inline($0))</th>" }.joined()
+        let body = bodyRows.map { row in
+            "<tr>" + tableCells(row).map { "<td>\(inline($0))</td>" }.joined() + "</tr>"
+        }.joined()
+        return "<table><thead><tr>\(head)</tr></thead><tbody>\(body)</tbody></table>"
+    }
+
+    // MARK: - Inline parsing
+
+    /// Render inline markdown inside already-block-classified text: code spans,
+    /// links, bold, italic. HTML is escaped first, so no user text becomes markup.
+    static func inline(_ text: String) -> String {
+        // 1) Pull out code spans so their contents are never treated as markup.
+        var placeholders: [String] = []
+        var working = ""
+        let buffer = Array(text)
+        var idx = 0
+        while idx < buffer.count {
+            if buffer[idx] == "`" {
+                var j = idx + 1
+                var code = ""
+                while j < buffer.count, buffer[j] != "`" { code.append(buffer[j]); j += 1 }
+                if j < buffer.count {  // closed span
+                    let token = "\u{0000}CODE\(placeholders.count)\u{0000}"
+                    placeholders.append("<code>\(escape(code))</code>")
+                    working += token
+                    idx = j + 1
+                    continue
+                }
+            }
+            working.append(buffer[idx]); idx += 1
+        }
+
+        // 2) Escape HTML on the remaining (non-code) text.
+        var html = escape(working)
+
+        // 3) Links, then bold, then italic (bold before italic so ** wins over *).
+        html = replace(html, #"\[([^\]]+)\]\(([^)\s]+)\)"#) { m in
+            "<a href=\"\(m[2])\">\(m[1])</a>"
+        }
+        html = replace(html, #"\*\*([^*]+)\*\*"#) { "<strong>\($0[1])</strong>" }
+        html = replace(html, #"__([^_]+)__"#) { "<strong>\($0[1])</strong>" }
+        html = replace(html, #"(?<![\*\w])\*([^*]+)\*(?![\*\w])"#) { "<em>\($0[1])</em>" }
+        html = replace(html, #"(?<![_\w])_([^_]+)_(?![_\w])"#) { "<em>\($0[1])</em>" }
+
+        // 4) Restore code spans.
+        for (n, replacement) in placeholders.enumerated() {
+            html = html.replacingOccurrences(of: "\u{0000}CODE\(n)\u{0000}", with: replacement)
+        }
+        return html
+    }
+
+    private static func replace(
+        _ input: String, _ pattern: String, _ transform: ([String]) -> String
+    ) -> String {
+        guard let re = try? NSRegularExpression(pattern: pattern) else { return input }
+        let ns = input as NSString
+        var result = ""
+        var last = 0
+        for match in re.matches(in: input, range: NSRange(location: 0, length: ns.length)) {
+            result += ns.substring(with: NSRange(location: last, length: match.range.location - last))
+            var groups: [String] = []
+            for g in 0..<match.numberOfRanges {
+                let r = match.range(at: g)
+                groups.append(r.location == NSNotFound ? "" : ns.substring(with: r))
+            }
+            result += transform(groups)
+            last = match.range.location + match.range.length
+        }
+        result += ns.substring(from: last)
+        return result
+    }
+
+    static func escape(_ s: String) -> String {
+        s.replacingOccurrences(of: "&", with: "&amp;")
+            .replacingOccurrences(of: "<", with: "&lt;")
+            .replacingOccurrences(of: ">", with: "&gt;")
+    }
+
+    // MARK: - Document shell
+
+    private static func document(title: String, body: String) -> String {
+        """
+        <!doctype html>
+        <html lang="en"><head><meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <title>\(title)</title>
+        <style>
+        :root { color-scheme: light dark;
+          --ink:#1c2230; --muted:#5b647f; --line:#e6e9f2; --bg:#ffffff;
+          --code-bg:#f4f6fb; --quote:#8891ad; --link:#2f6df6; }
+        @media (prefers-color-scheme: dark) {
+          :root { --ink:#e7ebf6; --muted:#9aa3c2; --line:#262c44; --bg:#0e1220;
+            --code-bg:#171d31; --quote:#7883a6; --link:#7aa2ff; } }
+        * { box-sizing:border-box; }
+        body { margin:0; background:var(--bg); color:var(--ink);
+          font:16px/1.6 -apple-system, system-ui, sans-serif;
+          padding:24px 20px; -webkit-text-size-adjust:100%; }
+        h1,h2,h3,h4,h5,h6 { line-height:1.25; margin:1.4em 0 .5em; font-weight:650; }
+        h1 { font-size:1.7em; margin-top:.2em; } h2 { font-size:1.4em; }
+        h3 { font-size:1.2em; } h4,h5,h6 { font-size:1.05em; }
+        p { margin:.7em 0; } a { color:var(--link); text-decoration:none; }
+        ul,ol { margin:.6em 0; padding-left:1.4em; } li { margin:.25em 0; }
+        code { background:var(--code-bg); padding:.12em .4em; border-radius:5px;
+          font:.88em ui-monospace, SFMono-Regular, Menlo, monospace; }
+        pre { background:var(--code-bg); padding:14px 16px; border-radius:12px;
+          overflow-x:auto; border:1px solid var(--line); }
+        pre code { background:none; padding:0; font-size:.85em; }
+        blockquote { margin:.8em 0; padding:.2em 0 .2em 14px; color:var(--muted);
+          border-left:3px solid var(--quote); }
+        hr { border:0; border-top:1px solid var(--line); margin:1.4em 0; }
+        table { border-collapse:collapse; width:100%; margin:.9em 0; font-size:.95em;
+          display:block; overflow-x:auto; }
+        th,td { border:1px solid var(--line); padding:8px 11px; text-align:left; }
+        th { background:var(--code-bg); font-weight:650; }
+        </style></head>
+        <body>
+        \(body)</body></html>
+        """
+    }
+}

--- a/Sources/HerdrKit/Markdown.swift
+++ b/Sources/HerdrKit/Markdown.swift
@@ -12,14 +12,21 @@ import Foundation
 public enum Markdown {
 
     /// Convert markdown to a self-contained, theme-aware HTML document suitable for
-    /// QuickLook. `title` names the browser/preview tab.
+    /// QuickLook. `title` names the browser/preview tab. Output is escaped/safe HTML
+    /// under a strict CSP, so a hostile `.md` cannot run script in the preview.
     public static func toStyledHTML(_ markdown: String, title: String = "Preview") -> String {
-        document(title: escape(title), body: renderBlocks(markdown))
+        // Strip NUL so it cannot collide with the code-span sentinel below.
+        let clean = markdown.replacingOccurrences(of: "\u{0000}", with: "")
+        return document(title: escape(title), body: renderBlocks(clean, depth: 0))
     }
+
+    /// Bound on blockquote nesting, so a hostile `>>>>…` file cannot recurse deep
+    /// enough to overflow the stack.
+    private static let maxBlockquoteDepth = 6
 
     // MARK: - Block parsing
 
-    private static func renderBlocks(_ markdown: String) -> String {
+    private static func renderBlocks(_ markdown: String, depth: Int) -> String {
         // Normalize newlines; keep blank lines (they separate blocks).
         let lines = markdown
             .replacingOccurrences(of: "\r\n", with: "\n")
@@ -83,7 +90,12 @@ public enum Markdown {
                     quote.append(q.trimmingCharacters(in: .whitespaces))
                     i += 1
                 }
-                html += "<blockquote>\(renderBlocks(quote.joined(separator: "\n")))</blockquote>\n"
+                // Bound recursion so a deeply nested `>>>>…` file can't overflow.
+                let inner =
+                    depth < maxBlockquoteDepth
+                    ? renderBlocks(quote.joined(separator: "\n"), depth: depth + 1)
+                    : "<p>\(inline(quote.joined(separator: " ")))</p>"
+                html += "<blockquote>\(inner)</blockquote>\n"
                 continue
             }
 
@@ -214,7 +226,8 @@ public enum Markdown {
 
         // 3) Links, then bold, then italic (bold before italic so ** wins over *).
         html = replace(html, #"\[([^\]]+)\]\(([^)\s]+)\)"#) { m in
-            "<a href=\"\(m[2])\">\(m[1])</a>"
+            // Drop an unsafe scheme (javascript:, data:, …) — render just the text.
+            Self.isSafeURL(m[2]) ? "<a href=\"\(m[2])\">\(m[1])</a>" : m[1]
         }
         html = replace(html, #"\*\*([^*]+)\*\*"#) { "<strong>\($0[1])</strong>" }
         html = replace(html, #"__([^_]+)__"#) { "<strong>\($0[1])</strong>" }
@@ -253,6 +266,28 @@ public enum Markdown {
         s.replacingOccurrences(of: "&", with: "&amp;")
             .replacingOccurrences(of: "<", with: "&lt;")
             .replacingOccurrences(of: ">", with: "&gt;")
+            .replacingOccurrences(of: "\"", with: "&quot;")
+            .replacingOccurrences(of: "'", with: "&#39;")
+    }
+
+    /// Whether a link destination is safe to place in an `href`. Allows http(s),
+    /// mailto, and relative/anchor links; blocks `javascript:`, `data:`, and any
+    /// other scheme that could execute in the preview's WebView. The URL has
+    /// already been HTML-escaped, so `escape`'d quotes here can't break the
+    /// attribute; this additionally stops a clickable `javascript:` href.
+    static func isSafeURL(_ url: String) -> Bool {
+        let lower = url.lowercased()
+        if lower.hasPrefix("#") || lower.hasPrefix("/") || lower.hasPrefix("./")
+            || lower.hasPrefix("../")
+        {
+            return true
+        }
+        for scheme in ["https://", "http://", "mailto:"] where lower.hasPrefix(scheme) {
+            return true
+        }
+        // No scheme delimiter at all → a bare/relative path; anything WITH a `:`
+        // that wasn't allowlisted above (javascript:, data:, vbscript:, …) is out.
+        return !lower.contains(":")
     }
 
     // MARK: - Document shell
@@ -261,6 +296,7 @@ public enum Markdown {
         """
         <!doctype html>
         <html lang="en"><head><meta charset="utf-8">
+        <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; img-src data:;">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>\(title)</title>
         <style>

--- a/Tests/HerdrKitTests/MarkdownTests.swift
+++ b/Tests/HerdrKitTests/MarkdownTests.swift
@@ -1,0 +1,85 @@
+import XCTest
+@testable import HerdrKit
+
+/// The Markdown → HTML converter is the real logic behind the app's formatted
+/// `.md` preview; the app only decides when to call it. Verified here on Linux.
+final class MarkdownTests: XCTestCase {
+
+    private func html(_ md: String) -> String { Markdown.toStyledHTML(md) }
+
+    func testHeadingsByLevel() {
+        let out = html("# One\n## Two\n### Three")
+        XCTAssertTrue(out.contains("<h1>One</h1>"))
+        XCTAssertTrue(out.contains("<h2>Two</h2>"))
+        XCTAssertTrue(out.contains("<h3>Three</h3>"))
+    }
+
+    func testBoldItalicInlineCode() {
+        let out = Markdown.inline("a **bold** and *italic* and `code()` here")
+        XCTAssertTrue(out.contains("<strong>bold</strong>"), out)
+        XCTAssertTrue(out.contains("<em>italic</em>"), out)
+        XCTAssertTrue(out.contains("<code>code()</code>"), out)
+    }
+
+    func testLink() {
+        let out = Markdown.inline("see [herdr](https://herdr.dev/docs)")
+        XCTAssertTrue(out.contains("<a href=\"https://herdr.dev/docs\">herdr</a>"), out)
+    }
+
+    func testHtmlIsEscaped() {
+        // Angle brackets and ampersands in prose must not become live markup.
+        let out = Markdown.inline("tags <script> & <b> stay literal")
+        XCTAssertTrue(out.contains("&lt;script&gt;"), out)
+        XCTAssertTrue(out.contains("&amp;"), out)
+        XCTAssertFalse(out.contains("<script>"), out)
+    }
+
+    func testCodeSpanContentIsNotParsedAsMarkup() {
+        // Inside a code span, ** and < are literal, not markup.
+        let out = Markdown.inline("`a **b** <c>`")
+        XCTAssertTrue(out.contains("<code>a **b** &lt;c&gt;</code>"), out)
+        XCTAssertFalse(out.contains("<strong>"), out)
+    }
+
+    func testUnorderedAndOrderedLists() {
+        let ul = html("- one\n- two\n- three")
+        XCTAssertTrue(ul.contains("<ul>"), ul)
+        XCTAssertEqual(ul.components(separatedBy: "<li>").count - 1, 3, ul)
+
+        let ol = html("1. first\n2. second")
+        XCTAssertTrue(ol.contains("<ol>"), ol)
+        XCTAssertTrue(ol.contains("<li>first</li>"), ol)
+    }
+
+    func testFencedCodeBlock() {
+        let out = html("```\nlet x = 1 < 2\n```")
+        XCTAssertTrue(out.contains("<pre><code>let x = 1 &lt; 2</code></pre>"), out)
+    }
+
+    func testGitHubTable() {
+        let out = html("| A | B |\n| --- | --- |\n| 1 | 2 |\n| 3 | 4 |")
+        XCTAssertTrue(out.contains("<table>"), out)
+        XCTAssertTrue(out.contains("<th>A</th>"), out)
+        XCTAssertTrue(out.contains("<td>1</td>"), out)
+        XCTAssertTrue(out.contains("<td>4</td>"), out)
+    }
+
+    func testBlockquoteAndHorizontalRule() {
+        let out = html("> quoted line\n\n---")
+        XCTAssertTrue(out.contains("<blockquote>"), out)
+        XCTAssertTrue(out.contains("<hr>"), out)
+    }
+
+    func testParagraphsSeparatedByBlankLine() {
+        let out = html("first para\n\nsecond para")
+        XCTAssertTrue(out.contains("<p>first para</p>"), out)
+        XCTAssertTrue(out.contains("<p>second para</p>"), out)
+    }
+
+    func testDocumentIsSelfContained() {
+        let out = html("# Title\n\nbody")
+        XCTAssertTrue(out.hasPrefix("<!doctype html>"), out)
+        XCTAssertTrue(out.contains("<style>"), out)
+        XCTAssertTrue(out.contains("prefers-color-scheme: dark"), out)
+    }
+}

--- a/Tests/HerdrKitTests/MarkdownTests.swift
+++ b/Tests/HerdrKitTests/MarkdownTests.swift
@@ -82,4 +82,47 @@ final class MarkdownTests: XCTestCase {
         XCTAssertTrue(out.contains("<style>"), out)
         XCTAssertTrue(out.contains("prefers-color-scheme: dark"), out)
     }
+
+    // MARK: - Injection safety
+
+    func testEscapeCoversQuotes() {
+        let out = Markdown.escape("say \"hi\" it's")
+        XCTAssertTrue(out.contains("&quot;"), out)
+        XCTAssertTrue(out.contains("&#39;"), out)
+    }
+
+    func testLinkAttributeInjectionIsNeutralized() {
+        // A quote in the URL must be escaped so it can't break out of href="..."
+        // and inject a live event handler.
+        let out = Markdown.inline(#"[x](https://a.com/"onmouseover="alert(1))"#)
+        XCTAssertFalse(out.contains("\"onmouseover=\""), out)  // no live attribute
+        XCTAssertTrue(out.contains("&quot;"), out)  // the quote is escaped
+    }
+
+    func testUnsafeSchemesAreDroppedNotLinked() {
+        let js = Markdown.inline("[click](javascript:alert(1))")
+        XCTAssertFalse(js.lowercased().contains("href"), js)  // no link at all
+        XCTAssertTrue(js.contains("click"), js)  // text preserved
+
+        let data = Markdown.inline("[x](data:text/html,<script>1</script>)")
+        XCTAssertFalse(data.lowercased().contains("href=\"data:"), data)
+    }
+
+    func testSafeSchemesAreLinked() {
+        XCTAssertTrue(Markdown.inline("[a](https://x.com)").contains(#"<a href="https://x.com">a</a>"#))
+        XCTAssertTrue(Markdown.inline("[a](mailto:x@y.com)").contains(#"href="mailto:x@y.com""#))
+        XCTAssertTrue(Markdown.inline("[a](/docs)").contains(#"href="/docs""#))
+    }
+
+    func testDocumentHasStrictCSP() {
+        let out = html("# x")
+        XCTAssertTrue(out.contains("Content-Security-Policy"), out)
+        XCTAssertTrue(out.contains("default-src 'none'"), out)
+    }
+
+    func testDeeplyNestedBlockquoteDoesNotCrash() {
+        // A hostile deeply-nested quote must render bounded, not overflow the stack.
+        let out = html(String(repeating: ">", count: 500) + " boom")
+        XCTAssertTrue(out.contains("<blockquote>"), "should still render a bounded quote")
+    }
 }


### PR DESCRIPTION
## What

A received `.md` file previewed as **raw source** — QuickLook shows the markdown text literally. Now, opening a markdown attachment converts it to a self-contained, theme-aware **styled HTML** document and previews that, so headings, bold/italic, lists, GitHub tables, code, blockquotes, and links all render. Non-markdown files preview exactly as before.

## How

- **HerdrKit `Markdown.swift`** — a dependency-free `Markdown.toStyledHTML(_:title:)` converter for the common CommonMark subset. Put in HerdrKit (not the app) precisely so the parsing logic is **unit-tested on Linux** — the app only decides *when* to call it. Output is always escaped/safe HTML.
- **`GramView.openFile`** — detects markdown by extension (`.md`/`.markdown`) or mime (`text/markdown`), renders it to HTML, writes a `.html` temp file (so QuickLook renders it as a page), and previews that. The existing temp-file cleanup, filename sanitization, and complete-file-protection paths are unchanged; non-markdown still writes raw bytes.

## Tests

`MarkdownTests` (11, Linux-runnable, all green): headings by level, inline bold/italic/code, links, **HTML escaping** (prose `<script>` stays literal), **code-span protection** (markup inside `` ` `` is literal), ordered/unordered lists, fenced code blocks, GFM tables, blockquotes + rules, paragraph separation, and self-contained doc shell. Full HerdrKit suite: 238 tests pass on `/opt/swift`.

The App SwiftUI target compiles on the macOS CI matrix.