### PR TITLE
Gram UX: copy message text on long-press; move Gestures to Settings

### DIFF
--- a/App/GramView.swift
+++ b/App/GramView.swift
@@ -3,6 +3,7 @@ import HerdrKit
 import PhotosUI
 import QuickLook
 import SwiftUI
+import UIKit
 import UniformTypeIdentifiers
 
 /// The Gram page: the owner's side of the owner<->agent message channel.
@@ -850,8 +851,18 @@ private struct GramRow: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(RoundedRectangle(cornerRadius: 12).fill(Palette.card))
         .overlay(RoundedRectangle(cornerRadius: 12).stroke(Palette.hairlineQuiet, lineWidth: 1))
-        // Long-press to delete a message (and its file bytes) for good.
+        // Long-press for the message actions. Copy the text (when there is any) —
+        // a file's bytes are reached via the chip's preview + system share sheet, so
+        // we don't add a second, weaker file-copy path here. Delete is destructive,
+        // pinned last.
         .contextMenu {
+            if !message.text.isEmpty {
+                Button {
+                    UIPasteboard.general.string = message.text
+                } label: {
+                    Label("Copy", systemImage: "doc.on.doc")
+                }
+            }
             Button(role: .destructive, action: onDelete) {
                 Label("Delete", systemImage: "trash")
             }

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -1182,10 +1182,6 @@ struct TerminalHomeView: View {
                 tabItem("bubble.left.and.bubble.right", "Gram", active: false)
             }
             .buttonStyle(.plain)
-            Button { activeCover = .gestures } label: {
-                tabItem("hand.draw", "Gestures", active: false)
-            }
-            .buttonStyle(.plain)
             Button { activeCover = .settings } label: {
                 tabItem("gearshape", "Settings", active: false)
             }
@@ -2191,6 +2187,9 @@ struct SettingsView: View {
     @AppStorage("notify.finishes") private var notifyFinishes = false
     @AppStorage("notify.gram") private var notifyGram = true
     @State private var copied = false
+    /// The gestures tutorial, opened from the Help row (its persistent home now that
+    /// it's no longer a tab). Presented as a child sheet over Settings.
+    @State private var showGestures = false
 
     var body: some View {
         ZStack {
@@ -2198,17 +2197,25 @@ struct SettingsView: View {
             VStack(spacing: 0) {
                 header
                 ScrollView {
-                    // Grouped into three subviews so the top-level builder stays
-                    // well under SwiftUI's 10-child ViewBuilder ceiling.
+                    // Grouped into subviews so the top-level builder stays well under
+                    // SwiftUI's 10-child ViewBuilder ceiling.
                     VStack(alignment: .leading, spacing: 0) {
                         connectionSection
                         notifySection
                         troubleSection
+                        helpSection
                         versionFooter
                     }
                     .padding(.bottom, 16)
                 }
             }
+        }
+        // The gestures reference lives here now (moved out of the main tab bar);
+        // reuse the same self-contained help view the first-run popup shows.
+        .sheet(isPresented: $showGestures) {
+            GesturesHelpView(onClose: { showGestures = false })
+                .presentationDetents([.large])
+                .presentationDragIndicator(.visible)
         }
     }
 
@@ -2265,6 +2272,13 @@ struct SettingsView: View {
             actionRow("Reconnect now", enabled: canReconnect,
                       note: "verify the host key first") { onReconnect() }
             actionRow(copied ? "Copied ✓" : "Copy diagnostics") { copyDiagnostics() }
+        }
+    }
+
+    private var helpSection: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            sectionLabel("HELP")
+            actionRow("Gestures", note: "how to move around the app") { showGestures = true }
         }
     }
 


### PR DESCRIPTION
Owner feedback via JARVIS (directive 56001; plan approved in fork-sync note 56008). Closes #77.

**(1) Copy on long-press** — `GramRow`'s long-press `.contextMenu` (Delete-only) gains **Copy** above Delete, copying `message.text` via `UIPasteboard`, shown only when text is non-empty. File bytes are deliberately **not** duplicated into the menu: the file chip already does tap → download → QuickLook → system share (Copy/Save), so `content` = the text body and files keep their one working path. (JARVIS confirmed this call.)

**(2) Gestures out of the main menu** — removed the persistent **Gestures tab** from the bottom bar; added a **HELP → Gestures** row in Settings that opens the same self-contained `GesturesHelpView` as a child sheet. The **first-run auto-present popup is unchanged** (one-time onboarding, not a menu item) — only the persistent entry moved.

App target compiles on macOS CI (HerdrKit unchanged). Folds into the next TestFlight — no separate build.