### PR TITLE
ci(signing): switch TestFlight lane to automatic signing (for #90 widget extension)

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -5,8 +5,8 @@
 # phone from Actions with NO developer Mac in the signing material), + its write-up
 # in workflow note 42758 on apps-coc/pr-reviews. Herdr differences are called out
 # inline. Key reuse: keephair is on the SAME Apple team (FXQ5Z9HHY6), so the
-# distribution CERTIFICATE is team-wide and shared; herdr only needs its own
-# provisioning PROFILE for com.jerryfane.herdr.
+# distribution CERTIFICATE is team-wide and shared; herdr's provisioning PROFILES are
+# created automatically by Xcode at archive time (-allowProvisioningUpdates + ASC key).
 #
 # WHAT THIS IS NOT: the Mac build box on the tailnet still builds every branch
 # for the SIMULATOR and screenshots it — that is the correctness signal and stays.

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -126,30 +126,24 @@ jobs:
           rm -f /tmp/dist.p12
           security find-identity -v -p codesigning build.keychain
 
-      - name: Install provisioning profile
+      - name: Write App Store Connect API key (automatic signing + upload)
+        # Automatic signing needs the ASC key at archive/export time so xcodebuild's
+        # -allowProvisioningUpdates can create/renew the Apple Distribution cert + the
+        # App Store profiles (app AND the widget extension, #90) on demand — no hand-minted
+        # profile. Written once here; archive + export reuse it via $ASC_KEYFILE. The
+        # always() cleanup removes ~/private_keys/AuthKey_*.p8.
         env:
-          PROVISIONING_PROFILE_BASE64: ${{ secrets.PROVISIONING_PROFILE_BASE64 }}
-          PROFILE_NAME: ${{ secrets.PROVISIONING_PROFILE_NAME }}
+          ASC_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+          ASC_P8_BASE64: ${{ secrets.APP_STORE_CONNECT_P8_BASE64 }}
         run: |
-          mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
-          echo "$PROVISIONING_PROFILE_BASE64" | base64 --decode \
-            > ~/Library/MobileDevice/Provisioning\ Profiles/herdr.mobileprovision
-          INSTALLED=$(/usr/libexec/PlistBuddy -c 'Print :Name' /dev/stdin <<< \
-            "$(security cms -D -i ~/Library/MobileDevice/Provisioning\ Profiles/herdr.mobileprovision)")
-          echo "installed profile: $INSTALLED"
-          # Preflight: three names must agree or the run fails deep — the installed
-          # profile, the export secret (PROVISIONING_PROFILE_NAME → ExportOptions), and
-          # the specifier project.yml archives with. Assert equality at the top.
-          SPECIFIER="Herdrup App Store"
-          if [ "$INSTALLED" != "$SPECIFIER" ] || [ "$PROFILE_NAME" != "$SPECIFIER" ]; then
-            echo "::error::profile-name mismatch — installed='$INSTALLED', secret PROVISIONING_PROFILE_NAME='$PROFILE_NAME', project.yml specifier='$SPECIFIER' (all three must match)."
-            exit 1
-          fi
+          mkdir -p ~/private_keys
+          KEYFILE="$HOME/private_keys/AuthKey_${ASC_KEY_ID}.p8"
+          echo "$ASC_P8_BASE64" | base64 --decode > "$KEYFILE"
+          echo "ASC_KEYFILE=$KEYFILE" >> "$GITHUB_ENV"
 
       - name: Write ExportOptions.plist
         env:
           TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          PROFILE_NAME: ${{ secrets.PROVISIONING_PROFILE_NAME }}
         run: |
           cat > /tmp/ExportOptions.plist <<EOF
           <?xml version="1.0" encoding="UTF-8"?>
@@ -158,37 +152,46 @@ jobs:
           <dict>
             <key>method</key><string>app-store-connect</string>
             <key>teamID</key><string>${TEAM_ID}</string>
-            <key>signingStyle</key><string>manual</string>
+            <key>signingStyle</key><string>automatic</string>
             <key>uploadSymbols</key><true/>
-            <key>provisioningProfiles</key>
-            <dict>
-              <key>com.jerryfane.herdr</key><string>${PROFILE_NAME}</string>
-            </dict>
           </dict>
           </plist>
           EOF
 
       - name: Archive
-        # Manual signing (team, style, profile specifier, Apple Distribution identity)
-        # is scoped to the Herdr APP target in project.yml (configs.Release) — NOT
-        # passed here on the command line. Passing it globally applied the provisioning
-        # profile to the SwiftPM dependency targets (swift-crypto / swift-nio via
-        # Citadel), which are libraries that "do not support provisioning profiles",
-        # and the archive failed (keephair trap b's cousin — but for a dependency-heavy
-        # app the fix is target scoping, not a specifier on the command line).
+        # Automatic signing: -allowProvisioningUpdates + the ASC API key let xcodebuild
+        # create/renew the Apple Distribution cert + App Store profiles (app AND widget
+        # extension) on demand. Signing settings (team, automatic style) live on the Herdr
+        # app target in project.yml (base) — NOT on this command line: a global specifier
+        # would try to sign the SwiftPM dependency targets (swift-crypto / swift-nio via
+        # Citadel), which "do not support provisioning profiles", and fail the archive.
+        env:
+          ASC_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
         run: |
           xcodebuild -project Herdr.xcodeproj -scheme Herdr \
             -configuration Distribution -destination 'generic/platform=iOS' \
             -archivePath /tmp/Herdr.xcarchive \
             -clonedSourcePackagesDirPath SourcePackages \
+            -allowProvisioningUpdates \
+            -authenticationKeyPath "$ASC_KEYFILE" \
+            -authenticationKeyID "$ASC_KEY_ID" \
+            -authenticationKeyIssuerID "$ASC_ISSUER_ID" \
             CURRENT_PROJECT_VERSION="$BUILD" \
             archive
 
       - name: Export .ipa
+        env:
+          ASC_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
         run: |
           xcodebuild -exportArchive -archivePath /tmp/Herdr.xcarchive \
             -exportOptionsPlist /tmp/ExportOptions.plist \
-            -exportPath /tmp/export
+            -exportPath /tmp/export \
+            -allowProvisioningUpdates \
+            -authenticationKeyPath "$ASC_KEYFILE" \
+            -authenticationKeyID "$ASC_KEY_ID" \
+            -authenticationKeyIssuerID "$ASC_ISSUER_ID"
 
       - name: Upload to TestFlight
         # The App Store Connect API key already exists (issuer + key id + .p8). altool

--- a/docs/testflight-lane.md
+++ b/docs/testflight-lane.md
@@ -9,36 +9,41 @@ lane is reviewable in-repo config + a workflow, not Xcode-UI state.
 `.github/workflows/testflight.yml` (GitHub Actions, macOS runner), on
 `workflow_dispatch` or a `v*` tag:
 
-- **Signs MANUALLY** from a distribution certificate + provisioning profile imported
-  from the repo's `testflight` GitHub **Environment** into a throwaway keychain.
-- Uses a **dedicated `Distribution` build configuration** (project.yml) so the manual
-  profile is scoped to the Herdr **app target** and never touches the SwiftPM
-  dependency targets (swift-crypto / swift-nio via Citadel) — libraries that "do not
-  support provisioning profiles" and would otherwise fail the archive.
+- **Signs AUTOMATICALLY**: the archive/export run `xcodebuild -allowProvisioningUpdates`
+  with the App Store Connect API key, so Xcode creates/renews the App Store provisioning
+  profiles on demand — for the app AND its widget extension. The shared team **distribution
+  certificate** is still imported from the `testflight` GitHub **Environment** into a
+  throwaway keychain; only the per-bundle PROFILES are automatic (no hand-minted profile).
+- Uses the **`Distribution` build configuration** (project.yml), which inherits the base
+  automatic signing scoped to the Herdr **app target** — the signing settings live on the
+  target, not the xcodebuild command line, so they never touch the SwiftPM dependency
+  targets (swift-crypto / swift-nio via Citadel), libraries that "do not support
+  provisioning profiles" and would otherwise fail the archive.
 - Archives → exports → uploads → **verifies at the destination**: polls `/v1/builds`
   and requires the build to reach `READY_FOR_BETA_TESTING` / `IN_BETA_TESTING` (failing
   loudly on `FAILED` / `INVALID` / `MISSING_EXPORT_COMPLIANCE`), so a green run always
   means the build actually arrived — not just that the pipeline was green.
 - **No developer Mac touches the signing material.** The Apple **Distribution
-  certificate + provisioning profile are created on Linux** via `openssl` + the App
-  Store Connect API key (the recipe the keephair seat proved). The team distribution
-  cert is shared across the owner's apps; herdr's profile is `Herdrup App Store`
-  against `com.jerryfane.herdr`.
+  certificate** is a team-wide cert (shared across the owner's apps), imported from the
+  Environment; the **provisioning profiles are created by Xcode on demand** at archive
+  time via `-allowProvisioningUpdates` + the App Store Connect API key — for
+  `com.jerryfane.herdr` and its widget extension, with no hand-minted profile to maintain.
 
 **Environment secrets** (`testflight`, scoped to main + `v*` tags — a feature-branch
 run cannot read them): `DIST_CERT_P12_BASE64`, `DIST_CERT_PASSWORD`,
 `KEYCHAIN_PASSWORD`, `APPLE_TEAM_ID`, `APP_STORE_CONNECT_ISSUER_ID`,
-`APP_STORE_CONNECT_KEY_ID`, `APP_STORE_CONNECT_P8_BASE64`, `PROVISIONING_PROFILE_BASE64`,
-`PROVISIONING_PROFILE_NAME`.
+`APP_STORE_CONNECT_KEY_ID`, `APP_STORE_CONNECT_P8_BASE64`. (The old
+`PROVISIONING_PROFILE_BASE64` / `PROVISIONING_PROFILE_NAME` are no longer used — the
+profiles are automatic now.)
 
 ## Signing config (project.yml)
 
 - Base `DEVELOPMENT_TEAM: FXQ5Z9HHY6` + `CODE_SIGN_STYLE: Automatic` — **inert for the
   buildbox's iphonesimulator build** (the simulator is never code-signed).
-- `Distribution` config (release-type): manual signing on the app target
-  (`CODE_SIGN_STYLE: Manual`, `PROVISIONING_PROFILE_SPECIFIER: "Herdrup App Store"`,
-  `CODE_SIGN_IDENTITY: "Apple Distribution"`). Used only by the CI archive.
-- `Release` stays automatic — it belongs to the Mac fallback lane, not the CI.
+- `Distribution` config (release-type): **inherits the base automatic signing** (it no
+  longer overrides to manual). Used by the CI archive, which passes
+  `-allowProvisioningUpdates` + the ASC key so Xcode manages the profiles.
+- `Release` also automatic — it belongs to the Mac fallback lane.
 
 ## Export compliance
 
@@ -66,14 +71,15 @@ uploads; a plain run is a signing dry-run.
 1. The App Store Connect **app record** for `com.jerryfane.herdr` (name Herdrup) —
    created in the ASC web UI, because Apple's API forbids app creation (POST /v1/apps →
    403; GET/UPDATE only).
-2. The `testflight` environment **secrets** (the nine above; the private keys never
+2. The `testflight` environment **secrets** (the seven above; the private keys never
    transit a pane/transcript — written repo-to-repo).
 3. (No per-build export-compliance answer is needed — `ITSAppUsesNonExemptEncryption =
    false` declares the standard-encryption exemption up front, so internal builds are
    testable on upload.)
 
-The bundle id, the shared distribution certificate, and the `Herdrup App Store` profile
-are created via the ASC API on Linux, not by hand.
+The bundle id and the shared distribution certificate are set up once; the App Store
+provisioning profiles are created automatically by Xcode at archive time (no hand-minted
+profile).
 
 ## Verification
 

--- a/project.yml
+++ b/project.yml
@@ -19,10 +19,10 @@ options:
   createIntermediateGroups: true
 
 # Debug + Release are the defaults (buildbox builds Debug-iphonesimulator; the Mac
-# lane scripts/testflight.sh archives Release with AUTOMATIC account signing).
-# Distribution is a release-type config used ONLY by the GitHub Actions CI archive,
-# which needs MANUAL signing — isolated here so the CI's manual profile does not
-# regress the Mac lane's automatic Release signing.
+# lane scripts/testflight.sh archives Release with automatic account signing).
+# Distribution is a release-type config used by the GitHub Actions CI archive, which
+# now also signs AUTOMATICALLY (xcodebuild -allowProvisioningUpdates + the App Store
+# Connect API key), so Xcode manages the profiles for the app and its widget extension.
 configs:
   Debug: debug
   Release: release

--- a/project.yml
+++ b/project.yml
@@ -182,15 +182,14 @@ targets:
         # they take effect only for a device archive. See scripts/testflight.sh.
         DEVELOPMENT_TEAM: FXQ5Z9HHY6
         CODE_SIGN_STYLE: Automatic
-      # The Distribution config (GitHub Actions CI archive) signs MANUALLY, scoped to
-      # THIS app target. It must NOT be passed on the xcodebuild command line: that
-      # applies the provisioning profile to EVERY target, including the SwiftPM
-      # dependency targets (swift-crypto / swift-nio, pulled via Citadel), which are
-      # libraries that "do not support provisioning profiles" — and the archive fails.
-      # Scoped here, only the app target carries the profile. It lives on Distribution,
-      # NOT Release, so the Mac lane's automatic Release signing (scripts/testflight.sh)
-      # is unaffected; Debug (the buildbox sim build) is never code-signed. The
-      # specifier matches the profile minted into the `testflight` GitHub environment.
+      # The Distribution config (GitHub Actions CI archive) now inherits the base
+      # AUTOMATIC signing (DEVELOPMENT_TEAM + CODE_SIGN_STYLE: Automatic) rather than
+      # overriding to a hand-minted profile: the CI archive/export run xcodebuild with
+      # `-allowProvisioningUpdates` + the App Store Connect API key, so Xcode creates and
+      # renews the Apple Distribution cert and the App Store profile(s) on demand — for the
+      # app AND for the widget extension (#90), which no longer needs a hand-minted profile.
+      # (Owner-authorised switch to automatic signing, Aug 14 2026.) Debug (the buildbox sim
+      # build) is never code-signed, so the green sim build is unaffected.
       configs:
         # aps-environment resolves from APS_ENVIRONMENT per config: `development` for an on-device
         # Debug build (which provisions against a development profile / sandbox APNs), `production` for
@@ -201,9 +200,7 @@ targets:
           APS_ENVIRONMENT: production
         Distribution:
           APS_ENVIRONMENT: production
-          CODE_SIGN_STYLE: Manual
-          PROVISIONING_PROFILE_SPECIFIER: "Herdrup App Store"
-          CODE_SIGN_IDENTITY: "Apple Distribution"
+          # Inherits DEVELOPMENT_TEAM + CODE_SIGN_STYLE: Automatic from the base.
 
   # UI-test bundle — the automated SCROLL RECEIPT. Launches the app in the
   # HERDR_SCREENSHOT_MOCK=scroll pane (a real SwiftTerm view fed 200 lines), swipes it,


### PR DESCRIPTION
Owner-authorized (Option 2, Aug 14): switch the TestFlight lane from manual signing to **automatic** so a widget extension (#90 Live Activity) can be added without hand-minting a second provisioning profile — Xcode creates/renews the Distribution cert + App Store profiles (app **and** widget) on demand.

## Changes
- **project.yml** — the `Distribution` config drops its manual overrides (`CODE_SIGN_STYLE: Manual`, `PROVISIONING_PROFILE_SPECIFIER`, `CODE_SIGN_IDENTITY`) and inherits the base **automatic** signing (`DEVELOPMENT_TEAM FXQ5Z9HHY6` + `CODE_SIGN_STYLE: Automatic`). The base was already automatic (the Mac lane uses it); this aligns CI.
- **testflight.yml**:
  - Replaced the manual-profile install step with a **"Write ASC API key"** step (`$ASC_KEYFILE`).
  - `ExportOptions.plist`: `signingStyle` → **automatic**, removed the `provisioningProfiles` dict.
  - **Archive** + **Export**: added `-allowProvisioningUpdates -authenticationKeyPath $ASC_KEYFILE -authenticationKeyID -authenticationKeyIssuerID`.
  - The Distribution cert import and the `always()` key/keychain cleanup are unchanged.

## How this gets verified
The `testflight` GitHub environment only permits `main`/tags to deploy (I confirmed a `workflow_dispatch` on this branch is rejected by the branch policy), so signing **can't** be exercised pre-merge. Plan: review this for correctness → merge → tag a build → confirm it archives, exports, and uploads under automatic signing. A failure there is **non-destructive** (no new build) and I'd iterate.

## Review focus
- Correctness of the `-allowProvisioningUpdates` + `-authenticationKey*` args on archive/export; `$ASC_KEYFILE` is set before archive and available to export.
- Secret handling: the ASC `.p8` is written to `~/private_keys` and removed by the `always()` cleanup; no key leaks to logs.
- The Distribution config still scopes signing to the app target (not the SwiftPM deps).
- Any leftover reference to the removed manual profile (`PROVISIONING_PROFILE_*`, `signingStyle manual`).