### PR TITLE
feat(nav): slide+fade the list↔terminal transition

### DIFF
--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -1090,7 +1090,16 @@ struct TerminalHomeView: View {
                 onClose: { frontID = nil; Task { await load() } },
                 onNavigate: { slot, delta in navigate(from: slot, delta: delta) })
                 .opacity(frontID != nil ? 1 : 0)
+                // Ease the list<->terminal transition instead of a hard cut: the terminal
+                // slides in from the right (and back out on close) while it fades. We animate
+                // the `frontID` STATE, not a gesture, so BOTH entry points — the header
+                // chevron and the left-edge swipe (EdgeSwipeBack fires a discrete onClose) —
+                // get the same motion, and neither EdgeSwipeBack nor the pane's
+                // foreground/PTY handoff is touched. Only nil<->non-nil animates; paging
+                // between panes (frontID stays non-nil) is unaffected.
+                .offset(x: frontID != nil ? 0 : 40)
                 .allowsHitTesting(frontID != nil)
+                .animation(.easeOut(duration: 0.26), value: frontID)
         }
         // ONE item-based sheet, not two stacked isPresented presentations (stacked
         // presentation modifiers on a single view are historically fragile). A SHEET

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -1099,7 +1099,12 @@ struct TerminalHomeView: View {
                 // between panes (frontID stays non-nil) is unaffected.
                 .offset(x: frontID != nil ? 0 : 40)
                 .allowsHitTesting(frontID != nil)
-                .animation(.easeOut(duration: 0.26), value: frontID)
+                // Key the animation on the BOOLEAN (shown vs not), NOT on frontID itself:
+                // frontID also changes when swipe-paging A->B (both non-nil), and
+                // `value: frontID` would fire the animation into the subtree then —
+                // cross-fading the inner pane swap and disturbing the paging XCUITest.
+                // `frontID != nil` only flips on the list<->terminal open/close.
+                .animation(.easeOut(duration: 0.26), value: frontID != nil)
         }
         // ONE item-based sheet, not two stacked isPresented presentations (stacked
         // presentation modifiers on a single view are historically fragile). A SHEET


### PR DESCRIPTION
Opening a terminal and backing out to the agent list was a **hard opacity cut** — the keep-alive container flipped `opacity 0↔1` with no motion, which reads as rough. Now the terminal **slides in from the right (and out on close) while it fades**, over 0.26s.

### Why it's safe in the delicate zone
- The animation is driven by the **`frontID` state**, not a gesture. Both back paths — the header chevron and the **left-edge swipe** — just flip `frontID` (`EdgeSwipeBack` fires a *discrete* `onClose`, it doesn't interactively drag), so they get identical motion.
- **`EdgeSwipeBack` is untouched.** The pane's `isForeground`/PTY-lock handoff is untouched. `PaneKeepAliveContainer` internals are untouched.
- Only the **list↔terminal** transition (`nil↔non-nil frontID`) animates. **Paging between mounted panes** (frontID stays non-nil) is unaffected — the swipe-paging behavior and its XCUITest are not in scope.

### Testing
Compiles on macOS CI (below). The motion itself is a feel thing → **verify on-device via the next TestFlight build** (per the standing gesture-proof rule; the change doesn't touch any gesture recognizer, but the transition is what a swipe triggers). Tunable in one line (offset distance / duration / fade).