### PR TITLE
feat: terminal-header status polish (pulsing dot · elapsed time · ⋯ mute) + Gram unread badge

### DIFF
--- a/App/DesignSystem.swift
+++ b/App/DesignSystem.swift
@@ -170,3 +170,33 @@ struct TurningRing: View {
             }
     }
 }
+
+/// A filled status dot that softly pulses while `active` (i.e. working) and
+/// holds perfectly still otherwise. Reuses TurningRing's onAppear +
+/// repeatForever idiom; a fading scale reads "alive" without implying a
+/// duration. Colour still carries the meaning — only the working state moves.
+struct PulsingDot: View {
+    var color: Color
+    var active: Bool
+    var diameter: CGFloat = 7
+    @State private var pulse = false
+    var body: some View {
+        Circle()
+            .fill(color)
+            .frame(width: diameter, height: diameter)
+            .opacity(active && pulse ? 0.4 : 1)
+            .scaleEffect(active && pulse ? 1.35 : 1)
+            .onAppear { if active { startPulsing() } }
+            .onChange(of: active) { _, isActive in
+                // Snap back to solid when it stops working, restart when it resumes.
+                pulse = false
+                if isActive { startPulsing() }
+            }
+    }
+
+    private func startPulsing() {
+        withAnimation(.easeInOut(duration: 0.8).repeatForever(autoreverses: true)) {
+            pulse = true
+        }
+    }
+}

--- a/App/GramView.swift
+++ b/App/GramView.swift
@@ -6,6 +6,14 @@ import SwiftUI
 import UIKit
 import UniformTypeIdentifiers
 
+/// The unread-gram count, lifted out of `GramView` so the tab bar can badge it
+/// even while the Gram tab is off-screen. Owned by the session-scoped home view;
+/// GramView writes it on load / mark-read while visible, and an ambient poller
+/// keeps it fresh while another tab is showing.
+final class GramUnreadTracker: ObservableObject {
+    @Published var count = 0
+}
+
 /// The Gram page: the owner's side of the owner<->agent message channel.
 ///
 /// The app is the OWNER. This shows the inbox (agent->owner messages the fleet
@@ -25,6 +33,10 @@ struct GramView: View {
     /// addressed directly (the server validates `to` against a live agent name).
     let agents: [AgentInfo]
     var onClose: (() -> Void)?
+    /// Shared unread count for the tab-bar badge. Optional (defaulted) so existing
+    /// call sites (and the DEBUG harness) compile unchanged; written on load and
+    /// mark-read so reading a message clears the badge without leaving the tab.
+    var unread: GramUnreadTracker? = nil
 
     /// The last server snapshot (newest first) and the owner's just-posted messages
     /// not yet reflected in a snapshot. `messages` composes them so a background poll
@@ -699,6 +711,8 @@ struct GramView: View {
         do {
             let fetched = try await client.gramList()
             serverMessages = fetched
+            // Keep the tab badge in step with what we just loaded.
+            unread?.count = fetched.filter { $0.isUnread }.count
             // Drop optimistic posts the server now reflects; unconfirmed ones stay
             // visible via `messages` (gram.post writes synchronously, so any in-flight
             // load started BEFORE a post can no longer discard it).
@@ -1123,6 +1137,8 @@ struct GramView: View {
                 // agent->owner message always lives in the server snapshot.
                 if let index = serverMessages.firstIndex(where: { $0.id == message.id }) {
                     serverMessages[index].readByOwner = true
+                    // Reading a message clears it from the badge immediately.
+                    unread?.count = serverMessages.filter { $0.isUnread }.count
                 }
             } catch {
                 // Leave it unread; the next poll re-surfaces it.

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -186,6 +186,9 @@ struct RootView: View {
     // `.id(session)` home view, so they survive a reconnect. RootView owns the client, so it is what
     // (re)sends the token to the server whenever a connection exists.
     @ObservedObject private var push = PushCenter.shared
+    /// Per-agent push mutes (the terminal header's ⋯ menu). Observed so a toggle
+    /// re-registers the device immediately (like the category prefs below).
+    @ObservedObject private var mute = MuteStore.shared
     // The #90 Live Activity's per-activity push token lives here (survives reconnect like the
     // device token); RootView registers it with the server so the widget updates in the background.
     @ObservedObject private var liveActivity = LiveActivityController.shared
@@ -239,6 +242,9 @@ struct RootView: View {
             .onChange(of: notifyDies) { _, _ in pushPrefsChanged() }
             .onChange(of: notifyFinishes) { _, _ in pushPrefsChanged() }
             .onChange(of: notifyGram) { _, _ in pushPrefsChanged() }
+            // A per-agent mute toggled in the terminal header: re-register the new set
+            // so the daemon starts/stops skipping that pane's pushes immediately.
+            .onChange(of: mute.mutedPanes) { _, _ in registerPush() }
         } else {
             ConnectView { connect($0) }
         }
@@ -251,7 +257,8 @@ struct RootView: View {
         // `client`, which the SwiftUI setter may not have published through yet on the same tick.
         guard let client = explicitClient ?? self.client, let token = push.deviceToken else { return }
         let p = PushCenter.Prefs.current
-        Task { try? await client.registerDevice(token: token, needsInput: p.needsInput, dies: p.dies, finishes: p.finishes, gram: p.gram) }
+        let muted = Array(MuteStore.shared.mutedPanes)
+        Task { try? await client.registerDevice(token: token, needsInput: p.needsInput, dies: p.dies, finishes: p.finishes, gram: p.gram, mutedPanes: muted) }
     }
 
     /// Register the current Live Activity push token with the server, if we have both a live client
@@ -1597,6 +1604,9 @@ struct TerminalPaneContent: View {
     /// lets a freshly-spawned agent flip rawKeys→intent once its composer appears,
     /// so a pre-filled task sends as a proper prompt.
     @State private var agent: AgentInfo?
+    /// Per-agent push mute, toggled from the header's ⋯ menu (keyed by this pane's
+    /// public id — the same id the push payload carries).
+    @ObservedObject private var mute = MuteStore.shared
     @State private var sending = false
     @State private var actionNote: String?
     /// In-flight guard for the [Switch] banner action, so repeated taps don't queue multiple
@@ -1778,18 +1788,75 @@ struct TerminalPaneContent: View {
                 }
             }
             if let group {
-                HStack(spacing: 6) {
-                    PulsingDot(color: group.color, active: group == .working)
-                    Text(group.sectionTitle).font(Typography.microLabel).tracking(1).foregroundStyle(group.color)
-                    Spacer()
+                HStack(spacing: 8) {
+                    // Left: the pulsing status pill (dot + status word).
+                    HStack(spacing: 6) {
+                        PulsingDot(color: group.color, active: group == .working)
+                        Text(group.sectionTitle).font(Typography.microLabel).tracking(1)
+                            .foregroundStyle(group.color)
+                    }
+                    .padding(.horizontal, 10).padding(.vertical, 5)
+                    .background(group.color.opacity(0.12)).clipShape(Capsule())
+
+                    Spacer(minLength: 6)
+
+                    // Center: how long the agent has been in this status (live).
+                    if let sinceMs = statusSinceMs {
+                        let start = Date(timeIntervalSince1970: Double(sinceMs) / 1000)
+                        TimelineView(.periodic(from: .now, by: 1)) { ctx in
+                            Text(elapsedLabel(ctx.date.timeIntervalSince(start)))
+                                .font(Typography.machine(12)).monospacedDigit()
+                                .foregroundStyle(Palette.textFaint)
+                        }
+                    }
+
+                    Spacer(minLength: 6)
+
+                    // Right: per-agent actions (⋯) — mute lives here.
+                    agentActionsMenu
                 }
-                .padding(.horizontal, 10).padding(.vertical, 5)
-                .background(group.color.opacity(0.12)).clipShape(Capsule())
-                .frame(maxWidth: .infinity, alignment: .leading)
+                .frame(maxWidth: .infinity)
             }
         }
         .padding(.horizontal, 16).padding(.top, 8).padding(.bottom, 10)
         .background(Palette.surface)
+    }
+
+    /// When the agent entered its current status — approximated by the last completed
+    /// turn (for idle, when it finished; for working, ≈ the current turn's start). Nil
+    /// when there is no completed turn yet, which hides the timer.
+    private var statusSinceMs: Int64? { agent?.lastCompletedTurn?.completedUnixMs }
+
+    /// Compact elapsed-time label: "45s", "1m 20s", "12m", "1h 5m". Seconds show only
+    /// for the first ten minutes, where they read as motion; past that the minute (then
+    /// hour) is enough.
+    private func elapsedLabel(_ interval: TimeInterval) -> String {
+        let total = Int(max(0, interval))
+        let s = total % 60, m = (total / 60) % 60, h = total / 3600
+        if h > 0 { return "\(h)h \(m)m" }
+        if m >= 10 { return "\(m)m" }
+        if m > 0 { return "\(m)m \(s)s" }
+        return "\(s)s"
+    }
+
+    /// The header's ⋯ overflow — the per-agent mute today, and the home for future
+    /// per-agent actions. When muted, the button shows a struck bell so the state reads
+    /// at a glance without opening the menu.
+    private var agentActionsMenu: some View {
+        Menu {
+            Button {
+                mute.toggle(paneID)
+            } label: {
+                Label(mute.isMuted(paneID) ? "Unmute notifications" : "Mute notifications",
+                      systemImage: mute.isMuted(paneID) ? "bell" : "bell.slash")
+            }
+        } label: {
+            Image(systemName: mute.isMuted(paneID) ? "bell.slash.fill" : "ellipsis")
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundStyle(mute.isMuted(paneID) ? Palette.waiting : Palette.textDim)
+                .frame(width: 30, height: 24)
+                .contentShape(Rectangle())
+        }
     }
 
     // MARK: classic-renderer banner

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -846,6 +846,9 @@ struct TerminalHomeView: View {
     /// fronts a keep-mounted pane OVER the tabs (see PaneKeepAliveContainer). Gram and
     /// Settings were modal covers before #88; they are persistent tabs now.
     @State private var selectedTab: HomeTab = .agents
+    /// Unread agent→owner grams, badged on the Gram tab. Session-scoped; written
+    /// by GramView while visible and by an ambient poll (below) while it isn't.
+    @StateObject private var gramUnread = GramUnreadTracker()
     /// First launch shows the gestures tutorial once; the "Gestures" tab reopens it.
     @AppStorage("hasSeenGesturesHelp") private var hasSeenGesturesHelp = false
     /// Shown once per connect when the daemon lacks the fork features (probe ==
@@ -1008,9 +1011,10 @@ struct TerminalHomeView: View {
 
                 // Gram and Settings were modal covers; they are persistent tabs now.
                 // Both are nav-agnostic and take no onClose as tabs (no close button).
-                GramView(client: client, agents: agents)
+                GramView(client: client, agents: agents, unread: gramUnread)
                     .tag(HomeTab.gram)
                     .tabItem { Label("Gram", systemImage: "bubble.left.and.bubble.right") }
+                    .badge(gramUnread.count == 0 ? nil : Text("\(gramUnread.count)"))
 
                 SettingsView(
                     host: host,
@@ -1054,6 +1058,19 @@ struct TerminalHomeView: View {
         // connect (this view is .id(session)-scoped) rather than on every tab switch —
         // which otherwise re-showed the fork notice and cancelled an in-flight load.
         .task { await load() }
+        // Ambient unread-gram poll for the tab badge, running ONLY while the Gram
+        // tab is not showing — GramView keeps its own 6s poll while visible and
+        // writes the count on load / mark-read. Keyed on selectedTab so it
+        // restarts on tab change and idles on Gram: exactly one poller is live.
+        .task(id: selectedTab) {
+            guard selectedTab != .gram else { return }
+            while !Task.isCancelled {
+                if let count = try? await client.gramList(unreadOnly: true).count {
+                    gramUnread.count = count
+                }
+                try? await Task.sleep(nanoseconds: 15_000_000_000)
+            }
+        }
         // Keep the session Live Activity (#90) in step with the herd: push a fresh
         // summary whenever the derived list changes, and once on appear so a
         // freshly-connected session reflects its agents right away. A no-op when the

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -1762,7 +1762,7 @@ struct TerminalPaneContent: View {
             }
             if let group {
                 HStack(spacing: 6) {
-                    Circle().fill(group.color).frame(width: 7, height: 7)
+                    PulsingDot(color: group.color, active: group == .working)
                     Text(group.sectionTitle).font(Typography.microLabel).tracking(1).foregroundStyle(group.color)
                     Spacer()
                 }

--- a/App/PushCenter.swift
+++ b/App/PushCenter.swift
@@ -64,3 +64,32 @@ final class PushCenter: ObservableObject {
         var anyEnabled: Bool { needsInput || dies || finishes || gram }
     }
 }
+
+/// The pane ids the owner has muted for push, per-device. Sent to the server on
+/// `notifications.register_device` (the daemon skips a muted pane's pushes), so a
+/// mute silences that agent even while the app is closed. Muting is PER-PANE — a
+/// new agent gets a new pane id and starts un-muted. A UserDefaults-backed singleton
+/// (mirrors PushCenter.Prefs' storage) so the deep terminal header can toggle it and
+/// RootView can observe it to re-register.
+final class MuteStore: ObservableObject {
+    static let shared = MuteStore()
+    private let key = "push.mutedPanes"
+
+    @Published private(set) var mutedPanes: Set<String>
+
+    init() {
+        mutedPanes = Set(UserDefaults.standard.stringArray(forKey: key) ?? [])
+    }
+
+    func isMuted(_ paneID: String) -> Bool { mutedPanes.contains(paneID) }
+
+    /// Set (and persist) a pane's mute. `@Published` publishes the change, so an
+    /// observing RootView re-registers the device and the header updates its icon.
+    func setMuted(_ muted: Bool, for paneID: String) {
+        guard !paneID.isEmpty else { return }
+        if muted { mutedPanes.insert(paneID) } else { mutedPanes.remove(paneID) }
+        UserDefaults.standard.set(Array(mutedPanes), forKey: key)
+    }
+
+    func toggle(_ paneID: String) { setMuted(!isMuted(paneID), for: paneID) }
+}

--- a/HerdrWidgets/AgentLiveActivity.swift
+++ b/HerdrWidgets/AgentLiveActivity.swift
@@ -109,15 +109,29 @@ private struct LockScreenView: View {
 }
 
 /// A filled status circle. A working agent gets a soft pulse so a glance at the
-/// Dynamic Island reads "something is running" without any text.
+/// Dynamic Island / lock screen reads "something is running" without any text;
+/// every other state stays a still circle (colour carries the meaning).
+///
+/// Best-effort: a Live Activity is rendered from system snapshots, not a live
+/// run loop, so `.symbolEffect(.pulse)` — the supported iOS 17 route — may be
+/// subtle or absent on some devices. It degrades to a static dot with no change
+/// to the colour contract.
 private struct StatusDot: View {
     let status: AgentActivityAttributes.Status
     var diameter: CGFloat = 10
 
     var body: some View {
-        Circle()
-            .fill(WidgetPalette.color(status))
-            .frame(width: diameter, height: diameter)
+        if status == .working {
+            Image(systemName: "circle.fill")
+                .resizable()
+                .frame(width: diameter, height: diameter)
+                .foregroundStyle(WidgetPalette.color(status))
+                .symbolEffect(.pulse, options: .repeating)
+        } else {
+            Circle()
+                .fill(WidgetPalette.color(status))
+                .frame(width: diameter, height: diameter)
+        }
     }
 }
 

--- a/Sources/HerdrKit/HerdrClient.swift
+++ b/Sources/HerdrKit/HerdrClient.swift
@@ -176,6 +176,9 @@ public actor HerdrClient {
         let notifyDies: Bool
         let notifyFinishes: Bool
         let notifyGram: Bool
+        /// Public pane ids the owner muted on this device — the server skips their
+        /// pushes. The client owns the set and sends the full list each time.
+        let mutedPanes: [String]
         enum CodingKeys: String, CodingKey {
             case deviceToken = "device_token"
             case platform
@@ -183,6 +186,7 @@ public actor HerdrClient {
             case notifyDies = "notify_dies"
             case notifyFinishes = "notify_finishes"
             case notifyGram = "notify_gram"
+            case mutedPanes = "muted_panes"
         }
     }
 
@@ -192,12 +196,14 @@ public actor HerdrClient {
     /// pref changes. A server that does not yet implement the method (or the `notify_gram` field)
     /// just ignores what it does not know, and an older server throws, which the caller ignores.
     public func registerDevice(
-        token: String, needsInput: Bool, dies: Bool, finishes: Bool, gram: Bool
+        token: String, needsInput: Bool, dies: Bool, finishes: Bool, gram: Bool,
+        mutedPanes: [String] = []
     ) async throws {
         _ = try await call("notifications.register_device",
                            RegisterDeviceParams(deviceToken: token, platform: "apns",
                                                 notifyNeedsInput: needsInput, notifyDies: dies,
-                                                notifyFinishes: finishes, notifyGram: gram),
+                                                notifyFinishes: finishes, notifyGram: gram,
+                                                mutedPanes: mutedPanes),
                            as: JSONNull.self)
     }
 


### PR DESCRIPTION
Three small, additive status-surface improvements.

**Pulsing "working" dot (#106)** — the blue working dot now softly pulses in the terminal header (new `PulsingDot`, mirroring the agents list's `TurningRing`) and in the widget `StatusDot` on the lock screen + Dynamic Island via `symbolEffect(.pulse)`. ⚠️ Live-Activity animation is best-effort (snapshot-rendered) — needs an on-device check; degrades to a static dot with no colour change.

**Gram unread badge (#105)** — the Gram tab badges the count of unread agent→owner messages, visible even off-screen (shared `GramUnreadTracker`, cleared on read, ambient 15s poll while another tab shows).

**Terminal-header content (#108)** — the status row is now: pulsing pill (left) · live elapsed-time-in-status (center) · ⋯ menu (right). The ⋯ menu mutes/unmutes push for THIS agent (per-pane, `MuteStore` → `notifications.register_device` `muted_panes`); the button shows a struck bell when muted. **Depends on the fork mute backend (jerryfane/herdr#58) merged + daemon redeployed** to suppress end-to-end.

HerdrKit compiles; App target is CI/buildbox only. On-device checks: the Live-Activity pulse and the mute end-to-end.

refs #105, refs #106, refs #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)