### PR TITLE
Settings redesign + StoreKit tip jar + open-source prep

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -8,7 +8,7 @@
 # distribution CERTIFICATE is team-wide and shared; herdr only needs its own
 # provisioning PROFILE for com.jerryfane.herdr.
 #
-# WHAT THIS IS NOT: the Mac build box (100.112.78.61:8787) still builds every branch
+# WHAT THIS IS NOT: the Mac build box on the tailnet still builds every branch
 # for the SIMULATOR and screenshots it — that is the correctness signal and stays.
 # This is the RELEASE path on a deliberately independent machine, so the two fail
 # independently. Runs only on demand or on a v* tag: an upload burns an App Store

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,13 @@ build/
 # build, so it is derived, not source.
 App/Info.plist
 SourcePackages/
+# Signing/secret material — none is committed today; these are defense-in-depth so
+# a future stray key can't be added by accident (the repo is public).
+*.p8
+*.p12
+*.mobileprovision
+*.cer
+*.pem
+*.key
+.env
+fastlane/

--- a/App/Herdr.storekit
+++ b/App/Herdr.storekit
@@ -1,0 +1,114 @@
+{
+  "identifier" : "980AC4F5-7AF6-4D87-A432-1EEDC19CDDBD",
+  "nonRenewingSubscriptions" : [
+
+  ],
+  "products" : [
+    {
+      "displayPrice" : "4.99",
+      "familyShareable" : false,
+      "internalID" : "8E5A606A-B6AB-41F4-AEEA-2116B481B0BB",
+      "localizations" : [
+        {
+          "description" : "A coffee-sized thank you",
+          "displayName" : "Coffee",
+          "locale" : "en_US"
+        }
+      ],
+      "productID" : "com.jerryfane.herdr.tip.coffee",
+      "referenceName" : "Coffee Tip",
+      "type" : "Consumable"
+    },
+    {
+      "displayPrice" : "9.99",
+      "familyShareable" : false,
+      "internalID" : "A0C81B34-25A0-436F-9A2F-6A5ED75493E4",
+      "localizations" : [
+        {
+          "description" : "A lunch-sized thank you",
+          "displayName" : "Lunch",
+          "locale" : "en_US"
+        }
+      ],
+      "productID" : "com.jerryfane.herdr.tip.lunch",
+      "referenceName" : "Lunch Tip",
+      "type" : "Consumable"
+    },
+    {
+      "displayPrice" : "19.99",
+      "familyShareable" : false,
+      "internalID" : "00D7C030-F80A-4E1E-A63F-A55D245585BD",
+      "localizations" : [
+        {
+          "description" : "A dinner-sized thank you",
+          "displayName" : "Dinner",
+          "locale" : "en_US"
+        }
+      ],
+      "productID" : "com.jerryfane.herdr.tip.dinner",
+      "referenceName" : "Dinner Tip",
+      "type" : "Consumable"
+    }
+  ],
+  "settings" : {
+    "_applicationInternalID" : "0",
+    "_developerTeamID" : "FXQ5Z9HHY6",
+    "_failTransactionsEnabled" : false,
+    "_locale" : "en_US",
+    "_storefront" : "USA",
+    "_storeKitErrors" : [
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "Load Products"
+      },
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "Purchase"
+      },
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "Verification"
+      },
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "App Store Sync"
+      },
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "Subscription Status"
+      },
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "App Transaction"
+      },
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "Manage Subscriptions Sheet"
+      },
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "Refund Request Sheet"
+      },
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "Offer Code Redeem Sheet"
+      }
+    ]
+  },
+  "subscriptionGroups" : [
+
+  ],
+  "version" : {
+    "major" : 3,
+    "minor" : 0
+  }
+}

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -3,6 +3,7 @@ import Foundation
 import Security
 import UIKit    // UIPasteboard (Copy diagnostics)
 import Darwin   // inet_pton/inet_ntop for IPv6 canonicalization
+import StoreKit // Product / tip jar (Settings' Support section)
 import HerdrKit
 
 // Phase 4, first real slice: terminal-first, on the merged pure-Swift transport.
@@ -2228,12 +2229,19 @@ struct SettingsView: View {
     /// The gestures tutorial, opened from the Help row (its persistent home now that
     /// it's no longer a tab). Presented as a child sheet over Settings.
     @State private var showGestures = false
+    /// The tip jar (StoreKit 2). Renders nothing until products load, so the section
+    /// is invisible before the App Store Connect products exist.
+    @ObservedObject private var tipStore = TipStore.shared
+    /// Opens the Privacy/Terms/GitHub links in the system browser. Overridable in
+    /// previews/UI-tests so automated runs never actually leave the app.
+    @Environment(\.openURL) private var openURL
 
     var body: some View {
         ZStack {
             Palette.ground.ignoresSafeArea()
             VStack(spacing: 0) {
                 header
+                Divider().overlay(Palette.hairlineQuiet)
                 ScrollView {
                     // Grouped into subviews so the top-level builder stays well under
                     // SwiftUI's 10-child ViewBuilder ceiling.
@@ -2242,7 +2250,10 @@ struct SettingsView: View {
                         notifySection
                         troubleSection
                         helpSection
+                        supportSection
+                        aboutSection
                         versionFooter
+                        githubFooter
                     }
                     .padding(.bottom, 16)
                 }
@@ -2255,22 +2266,29 @@ struct SettingsView: View {
                 .presentationDetents([.large])
                 .presentationDragIndicator(.visible)
         }
+        // Load the tip products when Settings opens. No-ops after a successful load;
+        // re-tries after a prior failure, so products created in ASC later appear.
+        .task { await tipStore.loadProducts() }
     }
 
-    // Header sits on the ground with a bottom hairline (not a filled bar); the
-    // one accent the kit uses here is the back affordance.
+    // Matches the Gram/Gestures header exactly: a left-aligned title in the app
+    // voice at .semibold, a bare xmark close on the right, and NO baked-in hairline
+    // (the body draws a separate Divider under it, like its sibling sheets). This is
+    // a sheet, not a nav push — xmark and swipe-down both dismiss, so there's no back.
     private var header: some View {
-        ZStack {
-            Text("Settings").font(Typography.app(20, .bold)).foregroundStyle(Palette.text)
-            HStack {
-                Button { onClose() } label: {
-                    Image(systemName: "chevron.left").font(.system(size: 16, weight: .semibold)).foregroundStyle(Palette.textDim)
-                }
-                Spacer()
+        HStack(spacing: 10) {
+            Text("Settings")
+                .font(Typography.app(20, .semibold))
+                .foregroundStyle(Palette.text)
+            Spacer()
+            Button(action: onClose) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundStyle(Palette.textDim)
             }
         }
-        .padding(.horizontal, 16).padding(.top, 8).padding(.bottom, 10)
-        .overlay(alignment: .bottom) { Rectangle().fill(Palette.hairline).frame(height: 1) }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
     }
 
     private var connectionSection: some View {
@@ -2292,16 +2310,67 @@ struct SettingsView: View {
     private var notifySection: some View {
         VStack(alignment: .leading, spacing: 0) {
             sectionLabel("NOTIFY ME WHEN")
-            toggleRow("An agent needs input", $notifyNeedsInput)
-            toggleRow("An agent dies", $notifyDies)
-            toggleRow("An agent finishes", $notifyFinishes)
-            toggleRow("A gram message arrives", $notifyGram)
-            // Honest about delivery: the toggles persist the choice, but push
-            // delivery is not wired yet — do not imply live notifications.
-            Text("Delivery is coming soon — these save your preference.")
-                .font(Typography.app(12)).foregroundStyle(Palette.textFaint)
-                .padding(.horizontal, 20).padding(.top, 8)
+            // One bordered card holds the four toggles AND the honest status row, so
+            // the group reads as a single feature rather than four stray rows plus a
+            // shrinking-violet footnote.
+            VStack(spacing: 0) {
+                groupedToggleRow("An agent needs input", $notifyNeedsInput)
+                rowDivider
+                groupedToggleRow("An agent dies", $notifyDies)
+                rowDivider
+                groupedToggleRow("An agent finishes", $notifyFinishes)
+                rowDivider
+                groupedToggleRow("A gram message arrives", $notifyGram)
+                rowDivider
+                notifyInfoRow
+            }
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+            .overlay(RoundedRectangle(cornerRadius: 12).stroke(Palette.hairline, lineWidth: 1))
+            .padding(.horizontal, 16).padding(.top, 10)
         }
+    }
+
+    private var rowDivider: some View {
+        Rectangle().fill(Palette.hairlineQuiet).frame(height: 1)
+    }
+
+    /// A word-state toggle row (ON/OFF, differentiated by the word not colour, per the
+    /// kit) WITHOUT its own border — the card around the group supplies one border for
+    /// all of them.
+    private func groupedToggleRow(_ label: String, _ value: Binding<Bool>) -> some View {
+        Button { value.wrappedValue.toggle() } label: {
+            HStack {
+                Text(label).font(Typography.app(15)).foregroundStyle(Palette.textDim)
+                Spacer()
+                Text(value.wrappedValue ? "ON" : "OFF")
+                    .font(Typography.machine(13, .bold)).foregroundStyle(Palette.text)
+            }
+            .padding(.horizontal, 16).padding(.vertical, 14)
+        }
+        .buttonStyle(.plain)
+        .accessibilityValue(Text(value.wrappedValue ? "on" : "off"))
+    }
+
+    /// The delivery caveat, promoted from a faint one-liner into an icon-led info row
+    /// inside the same card — so the one message that MUST land (push isn't wired yet)
+    /// reads as feature status, not a footnote. Kept strictly honest.
+    private var notifyInfoRow: some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: "bell.badge.slash")
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(Palette.textDim)
+                .frame(width: 26, height: 26)
+                .background(Circle().fill(Palette.surfaceRaised))
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Delivery is coming soon")
+                    .font(Typography.app(13, .semibold)).foregroundStyle(Palette.textDim)
+                Text("These switches save your preference now — push alerts turn on in a future update.")
+                    .font(Typography.app(12)).foregroundStyle(Palette.textFaint)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 16).padding(.vertical, 12)
     }
 
     private var troubleSection: some View {
@@ -2316,8 +2385,99 @@ struct SettingsView: View {
     private var helpSection: some View {
         VStack(alignment: .leading, spacing: 0) {
             sectionLabel("HELP")
-            actionRow("Gestures", note: "how to move around the app") { showGestures = true }
+            richActionRow("Gestures", systemImage: "hand.draw",
+                          subtitle: "How to move around the app") { showGestures = true }
         }
+    }
+
+    /// Outbound links to the public web pages. Distinguished from in-app rows by the
+    /// `arrow.up.right` trailing glyph (leaving the app), set inside `linkRow`.
+    private var aboutSection: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            sectionLabel("ABOUT")
+            linkRow("Privacy Policy", systemImage: "lock.shield",
+                    url: URL(string: "https://herdrup.themartian.app/legal/privacy")!)
+            linkRow("Terms of Service", systemImage: "doc.text",
+                    url: URL(string: "https://herdrup.themartian.app/legal/terms")!)
+        }
+    }
+
+    /// The tip jar (StoreKit 2). Renders ONLY when products are loaded — `.idle`,
+    /// `.loading`, and `.unavailable` all render nothing, so the section is simply
+    /// absent before the App Store Connect products exist or when offline.
+    @ViewBuilder
+    private var supportSection: some View {
+        if case .loaded(let products) = tipStore.loadState, !products.isEmpty {
+            VStack(alignment: .leading, spacing: 0) {
+                sectionLabel("SUPPORT THE PROJECT")
+                VStack(spacing: 0) {
+                    ForEach(Array(products.enumerated()), id: \.element.id) { index, product in
+                        tipRow(product)
+                        if index < products.count - 1 { rowDivider }
+                    }
+                }
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+                .overlay(RoundedRectangle(cornerRadius: 12).stroke(Palette.hairline, lineWidth: 1))
+                .padding(.horizontal, 16).padding(.top, 10)
+                supportFeedback
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var supportFeedback: some View {
+        switch tipStore.purchaseState {
+        case .thankYou:
+            Text("Thank you — it means a lot.")
+                .font(Typography.app(12, .medium)).foregroundStyle(Palette.done)
+                .padding(.horizontal, 20).padding(.top, 8)
+        case .failed(let message):
+            Text(message)
+                .font(Typography.app(12)).foregroundStyle(Palette.died)
+                .padding(.horizontal, 20).padding(.top, 8)
+        case .idle, .purchasing:
+            EmptyView()
+        }
+    }
+
+    private func tipRow(_ product: Product) -> some View {
+        Button { Task { await tipStore.purchase(product) } } label: {
+            HStack(spacing: 12) {
+                Image(systemName: tipGlyph(for: product.id))
+                    .font(.system(size: 15, weight: .semibold)).foregroundStyle(Palette.textDim)
+                    .frame(width: 30, height: 30)
+                    .background(RoundedRectangle(cornerRadius: 8).fill(Palette.surfaceRaised))
+                Text(product.displayName.isEmpty ? tipFallbackName(product.id) : product.displayName)
+                    .font(Typography.app(15)).foregroundStyle(Palette.text)
+                Spacer()
+                if isPurchasing(product) {
+                    ProgressView().tint(Palette.textDim)
+                } else {
+                    Text(product.displayPrice)
+                        .font(Typography.machine(13, .semibold)).foregroundStyle(Palette.text)
+                }
+            }
+            .padding(.horizontal, 16).padding(.vertical, 14)
+        }
+        .buttonStyle(.plain)
+        .disabled(isPurchasing(product))
+    }
+
+    private func isPurchasing(_ product: Product) -> Bool {
+        if case .purchasing(let id) = tipStore.purchaseState { return id == product.id }
+        return false
+    }
+
+    private func tipGlyph(for id: String) -> String {
+        if id == TipStore.coffeeID { return "cup.and.saucer.fill" }
+        if id == TipStore.lunchID { return "fork.knife" }
+        return "wineglass.fill"
+    }
+
+    private func tipFallbackName(_ id: String) -> String {
+        if id == TipStore.coffeeID { return "Coffee" }
+        if id == TipStore.lunchID { return "Lunch" }
+        return "Dinner"
     }
 
     /// The app names itself here — "herdrup mobile <version> (<build>)" — with the
@@ -2336,30 +2496,34 @@ struct SettingsView: View {
         .padding(.top, 28)
     }
 
+    /// The open-source affordance, at the very bottom — a quiet capsule, deliberately
+    /// not a card row: it says "the app IS open source", not "here's a setting". No
+    /// official GitHub SF Symbol exists; the code-brackets glyph reads as "source" and
+    /// sidesteps the Octocat trademark.
+    private var githubFooter: some View {
+        Button {
+            openURL(URL(string: "https://github.com/jerryfane/herdr-ios")!)
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: "chevron.left.forwardslash.chevron.right")
+                    .font(.system(size: 12, weight: .semibold))
+                Text("Open source on GitHub").font(Typography.app(12, .medium))
+            }
+            .foregroundStyle(Palette.textDim)
+            .padding(.horizontal, 14).padding(.vertical, 8)
+            .background(Capsule().stroke(Palette.hairline, lineWidth: 1))
+        }
+        .buttonStyle(.plain)
+        .frame(maxWidth: .infinity)
+        .padding(.top, 14)
+    }
+
     private func sectionLabel(_ text: String) -> some View {
         HStack(spacing: 8) {
             Text(text).font(Typography.microLabel).tracking(1.2).foregroundStyle(Palette.textFaint)
             Rectangle().fill(Palette.hairline).frame(height: 1)
         }
         .padding(.horizontal, 16).padding(.top, 14).padding(.bottom, 8)
-    }
-
-    private func toggleRow(_ label: String, _ value: Binding<Bool>) -> some View {
-        Button { value.wrappedValue.toggle() } label: {
-            HStack {
-                Text(label).font(Typography.app(15)).foregroundStyle(Palette.textDim)
-                Spacer()
-                // ON and OFF are BOTH the primary tier — differentiated by the
-                // word, not colour. Brand violet is reserved for the primary
-                // action + active tab, never a toggle state.
-                Text(value.wrappedValue ? "ON" : "OFF")
-                    .font(Typography.machine(13, .bold)).foregroundStyle(Palette.text)
-            }
-            .rowShell()
-        }
-        .buttonStyle(.plain)
-        .padding(.horizontal, 16).padding(.top, 10)
-        .accessibilityValue(Text(value.wrappedValue ? "on" : "off"))
     }
 
     private func actionRow(_ label: String, enabled: Bool = true, note: String? = nil, _ action: @escaping () -> Void) -> some View {
@@ -2379,6 +2543,44 @@ struct SettingsView: View {
         .buttonStyle(.plain)
         .disabled(!enabled)
         .padding(.horizontal, 16).padding(.top, 10)
+    }
+
+    /// An icon-led row with an ALWAYS-visible subtitle (unlike `actionRow`, whose
+    /// `note` shows only when disabled). Used for Gestures and, via `linkRow`, the
+    /// outbound Privacy/Terms links.
+    private func richActionRow(
+        _ label: String, systemImage: String, subtitle: String? = nil,
+        trailingGlyph: String = "chevron.right", _ action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            HStack(spacing: 12) {
+                Image(systemName: systemImage)
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundStyle(Palette.textDim)
+                    .frame(width: 30, height: 30)
+                    .background(RoundedRectangle(cornerRadius: 8).fill(Palette.surfaceRaised))
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(label).font(Typography.app(15)).foregroundStyle(Palette.text)
+                    if let subtitle {
+                        Text(subtitle).font(Typography.app(12)).foregroundStyle(Palette.textFaint)
+                    }
+                }
+                Spacer()
+                Image(systemName: trailingGlyph)
+                    .font(.system(size: 12, weight: .semibold)).foregroundStyle(Palette.textFaint)
+            }
+            .rowShell()
+        }
+        .buttonStyle(.plain)
+        .padding(.horizontal, 16).padding(.top, 10)
+    }
+
+    /// A `richActionRow` that opens an external URL in the system browser, marked with
+    /// the leaving-the-app glyph.
+    private func linkRow(_ label: String, systemImage: String, url: URL) -> some View {
+        richActionRow(label, systemImage: systemImage, trailingGlyph: "arrow.up.right") {
+            openURL(url)
+        }
     }
 
     private func copyDiagnostics() {

--- a/App/TipStore.swift
+++ b/App/TipStore.swift
@@ -1,0 +1,109 @@
+import Foundation
+import StoreKit
+
+/// The tip jar — a StoreKit 2 wrapper over three CONSUMABLE products (coffee /
+/// lunch / dinner). Buying a tip unlocks nothing, so there's no entitlement to
+/// track and every successful transaction is finished immediately. Modelled on the
+/// owner's proven FitBridge `StoreManager`, trimmed to the consumable case.
+///
+/// Singleton, mirroring `PushCenter.shared`: Settings observes `TipStore.shared`.
+/// The whole "Support" section stays invisible until `loadState == .loaded`, so
+/// nothing shows before the App Store Connect products exist (or when offline).
+@MainActor
+final class TipStore: ObservableObject {
+    static let shared = TipStore()
+
+    // Match the app's bundle id (com.jerryfane.herdr) and the owner's own
+    // `com.jerryfane.<app>.<tier>` convention (see FitBridge).
+    static let coffeeID = "com.jerryfane.herdr.tip.coffee"
+    static let lunchID  = "com.jerryfane.herdr.tip.lunch"
+    static let dinnerID = "com.jerryfane.herdr.tip.dinner"
+    static let productIDs = [coffeeID, lunchID, dinnerID]
+
+    enum LoadState {
+        case idle
+        case loading
+        case loaded([Product])
+        /// Empty result, a thrown error (offline, or products not yet created in
+        /// App Store Connect), or any other failure. The section HIDES on this —
+        /// a tip jar degrading to invisible is fine; a broken-looking empty
+        /// section is not.
+        case unavailable
+    }
+
+    enum PurchaseState: Equatable {
+        case idle
+        case purchasing(Product.ID)
+        case thankYou(Product.ID)
+        case failed(String)
+    }
+
+    @Published private(set) var loadState: LoadState = .idle
+    @Published private(set) var purchaseState: PurchaseState = .idle
+
+    private var updatesListener: Task<Void, Never>?
+
+    private init() {
+        // Drain any transaction that completes OUTSIDE an explicit purchase() call
+        // (e.g. an "Ask to Buy" approved later). A consumable grants nothing, so
+        // this only finishes it — an unfinished consumable re-delivers here on every
+        // launch, which is the classic StoreKit 2 leak.
+        updatesListener = Task.detached {
+            for await update in Transaction.updates {
+                if case .verified(let transaction) = update {
+                    await transaction.finish()
+                }
+            }
+        }
+    }
+
+    deinit { updatesListener?.cancel() }
+
+    /// Safe to call every time Settings opens: it re-fetches only from `.idle` or a
+    /// prior `.unavailable`, so a product created in ASC after first launch appears
+    /// the next time Settings opens — no app update required.
+    func loadProducts() async {
+        switch loadState {
+        case .loaded, .loading: return
+        case .idle, .unavailable: break
+        }
+        loadState = .loading
+        do {
+            let fetched = try await Product.products(for: Self.productIDs)
+            guard !fetched.isEmpty else { loadState = .unavailable; return }
+            let order = Self.productIDs
+            loadState = .loaded(fetched.sorted {
+                (order.firstIndex(of: $0.id) ?? 0) < (order.firstIndex(of: $1.id) ?? 0)
+            })
+        } catch {
+            loadState = .unavailable
+        }
+    }
+
+    func purchase(_ product: Product) async {
+        purchaseState = .purchasing(product.id)
+        do {
+            switch try await product.purchase() {
+            case .success(let verification):
+                guard case .verified(let transaction) = verification else {
+                    purchaseState = .failed("Couldn't verify that purchase.")
+                    return
+                }
+                await transaction.finish()   // consumable: nothing to grant or track
+                purchaseState = .thankYou(product.id)
+                // Auto-dismiss the thank-you after a beat (only if it's still showing).
+                Task { [weak self] in
+                    try? await Task.sleep(nanoseconds: 3_000_000_000)
+                    guard let self else { return }
+                    if case .thankYou = self.purchaseState { self.purchaseState = .idle }
+                }
+            case .userCancelled, .pending:
+                purchaseState = .idle
+            @unknown default:
+                purchaseState = .idle
+            }
+        } catch {
+            purchaseState = .failed("Couldn't complete the purchase. Try again.")
+        }
+    }
+}

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/project.yml
+++ b/project.yml
@@ -83,13 +83,19 @@ targets:
       # PhotosUI backs the Gram attachment picker's Photo/Video source (`PhotosPicker`
       # / `.photosPicker`). Linked explicitly for the same reason as QuickLook above.
       - sdk: PhotosUI.framework
+      # StoreKit 2 backs the Settings tip jar (`TipStore` / `Product`). Linked
+      # explicitly for the same reason as QuickLook/PhotosUI above.
+      - sdk: StoreKit.framework
     # Add the UI-test bundle to the auto-generated `Herdr` scheme's TEST action, so
     # `xcodebuild test -scheme Herdr -only-testing:HerdrUITests` runs it. This does NOT
     # touch the scheme's build/archive action, so the TestFlight lane (`-scheme Herdr`
-    # archive) is unaffected.
+    # archive) is unaffected. `storeKitConfiguration` points RUN/TEST at the local
+    # `.storekit` file, so the tip jar resolves prices in Simulator without App Store
+    # Connect — the archive action is untouched, so shipped builds hit the real store.
     scheme:
       testTargets:
         - HerdrUITests
+      storeKitConfiguration: App/Herdr.storekit
     info:
       path: App/Info.plist
       properties:


### PR DESCRIPTION
Owner UX/polish + open-source-readiness batch (PR A of the batch; Gram multi-attachment is a separate PR B).

## Settings redesign (`App/HerdrApp.swift`)
- **Header now matches the Gram/Gestures sheet exactly** — left-aligned semibold title + xmark close + a separate `Divider().overlay(Palette.hairlineQuiet)`, replacing the odd centered-bold title + back chevron. (Settings is a sheet, not a nav push; xmark and swipe-down both dismiss.)
- **Notification section** is now one bordered card holding the four toggles + an **icon-led status row** that keeps the honest *"Delivery is coming soon"* message — push delivery isn't wired end-to-end yet, so the copy stays truthful; it just reads as feature status now instead of a faint footnote.
- **Gestures** becomes a richer icon + always-visible-subtitle row (`richActionRow`). The old `actionRow` only rendered its note when *disabled*, so the Gestures subtitle was invisible.
- **New ABOUT section** links **Privacy** + **Terms** to the public pages (`herdrup.themartian.app/legal/privacy` and `/legal/terms`, both verified 200) via `@Environment(\.openURL)`.
- **"Open source on GitHub"** capsule at the very bottom → `github.com/jerryfane/herdr-ios`.

## Donations — StoreKit 2 tip jar (`App/TipStore.swift`, `App/Herdr.storekit`)
- `TipStore` (`@MainActor ObservableObject`, singleton like `PushCenter.shared`) loads three **consumable** products — `com.jerryfane.herdr.tip.{coffee,lunch,dinner}` — and finishes every transaction (consumables grant nothing; a `Transaction.updates` listener also drains Ask-to-Buy).
- A **SUPPORT THE PROJECT** section renders **only** when products load, so it's simply absent before the App Store Connect products exist or when offline — no broken/empty state.
- `project.yml` links `StoreKit.framework` explicitly (matching QuickLook/PhotosUI) and points RUN/TEST at `App/Herdr.storekit` via `scheme.storeKitConfiguration`; the **archive action is untouched**, so shipped builds hit the real store.

**⚠️ Owner action needed in App Store Connect before real purchases work** (Simulator works off the local `.storekit`): Agreements/Tax/Banking Active; create the 3 **Consumable** IAP products with those exact IDs (prices $4.99/$9.99/$19.99); mark Ready to Submit and attach to the next build's review.

## Open-source prep
- Add the standard **Apache-2.0 LICENSE** (matches the herdr daemon fork).
- Harden `.gitignore` (`*.p8`/`*.p12`/`*.mobileprovision`/`*.cer`/`*.pem`/`*.key`/`.env`/`fastlane/`) — defense-in-depth; none committed today.
- Redact the internal build-box tailnet IP from the TestFlight workflow comment.

## Notes / risk
- Built on Linux here (no iOS SDK) — **macOS CI is the compile gate.** StoreKit patterns are grounded in the owner's shipped FitBridge integration.
- No UI test asserts on the changed Settings strings (checked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)