### PR TITLE
feat(gram): determinate upload progress bar

### DIFF
--- a/App/GramView.swift
+++ b/App/GramView.swift
@@ -67,6 +67,9 @@ struct GramView: View {
     @State private var loadingPhoto = false
     /// True while a picked file is uploading (many small chunks over SSH).
     @State private var uploading = false
+    /// Byte progress of the file currently uploading: (bytesSent, totalBytes). Drives
+    /// the composer's determinate progress bar; nil when no upload is in flight.
+    @State private var uploadBytes: (sent: Int, total: Int)?
     /// Progress across a multi-file send: (already-sent, total). nil when idle or when
     /// only a single message is in flight.
     @State private var sendProgress: (sent: Int, total: Int)?
@@ -433,7 +436,27 @@ struct GramView: View {
                     }
                 }
             }
-            if let progress = sendProgress, progress.total > 1 {
+            if let up = uploadBytes {
+                let frac = up.total > 0 ? min(1, Double(up.sent) / Double(up.total)) : 0
+                VStack(alignment: .leading, spacing: 5) {
+                    HStack(spacing: 6) {
+                        Text(uploadStatusLabel(fraction: frac))
+                            .font(Typography.machine(11))
+                            .foregroundStyle(Palette.textFaint)
+                        Spacer(minLength: 8)
+                        if up.total >= 1024 * 1024 {
+                            Text("\(byteString(up.sent)) / \(byteString(up.total))")
+                                .font(Typography.machine(11))
+                                .foregroundStyle(Palette.textFaint)
+                                .monospacedDigit()
+                        }
+                    }
+                    ProgressView(value: frac)
+                        .tint(Palette.text)
+                }
+                .frame(maxWidth: .infinity)
+            } else if let progress = sendProgress, progress.total > 1 {
+                // Between files (this one's upload done, its message posting): keep the count.
                 Text("Sending \(progress.sent + 1) of \(progress.total)…")
                     .font(Typography.machine(11))
                     .foregroundStyle(Palette.textFaint)
@@ -645,6 +668,22 @@ struct GramView: View {
         }
     }
 
+    /// Label above the upload bar: "Sending k of N · NN%" for a batch, else "Uploading NN%".
+    private func uploadStatusLabel(fraction: Double) -> String {
+        let pct = Int((fraction * 100).rounded())
+        if let p = sendProgress, p.total > 1 {
+            return "Sending \(p.sent + 1) of \(p.total) · \(pct)%"
+        }
+        return "Uploading \(pct)%"
+    }
+
+    /// Compact byte size for the upload bar (e.g. "42.1 MB", "512 KB").
+    private func byteString(_ bytes: Int) -> String {
+        let mb = Double(bytes) / (1024 * 1024)
+        if mb >= 1 { return String(format: "%.1f MB", mb) }
+        return String(format: "%.0f KB", Double(bytes) / 1024)
+    }
+
     private func send() async {
         let text = draft.trimmingCharacters(in: .whitespacesAndNewlines)
         let files = attachedFiles
@@ -660,6 +699,7 @@ struct GramView: View {
             sending = false
             uploading = false
             sendProgress = nil
+            uploadBytes = nil
         }
         sendError = nil
 
@@ -690,8 +730,12 @@ struct GramView: View {
             let caption = index == 0 ? text : ""
             do {
                 uploading = true
-                let uploadID = try await client.gramUploadFile(file.data)
+                uploadBytes = (sent: 0, total: file.data.count)
+                let uploadID = try await client.gramUploadFile(file.data) { sent, total in
+                    uploadBytes = (sent: sent, total: total)
+                }
                 uploading = false
+                uploadBytes = nil
                 let posted = try await client.gramPost(
                     text: caption, to: to,
                     attachment: .init(uploadID: uploadID, name: file.name, mime: file.mime))

--- a/Sources/HerdrKit/HerdrClient.swift
+++ b/Sources/HerdrKit/HerdrClient.swift
@@ -349,9 +349,22 @@ public actor HerdrClient {
     /// `gramPost`. Chunks are sent in order; the server validates each against the
     /// running offset. A single request per chunk keeps every one under the SSH
     /// command-size cap.
-    public func gramUploadFile(_ data: Data) async throws -> String {
+    ///
+    /// `onProgress` (if given) is called on the main actor with `(bytesSent, totalBytes)`
+    /// — once at 0, then throttled to ~1% steps as chunks land, and once at completion —
+    /// so a caller can drive a determinate progress bar without flooding the UI on a
+    /// large (≈2100-chunk) 100 MB upload.
+    public func gramUploadFile(
+        _ data: Data,
+        onProgress: (@MainActor @Sendable (_ bytesSent: Int, _ totalBytes: Int) -> Void)? = nil
+    ) async throws -> String {
         let uploadID = "app-" + UUID().uuidString.replacingOccurrences(of: "-", with: "")
         var offset = 0
+        // Report at most ~once per 1% (or per chunk, whichever is coarser) so a big
+        // file's thousands of round-trips don't schedule thousands of UI updates.
+        let reportStep = max(Self.gramUploadChunkBytes, data.count / 100)
+        var lastReported = -reportStep
+        await onProgress?(0, data.count)
         while offset < data.count {
             let end = min(offset + Self.gramUploadChunkBytes, data.count)
             let chunk = data.subdata(in: offset..<end)
@@ -362,6 +375,10 @@ public actor HerdrClient {
                     dataBase64: chunk.base64EncodedString()),
                 as: JSONNull.self)
             offset = end
+            if offset == data.count || offset - lastReported >= reportStep {
+                lastReported = offset
+                await onProgress?(offset, data.count)
+            }
         }
         return uploadID
     }


### PR DESCRIPTION
When attaching media in Gram, the composer now shows a **real progress bar** instead of just a spinner.

### Why
With the file cap now 100 MB (~2,100 chunks over sequential SSH round-trips), a large upload could sit for tens of seconds showing only a spinner + a per-file "n of N" count — no sense of progress. (Flagged in kimi's #83 review.)

### What
- `HerdrClient.gramUploadFile` gains an optional `@MainActor onProgress` callback → `(bytesSent, totalBytes)`, fired at 0, **throttled to ~1% steps** as chunks land, and at completion (so a 100 MB upload doesn't schedule thousands of UI updates). `HerdrClient` is an `actor`; the callback is `@MainActor @Sendable` and `await`-ed in order.
- `GramView` drives a determinate `ProgressView` from it: label `"Uploading NN%"` (single) or `"Sending k of N · NN%"` (batch), plus an `"X.X MB / Y MB"` readout for files ≥ 1 MB. Falls back to the file-count line between files while a message posts.

No wire/protocol change; upload path and chunk size unchanged.