### PR TITLE
feat(connect): host manager — saved list + Add host, nicknames, hold-to-edit

### DIFF
--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -387,142 +387,102 @@ struct RootView: View {
     }
 }
 
-/// Collects host/key and constructs the transport. Constructing does not connect —
-/// the first request does — so this screen never blocks on the network.
+/// The connect screen: a manager of saved machines. Tap a host to connect (one tap);
+/// "Add host" and hold-to-Edit open the HostEditor sheet. Constructing the transport
+/// does not connect — the first request does — so this never blocks on the network.
 struct ConnectView: View {
     var onConnect: (SSHCredentials) -> Void
 
-    @State private var host = ""
-    @State private var username = ""
-    @State private var keyPEM = ""
-    @State private var showingKeySheet = false
     @ObservedObject private var savedHosts = SavedHostsStore.shared
-    @State private var saveThisHost = false
-
-    // Host accepts "host" or "host:port" (and "[ipv6]:port"); the port lives in
-    // the one field so the form stays the three rows the mockup shows. Parsing is
-    // HerdrKit's HostEndpoint (Linux-tested); an explicit bad port yields nil, so
-    // it is rejected here rather than silently connecting to :22.
-    private var endpoint: HostEndpoint? { HostEndpoint.parse(host) }
-    private var trimmedUser: String { username.trimmingCharacters(in: .whitespacesAndNewlines) }
-    private var trimmedKey: String { keyPEM.trimmingCharacters(in: .whitespacesAndNewlines) }
-    private var hostInvalid: Bool {
-        !host.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && endpoint == nil
-    }
-    private var canConnect: Bool {
-        endpoint != nil && !trimmedUser.isEmpty && !trimmedKey.isEmpty
-    }
+    /// The add/edit sheet target; nil = closed.
+    @State private var editorTarget: HostEditorTarget?
 
     var body: some View {
         ZStack {
             Palette.ground.ignoresSafeArea()
             ScrollView {
                 VStack(spacing: 16) {
-                    // Centered identity header: the app logo (the Lamb), the name, one
-                    // line of intent. The icon carries its own dark ground, so it reads
-                    // as the app mark — no surface tile behind it.
-                    VStack(spacing: 10) {
-                        Image("AppLogo")
-                            .resizable()
-                            .interpolation(.high)
-                            .frame(width: 64, height: 64)
-                            .clipShape(RoundedRectangle(cornerRadius: 15, style: .continuous))
-                        VStack(spacing: 4) {
-                            Text("herdrup")
-                                .font(Typography.app(28, .bold))
-                                .foregroundStyle(Palette.text)
-                            Text("connect to your machine")
-                                .font(Typography.machine(13))
-                                .foregroundStyle(Palette.textDim)
-                        }
-                    }
-                    .frame(maxWidth: .infinity)
-                    .padding(.top, 24)
-                    .padding(.bottom, 8)
-
-                    // Saved hosts — one-tap reconnect. Hidden on first launch so the
-                    // screen stays the clean three-row form until there is one to show.
-                    if !savedHosts.hosts.isEmpty {
+                    header
+                    // Saved machines — the list you manage + tap to connect. Empty on
+                    // first launch, where the Add button below is the way in.
+                    if savedHosts.hosts.isEmpty {
+                        emptyState
+                    } else {
                         savedHostsSection
                     }
-
-                    // The three settings-style rows: label left, value right.
-                    VStack(spacing: 10) {
-                        fieldRow("Host", text: $host, placeholder: "mac.tail-scale.ts.net")
-                        if hostInvalid {
-                            Text("check host or host:port")
-                                .font(Typography.app(12)).foregroundStyle(Palette.died)
-                                .frame(maxWidth: .infinity, alignment: .leading).padding(.horizontal, 4)
-                        }
-                        fieldRow("User", text: $username, placeholder: "jerry")
-                        keyRow
-                        // Save affordance: only offered once the form is complete, so
-                        // it never implies saving an empty/partial host.
-                        if canConnect {
-                            Toggle(isOn: $saveThisHost) {
-                                Text("Save this host for one-tap reconnect")
-                                    .font(Typography.app(13)).foregroundStyle(Palette.textDim)
-                            }
-                            .tint(Palette.text)
-                            .padding(.horizontal, 4).padding(.top, 2)
-                        }
-                    }
-
-                    // Primary action — INK fill. The design carries NO accent colour; the
-                    // one near-white fill in the whole app marks the control that ACTS.
-                    Button {
-                        guard let ep = endpoint else { return }
-                        // Persist BEFORE connecting (the key is in hand here). save()
-                        // stores host+user in UserDefaults + the key in the Keychain.
-                        if saveThisHost {
-                            savedHosts.save(host: host, username: trimmedUser, privateKeyPEM: trimmedKey)
-                        }
-                        onConnect(SSHCredentials(
-                            host: ep.host, port: ep.port,
-                            username: trimmedUser,
-                            // Gated on trimmedKey, so send trimmedKey — a trailing
-                            // space/CR otherwise enables Connect then throws
-                            // InvalidOpenSSHBoundary in Citadel's parser.
-                            privateKeyPEM: trimmedKey, remoteSocketPath: ""))
-                    } label: {
-                        Text("Connect")
-                            .font(Typography.app(16, .semibold))
-                            .frame(maxWidth: .infinity).padding(.vertical, 15)
-                            .background(canConnect ? Palette.text : Palette.surface)
-                            .foregroundStyle(canConnect ? Palette.ground : Palette.textFaint)
-                            .clipShape(RoundedRectangle(cornerRadius: 12))
-                    }
-                    .disabled(!canConnect)
-                    .padding(.top, 6)
-
-                    // Two faint captions (design copy), centered.
-                    VStack(spacing: 10) {
-                        Text("over your tailscale network · nothing public")
-                            .font(Typography.machine(12)).foregroundStyle(Palette.textFaint)
-                        Text("Seen once. Fails with a reason, never a spinner that gives up quietly.")
-                            .font(Typography.machine(11)).foregroundStyle(Palette.textFaint)
-                            .multilineTextAlignment(.center)
-                    }
-                    .frame(maxWidth: .infinity)
-                    .padding(.top, 4)
+                    addHostButton
+                    captions
                 }
                 .padding(22)
             }
         }
-        .sheet(isPresented: $showingKeySheet) { keySheet }
+        // Add / edit a host. Save & Connect (add) hands credentials up via onConnect.
+        .sheet(item: $editorTarget) { target in
+            HostEditor(target: target, store: savedHosts) { creds in
+                editorTarget = nil
+                onConnect(creds)
+            }
+        }
     }
 
-    /// A row with the label on the left and a right-aligned monospace value.
-    private func fieldRow(_ label: String, text: Binding<String>, placeholder: String) -> some View {
-        HStack {
-            Text(label).font(Typography.app(15)).foregroundStyle(Palette.textDim)
-            TextField(placeholder, text: text)
-                .multilineTextAlignment(.trailing)
-                .textInputAutocapitalization(.never).autocorrectionDisabled()
-                .font(Typography.machine(15)).foregroundStyle(Palette.text)
+    // Centered identity header: the app logo (the Lamb), the name, one line of intent.
+    // The icon carries its own dark ground, so it reads as the app mark.
+    private var header: some View {
+        VStack(spacing: 10) {
+            Image("AppLogo")
+                .resizable()
+                .interpolation(.high)
+                .frame(width: 64, height: 64)
+                .clipShape(RoundedRectangle(cornerRadius: 15, style: .continuous))
+            VStack(spacing: 4) {
+                Text("herdrup")
+                    .font(Typography.app(28, .bold))
+                    .foregroundStyle(Palette.text)
+                Text("connect to your machine")
+                    .font(Typography.machine(13))
+                    .foregroundStyle(Palette.textDim)
+            }
         }
-        .padding(.horizontal, 16).padding(.vertical, 14)
-        .background(Palette.surface).clipShape(RoundedRectangle(cornerRadius: 12))
+        .frame(maxWidth: .infinity)
+        .padding(.top, 24)
+        .padding(.bottom, 8)
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 6) {
+            Text("No saved machines yet")
+                .font(Typography.app(15, .semibold)).foregroundStyle(Palette.text)
+            Text("Add a machine to connect over your Tailscale network.")
+                .font(Typography.app(13)).foregroundStyle(Palette.textDim)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity).padding(.vertical, 16)
+    }
+
+    private var addHostButton: some View {
+        Button { editorTarget = .add } label: {
+            HStack(spacing: 8) {
+                Image(systemName: "plus").font(.system(size: 15, weight: .semibold))
+                Text("Add host").font(Typography.app(15, .semibold))
+            }
+            .foregroundStyle(Palette.text)
+            .frame(maxWidth: .infinity).padding(.vertical, 14)
+            .background(Palette.surface).clipShape(RoundedRectangle(cornerRadius: 12))
+        }
+        .buttonStyle(.plain)
+    }
+
+    // Two faint captions (design copy), centered.
+    private var captions: some View {
+        VStack(spacing: 10) {
+            Text("over your tailscale network · nothing public")
+                .font(Typography.machine(12)).foregroundStyle(Palette.textFaint)
+            Text("Seen once. Fails with a reason, never a spinner that gives up quietly.")
+                .font(Typography.machine(11)).foregroundStyle(Palette.textFaint)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.top, 4)
     }
 
     private var savedHostsSection: some View {
@@ -543,8 +503,8 @@ struct ConnectView: View {
                     .frame(width: 36, height: 36)
                     .background(Palette.surface).clipShape(RoundedRectangle(cornerRadius: 10))
                 VStack(alignment: .leading, spacing: 2) {
-                    Text(saved.host).font(Typography.machine(14)).foregroundStyle(Palette.text).lineLimit(1)
-                    Text(saved.username).font(Typography.machine(12)).foregroundStyle(Palette.textFaint)
+                    Text(saved.label).font(Typography.app(15, .semibold)).foregroundStyle(Palette.text).lineLimit(1)
+                    Text(secondaryLine(saved)).font(Typography.machine(12)).foregroundStyle(Palette.textFaint).lineLimit(1)
                 }
                 Spacer(minLength: 8)
                 Image(systemName: "arrow.right.circle.fill")
@@ -554,74 +514,35 @@ struct ConnectView: View {
             .background(Palette.card).clipShape(RoundedRectangle(cornerRadius: 14))
         }
         .buttonStyle(.plain)
+        // Hold to manage: Edit opens the editor pre-filled; Remove drops it.
         .contextMenu {
+            Button { editorTarget = .edit(saved) } label: {
+                Label("Edit", systemImage: "pencil")
+            }
             Button(role: .destructive) { savedHosts.delete(saved) } label: {
                 Label("Remove", systemImage: "trash")
             }
         }
     }
 
-    /// One-tap connect from a saved host. Pre-fills host+user FIRST, so if the key
-    /// is unreadable (deleted/device locked) the form is ready for a quick re-entry
-    /// rather than a silent dead tap; otherwise it builds the credentials and connects.
+    /// The secondary line: with a nickname, show `user@host`; without, just the user
+    /// (the host is already the row's title, so it isn't repeated).
+    private func secondaryLine(_ saved: SavedHost) -> String {
+        let hasNickname = (saved.nickname?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false)
+        return hasNickname ? "\(saved.username)@\(saved.host)" : saved.username
+    }
+
+    /// One-tap connect from a saved host. If the key is unreadable (deleted / device
+    /// locked), open the editor so it can be re-added rather than a silent dead tap.
     private func tapSavedHost(_ saved: SavedHost) {
-        host = saved.host
-        username = saved.username
         guard let ep = HostEndpoint.parse(saved.host),
               let key = savedHosts.key(for: saved)?.trimmingCharacters(in: .whitespacesAndNewlines),
-              !key.isEmpty else { return }
+              !key.isEmpty else {
+            editorTarget = .edit(saved)
+            return
+        }
         onConnect(SSHCredentials(host: ep.host, port: ep.port, username: saved.username,
                                  privateKeyPEM: key, remoteSocketPath: ""))
-    }
-
-    /// The key row NEVER renders the key itself — only whether one is loaded.
-    /// That is both the mockup ("id_ed25519 ✓") and the security rule: the
-    /// connect screen is screenshotted onto an open port, so the PEM must not be
-    /// on screen. Tapping opens a sheet to paste it.
-    private var keyRow: some View {
-        Button { showingKeySheet = true } label: {
-            HStack {
-                Text("Key").font(Typography.app(15)).foregroundStyle(Palette.textDim)
-                Spacer()
-                if keyPEM.isEmpty {
-                    Text("Add private key").font(Typography.app(15)).foregroundStyle(Palette.textFaint)
-                } else {
-                    Text("ed25519 key").font(Typography.machine(15)).foregroundStyle(Palette.text)
-                    Image(systemName: "checkmark").font(.system(size: 12, weight: .bold))
-                        .foregroundStyle(Palette.done)   // green ✓ — the key is loaded (per the .dc.html)
-                }
-            }
-            .padding(.horizontal, 16).padding(.vertical, 14)
-            .background(Palette.surface).clipShape(RoundedRectangle(cornerRadius: 12))
-        }
-        .buttonStyle(.plain)
-    }
-
-    private var keySheet: some View {
-        NavigationStack {
-            ZStack {
-                Palette.ground.ignoresSafeArea()
-                VStack(alignment: .leading, spacing: 12) {
-                    Text("Paste your ed25519 private key (PEM). It is held only in memory and sent over the SSH connection — never shown again.")
-                        .font(Typography.app(13)).foregroundStyle(Palette.textDim)
-                    TextEditor(text: $keyPEM)
-                        .font(Typography.machine(13)).foregroundStyle(Palette.text)
-                        .scrollContentBackground(.hidden)
-                        .padding(10).background(Palette.surface)
-                        .clipShape(RoundedRectangle(cornerRadius: 10))
-                    if !keyPEM.isEmpty {
-                        Button("Clear key") { keyPEM = "" }
-                            .font(Typography.app(14)).foregroundStyle(Palette.died)
-                    }
-                    Spacer()
-                }
-                .padding(20)
-            }
-            .navigationTitle("Private key")
-            .toolbar { ToolbarItem(placement: .topBarTrailing) {
-                Button("Done") { showingKeySheet = false }.foregroundStyle(Palette.textDim)
-            } }
-        }
     }
 }
 

--- a/App/HostEditor.swift
+++ b/App/HostEditor.swift
@@ -1,5 +1,6 @@
 import HerdrKit
 import SwiftUI
+import UIKit
 
 /// What the `HostEditor` sheet is working on: a brand-new host, or an existing one.
 enum HostEditorTarget: Identifiable {
@@ -31,6 +32,7 @@ struct HostEditor: View {
     @State private var keyPEM = ""
     @State private var showingKeySheet = false
     @State private var error: String?
+    @State private var keyError: String?
 
     private let editing: SavedHost?
 
@@ -161,22 +163,41 @@ struct HostEditor: View {
         .buttonStyle(.plain)
     }
 
+    /// The key is NEVER rendered on screen (the connect screen can be screenshotted onto
+    /// an open tailnet port, and a screen recording would otherwise capture it). Instead
+    /// it is pasted from the clipboard straight into memory / the Keychain, and only a
+    /// "key set" confirmation is shown.
     private var keySheet: some View {
         NavigationStack {
             ZStack {
                 Palette.ground.ignoresSafeArea()
-                VStack(alignment: .leading, spacing: 12) {
-                    Text("Paste your ed25519 private key (PEM). It is held in the Keychain (device-only) and sent over the SSH connection — never shown again.")
+                VStack(alignment: .leading, spacing: 14) {
+                    Text("Copy your ed25519 private key (PEM) to the clipboard, then paste it here. It is stored in the Keychain (device-only) and sent over the SSH connection — it is never displayed, so it can't appear in a screenshot.")
                         .font(Typography.app(13)).foregroundStyle(Palette.textDim)
-                    TextEditor(text: $keyPEM)
-                        .font(Typography.machine(13)).foregroundStyle(Palette.text)
-                        .scrollContentBackground(.hidden)
-                        .padding(10).background(Palette.surface)
-                        .clipShape(RoundedRectangle(cornerRadius: 10))
-                    if !keyPEM.isEmpty {
-                        Button("Clear key") { keyPEM = "" }
-                            .font(Typography.app(14)).foregroundStyle(Palette.died)
+
+                    Button { pasteKeyFromClipboard() } label: {
+                        HStack(spacing: 8) {
+                            Image(systemName: "doc.on.clipboard").font(.system(size: 15, weight: .semibold))
+                            Text("Paste key from clipboard").font(Typography.app(15, .semibold))
+                        }
+                        .foregroundStyle(Palette.text)
+                        .frame(maxWidth: .infinity).padding(.vertical, 14)
+                        .background(Palette.surface).clipShape(RoundedRectangle(cornerRadius: 12))
                     }
+                    .buttonStyle(.plain)
+
+                    if !keyPEM.isEmpty {
+                        HStack(spacing: 8) {
+                            Image(systemName: "checkmark.seal.fill").foregroundStyle(Palette.done)
+                            Text("Key set").font(Typography.app(15)).foregroundStyle(Palette.text)
+                            Spacer(minLength: 8)
+                            Button("Clear") { keyPEM = ""; keyError = nil }
+                                .font(Typography.app(14)).foregroundStyle(Palette.died)
+                        }
+                        .padding(.horizontal, 14).padding(.vertical, 12)
+                        .background(Palette.surface).clipShape(RoundedRectangle(cornerRadius: 12))
+                    }
+                    if let keyError { caption(keyError, color: Palette.died) }
                     Spacer()
                 }
                 .padding(20)
@@ -188,6 +209,22 @@ struct HostEditor: View {
                 }
             }
         }
+    }
+
+    /// Ingest a PEM key from the clipboard WITHOUT rendering it. Loosely sanity-checks it
+    /// looks like a PEM private key so a stray clipboard string isn't stored as a key.
+    private func pasteKeyFromClipboard() {
+        guard let s = UIPasteboard.general.string?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !s.isEmpty else {
+            keyError = "Nothing to paste — copy your private key to the clipboard first."
+            return
+        }
+        guard s.contains("PRIVATE KEY") else {
+            keyError = "That doesn't look like a private key (expected a PEM block)."
+            return
+        }
+        keyPEM = s
+        keyError = nil
     }
 
     private func primaryButton(_ title: String, action: @escaping () -> Void) -> some View {

--- a/App/HostEditor.swift
+++ b/App/HostEditor.swift
@@ -1,0 +1,211 @@
+import HerdrKit
+import SwiftUI
+
+/// What the `HostEditor` sheet is working on: a brand-new host, or an existing one.
+enum HostEditorTarget: Identifiable {
+    case add
+    case edit(SavedHost)
+    var id: String {
+        switch self {
+        case .add: return "add"
+        case .edit(let h): return h.id.uuidString
+        }
+    }
+}
+
+/// Add or edit a saved host: nickname + host(:port) + user + private key. Saving records
+/// the non-secret fields in UserDefaults and the key in the Keychain (via `SavedHostsStore`).
+/// Adding also offers Save & Connect. The key is WRITE-ONLY here (never displayed — the
+/// connect screen can be screenshotted onto an open port): on edit it starts blank and the
+/// stored key is kept unless a new one is pasted.
+struct HostEditor: View {
+    let target: HostEditorTarget
+    @ObservedObject var store: SavedHostsStore
+    /// Save & Connect (add mode): build credentials and hand them up to connect.
+    var onConnect: (SSHCredentials) -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var nickname: String
+    @State private var host: String
+    @State private var username: String
+    @State private var keyPEM = ""
+    @State private var showingKeySheet = false
+    @State private var error: String?
+
+    private let editing: SavedHost?
+
+    init(target: HostEditorTarget, store: SavedHostsStore, onConnect: @escaping (SSHCredentials) -> Void) {
+        self.target = target
+        self.store = store
+        self.onConnect = onConnect
+        switch target {
+        case .add:
+            editing = nil
+            _nickname = State(initialValue: "")
+            _host = State(initialValue: "")
+            _username = State(initialValue: "")
+        case .edit(let h):
+            editing = h
+            _nickname = State(initialValue: h.nickname ?? "")
+            _host = State(initialValue: h.host)
+            _username = State(initialValue: h.username)
+        }
+    }
+
+    private var endpoint: HostEndpoint? { HostEndpoint.parse(host) }
+    private var trimmedUser: String { username.trimmingCharacters(in: .whitespacesAndNewlines) }
+    private var trimmedKey: String { keyPEM.trimmingCharacters(in: .whitespacesAndNewlines) }
+    private var hostInvalid: Bool {
+        !host.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && endpoint == nil
+    }
+    /// Add requires a key; edit keeps the existing one when the field is left blank.
+    private var canSave: Bool {
+        guard endpoint != nil, !trimmedUser.isEmpty else { return false }
+        return editing != nil || !trimmedKey.isEmpty
+    }
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Palette.ground.ignoresSafeArea()
+                ScrollView {
+                    VStack(spacing: 10) {
+                        fieldRow("Nickname", text: $nickname, placeholder: "My Mac")
+                        fieldRow("Host", text: $host, placeholder: "mac.tail-scale.ts.net")
+                        if hostInvalid { caption("check host or host:port", color: Palette.died) }
+                        fieldRow("User", text: $username, placeholder: "jerry")
+                        keyRow
+                        if let error { caption(error, color: Palette.died) }
+
+                        if editing == nil {
+                            primaryButton("Save & Connect") { saveAndConnect() }
+                            Button("Save without connecting") { if save() { dismiss() } }
+                                .font(Typography.app(14)).foregroundStyle(Palette.textDim)
+                                .disabled(!canSave).padding(.top, 2)
+                        } else {
+                            primaryButton("Save") { if save() { dismiss() } }
+                        }
+                    }
+                    .padding(20)
+                }
+            }
+            .navigationTitle(editing == nil ? "Add host" : "Edit host")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }.foregroundStyle(Palette.textDim)
+                }
+            }
+        }
+        .sheet(isPresented: $showingKeySheet) { keySheet }
+    }
+
+    // MARK: - actions
+
+    /// Persist the host (add or update). Returns success; sets `error` on failure.
+    @discardableResult
+    private func save() -> Bool {
+        let ok: Bool
+        if let editing {
+            ok = store.update(editing, nickname: nickname, host: host, username: trimmedUser, privateKeyPEM: keyPEM)
+        } else {
+            ok = store.add(nickname: nickname, host: host, username: trimmedUser, privateKeyPEM: trimmedKey)
+        }
+        if !ok { error = "Couldn't save this host. Check the fields (a private key is required) and try again." }
+        return ok
+    }
+
+    private func saveAndConnect() {
+        guard let ep = endpoint, save() else { return }
+        // Add mode requires a key, so it is in hand here — connect straight away.
+        onConnect(SSHCredentials(host: ep.host, port: ep.port, username: trimmedUser,
+                                 privateKeyPEM: trimmedKey, remoteSocketPath: ""))
+        dismiss()
+    }
+
+    // MARK: - rows
+
+    private func fieldRow(_ label: String, text: Binding<String>, placeholder: String) -> some View {
+        HStack {
+            Text(label).font(Typography.app(15)).foregroundStyle(Palette.textDim)
+            TextField(placeholder, text: text)
+                .multilineTextAlignment(.trailing)
+                .textInputAutocapitalization(.never).autocorrectionDisabled()
+                .font(Typography.machine(15)).foregroundStyle(Palette.text)
+        }
+        .padding(.horizontal, 16).padding(.vertical, 14)
+        .background(Palette.surface).clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+
+    /// The key row NEVER renders the key itself — only whether one is set (the connect
+    /// screen is screenshotted onto an open port, so the PEM must not be on screen).
+    private var keyRow: some View {
+        Button { showingKeySheet = true } label: {
+            HStack {
+                Text("Key").font(Typography.app(15)).foregroundStyle(Palette.textDim)
+                Spacer()
+                if !keyPEM.isEmpty {
+                    Text(editing == nil ? "ed25519 key" : "new key")
+                        .font(Typography.machine(15)).foregroundStyle(Palette.text)
+                    Image(systemName: "checkmark").font(.system(size: 12, weight: .bold))
+                        .foregroundStyle(Palette.done)
+                } else if editing != nil {
+                    Text("saved · tap to replace").font(Typography.app(15)).foregroundStyle(Palette.textFaint)
+                } else {
+                    Text("Add private key").font(Typography.app(15)).foregroundStyle(Palette.textFaint)
+                }
+            }
+            .padding(.horizontal, 16).padding(.vertical, 14)
+            .background(Palette.surface).clipShape(RoundedRectangle(cornerRadius: 12))
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var keySheet: some View {
+        NavigationStack {
+            ZStack {
+                Palette.ground.ignoresSafeArea()
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("Paste your ed25519 private key (PEM). It is held in the Keychain (device-only) and sent over the SSH connection — never shown again.")
+                        .font(Typography.app(13)).foregroundStyle(Palette.textDim)
+                    TextEditor(text: $keyPEM)
+                        .font(Typography.machine(13)).foregroundStyle(Palette.text)
+                        .scrollContentBackground(.hidden)
+                        .padding(10).background(Palette.surface)
+                        .clipShape(RoundedRectangle(cornerRadius: 10))
+                    if !keyPEM.isEmpty {
+                        Button("Clear key") { keyPEM = "" }
+                            .font(Typography.app(14)).foregroundStyle(Palette.died)
+                    }
+                    Spacer()
+                }
+                .padding(20)
+            }
+            .navigationTitle("Private key")
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Done") { showingKeySheet = false }.foregroundStyle(Palette.textDim)
+                }
+            }
+        }
+    }
+
+    private func primaryButton(_ title: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Text(title)
+                .font(Typography.app(16, .semibold))
+                .frame(maxWidth: .infinity).padding(.vertical, 15)
+                .background(canSave ? Palette.text : Palette.surface)
+                .foregroundStyle(canSave ? Palette.ground : Palette.textFaint)
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+        }
+        .disabled(!canSave)
+        .padding(.top, 6)
+    }
+
+    private func caption(_ text: String, color: Color) -> some View {
+        Text(text)
+            .font(Typography.app(12)).foregroundStyle(color)
+            .frame(maxWidth: .infinity, alignment: .leading).padding(.horizontal, 4)
+    }
+}

--- a/App/SavedHosts.swift
+++ b/App/SavedHosts.swift
@@ -9,6 +9,15 @@ struct SavedHost: Codable, Identifiable, Hashable {
     let id: UUID
     var host: String
     var username: String
+    /// Optional friendly label ("My Mac"). Legacy saved hosts predate this field, so it
+    /// is OPTIONAL — old JSON without the key decodes to `nil` (no migration needed).
+    var nickname: String?
+
+    /// The primary display label: the nickname if set, else the host itself.
+    var label: String {
+        if let n = nickname?.trimmingCharacters(in: .whitespacesAndNewlines), !n.isEmpty { return n }
+        return host
+    }
 }
 
 /// Persists saved hosts: the host+username list in UserDefaults, each host's
@@ -32,24 +41,45 @@ final class SavedHostsStore: ObservableObject {
         }
     }
 
-    /// Saves (or updates in place) a host by host+username identity and stores its
-    /// key in the Keychain. Returns false — WITHOUT recording the host — if the key
+    /// Adds a NEW saved host (its own id) and stores its key in the Keychain. Returns
+    /// false — WITHOUT recording the host — if a required field is missing or the key
     /// could not be persisted, so the UI never offers a one-tap host it cannot open.
     @discardableResult
-    func save(host: String, username: String, privateKeyPEM: String) -> Bool {
+    func add(nickname: String, host: String, username: String, privateKeyPEM: String) -> Bool {
         let h = host.trimmingCharacters(in: .whitespacesAndNewlines)
         let u = username.trimmingCharacters(in: .whitespacesAndNewlines)
+        let n = nickname.trimmingCharacters(in: .whitespacesAndNewlines)
         let key = privateKeyPEM.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !h.isEmpty, !u.isEmpty, !key.isEmpty else { return false }
-
-        let existing = hosts.first { $0.host.compare(h, options: .caseInsensitive) == .orderedSame && $0.username == u }
-        let id = existing?.id ?? UUID()
+        let id = UUID()
         // Persist the key FIRST; only record the host if the key actually stuck.
         guard keychain.save(account: id.uuidString, secret: key) else { return false }
-        if existing == nil {
-            hosts.insert(SavedHost(id: id, host: h, username: u), at: 0)
-            persist()
+        hosts.insert(SavedHost(id: id, host: h, username: u, nickname: n.isEmpty ? nil : n), at: 0)
+        persist()
+        return true
+    }
+
+    /// Updates an existing saved host IN PLACE (by id): host / username / nickname, and
+    /// the private key only when `privateKeyPEM` is non-empty (empty = keep the current
+    /// key, so an edit never forces re-entering it). Returns false without changing
+    /// anything if a required field is missing or a provided key fails to persist.
+    @discardableResult
+    func update(_ existing: SavedHost, nickname: String, host: String, username: String, privateKeyPEM: String) -> Bool {
+        let h = host.trimmingCharacters(in: .whitespacesAndNewlines)
+        let u = username.trimmingCharacters(in: .whitespacesAndNewlines)
+        let n = nickname.trimmingCharacters(in: .whitespacesAndNewlines)
+        let key = privateKeyPEM.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !h.isEmpty, !u.isEmpty else { return false }
+        guard let i = hosts.firstIndex(where: { $0.id == existing.id }) else { return false }
+        // Replace the key only if a new one was entered; a failed persist aborts the whole
+        // update so the record never drifts out of lockstep with the Keychain.
+        if !key.isEmpty {
+            guard keychain.save(account: existing.id.uuidString, secret: key) else { return false }
         }
+        hosts[i].host = h
+        hosts[i].username = u
+        hosts[i].nickname = n.isEmpty ? nil : n
+        persist()
         return true
     }
 


### PR DESCRIPTION
Owner request: on the connect screen, keep the saved-host list, add an **"Add host"** button (with a **nickname**), and **hold a host to edit** it. Owner chose the **host-manager** layout (list + Add button; the form moves into an add/edit sheet).

## Changes
- **`SavedHost`** gains an **optional `nickname`** (legacy UserDefaults JSON without the key decodes to `nil` — no migration) and a `label` (nickname ?? host). The store's `save()` splits into **`add()`** (new id) and **`update()`** (in place by id; replaces the Keychain key **only** when a new one is entered, so record + key stay in lockstep).
- **`HostEditor.swift`** (new): the add/edit sheet — Nickname, Host, User, Key. **Add** → "Save & Connect" + "Save without connecting". **Edit** → "Save"; the key starts blank and is **kept** unless a new one is pasted (the PEM is never displayed — the connect screen can be screenshotted onto an open tailnet port).
- **`ConnectView`** is now the manager: header → saved list (or empty state) → **Add host** button. Tap a row → connect (one tap). **Long-press a row → Edit / Remove**. Rows show the **nickname** as the title with `user@host` beneath. A key that's unreadable on tap opens the editor to re-add it (no silent dead tap).

## Notes
- The always-visible inline connect form is gone; every connection now goes through a saved host (add once, tap to use). First launch shows the empty state + Add button.
- Net −184/+346; ConnectView shrank as the form moved into `HostEditor`.

## Test
- CI: simulator compile-check.
- On-device: Add host (with/without nickname) → Save & Connect; long-press → Edit (change nickname, keep key; or paste a new key) / Remove; legacy saved hosts still show + connect.

Part of the 1.0.1 batch (TestFlight-only; App Store submit stays owner-gated).