### PR TITLE
feat(settings,nav): install-instructions link + bug/feature link

### DIFF
--- a/App/ForkNoticeView.swift
+++ b/App/ForkNoticeView.swift
@@ -40,7 +40,7 @@ struct ForkNoticeView: View {
                 VStack(spacing: 10) {
                     ForEach(missing, id: \.name) { row($0) }
                 }
-                Text("Switch to — or update — jerryfane/herdr to turn them on.")
+                Text("Switch to or update jerryfane/herdr to turn them on.")
                     .font(Typography.app(13))
                     .foregroundStyle(Palette.textFaint)
                     .multilineTextAlignment(.center)
@@ -48,13 +48,27 @@ struct ForkNoticeView: View {
             }
             .padding(.horizontal, 28)
             Spacer(minLength: 0)
-            Button(action: onDismiss) {
-                Text("Continue anyway")
+            VStack(spacing: 8) {
+                // Primary action: send them to the fork's install instructions.
+                Link(destination: URL(string: "https://github.com/jerryfane/herdr")!) {
+                    HStack(spacing: 6) {
+                        Text("Install instructions")
+                        Image(systemName: "arrow.up.right").font(.system(size: 12, weight: .semibold))
+                    }
                     .font(Typography.app(16, .semibold))
                     .foregroundStyle(Palette.ground)
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 14)
                     .background(RoundedRectangle(cornerRadius: 14).fill(Palette.text))
+                }
+                // Never a lockout: dismissing is always one tap away.
+                Button(action: onDismiss) {
+                    Text("Continue anyway")
+                        .font(Typography.app(15, .semibold))
+                        .foregroundStyle(Palette.textDim)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 10)
+                }
             }
             .padding(.horizontal, 20)
             .padding(.bottom, 20)

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -2409,6 +2409,8 @@ struct SettingsView: View {
             sectionLabel("HELP")
             richActionRow("Gestures", systemImage: "hand.draw",
                           subtitle: "How to move around the app") { showGestures = true }
+            linkRow("Report a bug or request a feature", systemImage: "exclamationmark.bubble",
+                    url: URL(string: "https://github.com/jerryfane/herdrup/issues")!)
         }
     }
 


### PR DESCRIPTION
Two small link additions (owner-requested), fast-follow for v1.0.1 (does not touch the in-review 1.0 / build 37).

### Fork notice (`ForkNoticeView`)
- Adds a primary **"Install instructions"** link → `github.com/jerryfane/herdr`, so a user connected to a base daemon has a clear next step to get gram/push/live-terminal.
- "Continue anyway" stays as an always-available secondary button (still never a lockout).
- Drops the em dashes from the notice copy (user-facing).

### Settings → HELP
- Adds **"Report a bug or request a feature"** → `github.com/jerryfane/herdrup/issues`, using the existing `linkRow` (external-link glyph).

No behavior change beyond the two links. Uses existing patterns (`linkRow`, the notice's button styling).