### PR TITLE
ci(signing): export locally with the archive-created profile (fix cloud-signing export failure)

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -187,8 +187,7 @@ jobs:
             appid=$(/usr/libexec/PlistBuddy -c 'Print :Entitlements:application-identifier' /dev/stdin <<< "$plist" 2>/dev/null) || continue
             bundle="${appid#*.}"   # strip the TEAMID. prefix
             echo "embedded profile: $bundle -> $name"
-            PROFILES_XML="${PROFILES_XML}      <key>${bundle}</key><string>${name}</string>
-"
+            PROFILES_XML="${PROFILES_XML}<key>${bundle}</key><string>${name}</string>"
           done < <(find "$APP_DIR" -name embedded.mobileprovision)
           if [ -z "$PROFILES_XML" ]; then echo "::error::no embedded provisioning profiles in the archive"; exit 1; fi
           cat > /tmp/ExportOptions.plist <<EOF
@@ -201,8 +200,7 @@ jobs:
             <key>signingStyle</key><string>manual</string>
             <key>uploadSymbols</key><true/>
             <key>provisioningProfiles</key>
-            <dict>
-${PROFILES_XML}    </dict>
+            <dict>${PROFILES_XML}</dict>
           </dict>
           </plist>
           EOF

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -186,7 +186,19 @@ jobs:
             name=$(/usr/libexec/PlistBuddy -c 'Print :Name' /dev/stdin <<< "$plist" 2>/dev/null) || continue
             appid=$(/usr/libexec/PlistBuddy -c 'Print :Entitlements:application-identifier' /dev/stdin <<< "$plist" 2>/dev/null) || continue
             bundle="${appid#*.}"   # strip the TEAMID. prefix
-            echo "embedded profile: $bundle -> $name"
+            # Assert it's an APP STORE profile, not development / ad-hoc / enterprise: those
+            # embed a ProvisionedDevices list or ProvisionsAllDevices, or get-task-allow=true.
+            # Fail loudly — a wrong-type embedded profile means the archive signed wrong, and
+            # a manual app-store-connect export with it would fail cryptically anyway.
+            gta=$(/usr/libexec/PlistBuddy -c 'Print :Entitlements:get-task-allow' /dev/stdin <<< "$plist" 2>/dev/null || echo "")
+            has_devices=no
+            if /usr/libexec/PlistBuddy -c 'Print :ProvisionedDevices' /dev/stdin <<< "$plist" >/dev/null 2>&1; then has_devices=yes; fi
+            all_devices=$(/usr/libexec/PlistBuddy -c 'Print :ProvisionsAllDevices' /dev/stdin <<< "$plist" 2>/dev/null || echo "")
+            if [ "$gta" = "true" ] || [ "$has_devices" = "yes" ] || [ "$all_devices" = "true" ]; then
+              echo "::error::embedded profile for $bundle ('$name') is NOT an App Store profile (get-task-allow=$gta ProvisionedDevices=$has_devices ProvisionsAllDevices=$all_devices)"
+              exit 1
+            fi
+            echo "embedded App Store profile: $bundle -> $name"
             PROFILES_XML="${PROFILES_XML}<key>${bundle}</key><string>${name}</string>"
           done < <(find "$APP_DIR" -name embedded.mobileprovision)
           if [ -z "$PROFILES_XML" ]; then echo "::error::no embedded provisioning profiles in the archive"; exit 1; fi

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -141,23 +141,6 @@ jobs:
           echo "$ASC_P8_BASE64" | base64 --decode > "$KEYFILE"
           echo "ASC_KEYFILE=$KEYFILE" >> "$GITHUB_ENV"
 
-      - name: Write ExportOptions.plist
-        env:
-          TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-        run: |
-          cat > /tmp/ExportOptions.plist <<EOF
-          <?xml version="1.0" encoding="UTF-8"?>
-          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-          <plist version="1.0">
-          <dict>
-            <key>method</key><string>app-store-connect</string>
-            <key>teamID</key><string>${TEAM_ID}</string>
-            <key>signingStyle</key><string>automatic</string>
-            <key>uploadSymbols</key><true/>
-          </dict>
-          </plist>
-          EOF
-
       - name: Archive
         # Automatic signing: -allowProvisioningUpdates + the ASC API key let xcodebuild
         # create/renew the Apple Distribution cert + App Store profiles (app AND widget
@@ -181,17 +164,57 @@ jobs:
             archive
 
       - name: Export .ipa
+        # LOCAL signing on export. The Archive (automatic + -allowProvisioningUpdates) has
+        # already created and installed the App Store provisioning profile for our bundle
+        # id, so export with a MANUAL ExportOptions that names it. Xcode's automatic export
+        # otherwise attempts CLOUD signing, which needs a cloud-managed distribution cert
+        # this team does not use (we import our own) — the "Cloud signing permission error".
+        # The profile is discovered by name (no hand-minted profile / secret); when the
+        # widget extension lands, add its bundle id + a second provisioningProfiles entry.
         env:
-          ASC_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
-          ASC_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+          TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
+          PROFILE_DIR="$HOME/Library/MobileDevice/Provisioning Profiles"
+          # bash 3.2 on the runner — no associative arrays. Find the DISTRIBUTION profile
+          # (get-task-allow=false) that the archive installed for com.jerryfane.herdr.
+          APP_PROFILE=""
+          for p in "$PROFILE_DIR"/*.mobileprovision; do
+            [ -e "$p" ] || continue
+            plist=$(security cms -D -i "$p" 2>/dev/null) || continue
+            appid=$(/usr/libexec/PlistBuddy -c 'Print :Entitlements:application-identifier' /dev/stdin <<< "$plist" 2>/dev/null) || continue
+            gta=$(/usr/libexec/PlistBuddy -c 'Print :Entitlements:get-task-allow' /dev/stdin <<< "$plist" 2>/dev/null)
+            case "$appid" in
+              *.com.jerryfane.herdr)
+                if [ "$gta" = "false" ]; then
+                  APP_PROFILE=$(/usr/libexec/PlistBuddy -c 'Print :Name' /dev/stdin <<< "$plist" 2>/dev/null)
+                fi ;;
+            esac
+          done
+          if [ -z "$APP_PROFILE" ]; then
+            echo "::error::No installed App Store profile for com.jerryfane.herdr after archive."
+            ls -la "$PROFILE_DIR" || true
+            exit 1
+          fi
+          echo "export profile for com.jerryfane.herdr: $APP_PROFILE"
+          cat > /tmp/ExportOptions.plist <<EOF
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0">
+          <dict>
+            <key>method</key><string>app-store-connect</string>
+            <key>teamID</key><string>${TEAM_ID}</string>
+            <key>signingStyle</key><string>manual</string>
+            <key>uploadSymbols</key><true/>
+            <key>provisioningProfiles</key>
+            <dict>
+              <key>com.jerryfane.herdr</key><string>${APP_PROFILE}</string>
+            </dict>
+          </dict>
+          </plist>
+          EOF
           xcodebuild -exportArchive -archivePath /tmp/Herdr.xcarchive \
             -exportOptionsPlist /tmp/ExportOptions.plist \
-            -exportPath /tmp/export \
-            -allowProvisioningUpdates \
-            -authenticationKeyPath "$ASC_KEYFILE" \
-            -authenticationKeyID "$ASC_KEY_ID" \
-            -authenticationKeyIssuerID "$ASC_ISSUER_ID"
+            -exportPath /tmp/export
 
       - name: Upload to TestFlight
         # The App Store Connect API key already exists (issuer + key id + .p8). altool

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -164,38 +164,33 @@ jobs:
             archive
 
       - name: Export .ipa
-        # LOCAL signing on export. The Archive (automatic + -allowProvisioningUpdates) has
-        # already created and installed the App Store provisioning profile for our bundle
-        # id, so export with a MANUAL ExportOptions that names it. Xcode's automatic export
-        # otherwise attempts CLOUD signing, which needs a cloud-managed distribution cert
-        # this team does not use (we import our own) — the "Cloud signing permission error".
-        # The profile is discovered by name (no hand-minted profile / secret); when the
-        # widget extension lands, add its bundle id + a second provisioningProfiles entry.
+        # LOCAL signing on export. The Archive (automatic + -allowProvisioningUpdates)
+        # already created, downloaded, and EMBEDDED the App Store profile(s) it signed with
+        # INTO the .xcarchive, so read them straight from there. That is authoritative (the
+        # exact profiles the app was signed with) and immune to the runner's Xcode-version
+        # profile directory (Xcode 16+ moved it out of ~/Library/MobileDevice) and to
+        # dev/ad-hoc/expiry ambiguity. Export MANUALLY with those so Xcode never attempts
+        # CLOUD signing, which needs a cloud-managed distribution cert this team does not use
+        # (we import our own) — the "Cloud signing permission error". `find` picks up the app
+        # AND any PlugIns/*.appex profile, so the widget extension needs no change here.
         env:
           TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
-          PROFILE_DIR="$HOME/Library/MobileDevice/Provisioning Profiles"
-          # bash 3.2 on the runner — no associative arrays. Find the DISTRIBUTION profile
-          # (get-task-allow=false) that the archive installed for com.jerryfane.herdr.
-          APP_PROFILE=""
-          for p in "$PROFILE_DIR"/*.mobileprovision; do
-            [ -e "$p" ] || continue
-            plist=$(security cms -D -i "$p" 2>/dev/null) || continue
+          APP_DIR=$(ls -d /tmp/Herdr.xcarchive/Products/Applications/*.app 2>/dev/null | head -1)
+          [ -d "$APP_DIR" ] || { echo "::error::no .app in the archive"; ls -la /tmp/Herdr.xcarchive/Products/Applications || true; exit 1; }
+          # Map every embedded profile (app + appex) to its bundle id. Process substitution
+          # (not a pipe) keeps the appended var in this shell; bash 3.2 on the runner is fine.
+          PROFILES_XML=""
+          while IFS= read -r mp; do
+            plist=$(security cms -D -i "$mp" 2>/dev/null) || continue
+            name=$(/usr/libexec/PlistBuddy -c 'Print :Name' /dev/stdin <<< "$plist" 2>/dev/null) || continue
             appid=$(/usr/libexec/PlistBuddy -c 'Print :Entitlements:application-identifier' /dev/stdin <<< "$plist" 2>/dev/null) || continue
-            gta=$(/usr/libexec/PlistBuddy -c 'Print :Entitlements:get-task-allow' /dev/stdin <<< "$plist" 2>/dev/null)
-            case "$appid" in
-              *.com.jerryfane.herdr)
-                if [ "$gta" = "false" ]; then
-                  APP_PROFILE=$(/usr/libexec/PlistBuddy -c 'Print :Name' /dev/stdin <<< "$plist" 2>/dev/null)
-                fi ;;
-            esac
-          done
-          if [ -z "$APP_PROFILE" ]; then
-            echo "::error::No installed App Store profile for com.jerryfane.herdr after archive."
-            ls -la "$PROFILE_DIR" || true
-            exit 1
-          fi
-          echo "export profile for com.jerryfane.herdr: $APP_PROFILE"
+            bundle="${appid#*.}"   # strip the TEAMID. prefix
+            echo "embedded profile: $bundle -> $name"
+            PROFILES_XML="${PROFILES_XML}      <key>${bundle}</key><string>${name}</string>
+"
+          done < <(find "$APP_DIR" -name embedded.mobileprovision)
+          if [ -z "$PROFILES_XML" ]; then echo "::error::no embedded provisioning profiles in the archive"; exit 1; fi
           cat > /tmp/ExportOptions.plist <<EOF
           <?xml version="1.0" encoding="UTF-8"?>
           <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -207,11 +202,11 @@ jobs:
             <key>uploadSymbols</key><true/>
             <key>provisioningProfiles</key>
             <dict>
-              <key>com.jerryfane.herdr</key><string>${APP_PROFILE}</string>
-            </dict>
+${PROFILES_XML}    </dict>
           </dict>
           </plist>
           EOF
+          echo "--- ExportOptions.plist ---"; cat /tmp/ExportOptions.plist
           xcodebuild -exportArchive -archivePath /tmp/Herdr.xcarchive \
             -exportOptionsPlist /tmp/ExportOptions.plist \
             -exportPath /tmp/export


### PR DESCRIPTION
Follow-up to #99. The automatic-signing verification build (`v0.1.37`) **archived cleanly** but **Export failed**: `Cloud signing permission error` / `No profiles for 'com.jerryfane.herdr' were found`. Xcode's automatic *export* attempts **cloud signing** (a cloud-managed distribution cert), but this team uses a **manually-imported** distribution cert — the two conflict.

## Fix
- **Archive** stays automatic (`-allowProvisioningUpdates` + ASC key) — it already creates + installs the App Store profile; that step passed.
- **Export** now signs **locally**: it scans `~/Library/MobileDevice/Provisioning Profiles` for the **distribution** profile (`get-task-allow == false`) matching `com.jerryfane.herdr` that the archive installed, writes a **manual** `ExportOptions` naming it, and exports without cloud signing / the ASC key.
- No hand-minted profile or new secret; when the widget extension lands I add its bundle id + a second `provisioningProfiles` entry.

## Verify
Same as #99: the `testflight` environment blocks branch dispatch, so this is proven by a **post-merge tagged build** (non-destructive on failure). Archive already succeeded on `v0.1.37`; this only changes Export.

## Review focus
- bash **3.2**-safe (runner default) — no associative arrays; `PlistBuddy /dev/stdin <<<` matches the pattern the old install-profile step used.
- Correctly picks the **distribution** profile (not a dev one); fails loudly if none found.
- No secret/log leak.