### PR TITLE
ci(signing): revert TestFlight lane to manual signing (automatic export blocked)

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -5,8 +5,8 @@
 # phone from Actions with NO developer Mac in the signing material), + its write-up
 # in workflow note 42758 on apps-coc/pr-reviews. Herdr differences are called out
 # inline. Key reuse: keephair is on the SAME Apple team (FXQ5Z9HHY6), so the
-# distribution CERTIFICATE is team-wide and shared; herdr's provisioning PROFILES are
-# created automatically by Xcode at archive time (-allowProvisioningUpdates + ASC key).
+# distribution CERTIFICATE is team-wide and shared; herdr only needs its own
+# provisioning PROFILE for com.jerryfane.herdr.
 #
 # WHAT THIS IS NOT: the Mac build box on the tailnet still builds every branch
 # for the SIMULATOR and screenshots it — that is the correctness signal and stays.
@@ -126,82 +126,31 @@ jobs:
           rm -f /tmp/dist.p12
           security find-identity -v -p codesigning build.keychain
 
-      - name: Write App Store Connect API key (automatic signing + upload)
-        # Automatic signing needs the ASC key at archive/export time so xcodebuild's
-        # -allowProvisioningUpdates can create/renew the Apple Distribution cert + the
-        # App Store profiles (app AND the widget extension, #90) on demand — no hand-minted
-        # profile. Written once here; archive + export reuse it via $ASC_KEYFILE. The
-        # always() cleanup removes ~/private_keys/AuthKey_*.p8.
+      - name: Install provisioning profile
         env:
-          ASC_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
-          ASC_P8_BASE64: ${{ secrets.APP_STORE_CONNECT_P8_BASE64 }}
+          PROVISIONING_PROFILE_BASE64: ${{ secrets.PROVISIONING_PROFILE_BASE64 }}
+          PROFILE_NAME: ${{ secrets.PROVISIONING_PROFILE_NAME }}
         run: |
-          mkdir -p ~/private_keys
-          KEYFILE="$HOME/private_keys/AuthKey_${ASC_KEY_ID}.p8"
-          echo "$ASC_P8_BASE64" | base64 --decode > "$KEYFILE"
-          echo "ASC_KEYFILE=$KEYFILE" >> "$GITHUB_ENV"
+          mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
+          echo "$PROVISIONING_PROFILE_BASE64" | base64 --decode \
+            > ~/Library/MobileDevice/Provisioning\ Profiles/herdr.mobileprovision
+          INSTALLED=$(/usr/libexec/PlistBuddy -c 'Print :Name' /dev/stdin <<< \
+            "$(security cms -D -i ~/Library/MobileDevice/Provisioning\ Profiles/herdr.mobileprovision)")
+          echo "installed profile: $INSTALLED"
+          # Preflight: three names must agree or the run fails deep — the installed
+          # profile, the export secret (PROVISIONING_PROFILE_NAME → ExportOptions), and
+          # the specifier project.yml archives with. Assert equality at the top.
+          SPECIFIER="Herdrup App Store"
+          if [ "$INSTALLED" != "$SPECIFIER" ] || [ "$PROFILE_NAME" != "$SPECIFIER" ]; then
+            echo "::error::profile-name mismatch — installed='$INSTALLED', secret PROVISIONING_PROFILE_NAME='$PROFILE_NAME', project.yml specifier='$SPECIFIER' (all three must match)."
+            exit 1
+          fi
 
-      - name: Archive
-        # Automatic signing: -allowProvisioningUpdates + the ASC API key let xcodebuild
-        # create/renew the Apple Distribution cert + App Store profiles (app AND widget
-        # extension) on demand. Signing settings (team, automatic style) live on the Herdr
-        # app target in project.yml (base) — NOT on this command line: a global specifier
-        # would try to sign the SwiftPM dependency targets (swift-crypto / swift-nio via
-        # Citadel), which "do not support provisioning profiles", and fail the archive.
-        env:
-          ASC_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
-          ASC_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
-        run: |
-          xcodebuild -project Herdr.xcodeproj -scheme Herdr \
-            -configuration Distribution -destination 'generic/platform=iOS' \
-            -archivePath /tmp/Herdr.xcarchive \
-            -clonedSourcePackagesDirPath SourcePackages \
-            -allowProvisioningUpdates \
-            -authenticationKeyPath "$ASC_KEYFILE" \
-            -authenticationKeyID "$ASC_KEY_ID" \
-            -authenticationKeyIssuerID "$ASC_ISSUER_ID" \
-            CURRENT_PROJECT_VERSION="$BUILD" \
-            archive
-
-      - name: Export .ipa
-        # LOCAL signing on export. The Archive (automatic + -allowProvisioningUpdates)
-        # already created, downloaded, and EMBEDDED the App Store profile(s) it signed with
-        # INTO the .xcarchive, so read them straight from there. That is authoritative (the
-        # exact profiles the app was signed with) and immune to the runner's Xcode-version
-        # profile directory (Xcode 16+ moved it out of ~/Library/MobileDevice) and to
-        # dev/ad-hoc/expiry ambiguity. Export MANUALLY with those so Xcode never attempts
-        # CLOUD signing, which needs a cloud-managed distribution cert this team does not use
-        # (we import our own) — the "Cloud signing permission error". `find` picks up the app
-        # AND any PlugIns/*.appex profile, so the widget extension needs no change here.
+      - name: Write ExportOptions.plist
         env:
           TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          PROFILE_NAME: ${{ secrets.PROVISIONING_PROFILE_NAME }}
         run: |
-          APP_DIR=$(ls -d /tmp/Herdr.xcarchive/Products/Applications/*.app 2>/dev/null | head -1)
-          [ -d "$APP_DIR" ] || { echo "::error::no .app in the archive"; ls -la /tmp/Herdr.xcarchive/Products/Applications || true; exit 1; }
-          # Map every embedded profile (app + appex) to its bundle id. Process substitution
-          # (not a pipe) keeps the appended var in this shell; bash 3.2 on the runner is fine.
-          PROFILES_XML=""
-          while IFS= read -r mp; do
-            plist=$(security cms -D -i "$mp" 2>/dev/null) || continue
-            name=$(/usr/libexec/PlistBuddy -c 'Print :Name' /dev/stdin <<< "$plist" 2>/dev/null) || continue
-            appid=$(/usr/libexec/PlistBuddy -c 'Print :Entitlements:application-identifier' /dev/stdin <<< "$plist" 2>/dev/null) || continue
-            bundle="${appid#*.}"   # strip the TEAMID. prefix
-            # Assert it's an APP STORE profile, not development / ad-hoc / enterprise: those
-            # embed a ProvisionedDevices list or ProvisionsAllDevices, or get-task-allow=true.
-            # Fail loudly — a wrong-type embedded profile means the archive signed wrong, and
-            # a manual app-store-connect export with it would fail cryptically anyway.
-            gta=$(/usr/libexec/PlistBuddy -c 'Print :Entitlements:get-task-allow' /dev/stdin <<< "$plist" 2>/dev/null || echo "")
-            has_devices=no
-            if /usr/libexec/PlistBuddy -c 'Print :ProvisionedDevices' /dev/stdin <<< "$plist" >/dev/null 2>&1; then has_devices=yes; fi
-            all_devices=$(/usr/libexec/PlistBuddy -c 'Print :ProvisionsAllDevices' /dev/stdin <<< "$plist" 2>/dev/null || echo "")
-            if [ "$gta" = "true" ] || [ "$has_devices" = "yes" ] || [ "$all_devices" = "true" ]; then
-              echo "::error::embedded profile for $bundle ('$name') is NOT an App Store profile (get-task-allow=$gta ProvisionedDevices=$has_devices ProvisionsAllDevices=$all_devices)"
-              exit 1
-            fi
-            echo "embedded App Store profile: $bundle -> $name"
-            PROFILES_XML="${PROFILES_XML}<key>${bundle}</key><string>${name}</string>"
-          done < <(find "$APP_DIR" -name embedded.mobileprovision)
-          if [ -z "$PROFILES_XML" ]; then echo "::error::no embedded provisioning profiles in the archive"; exit 1; fi
           cat > /tmp/ExportOptions.plist <<EOF
           <?xml version="1.0" encoding="UTF-8"?>
           <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -212,11 +161,31 @@ jobs:
             <key>signingStyle</key><string>manual</string>
             <key>uploadSymbols</key><true/>
             <key>provisioningProfiles</key>
-            <dict>${PROFILES_XML}</dict>
+            <dict>
+              <key>com.jerryfane.herdr</key><string>${PROFILE_NAME}</string>
+            </dict>
           </dict>
           </plist>
           EOF
-          echo "--- ExportOptions.plist ---"; cat /tmp/ExportOptions.plist
+
+      - name: Archive
+        # Manual signing (team, style, profile specifier, Apple Distribution identity)
+        # is scoped to the Herdr APP target in project.yml (configs.Release) — NOT
+        # passed here on the command line. Passing it globally applied the provisioning
+        # profile to the SwiftPM dependency targets (swift-crypto / swift-nio via
+        # Citadel), which are libraries that "do not support provisioning profiles",
+        # and the archive failed (keephair trap b's cousin — but for a dependency-heavy
+        # app the fix is target scoping, not a specifier on the command line).
+        run: |
+          xcodebuild -project Herdr.xcodeproj -scheme Herdr \
+            -configuration Distribution -destination 'generic/platform=iOS' \
+            -archivePath /tmp/Herdr.xcarchive \
+            -clonedSourcePackagesDirPath SourcePackages \
+            CURRENT_PROJECT_VERSION="$BUILD" \
+            archive
+
+      - name: Export .ipa
+        run: |
           xcodebuild -exportArchive -archivePath /tmp/Herdr.xcarchive \
             -exportOptionsPlist /tmp/ExportOptions.plist \
             -exportPath /tmp/export

--- a/docs/testflight-lane.md
+++ b/docs/testflight-lane.md
@@ -9,41 +9,36 @@ lane is reviewable in-repo config + a workflow, not Xcode-UI state.
 `.github/workflows/testflight.yml` (GitHub Actions, macOS runner), on
 `workflow_dispatch` or a `v*` tag:
 
-- **Signs AUTOMATICALLY**: the archive/export run `xcodebuild -allowProvisioningUpdates`
-  with the App Store Connect API key, so Xcode creates/renews the App Store provisioning
-  profiles on demand — for the app AND its widget extension. The shared team **distribution
-  certificate** is still imported from the `testflight` GitHub **Environment** into a
-  throwaway keychain; only the per-bundle PROFILES are automatic (no hand-minted profile).
-- Uses the **`Distribution` build configuration** (project.yml), which inherits the base
-  automatic signing scoped to the Herdr **app target** — the signing settings live on the
-  target, not the xcodebuild command line, so they never touch the SwiftPM dependency
-  targets (swift-crypto / swift-nio via Citadel), libraries that "do not support
-  provisioning profiles" and would otherwise fail the archive.
+- **Signs MANUALLY** from a distribution certificate + provisioning profile imported
+  from the repo's `testflight` GitHub **Environment** into a throwaway keychain.
+- Uses a **dedicated `Distribution` build configuration** (project.yml) so the manual
+  profile is scoped to the Herdr **app target** and never touches the SwiftPM
+  dependency targets (swift-crypto / swift-nio via Citadel) — libraries that "do not
+  support provisioning profiles" and would otherwise fail the archive.
 - Archives → exports → uploads → **verifies at the destination**: polls `/v1/builds`
   and requires the build to reach `READY_FOR_BETA_TESTING` / `IN_BETA_TESTING` (failing
   loudly on `FAILED` / `INVALID` / `MISSING_EXPORT_COMPLIANCE`), so a green run always
   means the build actually arrived — not just that the pipeline was green.
 - **No developer Mac touches the signing material.** The Apple **Distribution
-  certificate** is a team-wide cert (shared across the owner's apps), imported from the
-  Environment; the **provisioning profiles are created by Xcode on demand** at archive
-  time via `-allowProvisioningUpdates` + the App Store Connect API key — for
-  `com.jerryfane.herdr` and its widget extension, with no hand-minted profile to maintain.
+  certificate + provisioning profile are created on Linux** via `openssl` + the App
+  Store Connect API key (the recipe the keephair seat proved). The team distribution
+  cert is shared across the owner's apps; herdr's profile is `Herdrup App Store`
+  against `com.jerryfane.herdr`.
 
 **Environment secrets** (`testflight`, scoped to main + `v*` tags — a feature-branch
 run cannot read them): `DIST_CERT_P12_BASE64`, `DIST_CERT_PASSWORD`,
 `KEYCHAIN_PASSWORD`, `APPLE_TEAM_ID`, `APP_STORE_CONNECT_ISSUER_ID`,
-`APP_STORE_CONNECT_KEY_ID`, `APP_STORE_CONNECT_P8_BASE64`. (The old
-`PROVISIONING_PROFILE_BASE64` / `PROVISIONING_PROFILE_NAME` are no longer used — the
-profiles are automatic now.)
+`APP_STORE_CONNECT_KEY_ID`, `APP_STORE_CONNECT_P8_BASE64`, `PROVISIONING_PROFILE_BASE64`,
+`PROVISIONING_PROFILE_NAME`.
 
 ## Signing config (project.yml)
 
 - Base `DEVELOPMENT_TEAM: FXQ5Z9HHY6` + `CODE_SIGN_STYLE: Automatic` — **inert for the
   buildbox's iphonesimulator build** (the simulator is never code-signed).
-- `Distribution` config (release-type): **inherits the base automatic signing** (it no
-  longer overrides to manual). Used by the CI archive, which passes
-  `-allowProvisioningUpdates` + the ASC key so Xcode manages the profiles.
-- `Release` also automatic — it belongs to the Mac fallback lane.
+- `Distribution` config (release-type): manual signing on the app target
+  (`CODE_SIGN_STYLE: Manual`, `PROVISIONING_PROFILE_SPECIFIER: "Herdrup App Store"`,
+  `CODE_SIGN_IDENTITY: "Apple Distribution"`). Used only by the CI archive.
+- `Release` stays automatic — it belongs to the Mac fallback lane, not the CI.
 
 ## Export compliance
 
@@ -71,15 +66,14 @@ uploads; a plain run is a signing dry-run.
 1. The App Store Connect **app record** for `com.jerryfane.herdr` (name Herdrup) —
    created in the ASC web UI, because Apple's API forbids app creation (POST /v1/apps →
    403; GET/UPDATE only).
-2. The `testflight` environment **secrets** (the seven above; the private keys never
+2. The `testflight` environment **secrets** (the nine above; the private keys never
    transit a pane/transcript — written repo-to-repo).
 3. (No per-build export-compliance answer is needed — `ITSAppUsesNonExemptEncryption =
    false` declares the standard-encryption exemption up front, so internal builds are
    testable on upload.)
 
-The bundle id and the shared distribution certificate are set up once; the App Store
-provisioning profiles are created automatically by Xcode at archive time (no hand-minted
-profile).
+The bundle id, the shared distribution certificate, and the `Herdrup App Store` profile
+are created via the ASC API on Linux, not by hand.
 
 ## Verification
 

--- a/project.yml
+++ b/project.yml
@@ -19,10 +19,10 @@ options:
   createIntermediateGroups: true
 
 # Debug + Release are the defaults (buildbox builds Debug-iphonesimulator; the Mac
-# lane scripts/testflight.sh archives Release with automatic account signing).
-# Distribution is a release-type config used by the GitHub Actions CI archive, which
-# now also signs AUTOMATICALLY (xcodebuild -allowProvisioningUpdates + the App Store
-# Connect API key), so Xcode manages the profiles for the app and its widget extension.
+# lane scripts/testflight.sh archives Release with AUTOMATIC account signing).
+# Distribution is a release-type config used ONLY by the GitHub Actions CI archive,
+# which needs MANUAL signing — isolated here so the CI's manual profile does not
+# regress the Mac lane's automatic Release signing.
 configs:
   Debug: debug
   Release: release
@@ -182,14 +182,15 @@ targets:
         # they take effect only for a device archive. See scripts/testflight.sh.
         DEVELOPMENT_TEAM: FXQ5Z9HHY6
         CODE_SIGN_STYLE: Automatic
-      # The Distribution config (GitHub Actions CI archive) now inherits the base
-      # AUTOMATIC signing (DEVELOPMENT_TEAM + CODE_SIGN_STYLE: Automatic) rather than
-      # overriding to a hand-minted profile: the CI archive/export run xcodebuild with
-      # `-allowProvisioningUpdates` + the App Store Connect API key, so Xcode creates and
-      # renews the Apple Distribution cert and the App Store profile(s) on demand — for the
-      # app AND for the widget extension (#90), which no longer needs a hand-minted profile.
-      # (Owner-authorised switch to automatic signing, Aug 14 2026.) Debug (the buildbox sim
-      # build) is never code-signed, so the green sim build is unaffected.
+      # The Distribution config (GitHub Actions CI archive) signs MANUALLY, scoped to
+      # THIS app target. It must NOT be passed on the xcodebuild command line: that
+      # applies the provisioning profile to EVERY target, including the SwiftPM
+      # dependency targets (swift-crypto / swift-nio, pulled via Citadel), which are
+      # libraries that "do not support provisioning profiles" — and the archive fails.
+      # Scoped here, only the app target carries the profile. It lives on Distribution,
+      # NOT Release, so the Mac lane's automatic Release signing (scripts/testflight.sh)
+      # is unaffected; Debug (the buildbox sim build) is never code-signed. The
+      # specifier matches the profile minted into the `testflight` GitHub environment.
       configs:
         # aps-environment resolves from APS_ENVIRONMENT per config: `development` for an on-device
         # Debug build (which provisions against a development profile / sandbox APNs), `production` for
@@ -200,7 +201,9 @@ targets:
           APS_ENVIRONMENT: production
         Distribution:
           APS_ENVIRONMENT: production
-          # Inherits DEVELOPMENT_TEAM + CODE_SIGN_STYLE: Automatic from the base.
+          CODE_SIGN_STYLE: Manual
+          PROVISIONING_PROFILE_SPECIFIER: "Herdrup App Store"
+          CODE_SIGN_IDENTITY: "Apple Distribution"
 
   # UI-test bundle — the automated SCROLL RECEIPT. Launches the app in the
   # HERDR_SCREENSHOT_MOCK=scroll pane (a real SwiftTerm view fed 200 lines), swipes it,


### PR DESCRIPTION
## Why

The automatic-signing switch (#99 + #100) **cannot produce an uploadable build with this account** — proven end-to-end by tag `v0.1.38`:

- **Archive succeeds, but an automatically-signed archive is signed for _development_.** It embeds `iOS Team Provisioning Profile` (`get-task-allow=true`, `ProvisionedDevices` set), not an App Store profile — the App Store profile is only ever applied at **export**. So #100's premise (reuse the archive's embedded profile for the app-store export) is impossible by construction. My own App-Store-type assertion correctly caught it and failed the export loudly.
- **Automatic export (v0.1.37) fails: `Cloud signing permission error / No profiles for com.jerryfane.herdr were found`.** Xcode 16 automatic distribution export wants a **cloud-managed** signing certificate, which this team's ASC key cannot authorize (we import our own distribution cert). The key can create _development_ profiles — hence the archive works — but not distribution cloud signing.

## What this does

Restores the **exact manual lane that uploaded builds 39/40/41**: import the distribution cert + the pre-created `Herdrup App Store` profile from the `testflight` environment, manual export.

- `testflight.yml` + `docs/testflight-lane.md`: byte-identical to the proven pre-#99 version.
- `project.yml`: **only** the Distribution signing config reverts to Manual — the voice/WebKit framework additions (`AVFoundation`/`Speech`/`WebKit`) and mic/speech usage strings are preserved.

## Widget (#90)

The widget extension does not exist yet, so app-only manual signing is complete for now. Its distribution profile is deferred to when the widget target is added — either a one-time widget App ID/profile, or CI-side creation via the ASC API referencing our cert (**not** cloud signing).

## Verification

Buildbox sim build stays green (signing is inert there). Post-merge: a `v0.1.x` tag archives → exports → uploads with the current app code on the proven manual config.