### PR TITLE
feat(voice): mic-button dictation for the Gram composer + terminal reply (#89)

### DIFF
--- a/App/GramView.swift
+++ b/App/GramView.swift
@@ -539,6 +539,8 @@ struct GramView: View {
                     .padding(.horizontal, 12)
                     .padding(.vertical, 9)
                     .background(RoundedRectangle(cornerRadius: 10).fill(Palette.surface))
+                // Dictate into the draft (on-device); appends, never clobbers typed text.
+                MicButton(text: $draft)
                 Button {
                     Task { await send() }
                 } label: {

--- a/App/GramView.swift
+++ b/App/GramView.swift
@@ -544,7 +544,9 @@ struct GramView: View {
                     .background(RoundedRectangle(cornerRadius: 10).fill(Palette.surface))
                     .disabled(draftDictating)   // dictation owns the field while live
                 // Dictate into the draft (on-device); appends, never clobbers typed text.
+                // Disabled during a send so dictation can't race the field-clear.
                 MicButton(text: $draft, recording: $draftDictating)
+                    .disabled(sending || loadingPhoto)
                 Button {
                     Task { await send() }
                 } label: {
@@ -573,8 +575,10 @@ struct GramView: View {
 
     private var canSend: Bool {
         // Also blocked while a photo is loading, so tapping Send mid-load can't fire a
-        // text-only message that races the attachment in behind it.
-        guard !sending, !loadingPhoto else { return false }
+        // text-only message that races the attachment in behind it, and while dictating
+        // (see MicButton): sending mid-dictation would clear the field, then the next
+        // recognition partial would restore the just-sent text and re-enable a duplicate.
+        guard !sending, !loadingPhoto, !draftDictating else { return false }
         return !attachedFiles.isEmpty
             || !draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }

--- a/App/GramView.swift
+++ b/App/GramView.swift
@@ -34,6 +34,9 @@ struct GramView: View {
     @State private var phase: LoadPhase = .loading
     @State private var recipient: Recipient = .queue
     @State private var draft: String = ""
+    /// True while dictating into the composer, so the field is disabled (typing can't be
+    /// overwritten by the next partial) while the live transcript still appends.
+    @State private var draftDictating = false
     @State private var sending = false
     /// A send failure. Kept SEPARATE from load state so a successful background poll
     /// never clears it before the owner sees it.
@@ -539,8 +542,9 @@ struct GramView: View {
                     .padding(.horizontal, 12)
                     .padding(.vertical, 9)
                     .background(RoundedRectangle(cornerRadius: 10).fill(Palette.surface))
+                    .disabled(draftDictating)   // dictation owns the field while live
                 // Dictate into the draft (on-device); appends, never clobbers typed text.
-                MicButton(text: $draft)
+                MicButton(text: $draft, recording: $draftDictating)
                 Button {
                     Task { await send() }
                 } label: {

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -2008,6 +2008,10 @@ struct TerminalPaneContent: View {
                 .onChange(of: reply) { oldValue, newValue in
                     handleReplyChange(old: oldValue, new: newValue)
                 }
+            // Dictate into the reply (on-device); appends to whatever is typed. A
+            // multi-char dictation append can't trip the ctrl-chord guard above (it
+            // requires a single-char append), so the two coexist safely.
+            MicButton(text: $reply, diameter: 40, iconSize: 15)
             Button { sendTapped() } label: {
                 Image(systemName: "arrow.up").font(.system(size: 15, weight: .bold))
                     .foregroundStyle(canSend ? Palette.ground : Palette.textFaint)

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -2018,9 +2018,12 @@ struct TerminalPaneContent: View {
             // onStart disarms any pending ctrl chord and `replyDictating` suppresses the
             // chord interception, so a dictation partial is never read as a control byte.
             MicButton(text: $reply, diameter: 40, iconSize: 15,
-                      isActive: isForeground, recording: $replyDictating,
+                      isActive: isForeground && !autoDelivering, recording: $replyDictating,
                       onStart: { ctrlArmed = false })
-                .disabled(sending)   // mutually gated with Send (see canSend)
+                // Mutually gated with Send AND the programmatic pre-fill auto-deliver:
+                // isActive drops on autoDelivering so an in-flight dictation stops before
+                // the auto-deliver clears the reply, and it can't be started during either.
+                .disabled(sending || autoDelivering)
             Button { sendTapped() } label: {
                 Image(systemName: "arrow.up").font(.system(size: 15, weight: .bold))
                     .foregroundStyle(canSend ? Palette.ground : Palette.textFaint)

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -1689,7 +1689,7 @@ struct TerminalPaneContent: View {
     // owns delivery then). A pending pre-fill does NOT disable the button once the
     // loop stops — instead the button ROUTES a pre-fill through the prompt-only
     // path (see the replyBar action), so it can never fall to rawKeys send_text.
-    private var canSend: Bool { !reply.trimmingCharacters(in: .whitespaces).isEmpty && !sending && !autoDelivering }
+    private var canSend: Bool { !reply.trimmingCharacters(in: .whitespaces).isEmpty && !sending && !autoDelivering && !replyDictating }
 
     /// Whether to offer the one-time "switch to smooth (classic) scrolling" banner:
     /// ONLY for Claude Code panes (agent kind contains "claude") and only until the reader
@@ -2020,6 +2020,7 @@ struct TerminalPaneContent: View {
             MicButton(text: $reply, diameter: 40, iconSize: 15,
                       isActive: isForeground, recording: $replyDictating,
                       onStart: { ctrlArmed = false })
+                .disabled(sending)   // mutually gated with Send (see canSend)
             Button { sendTapped() } label: {
                 Image(systemName: "arrow.up").font(.system(size: 15, weight: .bold))
                     .foregroundStyle(canSend ? Palette.ground : Palette.textFaint)

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -1634,6 +1634,10 @@ struct TerminalPaneContent: View {
     /// typed in the reply field is then sent as its control byte (and consumed, not
     /// added to the message), and the modifier disarms. See `handleReplyChange`.
     @State private var ctrlArmed = false
+    /// True while dictating into the reply: disables the field (so typing can't be
+    /// overwritten by the next partial) and suppresses the ctrl-chord interception (so a
+    /// single-char dictation partial can't be misread as a control chord).
+    @State private var replyDictating = false
     /// Focus of the reply field, so the software keyboard can be DISMISSED — via the
     /// keyboard-toolbar chevron or a tap on the (read-only) terminal.
     @FocusState private var replyFocused: Bool
@@ -2003,15 +2007,19 @@ struct TerminalPaneContent: View {
                 .padding(.horizontal, 16).padding(.vertical, 11)
                 .background(Palette.surface).clipShape(Capsule())
                 .focused($replyFocused)
+                .disabled(replyDictating)   // dictation owns the field while live
                 // Ctrl-toggle interception: while armed, the next character typed
                 // here becomes a control byte instead of message text.
                 .onChange(of: reply) { oldValue, newValue in
                     handleReplyChange(old: oldValue, new: newValue)
                 }
-            // Dictate into the reply (on-device); appends to whatever is typed. A
-            // multi-char dictation append can't trip the ctrl-chord guard above (it
-            // requires a single-char append), so the two coexist safely.
-            MicButton(text: $reply, diameter: 40, iconSize: 15)
+            // Dictate into the reply (on-device). isActive: isForeground stops the mic
+            // if this pane stops being the front one (no hot mic behind a hidden pane);
+            // onStart disarms any pending ctrl chord and `replyDictating` suppresses the
+            // chord interception, so a dictation partial is never read as a control byte.
+            MicButton(text: $reply, diameter: 40, iconSize: 15,
+                      isActive: isForeground, recording: $replyDictating,
+                      onStart: { ctrlArmed = false })
             Button { sendTapped() } label: {
                 Image(systemName: "arrow.up").font(.system(size: 15, weight: .bold))
                     .foregroundStyle(canSend ? Palette.ground : Palette.textFaint)
@@ -2062,6 +2070,9 @@ struct TerminalPaneContent: View {
     /// single added character (typing) — not deletion or the programmatic clear
     /// after a send — so a backspace can never be misread as a chord.
     private func handleReplyChange(old: String, new: String) {
+        // A dictation append (even a single-char first partial) must never be read as a
+        // ctrl chord — only real typing arms and fires one.
+        guard !replyDictating else { return }
         guard ctrlArmed else { return }
         // Treat ONLY a clean single-char APPEND as a chord: `new` must be `old`
         // plus one trailing character. A mid-cursor insertion or paste (where the

--- a/App/VoiceInput.swift
+++ b/App/VoiceInput.swift
@@ -5,18 +5,18 @@ import SwiftUI
 /// On-device voice dictation for a text field.
 ///
 /// Tap the mic to start, speak, tap again (or it auto-finalizes on a pause) to stop.
-/// Recognition runs ON-DEVICE where the device supports it (private, offline); it falls
-/// back to Apple's standard speech service only where on-device recognition is not
-/// available for the user's locale. The recognized text is exposed as a live transcript;
-/// `MicButton` appends it to the bound field so it never erases text already typed.
+/// Recognition runs ON-DEVICE ONLY (private, offline); where the device/locale cannot do
+/// it on-device, dictation reports unavailable rather than silently sending audio to
+/// Apple's servers — so the permission promise ("stays on your phone") is always true.
+/// The recognized text is exposed as a live transcript; `MicButton` appends it to the
+/// bound field so it never erases text already typed.
 ///
 /// Deliberately built on `SFSpeechRecognizer` (works on the iOS 17 floor) rather than
 /// iOS 26's `SpeechTranscriber`, so nothing here gates compilation on the Xcode 26 SDK;
-/// the newer, more accurate transcriber is a follow-up once the build runner's Xcode is
-/// confirmed.
+/// the newer transcriber is a follow-up once the build runner's Xcode is confirmed.
 @MainActor
 final class SpeechDictator: ObservableObject {
-    enum State: Equatable { case idle, recording, denied, unavailable }
+    enum State: Equatable { case idle, requesting, recording, denied, unavailable }
 
     @Published private(set) var state: State = .idle
     /// The live transcript of the CURRENT dictation session (partial results → final).
@@ -28,16 +28,26 @@ final class SpeechDictator: ObservableObject {
     private let engine = AVAudioEngine()
     private var request: SFSpeechAudioBufferRecognitionRequest?
     private var task: SFSpeechRecognitionTask?
+    /// Bumped for every session and on every stop/finalize. An in-flight recognition
+    /// callback captures its generation and no-ops if it no longer matches, so a stale
+    /// callback from a finished session can't touch a newer one.
+    private var generation = 0
 
     var isRecording: Bool { state == .recording }
 
     /// Start a dictation session, requesting mic + speech permission on first use.
     func start() {
-        guard state != .recording else { return }
+        // Block re-entry while a start is already in flight or a session is live: a rapid
+        // double-tap would otherwise install a SECOND tap on the input node (a crash) and
+        // spawn a second recognition task.
+        guard state != .requesting, state != .recording else { return }
         transcript = ""
         note = nil
+        state = .requesting
         requestPermissions { [weak self] granted in
             guard let self else { return }
+            // A stop() (or another start) may have superseded this request meanwhile.
+            guard self.state == .requesting else { return }
             guard granted else {
                 self.state = .denied
                 self.note = "To dictate, enable Microphone and Speech Recognition for Herdrup in Settings."
@@ -55,7 +65,8 @@ final class SpeechDictator: ObservableObject {
 
     /// Stop the current session and finalize; the transcript stays put.
     func stop() {
-        guard state == .recording else { return }
+        guard state == .recording || state == .requesting else { return }
+        generation &+= 1   // invalidate any in-flight callbacks from this session
         finishAudio()
         state = .idle
     }
@@ -79,6 +90,13 @@ final class SpeechDictator: ObservableObject {
             note = "Dictation isn't available right now."
             return
         }
+        // On-device ONLY — we never fall back to Apple's server recognition, so the
+        // "stays on your phone" permission copy holds for every path.
+        guard recognizer.supportsOnDeviceRecognition else {
+            state = .unavailable
+            note = "On-device dictation isn't available for your language on this device."
+            return
+        }
 
         let session = AVAudioSession.sharedInstance()
         try session.setCategory(.record, mode: .measurement, options: .duckOthers)
@@ -86,9 +104,11 @@ final class SpeechDictator: ObservableObject {
 
         let request = SFSpeechAudioBufferRecognitionRequest()
         request.shouldReportPartialResults = true
-        // Keep it on-device (private, offline) wherever the device/locale supports it.
-        if recognizer.supportsOnDeviceRecognition { request.requiresOnDeviceRecognition = true }
+        request.requiresOnDeviceRecognition = true
         self.request = request
+
+        generation &+= 1
+        let gen = generation
 
         let input = engine.inputNode
         let format = input.outputFormat(forBus: 0)
@@ -102,10 +122,11 @@ final class SpeechDictator: ObservableObject {
         task = recognizer.recognitionTask(with: request) { [weak self] result, error in
             guard let self else { return }
             Task { @MainActor in
+                // Ignore a callback that belongs to a session we've already torn down.
+                guard gen == self.generation, self.state == .recording else { return }
                 if let result { self.transcript = result.bestTranscription.formattedString }
-                // Finalize on error or a final result, but only if we're still recording
-                // (a manual stop already tore the session down).
-                if (error != nil || (result?.isFinal ?? false)), self.state == .recording {
+                if error != nil || (result?.isFinal ?? false) {
+                    self.generation &+= 1
                     self.finishAudio()
                     self.state = .idle
                 }
@@ -117,7 +138,7 @@ final class SpeechDictator: ObservableObject {
         engine.inputNode.removeTap(onBus: 0)
         if engine.isRunning { engine.stop() }
         request?.endAudio()
-        task?.finish()
+        task?.cancel()
         request = nil
         task = nil
         try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
@@ -129,7 +150,9 @@ final class SpeechDictator: ObservableObject {
 /// A mic button that dictates into a bound text field. The recognized text is APPENDED
 /// to whatever is already in the field (captured when recording starts), so dictation
 /// never erases what the user typed. Idle shows a mic; recording shows a red stop icon.
-/// Permission/availability problems surface as a small alert.
+/// Recording auto-stops when the app backgrounds, when the enclosing surface goes
+/// inactive (a keep-mounted terminal pane that is no longer front — so the mic is never
+/// hot behind a hidden pane), or when the button leaves the hierarchy.
 struct MicButton: View {
     @Binding var text: String
     /// Idle tint (matches the sibling composer/reply glyphs at each site).
@@ -138,7 +161,16 @@ struct MicButton: View {
     /// (Gram composer is 38/16; the terminal reply bar is 40/15).
     var diameter: CGFloat = 38
     var iconSize: CGFloat = 16
+    /// False when the enclosing surface is backgrounded (e.g. a keep-mounted terminal
+    /// pane that is no longer front): recording auto-stops so the mic never runs hidden.
+    var isActive: Bool = true
+    /// Mirrors the live recording state out to the parent (used to disable the field
+    /// while dictating and to suppress the terminal's ctrl-chord interception).
+    var recording: Binding<Bool>?
+    /// Called when a dictation session begins — e.g. to disarm a pending ctrl chord.
+    var onStart: () -> Void = {}
 
+    @Environment(\.scenePhase) private var scenePhase
     @StateObject private var dictator = SpeechDictator()
     /// The field's content when recording started; the transcript is appended after it.
     @State private var base: String = ""
@@ -150,6 +182,7 @@ struct MicButton: View {
                 dictator.stop()
             } else {
                 base = text
+                onStart()
                 dictator.start()
             }
         } label: {
@@ -165,6 +198,10 @@ struct MicButton: View {
             guard !t.isEmpty else { return }
             text = base.isEmpty ? t : base + " " + t
         }
+        .onChange(of: dictator.isRecording) { _, r in recording?.wrappedValue = r }
+        .onChange(of: isActive) { _, active in if !active { dictator.stop() } }
+        .onChange(of: scenePhase) { _, phase in if phase != .active { dictator.stop() } }
+        .onDisappear { dictator.stop() }
         .onChange(of: dictator.note) { _, n in showNote = n != nil }
         .alert("Dictation", isPresented: $showNote, presenting: dictator.note) { _ in
             Button("OK", role: .cancel) {}

--- a/App/VoiceInput.swift
+++ b/App/VoiceInput.swift
@@ -1,0 +1,173 @@
+import AVFoundation
+import Speech
+import SwiftUI
+
+/// On-device voice dictation for a text field.
+///
+/// Tap the mic to start, speak, tap again (or it auto-finalizes on a pause) to stop.
+/// Recognition runs ON-DEVICE where the device supports it (private, offline); it falls
+/// back to Apple's standard speech service only where on-device recognition is not
+/// available for the user's locale. The recognized text is exposed as a live transcript;
+/// `MicButton` appends it to the bound field so it never erases text already typed.
+///
+/// Deliberately built on `SFSpeechRecognizer` (works on the iOS 17 floor) rather than
+/// iOS 26's `SpeechTranscriber`, so nothing here gates compilation on the Xcode 26 SDK;
+/// the newer, more accurate transcriber is a follow-up once the build runner's Xcode is
+/// confirmed.
+@MainActor
+final class SpeechDictator: ObservableObject {
+    enum State: Equatable { case idle, recording, denied, unavailable }
+
+    @Published private(set) var state: State = .idle
+    /// The live transcript of the CURRENT dictation session (partial results → final).
+    @Published private(set) var transcript: String = ""
+    /// A user-facing note (permission denied, unavailable), surfaced by `MicButton`.
+    @Published private(set) var note: String?
+
+    private let recognizer = SFSpeechRecognizer()  // the user's current locale
+    private let engine = AVAudioEngine()
+    private var request: SFSpeechAudioBufferRecognitionRequest?
+    private var task: SFSpeechRecognitionTask?
+
+    var isRecording: Bool { state == .recording }
+
+    /// Start a dictation session, requesting mic + speech permission on first use.
+    func start() {
+        guard state != .recording else { return }
+        transcript = ""
+        note = nil
+        requestPermissions { [weak self] granted in
+            guard let self else { return }
+            guard granted else {
+                self.state = .denied
+                self.note = "To dictate, enable Microphone and Speech Recognition for Herdrup in Settings."
+                return
+            }
+            do {
+                try self.beginSession()
+            } catch {
+                self.teardown()
+                self.state = .unavailable
+                self.note = "Couldn't start dictation. Try again."
+            }
+        }
+    }
+
+    /// Stop the current session and finalize; the transcript stays put.
+    func stop() {
+        guard state == .recording else { return }
+        finishAudio()
+        state = .idle
+    }
+
+    // MARK: - internals
+
+    private func requestPermissions(_ completion: @escaping (Bool) -> Void) {
+        SFSpeechRecognizer.requestAuthorization { auth in
+            let speechOK = auth == .authorized
+            // AVAudioApplication.requestRecordPermission is the iOS 17+ replacement for
+            // the deprecated AVAudioSession.requestRecordPermission.
+            AVAudioApplication.requestRecordPermission { micOK in
+                Task { @MainActor in completion(speechOK && micOK) }
+            }
+        }
+    }
+
+    private func beginSession() throws {
+        guard let recognizer, recognizer.isAvailable else {
+            state = .unavailable
+            note = "Dictation isn't available right now."
+            return
+        }
+
+        let session = AVAudioSession.sharedInstance()
+        try session.setCategory(.record, mode: .measurement, options: .duckOthers)
+        try session.setActive(true, options: .notifyOthersOnDeactivation)
+
+        let request = SFSpeechAudioBufferRecognitionRequest()
+        request.shouldReportPartialResults = true
+        // Keep it on-device (private, offline) wherever the device/locale supports it.
+        if recognizer.supportsOnDeviceRecognition { request.requiresOnDeviceRecognition = true }
+        self.request = request
+
+        let input = engine.inputNode
+        let format = input.outputFormat(forBus: 0)
+        input.installTap(onBus: 0, bufferSize: 1024, format: format) { [weak request] buffer, _ in
+            request?.append(buffer)
+        }
+        engine.prepare()
+        try engine.start()
+        state = .recording
+
+        task = recognizer.recognitionTask(with: request) { [weak self] result, error in
+            guard let self else { return }
+            Task { @MainActor in
+                if let result { self.transcript = result.bestTranscription.formattedString }
+                // Finalize on error or a final result, but only if we're still recording
+                // (a manual stop already tore the session down).
+                if (error != nil || (result?.isFinal ?? false)), self.state == .recording {
+                    self.finishAudio()
+                    self.state = .idle
+                }
+            }
+        }
+    }
+
+    private func finishAudio() {
+        engine.inputNode.removeTap(onBus: 0)
+        if engine.isRunning { engine.stop() }
+        request?.endAudio()
+        task?.finish()
+        request = nil
+        task = nil
+        try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+    }
+
+    private func teardown() { finishAudio() }
+}
+
+/// A mic button that dictates into a bound text field. The recognized text is APPENDED
+/// to whatever is already in the field (captured when recording starts), so dictation
+/// never erases what the user typed. Idle shows a mic; recording shows a red stop icon.
+/// Permission/availability problems surface as a small alert.
+struct MicButton: View {
+    @Binding var text: String
+    /// Idle tint (matches the sibling composer/reply glyphs at each site).
+    var tint: Color = Palette.textDim
+    /// Circular footprint + glyph size, matched to the sibling buttons at each site
+    /// (Gram composer is 38/16; the terminal reply bar is 40/15).
+    var diameter: CGFloat = 38
+    var iconSize: CGFloat = 16
+
+    @StateObject private var dictator = SpeechDictator()
+    /// The field's content when recording started; the transcript is appended after it.
+    @State private var base: String = ""
+    @State private var showNote = false
+
+    var body: some View {
+        Button {
+            if dictator.isRecording {
+                dictator.stop()
+            } else {
+                base = text
+                dictator.start()
+            }
+        } label: {
+            Image(systemName: dictator.isRecording ? "stop.circle.fill" : "mic.fill")
+                .font(.system(size: iconSize, weight: .semibold))
+                .foregroundStyle(dictator.isRecording ? Palette.died : tint)
+                .frame(width: diameter, height: diameter)
+                .background(Circle().fill(Palette.surface))
+        }
+        .accessibilityLabel(dictator.isRecording ? "Stop dictation" : "Dictate")
+        // Live-append the transcript to the bound field as partial results arrive.
+        .onChange(of: dictator.transcript) { _, t in
+            guard !t.isEmpty else { return }
+            text = base.isEmpty ? t : base + " " + t
+        }
+        .onChange(of: dictator.note) { _, n in showNote = n != nil }
+        .alert("Dictation", isPresented: $showNote, presenting: dictator.note) { _ in
+            Button("OK", role: .cancel) {}
+        } message: { Text($0) }
+    }
+}

--- a/App/VoiceInput.swift
+++ b/App/VoiceInput.swift
@@ -34,6 +34,11 @@ final class SpeechDictator: ObservableObject {
     private var generation = 0
 
     var isRecording: Bool { state == .recording }
+    /// Busy from the moment the mic is tapped (permission acquisition) through recording.
+    /// Callers gate Send on this so a rapid Send DURING permission acquisition can't clear
+    /// the field out from under a session that is about to start (and then have the next
+    /// partial restore the just-sent text).
+    var isBusy: Bool { state == .recording || state == .requesting }
 
     /// Start a dictation session, requesting mic + speech permission on first use.
     func start() {
@@ -198,7 +203,9 @@ struct MicButton: View {
             guard !t.isEmpty else { return }
             text = base.isEmpty ? t : base + " " + t
         }
-        .onChange(of: dictator.isRecording) { _, r in recording?.wrappedValue = r }
+        // Mirror BUSY (requesting-or-recording), so the parent gates Send from the moment
+        // the mic is tapped — not only once recognition is live.
+        .onChange(of: dictator.state) { _, _ in recording?.wrappedValue = dictator.isBusy }
         .onChange(of: isActive) { _, active in if !active { dictator.stop() } }
         .onChange(of: scenePhase) { _, phase in if phase != .active { dictator.stop() } }
         .onDisappear { dictator.stop() }

--- a/project.yml
+++ b/project.yml
@@ -89,6 +89,11 @@ targets:
       # WebKit backs the Gram HTML/SVG viewer (`HtmlWebView` / `WKWebView`). Linked
       # explicitly for the same reason as QuickLook/PhotosUI/StoreKit above.
       - sdk: WebKit.framework
+      # AVFoundation + Speech back voice dictation (`VoiceInput` / `MicButton`): audio
+      # capture (AVAudioEngine) and on-device transcription (SFSpeechRecognizer). Linked
+      # explicitly for the same reason as the frameworks above.
+      - sdk: AVFoundation.framework
+      - sdk: Speech.framework
     # Add the UI-test bundle to the auto-generated `Herdr` scheme's TEST action, so
     # `xcodebuild test -scheme Herdr -only-testing:HerdrUITests` runs it. This does NOT
     # touch the scheme's build/archive action, so the TestFlight lane (`-scheme Herdr`
@@ -110,6 +115,11 @@ targets:
         # this via ASSETCATALOG_COMPILER_APPICON_NAME, but this Info.plist is
         # generated (GENERATE_INFOPLIST_FILE: NO), so we set it explicitly too.
         CFBundleIconName: AppIcon
+        # Voice input (#89): the mic button by the Gram composer and terminal reply bar
+        # dictates on-device. Both strings are required or the app crashes the first time
+        # it requests the permission.
+        NSMicrophoneUsageDescription: Herdrup uses the microphone only while you hold a dictation session, to turn your speech into text in the message field. Audio is transcribed on-device and never leaves your phone.
+        NSSpeechRecognitionUsageDescription: Herdrup transcribes your dictation into text on-device, so you can talk instead of type. Your speech is not sent anywhere.
         # Export compliance: herdr uses ONLY standard, published encryption (AES/SSH
         # via a standard library — no proprietary or custom cryptography), which
         # QUALIFIES FOR THE STANDARD MASS-MARKET EXEMPTION (EAR Category 5 Part 2). So


### PR DESCRIPTION
Closes #89.

## What
On-device **voice input** at both text fields — the owner's "touch a mic icon and talk, cleaned up with a bit of local AI." Tap the mic, speak, tap again (or pause) to finalize; the recognized text is **appended** to whatever's already typed (captured at record-start), so dictation never erases the field.

## How
- **`App/VoiceInput.swift`**
  - `SpeechDictator` (`@MainActor ObservableObject`): `AVAudioEngine` capture → `SFSpeechRecognizer`. Sets `requiresOnDeviceRecognition` wherever the device/locale supports it, so it's **private and offline**; falls back to Apple's standard speech service only where on-device isn't available. Requests mic + speech permission on first use; denial/unavailability surface as `note`.
  - `MicButton` (reusable): owns the dictator, appends the live transcript to a `@Binding var text`, shows mic (idle) / red stop (recording), and alerts on permission problems. Size is parameterized to match each site.
- **Wiring**: `GramView` composer (`$draft`, 38/16) and the terminal `replyBar` (`$reply`, 40/15). A multi-char dictation append **cannot** trip the reply bar's ctrl-chord interceptor — that only fires on a clean single-char append (`new.count == old.count + 1`), verified in `handleReplyChange`.
- **`project.yml`**: `NSMicrophoneUsageDescription` + `NSSpeechRecognitionUsageDescription` (required or the app crashes on first permission request), and links `AVFoundation` + `Speech`.

## Deliberately out of scope (follow-ups)
- **iOS 26 `SpeechTranscriber`/`SpeechAnalyzer`** (newer, more accurate) and a **Foundation Models** cleanup pass (filler-word/punctuation) — both are iOS-26-only APIs. Built on `SFSpeechRecognizer` (the iOS 17 floor) so **nothing gates compilation on the Xcode 26 SDK**; these land once the runner's Xcode 26 is confirmed.

## Test
- CI: simulator compile-check.
- On-device (TestFlight): tap mic in Gram + terminal → grant permission → speak → text lands in the field (appended after any typed text); airplane mode still works where on-device is supported; permission-denied shows the Settings hint.

Part of the 1.0.1 batch (TestFlight-only for now; not going to the App Store until the owner's go-ahead).