### PR TITLE
App UX batch: attachment type picker, swipe-down sheets, first-run gestures helper

### DIFF
--- a/App/GesturesHelpView.swift
+++ b/App/GesturesHelpView.swift
@@ -1,0 +1,127 @@
+import SwiftUI
+
+/// A first-run tutorial that teaches the app's gestures — the ones that aren't
+/// obvious because they have no on-screen affordance (swipe between agents, edge
+/// swipe back, double-tap to tail, press-and-hold to act). Shown once on first
+/// launch (gated by `@AppStorage("hasSeenGesturesHelp")`) and re-openable any time
+/// from the "Gestures" tab. Presented through the app's single `activeCover` sheet,
+/// so it inherits the swipe-down-to-dismiss grabber like Settings and Gram.
+struct GesturesHelpView: View {
+    var onClose: () -> Void
+
+    /// One taught gesture: the SF Symbol hinting the motion, what you do, and what
+    /// it does. Kept in one list so the tutorial and the real behavior stay together.
+    private struct Gesture: Identifiable {
+        let symbol: String
+        let title: String
+        let detail: String
+        var id: String { title }  // titles are unique + stable → stable ForEach identity
+    }
+
+    private static let gestures: [Gesture] = [
+        .init(symbol: "hand.tap",
+              title: "Tap an agent",
+              detail: "Opens its live terminal."),
+        .init(symbol: "arrow.left.and.right",
+              title: "Swipe left or right",
+              detail: "Moves to the next or previous agent's terminal."),
+        .init(symbol: "chevron.backward",
+              title: "Swipe in from the left edge",
+              detail: "Goes back to the agents list."),
+        .init(symbol: "arrow.down.to.line",
+              title: "Double-tap the terminal",
+              detail: "Jumps to the newest output."),
+        .init(symbol: "arrow.up.and.down",
+              title: "Drag up and down",
+              detail: "Scrolls back through the terminal history."),
+        .init(symbol: "hand.point.up.left",
+              title: "Press and hold an agent",
+              detail: "Stops it."),
+        .init(symbol: "trash",
+              title: "Press and hold a message in Gram",
+              detail: "Deletes it — and its file — for good."),
+        .init(symbol: "arrow.clockwise",
+              title: "Pull down in Gram",
+              detail: "Refreshes the messages."),
+    ]
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider().overlay(Palette.hairlineQuiet)
+            ScrollView {
+                VStack(spacing: 10) {
+                    ForEach(Self.gestures) { row(for: $0) }
+                }
+                .padding(.horizontal, 16)
+                .padding(.top, 14)
+                .padding(.bottom, 12)
+            }
+            footer
+        }
+        .background(Palette.ground.ignoresSafeArea())
+    }
+
+    private var header: some View {
+        HStack(spacing: 10) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Gestures")
+                    .font(Typography.app(20, .semibold))
+                    .foregroundStyle(Palette.text)
+                Text("How to move around Herdr")
+                    .font(Typography.app(12))
+                    .foregroundStyle(Palette.textFaint)
+            }
+            Spacer(minLength: 0)
+            Button(action: onClose) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 15, weight: .medium))
+                    .foregroundStyle(Palette.textDim)
+                    .frame(width: 36, height: 36)
+                    .background(Palette.surface)
+                    .clipShape(Circle())
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.top, 8)
+        .padding(.bottom, 10)
+    }
+
+    private func row(for gesture: Gesture) -> some View {
+        HStack(spacing: 14) {
+            Image(systemName: gesture.symbol)
+                .font(.system(size: 18, weight: .medium))
+                .foregroundStyle(Palette.brand)
+                .frame(width: 44, height: 44)
+                .background(RoundedRectangle(cornerRadius: 12).fill(Palette.surfaceRaised))
+            VStack(alignment: .leading, spacing: 3) {
+                Text(gesture.title)
+                    .font(Typography.app(15, .semibold))
+                    .foregroundStyle(Palette.text)
+                Text(gesture.detail)
+                    .font(Typography.app(13))
+                    .foregroundStyle(Palette.textDim)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(RoundedRectangle(cornerRadius: 14).fill(Palette.surface))
+    }
+
+    private var footer: some View {
+        Button(action: onClose) {
+            Text("Got it")
+                .font(Typography.app(16, .semibold))
+                .foregroundStyle(Palette.ground)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 14)
+                .background(RoundedRectangle(cornerRadius: 14).fill(Palette.text))
+        }
+        .padding(.horizontal, 16)
+        .padding(.top, 8)
+        .padding(.bottom, 12)
+        .background(Palette.ground)
+    }
+}

--- a/App/GramView.swift
+++ b/App/GramView.swift
@@ -1,3 +1,4 @@
+import CoreTransferable
 import HerdrKit
 import PhotosUI
 import QuickLook
@@ -53,6 +54,10 @@ struct GramView: View {
     @State private var showPhotoPicker = false
     /// The item chosen from the photo library, loaded into a `PickedAttachment`.
     @State private var photoItem: PhotosPickerItem?
+    /// True while a photo-library pick is loading (iCloud items can take a moment).
+    /// Gates Send and the paperclip so a text-only send can't race the load and a
+    /// second pick can't start concurrently.
+    @State private var loadingPhoto = false
     /// True while a picked file is uploading (many small chunks over SSH).
     @State private var uploading = false
     /// A downloaded file written to a temp URL, presented via QuickLook when set.
@@ -169,6 +174,9 @@ struct GramView: View {
         .onDisappear {
             if let previewURL { try? FileManager.default.removeItem(at: previewURL) }
         }
+        // Don't let a swipe-down (the new sheet dismissal) abandon an in-flight send
+        // or a photo load mid-way — the chunked upload would keep running off-screen.
+        .interactiveDismissDisabled(sending || loadingPhoto)
     }
 
     /// A load error / send error, shown ABOVE the composer in every phase — the
@@ -332,13 +340,21 @@ struct GramView: View {
                 Button {
                     showAttachTypeDialog = true
                 } label: {
-                    Image(systemName: "paperclip")
-                        .font(.system(size: 16, weight: .semibold))
-                        .foregroundStyle(Palette.textDim)
-                        .frame(width: 38, height: 38)
-                        .background(Circle().fill(Palette.surface))
+                    Group {
+                        if loadingPhoto {
+                            // An iCloud-backed pick can take a beat to materialize;
+                            // show it's working rather than a dead paperclip.
+                            ProgressView().tint(Palette.textDim)
+                        } else {
+                            Image(systemName: "paperclip")
+                                .font(.system(size: 16, weight: .semibold))
+                                .foregroundStyle(Palette.textDim)
+                        }
+                    }
+                    .frame(width: 38, height: 38)
+                    .background(Circle().fill(Palette.surface))
                 }
-                .disabled(sending)
+                .disabled(sending || loadingPhoto)
                 TextField("Message an agent…", text: $draft, axis: .vertical)
                     .font(Typography.app(15))
                     .foregroundStyle(Palette.text)
@@ -374,7 +390,9 @@ struct GramView: View {
     }
 
     private var canSend: Bool {
-        guard !sending else { return false }
+        // Also blocked while a photo is loading, so tapping Send mid-load can't fire a
+        // text-only message that races the attachment in behind it.
+        guard !sending, !loadingPhoto else { return false }
         return attachedFile != nil
             || !draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
@@ -542,43 +560,73 @@ struct GramView: View {
         }
     }
 
-    /// Load a photo-library pick into a `PickedAttachment`. The library gives us raw
-    /// bytes (not a security-scoped file URL), so the size check runs after the load;
-    /// the same 10 MB cap the file path enforces still applies.
+    /// An over-cap library pick, thrown from `PickedMedia`'s importer BEFORE the bytes
+    /// are read into memory — so a multi-GB 4K/ProRes video is rejected by its on-disk
+    /// size, never materialized (which would jetsam the app).
+    private enum PickedMediaError: Error { case tooLarge }
+
+    /// A photo-library pick loaded as a size-checked file. PhotosUI exports the item to
+    /// a temp file; we stat that file and reject an over-cap pick THERE, mirroring the
+    /// document path's "reject before reading into memory" guard, then read the bytes
+    /// only once we know they fit.
+    private struct PickedMedia: Transferable {
+        let data: Data
+        static var transferRepresentation: some TransferRepresentation {
+            FileRepresentation(importedContentType: .item) { received in
+                let size = (try? received.file.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0
+                guard size <= GramView.maxFileBytes else { throw PickedMediaError.tooLarge }
+                return PickedMedia(data: try Data(contentsOf: received.file))
+            }
+        }
+    }
+
+    /// Load a photo-library pick into a `PickedAttachment`. Routes through `PickedMedia`
+    /// so the 10 MB cap is enforced on the exported file's size before any bytes are
+    /// read — the same invariant the document path holds, so an over-cap video shows
+    /// the "too large" error instead of jetsamming the app.
     private func loadPickedPhoto(_ item: PhotosPickerItem) async {
-        defer { photoItem = nil }  // reset so re-picking the same item fires onChange again
+        loadingPhoto = true
+        defer {
+            loadingPhoto = false
+            photoItem = nil  // reset so re-picking the same item fires onChange again
+        }
         do {
-            guard let data = try await item.loadTransferable(type: Data.self) else {
+            guard let media = try await item.loadTransferable(type: PickedMedia.self) else {
                 sendError = "Couldn't read that item."
                 return
             }
-            guard !data.isEmpty else {
+            guard !media.data.isEmpty else {
                 sendError = "That item is empty."
                 return
             }
-            guard data.count <= Self.maxFileBytes else {
-                sendError = "That item is too large (max 10 MB)."
-                return
-            }
             let (name, mime) = Self.photoNameAndMime(for: item)
-            attachedFile = PickedAttachment(name: name, mime: mime, data: data)
+            attachedFile = PickedAttachment(name: name, mime: mime, data: media.data)
             sendError = nil
+        } catch is PickedMediaError {
+            sendError = "That item is too large (max 10 MB)."
         } catch {
             sendError = "Couldn't read that item."
         }
     }
 
     /// Derive a filename + MIME for a library pick from its concrete content type
-    /// (HEIC, JPEG, MOV, …); fall back to jpeg/mov if the type doesn't report one.
+    /// (HEIC, JPEG, MOV, …). The name carries a short unique discriminator so three
+    /// photos don't all arrive as "image.heic" — identical chips for the owner and a
+    /// name collision for any receiving agent that stores attachments by name.
     private static func photoNameAndMime(for item: PhotosPickerItem) -> (String, String) {
+        let disc = UUID().uuidString.prefix(8).lowercased()
         if let type = item.supportedContentTypes.first,
             let ext = type.preferredFilenameExtension,
             let mime = type.preferredMIMEType
         {
             let base = type.conforms(to: .movie) ? "video" : "image"
-            return ("\(base).\(ext)", mime)
+            return ("\(base)-\(disc).\(ext)", mime)
         }
-        return ("image.jpg", "image/jpeg")
+        // The type reported no extension/MIME — still make a movie-aware, unique name.
+        if let type = item.supportedContentTypes.first, type.conforms(to: .movie) {
+            return ("video-\(disc).mov", "video/quicktime")
+        }
+        return ("image-\(disc).jpg", "image/jpeg")
     }
 
     private static func mimeType(for url: URL) -> String {

--- a/App/GramView.swift
+++ b/App/GramView.swift
@@ -1,4 +1,5 @@
 import HerdrKit
+import PhotosUI
 import QuickLook
 import SwiftUI
 import UniformTypeIdentifiers
@@ -46,6 +47,12 @@ struct GramView: View {
     /// time), nil when none is staged.
     @State private var attachedFile: PickedAttachment?
     @State private var showFileImporter = false
+    /// The paperclip opens this chooser first, so we know which system picker to
+    /// present: the photo library (image/video) or the document picker (any file).
+    @State private var showAttachTypeDialog = false
+    @State private var showPhotoPicker = false
+    /// The item chosen from the photo library, loaded into a `PickedAttachment`.
+    @State private var photoItem: PhotosPickerItem?
     /// True while a picked file is uploading (many small chunks over SSH).
     @State private var uploading = false
     /// A downloaded file written to a temp URL, presented via QuickLook when set.
@@ -125,6 +132,22 @@ struct GramView: View {
         // refresh (the gram store has no event stream); the loop ends when the view
         // goes away (task cancellation).
         .task { await pollLoop() }
+        // Paperclip → choose the source so we open the RIGHT system picker: the
+        // photo library for media, or the document picker for an arbitrary file.
+        .confirmationDialog("Attach", isPresented: $showAttachTypeDialog, titleVisibility: .visible) {
+            Button("Photo or Video") { showPhotoPicker = true }
+            Button("File") { showFileImporter = true }
+            Button("Cancel", role: .cancel) {}
+        }
+        .photosPicker(
+            isPresented: $showPhotoPicker,
+            selection: $photoItem,
+            matching: .any(of: [.images, .videos])
+        )
+        .onChange(of: photoItem) { _, newItem in
+            guard let newItem else { return }
+            Task { await loadPickedPhoto(newItem) }
+        }
         .fileImporter(
             isPresented: $showFileImporter,
             allowedContentTypes: [.item],
@@ -307,7 +330,7 @@ struct GramView: View {
             if let attachedFile { attachmentChip(attachedFile) }
             HStack(alignment: .bottom, spacing: 8) {
                 Button {
-                    showFileImporter = true
+                    showAttachTypeDialog = true
                 } label: {
                     Image(systemName: "paperclip")
                         .font(.system(size: 16, weight: .semibold))
@@ -517,6 +540,45 @@ struct GramView: View {
         } catch {
             sendError = "Couldn't read that file."
         }
+    }
+
+    /// Load a photo-library pick into a `PickedAttachment`. The library gives us raw
+    /// bytes (not a security-scoped file URL), so the size check runs after the load;
+    /// the same 10 MB cap the file path enforces still applies.
+    private func loadPickedPhoto(_ item: PhotosPickerItem) async {
+        defer { photoItem = nil }  // reset so re-picking the same item fires onChange again
+        do {
+            guard let data = try await item.loadTransferable(type: Data.self) else {
+                sendError = "Couldn't read that item."
+                return
+            }
+            guard !data.isEmpty else {
+                sendError = "That item is empty."
+                return
+            }
+            guard data.count <= Self.maxFileBytes else {
+                sendError = "That item is too large (max 10 MB)."
+                return
+            }
+            let (name, mime) = Self.photoNameAndMime(for: item)
+            attachedFile = PickedAttachment(name: name, mime: mime, data: data)
+            sendError = nil
+        } catch {
+            sendError = "Couldn't read that item."
+        }
+    }
+
+    /// Derive a filename + MIME for a library pick from its concrete content type
+    /// (HEIC, JPEG, MOV, …); fall back to jpeg/mov if the type doesn't report one.
+    private static func photoNameAndMime(for item: PhotosPickerItem) -> (String, String) {
+        if let type = item.supportedContentTypes.first,
+            let ext = type.preferredFilenameExtension,
+            let mime = type.preferredMIMEType
+        {
+            let base = type.conforms(to: .movie) ? "video" : "image"
+            return ("\(base).\(ext)", mime)
+        }
+        return ("image.jpg", "image/jpeg")
     }
 
     private static func mimeType(for url: URL) -> String {

--- a/App/GramView.swift
+++ b/App/GramView.swift
@@ -560,22 +560,34 @@ struct GramView: View {
         }
     }
 
-    /// An over-cap library pick, thrown from `PickedMedia`'s importer BEFORE the bytes
-    /// are read into memory — so a multi-GB 4K/ProRes video is rejected by its on-disk
-    /// size, never materialized (which would jetsam the app).
-    private enum PickedMediaError: Error { case tooLarge }
-
     /// A photo-library pick loaded as a size-checked file. PhotosUI exports the item to
-    /// a temp file; we stat that file and reject an over-cap pick THERE, mirroring the
-    /// document path's "reject before reading into memory" guard, then read the bytes
-    /// only once we know they fit.
+    /// a temp file; the importer stats that file and rejects an over-cap (or unstat-able)
+    /// pick THERE — `data == nil` — before any bytes are read, mirroring the document
+    /// path's "reject before reading into memory" guard.
+    ///
+    /// Rejection is signalled as a VALUE (`data == nil`), NOT a thrown error, on purpose:
+    /// `loadTransferable` routes through NSItemProvider's Obj-C error bridge, across which
+    /// a thrown Swift error type may not survive — so a `nil` payload is the only reliable
+    /// way to carry "rejected" back and still show the right message.
     private struct PickedMedia: Transferable {
-        let data: Data
+        /// Non-nil only for an in-cap, readable pick; nil = rejected (over-cap OR the
+        /// exported file's size could not be determined — treated as over-cap, never
+        /// read blindly into memory).
+        let data: Data?
         static var transferRepresentation: some TransferRepresentation {
             FileRepresentation(importedContentType: .item) { received in
-                let size = (try? received.file.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0
-                guard size <= GramView.maxFileBytes else { throw PickedMediaError.tooLarge }
-                return PickedMedia(data: try Data(contentsOf: received.file))
+                // Unknown size is treated as OVER-cap (reject), never under-cap — an
+                // unstat-able export must not fall through to an unbounded read.
+                guard let size = try? received.file.resourceValues(forKeys: [.fileSizeKey]).fileSize,
+                    size <= GramView.maxFileBytes
+                else {
+                    return PickedMedia(data: nil)
+                }
+                let data = try Data(contentsOf: received.file)
+                // Belt-and-braces, matching the document path: reject if the read somehow
+                // exceeded the stat'd size, so an over-cap Data can never reach the caller.
+                guard data.count <= GramView.maxFileBytes else { return PickedMedia(data: nil) }
+                return PickedMedia(data: data)
             }
         }
     }
@@ -591,19 +603,23 @@ struct GramView: View {
             photoItem = nil  // reset so re-picking the same item fires onChange again
         }
         do {
+            // A nil transferable = couldn't produce a file; a non-nil transferable with a
+            // nil `data` = rejected by the size guard (over-cap / unstat-able).
             guard let media = try await item.loadTransferable(type: PickedMedia.self) else {
                 sendError = "Couldn't read that item."
                 return
             }
-            guard !media.data.isEmpty else {
+            guard let data = media.data else {
+                sendError = "That item is too large (max 10 MB)."
+                return
+            }
+            guard !data.isEmpty else {
                 sendError = "That item is empty."
                 return
             }
             let (name, mime) = Self.photoNameAndMime(for: item)
-            attachedFile = PickedAttachment(name: name, mime: mime, data: media.data)
+            attachedFile = PickedAttachment(name: name, mime: mime, data: data)
             sendError = nil
-        } catch is PickedMediaError {
-            sendError = "That item is too large (max 10 MB)."
         } catch {
             sendError = "Couldn't read that item."
         }

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -864,9 +864,11 @@ struct TerminalHomeView: View {
     @State private var trustFailed = false
     @State private var search = ""
     @State private var activeCover: ActiveCover?
+    /// First launch shows the gestures tutorial once; the "Gestures" tab reopens it.
+    @AppStorage("hasSeenGesturesHelp") private var hasSeenGesturesHelp = false
 
     private enum ActiveCover: Int, Identifiable {
-        case settings, newAgent, gram
+        case settings, newAgent, gram, gestures
         var id: Int { rawValue }
     }
 
@@ -1025,6 +1027,15 @@ struct TerminalHomeView: View {
                 }
                 .toolbar(.hidden, for: .navigationBar)
                 .task { await load() }
+                // First launch: show the gestures tutorial once. Guarded so a pending
+                // gram deep-link (which sets activeCover) is never stomped — and if one
+                // is up, openGramIfPending defers until this sheet closes.
+                .onAppear {
+                    if !hasSeenGesturesHelp {
+                        hasSeenGesturesHelp = true
+                        if activeCover == nil { activeCover = .gestures }
+                    }
+                }
                 // A push tapped while the home view is already loaded (app foregrounded / already
                 // on the list) deep-links immediately; the cold-launch / just-loaded case is handled
                 // at the end of load().
@@ -1041,41 +1052,50 @@ struct TerminalHomeView: View {
                 .opacity(frontID != nil ? 1 : 0)
                 .allowsHitTesting(frontID != nil)
         }
-        // ONE item-based cover, not two stacked isPresented covers (stacked
-        // presentation modifiers on a single view are historically fragile).
-        // onDismiss applies a queued open AFTER the cover is fully gone.
-        .fullScreenCover(item: $activeCover, onDismiss: {
+        // ONE item-based sheet, not two stacked isPresented presentations (stacked
+        // presentation modifiers on a single view are historically fragile). A SHEET
+        // (not a full-screen cover) so it presents bottom-up and swipe-down dismisses
+        // it — the header close buttons still work too. onDismiss applies a queued
+        // open AFTER the sheet is fully gone.
+        .sheet(item: $activeCover, onDismiss: {
             if let slot = pendingOpenSlot { pendingOpenSlot = nil; open(slot) }
-            openGramIfPending()   // a gram tap deferred while another cover was up
+            openGramIfPending()   // a gram tap deferred while another sheet was up
         }) { cover in
-            switch cover {
-            case .settings:
-                SettingsView(
-                    host: host,
-                    connected: error == nil && !loading,
-                    // Withhold reconnect during a host-key rejection — reconnecting
-                    // then would first-contact-trust the next key (same gate as the
-                    // recovery screen's withheld retry).
-                    canReconnect: rejectedFingerprint == nil,
-                    onReconnect: { activeCover = nil; onReconnect() },
-                    onClose: { activeCover = nil })
-            case .newAgent:
-                NewAgentView(
-                    client: client,
-                    // Spawn done: queue the new pane, then dismiss the cover; the
-                    // cover's onDismiss opens the pane with the task pre-filled.
-                    onStarted: { paneID, name, task in
-                        pendingOpenSlot = PaneSlot(paneID: paneID, title: name, agent: nil,
-                                                   initialReply: task, siblings: [])
-                        activeCover = nil
-                    },
-                    onCancel: { activeCover = nil })
-            case .gram:
-                GramView(
-                    client: client,
-                    agents: agents,
-                    onClose: { activeCover = nil })
+            Group {
+                switch cover {
+                case .settings:
+                    SettingsView(
+                        host: host,
+                        connected: error == nil && !loading,
+                        // Withhold reconnect during a host-key rejection — reconnecting
+                        // then would first-contact-trust the next key (same gate as the
+                        // recovery screen's withheld retry).
+                        canReconnect: rejectedFingerprint == nil,
+                        onReconnect: { activeCover = nil; onReconnect() },
+                        onClose: { activeCover = nil })
+                case .newAgent:
+                    NewAgentView(
+                        client: client,
+                        // Spawn done: queue the new pane, then dismiss the sheet; the
+                        // onDismiss opens the pane with the task pre-filled.
+                        onStarted: { paneID, name, task in
+                            pendingOpenSlot = PaneSlot(paneID: paneID, title: name, agent: nil,
+                                                       initialReply: task, siblings: [])
+                            activeCover = nil
+                        },
+                        onCancel: { activeCover = nil })
+                case .gram:
+                    GramView(
+                        client: client,
+                        agents: agents,
+                        onClose: { activeCover = nil })
+                case .gestures:
+                    GesturesHelpView(onClose: { activeCover = nil })
+                }
             }
+            // Full-height bottom-up sheet with a grabber, so swipe-down closes it.
+            .presentationDetents([.large])
+            .presentationDragIndicator(.visible)
         }
     }
 
@@ -1149,6 +1169,10 @@ struct TerminalHomeView: View {
             .disabled(terminalTarget == nil)
             Button { activeCover = .gram } label: {
                 tabItem("bubble.left.and.bubble.right", "Gram", active: false)
+            }
+            .buttonStyle(.plain)
+            Button { activeCover = .gestures } label: {
+                tabItem("hand.draw", "Gestures", active: false)
             }
             .buttonStyle(.plain)
             Button { activeCover = .settings } label: {

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -698,6 +698,11 @@ struct NewAgentView: View {
                 }
             }
         }
+        // Under a .sheet a swipe-down is an unguarded exit, but a spawn keeps running
+        // off-screen and its queued pane would be stranded (pendingOpenSlot never
+        // drains, then fires on an unrelated sheet close). Block interactive dismissal
+        // mid-spawn — the same invariant the Cancel button's .disabled(starting) holds.
+        .interactiveDismissDisabled(starting)
     }
 
     private var header: some View {
@@ -1027,13 +1032,19 @@ struct TerminalHomeView: View {
                 }
                 .toolbar(.hidden, for: .navigationBar)
                 .task { await load() }
-                // First launch: show the gestures tutorial once. Guarded so a pending
-                // gram deep-link (which sets activeCover) is never stomped — and if one
-                // is up, openGramIfPending defers until this sheet closes.
+                // First launch: show the gestures tutorial once — but NOT over a pending
+                // push deep-link (openGramIfPending / applyDeepLink would dismiss it to
+                // show Gram or the pane, wasting the one-shot). Burn the seen-flag ONLY
+                // when we actually present, so a deep-linked first launch still gets the
+                // tutorial on its next clean launch rather than never.
                 .onAppear {
-                    if !hasSeenGesturesHelp {
+                    if !hasSeenGesturesHelp,
+                        activeCover == nil,
+                        !push.pendingGram,
+                        push.pendingPaneID == nil
+                    {
                         hasSeenGesturesHelp = true
-                        if activeCover == nil { activeCover = .gestures }
+                        activeCover = .gestures
                     }
                 }
                 // A push tapped while the home view is already loaded (app foregrounded / already

--- a/project.yml
+++ b/project.yml
@@ -80,6 +80,9 @@ targets:
       # QuickLook backs the Gram page's file preview (`.quickLookPreview`). Linked
       # explicitly so the SwiftUI modifier resolves regardless of auto-linking.
       - sdk: QuickLook.framework
+      # PhotosUI backs the Gram attachment picker's Photo/Video source (`PhotosPicker`
+      # / `.photosPicker`). Linked explicitly for the same reason as QuickLook above.
+      - sdk: PhotosUI.framework
     # Add the UI-test bundle to the auto-generated `Herdr` scheme's TEST action, so
     # `xcodebuild test -scheme Herdr -only-testing:HerdrUITests` runs it. This does NOT
     # touch the scheme's build/archive action, so the TestFlight lane (`-scheme Herdr`


### PR DESCRIPTION
Owner's Phase A onboarding/UX batch — three asks, one TestFlight (v0.1.26+):

### #6 — Attachment type picker (Photo/Video vs File)
The Gram paperclip now opens a confirmationDialog: **Photo or Video** presents a
`PhotosPicker` (photo library); **File** keeps the existing document picker. A
library pick loads via `loadTransferable(Data)`, derives `name`+`mime` from the
item's concrete content type (HEIC/JPEG/MOV…, fallback `image.jpg`/`video.mov`),
and feeds the **same** 10 MB-capped `PickedAttachment` → chunked-upload path. No
Info.plist change (PhotosPicker is out-of-process, needs no usage string).

### #2 — Swipe-down to dismiss Settings + Gram
They presented as a `.fullScreenCover`, which can't be swiped away. Switched the
single item-based presentation to `.sheet` + `.presentationDetents([.large])` +
`.presentationDragIndicator(.visible)` — bottom-up, swipe-down closes; header
close buttons still work; queued-open `onDismiss` unchanged. One shared
presentation drives Settings/Gram/New-agent, so **all three** become large sheets
(standard iOS; New-agent gains swipe-to-cancel).

### #1 — First-run gestures helper
New `GesturesHelpView` teaches the non-obvious gestures (swipe between agents,
edge-swipe back, double-tap to tail, drag to scroll, press-and-hold to
stop/delete, pull-to-refresh) — SF Symbol + one line each, DesignSystem-styled.
Shown once via `@AppStorage("hasSeenGesturesHelp")`, re-openable from a new
**Gestures** tab. Presented through the **same** `activeCover` sheet (new
`.gestures` case), not a second `.sheet`, to keep the single-presentation
invariant the nav deliberately maintains.

`PhotosUI.framework` linked explicitly in `project.yml` (same as QuickLook, per
the cross-import-overlay compile lesson).

### Review notes
- The App target compiles only on the **macOS CI matrix** (`build-and-uitest`) —
  HerdrKit is unchanged here, so there are no new Linux tests. Please treat CI
  green as the compile gate.
- Independent of PR #74 (HTML sandbox); disjoint regions of `GramView` (this
  touches the composer/attach path, #74 touches `openFile`). Will rebase onto
  main after whichever lands first.
