### PR TITLE
feat(#90): Live Activity shows the host nickname instead of the IP

### DIFF
--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -332,9 +332,14 @@ struct RootView: View {
         // Bring up the session Live Activity (#90) in a "connecting" state; the home
         // view's onChange pushes real agent status the moment the first list arrives.
         // Label it with the saved host's NICKNAME when there is one (falling back to the
-        // raw host/IP), so the lock screen reads "My Mac" rather than an address.
-        let savedLabel = SavedHostsStore.shared.hosts
-            .first { $0.host == creds.host && $0.username == creds.username }?.label
+        // raw host/IP), so the lock screen reads "My Mac" rather than an address. Match the
+        // saved record the SAME way connect-from-saved does (HostEndpoint.parse, above):
+        // `saved.host` may be "host:port" while `creds.host`/`creds.port` are already parsed
+        // apart, so a raw string compare would miss any host saved with an explicit port.
+        let savedLabel = SavedHostsStore.shared.hosts.first { saved in
+            guard let ep = HostEndpoint.parse(saved.host) else { return false }
+            return ep.host == creds.host && ep.port == creds.port && saved.username == creds.username
+        }?.label
         LiveActivityController.shared.start(hostLabel: savedLabel ?? creds.host, state: LiveActivityController.connecting)
         // PRE-WARM: start the SSH handshake + first agent fetch the instant Connect
         // is tapped, so it overlaps the ConnectView→TerminalHomeView transition

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -331,7 +331,11 @@ struct RootView: View {
         client = newClient
         // Bring up the session Live Activity (#90) in a "connecting" state; the home
         // view's onChange pushes real agent status the moment the first list arrives.
-        LiveActivityController.shared.start(hostLabel: creds.host, state: LiveActivityController.connecting)
+        // Label it with the saved host's NICKNAME when there is one (falling back to the
+        // raw host/IP), so the lock screen reads "My Mac" rather than an address.
+        let savedLabel = SavedHostsStore.shared.hosts
+            .first { $0.host == creds.host && $0.username == creds.username }?.label
+        LiveActivityController.shared.start(hostLabel: savedLabel ?? creds.host, state: LiveActivityController.connecting)
         // PRE-WARM: start the SSH handshake + first agent fetch the instant Connect
         // is tapped, so it overlaps the ConnectView→TerminalHomeView transition
         // instead of following it. The transport dedups concurrent connects, so this


### PR DESCRIPTION
The Live Activity (lock screen / Dynamic Island) labelled the session with the raw host — usually an IP. Now it prefers the **saved host's nickname** (`SavedHost.label`) when one is set, falling back to the host/IP only when there's no nickname.

Resolved in `connect()` by matching the credentials against `SavedHostsStore.shared.hosts` (host + username). A fresh, unsaved connection with no nickname still shows the host string. Foreground-only change; no signing/target impact.

Owner-requested (Aug 15).