### PR TITLE
feat(#90): background push for the Live Activity — iOS half (activity token + register)

### DIFF
--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -186,6 +186,9 @@ struct RootView: View {
     // `.id(session)` home view, so they survive a reconnect. RootView owns the client, so it is what
     // (re)sends the token to the server whenever a connection exists.
     @ObservedObject private var push = PushCenter.shared
+    // The #90 Live Activity's per-activity push token lives here (survives reconnect like the
+    // device token); RootView registers it with the server so the widget updates in the background.
+    @ObservedObject private var liveActivity = LiveActivityController.shared
     // Mirror the Settings push toggles here so a change WHILE CONNECTED re-registers the new prefs
     // with the server (and can surface the permission prompt if a category was just enabled) —
     // otherwise a toggle would only take effect on the next connect/reconnect. Keys + defaults match
@@ -225,6 +228,9 @@ struct RootView: View {
             // A device token can arrive AFTER connect (the APNs callback is async + independent of
             // SSH); register it whenever it lands while connected.
             .onChange(of: push.deviceToken) { _, _ in registerPush() }
+            // The Live Activity push token also arrives async (after start) and can rotate; register
+            // it whenever it lands so the server can push widget updates while the app is closed.
+            .onChange(of: liveActivity.pushToken) { _, _ in registerActivityPush() }
             // A push-category toggle flipped in Settings while connected: re-register the new prefs
             // (and prompt if a category was just enabled), instead of waiting for a reconnect.
             .onChange(of: notifyNeedsInput) { _, _ in pushPrefsChanged() }
@@ -244,6 +250,14 @@ struct RootView: View {
         guard let client = explicitClient ?? self.client, let token = push.deviceToken else { return }
         let p = PushCenter.Prefs.current
         Task { try? await client.registerDevice(token: token, needsInput: p.needsInput, dies: p.dies, finishes: p.finishes, gram: p.gram) }
+    }
+
+    /// Register the current Live Activity push token with the server, if we have both a live client
+    /// and a token. Idempotent + best-effort — mirrors registerPush; a server without the method
+    /// just throws, and the widget still updates in the foreground.
+    private func registerActivityPush(with explicitClient: HerdrClient? = nil) {
+        guard let client = explicitClient ?? self.client, let token = liveActivity.pushToken else { return }
+        Task { try? await client.registerActivity(token: token) }
     }
 
     /// A push-category toggle changed while connected: re-register the current prefs with the server so the
@@ -349,6 +363,7 @@ struct RootView: View {
         // connection). Best-effort: a failure here surfaces normally in load().
         Task { _ = try? await newClient.agentList() }
         registerPush(with: newClient)   // re-send a cached token to the freshly-connected server
+        registerActivityPush(with: newClient)   // and any existing Live Activity token (reclaimed activity)
         // Request the notification permission PROMPT here — push can now actually deliver: the build
         // carries the aps-environment entitlement AND the server runs the 2c APNs sender. This is the
         // call the 2b scaffolding deferred: 2b left it out on purpose (iOS grants alert authorization
@@ -363,6 +378,11 @@ struct RootView: View {
     }
 
     private func disconnect() {
+        // Tell the server to stop pushing to the Live Activity we're about to end — capture the
+        // token + client BEFORE we drop them below.
+        if let token = liveActivity.pushToken, let c = client {
+            Task { try? await c.unregisterActivity(token: token) }
+        }
         let closing = transport
         Task { await closing?.close() }
         client = nil
@@ -385,6 +405,7 @@ struct RootView: View {
         client = newClient
         session += 1
         registerPush(with: newClient)   // the reconnect built a fresh client actor — re-register the token with it
+        registerActivityPush(with: newClient)   // re-register the Live Activity token with the fresh client too
     }
 
     /// A verified key rotation: pin the EXACT fingerprint the user verified out

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -230,7 +230,9 @@ struct RootView: View {
             .onChange(of: push.deviceToken) { _, _ in registerPush() }
             // The Live Activity push token also arrives async (after start) and can rotate; register
             // it whenever it lands so the server can push widget updates while the app is closed.
-            .onChange(of: liveActivity.pushToken) { _, _ in registerActivityPush() }
+            // initial: true so a token that arrived BEFORE this connected subtree mounted (or a
+            // reclaimed activity's existing token) is registered on appear, not silently missed.
+            .onChange(of: liveActivity.pushToken, initial: true) { _, _ in registerActivityPush() }
             // A push-category toggle flipped in Settings while connected: re-register the new prefs
             // (and prompt if a category was just enabled), instead of waiting for a reconnect.
             .onChange(of: notifyNeedsInput) { _, _ in pushPrefsChanged() }
@@ -378,13 +380,19 @@ struct RootView: View {
     }
 
     private func disconnect() {
-        // Tell the server to stop pushing to the Live Activity we're about to end — capture the
-        // token + client BEFORE we drop them below.
-        if let token = liveActivity.pushToken, let c = client {
-            Task { try? await c.unregisterActivity(token: token) }
-        }
+        // Unregister the Live Activity token, THEN close the transport — in ONE task so the
+        // unregister reaches the server over the still-open connection before close tears it down.
+        // Independent tasks would race, and close winning would strand the registration
+        // server-side. Capture token + client before we drop them below.
         let closing = transport
-        Task { await closing?.close() }
+        let activityToken = liveActivity.pushToken
+        let liveClient = client
+        Task {
+            if let token = activityToken, let liveClient {
+                try? await liveClient.unregisterActivity(token: token)
+            }
+            await closing?.close()
+        }
         client = nil
         transport = nil
         credentials = nil

--- a/App/LiveActivityController.swift
+++ b/App/LiveActivityController.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Combine
 import ActivityKit
 import HerdrKit
 
@@ -11,11 +12,19 @@ import HerdrKit
 /// starts/ends it around connect/disconnect, while the agents list view pushes status
 /// updates — neither owns the other, so they share this.
 @MainActor
-final class LiveActivityController {
+final class LiveActivityController: ObservableObject {
     static let shared = LiveActivityController()
     private init() {}
 
     private var activity: Activity<AgentActivityAttributes>?
+
+    /// The current activity's APNs push token (hex), or nil when there is no activity / no token
+    /// yet. RootView observes this and registers it with the server so the widget can update in
+    /// the BACKGROUND. Published because the token arrives asynchronously after `start`.
+    @Published private(set) var pushToken: String?
+
+    /// Watches `activity.pushTokenUpdates`; cancelled/replaced whenever the activity changes.
+    private var tokenTask: Task<Void, Never>?
 
     /// Whether the system currently permits Live Activities (user toggle + capability).
     private var enabled: Bool { ActivityAuthorizationInfo().areActivitiesEnabled }
@@ -43,18 +52,35 @@ final class LiveActivityController {
                 }
             }
         }
-        if activity != nil { update(state); return }
+        if activity != nil { observePushToken(); update(state); return }
         let attributes = AgentActivityAttributes(hostLabel: hostLabel)
         do {
+            // pushType: .token so ActivityKit issues a per-activity push token — the server uses
+            // it to update the widget in the BACKGROUND (locked / app closed). Foreground updates
+            // still go through update() directly.
             activity = try Activity.request(
                 attributes: attributes,
                 content: ActivityContent(state: state, staleDate: nil),
-                pushType: nil
+                pushType: .token
             )
+            observePushToken()
         } catch {
             // request() can throw (activities disabled mid-call, too many active).
             // Non-fatal — the app is fully usable without the Live Activity.
             activity = nil
+        }
+    }
+
+    /// Watch the current activity's push-token stream and publish the latest token as hex, so
+    /// RootView can register it with the server for background updates. Re-entrant: cancels any
+    /// prior watch first (a reclaimed activity across relaunch re-issues its token here too).
+    private func observePushToken() {
+        tokenTask?.cancel()
+        guard let activity else { pushToken = nil; return }
+        tokenTask = Task { [weak self] in
+            for await data in activity.pushTokenUpdates {
+                self?.pushToken = data.map { String(format: "%02x", $0) }.joined()
+            }
         }
     }
 
@@ -68,6 +94,9 @@ final class LiveActivityController {
     /// activity of this type, not just the tracked one, so an orphan left by a prior
     /// process (killed mid-session) can't survive as a stuck banner.
     func end() {
+        tokenTask?.cancel()
+        tokenTask = nil
+        pushToken = nil
         activity = nil
         Task {
             for a in Activity<AgentActivityAttributes>.activities {

--- a/Sources/HerdrKit/HerdrClient.swift
+++ b/Sources/HerdrKit/HerdrClient.swift
@@ -201,6 +201,33 @@ public actor HerdrClient {
                            as: JSONNull.self)
     }
 
+    struct RegisterActivityParams: Encodable {
+        let activityPushToken: String
+        enum CodingKeys: String, CodingKey {
+            case activityPushToken = "activity_push_token"
+        }
+    }
+
+    /// Register a Live Activity's PER-ACTIVITY push token so the server can update the
+    /// lock-screen / Dynamic Island widget with the session's agent status while the app is
+    /// closed. Distinct from `registerDevice` (that is the one device APNs token; this is one
+    /// token per running Live Activity). Idempotent — safe to re-send on (re)connect and each
+    /// time the token rotates. A server that does not implement the method throws, which the
+    /// caller ignores (the widget still updates in the foreground).
+    public func registerActivity(token: String) async throws {
+        _ = try await call("notifications.register_activity",
+                           RegisterActivityParams(activityPushToken: token),
+                           as: JSONNull.self)
+    }
+
+    /// Stop pushing to a Live Activity token (the activity ended / the session disconnected),
+    /// so the server prunes it instead of pushing to a dead activity. Best-effort like the above.
+    public func unregisterActivity(token: String) async throws {
+        _ = try await call("notifications.unregister_activity",
+                           RegisterActivityParams(activityPushToken: token),
+                           as: JSONNull.self)
+    }
+
     // MARK: - Gram (owner<->agent messages)
 
     struct GramListParams: Encodable {


### PR DESCRIPTION
First half of #90 slice 2 (background updates). The widget currently updates only while the app runs; this adds the iOS plumbing so the server can update it while the app is **closed**.

- **LiveActivityController** — request with `pushType: .token` (was `nil`), observe `activity.pushTokenUpdates`, publish the per-activity token (hex) as `@Published pushToken`; `end()` cancels the watch and clears it. Now an `ObservableObject`.
- **HerdrClient** — `notifications.register_activity` / `.unregister_activity` RPCs (the per-activity token, distinct from the one device token). Best-effort like `registerDevice`.
- **RootView** — register the token when it lands/rotates (`onChange`), on connect, and on reconnect (mirrors `registerPush`); unregister on disconnect before ending the activity.

**Inert until the backend half lands** (the `notifications.register_activity` RPC + an APNs `liveactivity` sender in the herdr fork). `registerActivity` is best-effort, so against the current daemon it's a no-op; foreground behaviour is unchanged. Sim CI validates compile.