### PR TITLE
Phase B: gram setup card (#3) + herdr-fork check (#4)

### DIFF
--- a/App/ForkNoticeView.swift
+++ b/App/ForkNoticeView.swift
@@ -1,9 +1,11 @@
 import SwiftUI
 
-/// Shown once per connect when the daemon isn't our fork (`HerdrClient.probeFork()`
-/// == `.notFork`). The base daemon runs the terminals fine, but the features that
-/// make Herdrup itself — gram, push, the live terminal — are fork-only. Advisory,
-/// never a lockout: "Continue anyway" always dismisses.
+/// Shown once per connect when the daemon lacks the fork-only features
+/// (`HerdrClient.probeFork()` == `.notFork`) — a base daemon, OR a jerryfane/herdr
+/// build that predates gram (the probe can't tell them apart, so the copy says
+/// "update or switch", not "you're not on the fork"). The daemon runs the terminals
+/// fine; gram, push, and the live terminal are what's missing. Advisory, never a
+/// lockout: "Continue anyway" always dismisses.
 struct ForkNoticeView: View {
     var onDismiss: () -> Void
 
@@ -22,11 +24,14 @@ struct ForkNoticeView: View {
                     .font(.system(size: 40, weight: .regular))
                     .foregroundStyle(Palette.waiting)
                 VStack(spacing: 8) {
-                    Text("You're not on the Herdr fork")
+                    Text("This daemon is missing the Herdr features")
                         .font(Typography.app(22, .bold))
                         .foregroundStyle(Palette.text)
                         .multilineTextAlignment(.center)
-                    Text("Your agents connect fine, but the features Herdrup adds run on the jerryfane/herdr fork of the daemon:")
+                    // Capability, not identity: the probe can't tell a base daemon from
+                    // a jerryfane/herdr build that predates gram, so the copy must be
+                    // true of BOTH — "update or switch", never "you're not on the fork".
+                    Text("Your agents connect fine, but gram, push, and the live terminal need the jerryfane/herdr fork of the daemon:")
                         .font(Typography.app(14))
                         .foregroundStyle(Palette.textDim)
                         .multilineTextAlignment(.center)
@@ -35,7 +40,7 @@ struct ForkNoticeView: View {
                 VStack(spacing: 10) {
                     ForEach(missing, id: \.name) { row($0) }
                 }
-                Text("Switch your daemon to jerryfane/herdr to turn them on.")
+                Text("Switch to — or update — jerryfane/herdr to turn them on.")
                     .font(Typography.app(13))
                     .foregroundStyle(Palette.textFaint)
                     .multilineTextAlignment(.center)

--- a/App/ForkNoticeView.swift
+++ b/App/ForkNoticeView.swift
@@ -1,0 +1,78 @@
+import SwiftUI
+
+/// Shown once per connect when the daemon isn't our fork (`HerdrClient.probeFork()`
+/// == `.notFork`). The base daemon runs the terminals fine, but the features that
+/// make Herdrup itself — gram, push, the live terminal — are fork-only. Advisory,
+/// never a lockout: "Continue anyway" always dismisses.
+struct ForkNoticeView: View {
+    var onDismiss: () -> Void
+
+    /// (symbol, feature, one-line what-it-is) for each fork-only capability.
+    private let missing: [(symbol: String, name: String, detail: String)] = [
+        ("bubble.left.and.bubble.right", "Gram", "message your agents from here"),
+        ("bell.badge", "Push notifications", "alerts when an agent needs you"),
+        ("terminal", "The live terminal", "the real-time, scrollable view"),
+    ]
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Spacer(minLength: 0)
+            VStack(spacing: 22) {
+                Image(systemName: "arrow.triangle.branch")
+                    .font(.system(size: 40, weight: .regular))
+                    .foregroundStyle(Palette.waiting)
+                VStack(spacing: 8) {
+                    Text("You're not on the Herdr fork")
+                        .font(Typography.app(22, .bold))
+                        .foregroundStyle(Palette.text)
+                        .multilineTextAlignment(.center)
+                    Text("Your agents connect fine, but the features Herdrup adds run on the jerryfane/herdr fork of the daemon:")
+                        .font(Typography.app(14))
+                        .foregroundStyle(Palette.textDim)
+                        .multilineTextAlignment(.center)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                VStack(spacing: 10) {
+                    ForEach(missing, id: \.name) { row($0) }
+                }
+                Text("Switch your daemon to jerryfane/herdr to turn them on.")
+                    .font(Typography.app(13))
+                    .foregroundStyle(Palette.textFaint)
+                    .multilineTextAlignment(.center)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .padding(.horizontal, 28)
+            Spacer(minLength: 0)
+            Button(action: onDismiss) {
+                Text("Continue anyway")
+                    .font(Typography.app(16, .semibold))
+                    .foregroundStyle(Palette.ground)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 14)
+                    .background(RoundedRectangle(cornerRadius: 14).fill(Palette.text))
+            }
+            .padding(.horizontal, 20)
+            .padding(.bottom, 20)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Palette.ground.ignoresSafeArea())
+    }
+
+    private func row(_ item: (symbol: String, name: String, detail: String)) -> some View {
+        HStack(spacing: 14) {
+            Image(systemName: item.symbol)
+                .font(.system(size: 18, weight: .medium))
+                .foregroundStyle(Palette.brand)
+                .frame(width: 40, height: 40)
+                .background(RoundedRectangle(cornerRadius: 11).fill(Palette.surfaceRaised))
+            VStack(alignment: .leading, spacing: 2) {
+                Text(item.name).font(Typography.app(15, .semibold)).foregroundStyle(Palette.text)
+                Text(item.detail).font(Typography.app(13)).foregroundStyle(Palette.textDim)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(RoundedRectangle(cornerRadius: 14).fill(Palette.surface))
+    }
+}

--- a/App/GramView.swift
+++ b/App/GramView.swift
@@ -61,6 +61,11 @@ struct GramView: View {
     @State private var loadingPhoto = false
     /// True while a picked file is uploading (many small chunks over SSH).
     @State private var uploading = false
+    /// Dismissed the "set up gram for your agents" card. It also auto-hides once any
+    /// agent has messaged (proof they've set the skill up), so this is the manual out.
+    @AppStorage("gram.setupCardDismissed") private var setupCardDismissed = false
+    /// Momentary "Copied ✓" on the setup card's copy button.
+    @State private var setupCommandCopied = false
     /// A downloaded file written to a temp URL, presented via QuickLook when set.
     @State private var previewURL: URL?
     /// The message id whose file is currently downloading, to show a spinner on it.
@@ -261,7 +266,7 @@ struct GramView: View {
                 }
                 .padding(.horizontal, 32)
             }
-        case .loaded where messages.isEmpty:
+        case .loaded where messages.isEmpty && !shouldShowSetupCard:
             centered {
                 VStack(spacing: 8) {
                     Image(systemName: "tray")
@@ -280,6 +285,7 @@ struct GramView: View {
         case .loaded:
             ScrollView {
                 LazyVStack(spacing: 10) {
+                    if shouldShowSetupCard { setupCard }
                     ForEach(messages) { message in
                         GramRow(
                             message: message,
@@ -299,6 +305,65 @@ struct GramView: View {
     private func centered<V: View>(@ViewBuilder _ inner: () -> V) -> some View {
         VStack { Spacer(); inner(); Spacer() }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    /// The one-liner an agent runs to install the gram skill (from the fork's raw URL).
+    private static let setupCommand =
+        "curl -fsSL https://raw.githubusercontent.com/jerryfane/herdr/master/"
+        + "skills/herdrup-gram-skill/SKILL.md --create-dirs "
+        + "-o ~/.claude/skills/herdrup-gram-skill/SKILL.md"
+
+    /// Show the "set up gram" card until an agent has actually messaged (proof the
+    /// skill is in use) or the owner dismisses it.
+    private var shouldShowSetupCard: Bool {
+        !setupCardDismissed && !messages.contains(where: \.isFromAgent)
+    }
+
+    /// A dismissable card teaching the owner how to give their agents the gram skill:
+    /// the install command + a Copy button. Auto-hides once an agent messages.
+    private var setupCard: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .top, spacing: 10) {
+                VStack(alignment: .leading, spacing: 3) {
+                    Text("Set up gram for your agents")
+                        .font(Typography.app(15, .semibold))
+                        .foregroundStyle(Palette.text)
+                    Text("Paste this to your agents so they can message you here.")
+                        .font(Typography.app(13))
+                        .foregroundStyle(Palette.textDim)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                Spacer(minLength: 0)
+                Button { setupCardDismissed = true } label: {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(Palette.textFaint)
+                        .frame(width: 26, height: 26)
+                        .background(Circle().fill(Palette.surfaceRaised))
+                }
+            }
+            Text(Self.setupCommand)
+                .font(Typography.machine(11))
+                .foregroundStyle(Palette.textDim)
+                .textSelection(.enabled)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(10)
+                .background(RoundedRectangle(cornerRadius: 8).fill(Palette.groundMachine))
+            Button {
+                UIPasteboard.general.string = Self.setupCommand
+                setupCommandCopied = true
+            } label: {
+                Text(setupCommandCopied ? "Copied ✓" : "Copy command")
+                    .font(Typography.app(13, .semibold))
+                    .foregroundStyle(Palette.ground)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 9)
+                    .background(RoundedRectangle(cornerRadius: 9).fill(Palette.text))
+            }
+        }
+        .padding(14)
+        .background(RoundedRectangle(cornerRadius: 14).fill(Palette.surface))
+        .overlay(RoundedRectangle(cornerRadius: 14).stroke(Palette.hairline, lineWidth: 1))
     }
 
     // MARK: - Composer

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -871,9 +871,13 @@ struct TerminalHomeView: View {
     @State private var activeCover: ActiveCover?
     /// First launch shows the gestures tutorial once; the "Gestures" tab reopens it.
     @AppStorage("hasSeenGesturesHelp") private var hasSeenGesturesHelp = false
-    /// Shown once per connect when the daemon isn't our fork (probe == .notFork).
-    /// Advisory, dismissable — the base daemon still lists/controls agents.
+    /// Shown once per connect when the daemon lacks the fork features (probe ==
+    /// .notFork). Advisory, dismissable — the base daemon still lists/controls agents.
     @State private var showForkNotice = false
+    /// Set when the probe returns .notFork WHILE a cover (e.g. the first-run gestures
+    /// sheet) is up — draining it from the sheet's onDismiss serializes the notice
+    /// with `activeCover`, so the two presentations are never armed at once.
+    @State private var pendingForkNotice = false
 
     private enum ActiveCover: Int, Identifiable {
         case settings, newAgent, gram, gestures
@@ -1036,10 +1040,14 @@ struct TerminalHomeView: View {
                 .toolbar(.hidden, for: .navigationBar)
                 .task { await load() }
                 // Once per connect (this view is .id(session)-scoped): if the daemon
-                // isn't our fork, surface the advisory notice. Only a DEFINITIVE
-                // not-fork flips it — network/other errors stay quiet (see probeFork).
+                // lacks the fork features, surface the advisory notice. Only a
+                // DEFINITIVE not-fork flips it — network/other errors stay quiet (see
+                // probeFork). If a cover is already up (e.g. the first-run gestures
+                // sheet the onAppear below opens synchronously), DEFER — the sheet's
+                // onDismiss drains it, so we never arm two presentations at once.
                 .task {
-                    if await client.probeFork() == .notFork { showForkNotice = true }
+                    guard await client.probeFork() == .notFork else { return }
+                    if activeCover == nil { showForkNotice = true } else { pendingForkNotice = true }
                 }
                 // First launch: show the gestures tutorial once — but NOT over a pending
                 // push deep-link (openGramIfPending / applyDeepLink would dismiss it to
@@ -1080,6 +1088,13 @@ struct TerminalHomeView: View {
         .sheet(item: $activeCover, onDismiss: {
             if let slot = pendingOpenSlot { pendingOpenSlot = nil; open(slot) }
             openGramIfPending()   // a gram tap deferred while another sheet was up
+            // A fork notice deferred behind this sheet fires now — but only if nothing
+            // else claimed the foreground (a queued gram sets activeCover above), so
+            // the fullScreenCover never races the sheet.
+            if pendingForkNotice && activeCover == nil {
+                pendingForkNotice = false
+                showForkNotice = true
+            }
         }) { cover in
             Group {
                 switch cover {

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -984,6 +984,10 @@ struct TerminalHomeView: View {
     /// flag before this view existed). Clearing it lets a later tap re-trigger.
     private func openGramIfPending() {
         guard push.pendingGram else { return }
+        // The fork notice (a fullScreenCover) is up: don't arm the .gram sheet over it
+        // — that recreates the two-presentations-on-one-view collision. Leave the flag
+        // set; the notice's onDismiss re-invokes this once it's gone.
+        if showForkNotice { return }
         // Another cover is already presented: `fullScreenCover(item:)` does not
         // reliably swap to a new item while up, so dismiss it first (keeping the flag
         // armed). The cover's onDismiss re-invokes this, and with none presented it
@@ -1132,9 +1136,14 @@ struct TerminalHomeView: View {
             .presentationDetents([.large])
             .presentationDragIndicator(.visible)
         }
-        // Advisory full-screen notice when the daemon isn't our fork. Dismissable —
-        // it never blocks basic use (the base daemon still lists + controls agents).
-        .fullScreenCover(isPresented: $showForkNotice) {
+        // Advisory full-screen notice when the daemon lacks the fork features.
+        // Dismissable — it never blocks basic use. onDismiss drains anything that
+        // arrived WHILE it was up (a gram push / pane deep-link deferred against it),
+        // so those never armed a competing presentation over the cover.
+        .fullScreenCover(isPresented: $showForkNotice, onDismiss: {
+            openGramIfPending()
+            applyDeepLink()
+        }) {
             ForkNoticeView(onDismiss: { showForkNotice = false })
         }
     }

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -871,6 +871,9 @@ struct TerminalHomeView: View {
     @State private var activeCover: ActiveCover?
     /// First launch shows the gestures tutorial once; the "Gestures" tab reopens it.
     @AppStorage("hasSeenGesturesHelp") private var hasSeenGesturesHelp = false
+    /// Shown once per connect when the daemon isn't our fork (probe == .notFork).
+    /// Advisory, dismissable — the base daemon still lists/controls agents.
+    @State private var showForkNotice = false
 
     private enum ActiveCover: Int, Identifiable {
         case settings, newAgent, gram, gestures
@@ -1032,6 +1035,12 @@ struct TerminalHomeView: View {
                 }
                 .toolbar(.hidden, for: .navigationBar)
                 .task { await load() }
+                // Once per connect (this view is .id(session)-scoped): if the daemon
+                // isn't our fork, surface the advisory notice. Only a DEFINITIVE
+                // not-fork flips it — network/other errors stay quiet (see probeFork).
+                .task {
+                    if await client.probeFork() == .notFork { showForkNotice = true }
+                }
                 // First launch: show the gestures tutorial once — but NOT over a pending
                 // push deep-link (openGramIfPending / applyDeepLink would dismiss it to
                 // show Gram or the pane, wasting the one-shot). Burn the seen-flag ONLY
@@ -1107,6 +1116,11 @@ struct TerminalHomeView: View {
             // Full-height bottom-up sheet with a grabber, so swipe-down closes it.
             .presentationDetents([.large])
             .presentationDragIndicator(.visible)
+        }
+        // Advisory full-screen notice when the daemon isn't our fork. Dismissable —
+        // it never blocks basic use (the base daemon still lists + controls agents).
+        .fullScreenCover(isPresented: $showForkNotice) {
+            ForkNoticeView(onDismiss: { showForkNotice = false })
         }
     }
 

--- a/Sources/HerdrKit/HerdrClient.swift
+++ b/Sources/HerdrKit/HerdrClient.swift
@@ -251,9 +251,16 @@ public actor HerdrClient {
             if error.code == "gram_unavailable" {
                 return .isFork  // fork HAS gram.list; the shared server is just down
             }
+            let lowered = error.message.lowercased()
             if error.code == "invalid_request",
-                error.message.lowercased().contains("unknown variant")
+                lowered.contains("unknown variant"),
+                lowered.contains("gram.list")
             {
+                // serde's variant error always names the offending tag ("unknown
+                // variant `gram.list`, …"). Requiring the METHOD name narrows this to
+                // the top-level method enum — so if gram.list ever gains an enum-typed
+                // PARAM, an older fork that rejects that param's variant degrades to
+                // indeterminate (quiet) instead of a false notFork.
                 return .notFork
             }
             return .indeterminate  // some other API error on a well-formed call

--- a/Sources/HerdrKit/HerdrClient.swift
+++ b/Sources/HerdrKit/HerdrClient.swift
@@ -224,6 +224,44 @@ public actor HerdrClient {
                        as: GramListResult.self).messages
     }
 
+    /// Whether the connected daemon is our fork or the upstream base.
+    public enum ForkProbe: Sendable, Equatable {
+        /// Has the fork-only methods (gram, live terminal, push).
+        case isFork
+        /// The base daemon — rejected a fork-only method as unknown.
+        case notFork
+        /// Couldn't tell (network/transport error, or an unexpected API error on a
+        /// well-formed call). Callers should NOT prompt on this — assume fork.
+        case indeterminate
+    }
+
+    /// Detect the fork by calling a fork-only method (`gram.list`). The base daemon
+    /// parses `method` as an enum, so it cannot even DESERIALIZE an unknown method and
+    /// answers `invalid_request` / "unknown variant" — an outcome a well-formed
+    /// `gram.list` never produces on the fork (which returns a list, or
+    /// `gram_unavailable` when the shared server is down). Everything that is not a
+    /// definitive "unknown method" is treated as `indeterminate`, so a real fork user
+    /// is never falsely told to install the fork (a false positive is worse than a
+    /// missed one — the notice is only advisory).
+    public func probeFork() async -> ForkProbe {
+        do {
+            _ = try await gramList()
+            return .isFork
+        } catch let error as APIError {
+            if error.code == "gram_unavailable" {
+                return .isFork  // fork HAS gram.list; the shared server is just down
+            }
+            if error.code == "invalid_request",
+                error.message.lowercased().contains("unknown variant")
+            {
+                return .notFork
+            }
+            return .indeterminate  // some other API error on a well-formed call
+        } catch {
+            return .indeterminate  // network / decode / transport error
+        }
+    }
+
     /// A file already uploaded via `gramUploadFile`, ready to attach to a post.
     public struct GramFileAttachment: Sendable {
         public let uploadID: String

--- a/Tests/HerdrKitTests/ForkProbeTests.swift
+++ b/Tests/HerdrKitTests/ForkProbeTests.swift
@@ -55,6 +55,35 @@ final class ForkProbeTests: XCTestCase {
         XCTAssertEqual(r, .isFork)
     }
 
+    func testUnknownVariantNotNamingTheMethodIsIndeterminate() async {
+        // "unknown variant" that does NOT name gram.list (e.g. a future enum-typed
+        // PARAM an older fork rejects) must degrade to indeterminate, never a false
+        // notFork on a real fork user.
+        let line = error(code: "invalid_request",
+                         message: "invalid request: unknown variant `weekly`, expected one of `all`, `unread`")
+        let client = HerdrClient(transport: CannedTransport(line: line))
+        let r = await client.probeFork()
+        XCTAssertEqual(r, .indeterminate)
+    }
+
+    func testMixedCaseUnknownVariantIsNotFork() async {
+        // The match is case-insensitive (.lowercased()), so a reworded/mixed-case
+        // phrasing still classifies correctly.
+        let line = error(code: "invalid_request",
+                         message: "Invalid Request: Unknown Variant `gram.list`, expected one of ...")
+        let client = HerdrClient(transport: CannedTransport(line: line))
+        let r = await client.probeFork()
+        XCTAssertEqual(r, .notFork)
+    }
+
+    func testUndecodableSuccessLineIsIndeterminate() async {
+        // A 200-shaped line that doesn't decode to the result type throws a
+        // DecodingError (not an APIError) → the trailing catch → indeterminate.
+        let client = HerdrClient(transport: CannedTransport(line: #"{"id":"x","result":{"wrong":true}}"#))
+        let r = await client.probeFork()
+        XCTAssertEqual(r, .indeterminate)
+    }
+
     func testOtherInvalidRequestIsIndeterminate() async {
         // invalid_request WITHOUT "unknown variant" (e.g. a future required param) must
         // NOT flag a fork user — fail safe to indeterminate.

--- a/Tests/HerdrKitTests/ForkProbeTests.swift
+++ b/Tests/HerdrKitTests/ForkProbeTests.swift
@@ -1,0 +1,80 @@
+import XCTest
+import Foundation
+@testable import HerdrKit
+
+/// `probeFork()` decides whether to show the "you're not on the Herdr fork" notice.
+/// The whole point is that a real fork user is NEVER falsely told to install the
+/// fork — so only a definitive "unknown method" is `notFork`; everything else is
+/// `indeterminate` (assume fork, stay quiet). Verified on Linux.
+final class ForkProbeTests: XCTestCase {
+
+    /// Returns one canned line for any request, or throws a canned transport error.
+    private struct CannedTransport: HerdrTransport {
+        let line: String?
+        let thrown: Error?
+        init(line: String) { self.line = line; self.thrown = nil }
+        init(thrown: Error) { self.line = nil; self.thrown = thrown }
+        func roundTrip(_ requestLine: String) async throws -> String {
+            if let thrown { throw thrown }
+            return line!
+        }
+        func stream(_ requestLine: String) -> AsyncThrowingStream<String, Error> {
+            AsyncThrowingStream { $0.finish() }
+        }
+    }
+
+    private struct SocketClosed: Error {}
+
+    private func result(_ raw: String) -> String { #"{"id":"x","result":\#(raw)}"# }
+    private func error(code: String, message: String) -> String {
+        #"{"id":"x","error":{"code":"\#(code)","message":"\#(message)"}}"#
+    }
+
+    func testSuccessfulGramListIsFork() async {
+        let client = HerdrClient(transport: CannedTransport(line: result(#"{"messages":[]}"#)))
+        let r = await client.probeFork()
+        XCTAssertEqual(r, .isFork)
+    }
+
+    func testUnknownVariantIsNotFork() async {
+        // Exactly what the base daemon returns: it can't deserialize the unknown
+        // `gram.list` method variant.
+        let line = error(code: "invalid_request",
+                         message: "invalid request: unknown variant `gram.list`, expected one of ...")
+        let client = HerdrClient(transport: CannedTransport(line: line))
+        let r = await client.probeFork()
+        XCTAssertEqual(r, .notFork)
+    }
+
+    func testGramUnavailableIsFork() async {
+        // The fork HAS gram.list; the shared server is simply down. Must NOT be read
+        // as "not the fork".
+        let line = error(code: "gram_unavailable", message: "not connected to the shared Herdr server")
+        let client = HerdrClient(transport: CannedTransport(line: line))
+        let r = await client.probeFork()
+        XCTAssertEqual(r, .isFork)
+    }
+
+    func testOtherInvalidRequestIsIndeterminate() async {
+        // invalid_request WITHOUT "unknown variant" (e.g. a future required param) must
+        // NOT flag a fork user — fail safe to indeterminate.
+        let line = error(code: "invalid_request", message: "invalid request: missing field `foo`")
+        let client = HerdrClient(transport: CannedTransport(line: line))
+        let r = await client.probeFork()
+        XCTAssertEqual(r, .indeterminate)
+    }
+
+    func testUnrelatedApiErrorIsIndeterminate() async {
+        let line = error(code: "internal", message: "boom")
+        let client = HerdrClient(transport: CannedTransport(line: line))
+        let r = await client.probeFork()
+        XCTAssertEqual(r, .indeterminate)
+    }
+
+    func testTransportErrorIsIndeterminate() async {
+        // A dropped connection must never be read as "not the fork".
+        let client = HerdrClient(transport: CannedTransport(thrown: SocketClosed()))
+        let r = await client.probeFork()
+        XCTAssertEqual(r, .indeterminate)
+    }
+}


### PR DESCRIPTION
Owner's onboarding batch, Phase B (asks 3 + 4). Both app-side, one PR. Owner steered the #4 presentation (full-screen dismissable) and approved the #3 card directly.

### #3 — 'Set up gram for your agents' card (GramView)
Dismissable card at the top of the Gram page with the one-line `curl` that installs the gram skill from the fork's raw URL + a **Copy** button. Shown until an agent has actually messaged (`!messages.contains(isFromAgent)` = they haven't set it up) or the owner dismisses it (`@AppStorage`). The raw-URL target (fork skill file) already merged.

### #4 — herdr-fork check (HerdrKit + HerdrApp + new ForkNoticeView)
After connect, one probe calls a fork-only method. **Detection lives in HerdrKit** (`HerdrClient.probeFork() -> isFork / notFork / indeterminate`) so it's **unit-tested on Linux (6 tests, every branch)**:
- a non-fork daemon can't deserialize the unknown method → `invalid_request` / *'unknown variant'* → **notFork**
- success or `gram_unavailable` → **isFork**
- network / any other error → **indeterminate** (assume fork)

Only the definitive not-fork signal prompts, so **a real fork user is never falsely told to install the fork**. On notFork, a full-screen but **dismissable** `ForkNoticeView` explains gram/push/live-terminal are fork-only + how to switch; 'Continue anyway' always dismisses (the base daemon still lists + controls agents).

App compiles on macOS CI; HerdrKit **257 tests pass** locally. Bundles with #78 into the next TestFlight.