### PR TITLE
feat: connect to a host with a password, not only a private key

### DIFF
--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -521,7 +521,7 @@ struct ConnectView: View {
             Text("Connects privately over your Tailscale network — nothing is exposed to the public internet.")
                 .font(Typography.machine(12)).foregroundStyle(Palette.textFaint)
                 .multilineTextAlignment(.center)
-            Text("Your key stays in this device's Keychain, never uploaded.")
+            Text("Your key or password stays in this device's Keychain, never uploaded.")
                 .font(Typography.machine(11)).foregroundStyle(Palette.textFaint)
                 .multilineTextAlignment(.center)
         }
@@ -579,14 +579,31 @@ struct ConnectView: View {
     /// One-tap connect from a saved host. If the key is unreadable (deleted / device
     /// locked), open the editor so it can be re-added rather than a silent dead tap.
     private func tapSavedHost(_ saved: SavedHost) {
-        guard let ep = HostEndpoint.parse(saved.host),
-              let key = savedHosts.key(for: saved)?.trimmingCharacters(in: .whitespacesAndNewlines),
-              !key.isEmpty else {
+        guard let ep = HostEndpoint.parse(saved.host) else {
             editorTarget = .edit(saved)
             return
         }
-        onConnect(SSHCredentials(host: ep.host, port: ep.port, username: saved.username,
-                                 privateKeyPEM: key, remoteSocketPath: ""))
+        let creds: SSHCredentials
+        switch saved.auth {
+        case .key:
+            // A missing secret opens the editor rather than a silent dead tap.
+            guard let key = savedHosts.key(for: saved)?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !key.isEmpty else {
+                editorTarget = .edit(saved)
+                return
+            }
+            creds = SSHCredentials(host: ep.host, port: ep.port, username: saved.username,
+                                   privateKeyPEM: key, remoteSocketPath: "")
+        case .password:
+            // Not trimmed — a password's leading/trailing spaces can be significant.
+            guard let password = savedHosts.password(for: saved), !password.isEmpty else {
+                editorTarget = .edit(saved)
+                return
+            }
+            creds = SSHCredentials(host: ep.host, port: ep.port, username: saved.username,
+                                   password: password, remoteSocketPath: "")
+        }
+        onConnect(creds)
     }
 }
 

--- a/App/HostEditor.swift
+++ b/App/HostEditor.swift
@@ -31,6 +31,11 @@ struct HostEditor: View {
     @State private var username: String
     @State private var keyPEM = ""
     @State private var showingKeySheet = false
+    /// Whether this host authenticates with a key or a password (segmented picker).
+    @State private var authKind: SavedAuthKind
+    /// The password (password mode). Masked by a SecureField, so unlike the key it can
+    /// be entered inline; write-only on edit (blank keeps the stored one).
+    @State private var password = ""
     @State private var error: String?
     @State private var keyError: String?
 
@@ -46,11 +51,13 @@ struct HostEditor: View {
             _nickname = State(initialValue: "")
             _host = State(initialValue: "")
             _username = State(initialValue: "")
+            _authKind = State(initialValue: .key)
         case .edit(let h):
             editing = h
             _nickname = State(initialValue: h.nickname ?? "")
             _host = State(initialValue: h.host)
             _username = State(initialValue: h.username)
+            _authKind = State(initialValue: h.auth)
         }
     }
 
@@ -60,10 +67,20 @@ struct HostEditor: View {
     private var hostInvalid: Bool {
         !host.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && endpoint == nil
     }
-    /// Add requires a key; edit keeps the existing one when the field is left blank.
+    /// Add requires the chosen secret; edit keeps the existing one when the field is
+    /// left blank (whichever auth kind).
     private var canSave: Bool {
         guard endpoint != nil, !trimmedUser.isEmpty else { return false }
-        return editing != nil || !trimmedKey.isEmpty
+        if editing != nil { return true }
+        return authKind == .key ? !trimmedKey.isEmpty : !password.isEmpty
+    }
+
+    /// The secret to persist, or nil when the field is blank (edit keeps the current one).
+    private func currentSecret() -> HostSecret? {
+        switch authKind {
+        case .key: return trimmedKey.isEmpty ? nil : .key(trimmedKey)
+        case .password: return password.isEmpty ? nil : .password(password)
+        }
     }
 
     var body: some View {
@@ -76,7 +93,8 @@ struct HostEditor: View {
                         fieldRow("Host", text: $host, placeholder: "mac.tail-scale.ts.net")
                         if hostInvalid { caption("check host or host:port", color: Palette.died) }
                         fieldRow("User", text: $username, placeholder: "jerry")
-                        keyRow
+                        authPicker
+                        if authKind == .key { keyRow } else { passwordRow }
                         if let error { caption(error, color: Palette.died) }
 
                         if editing == nil {
@@ -107,21 +125,33 @@ struct HostEditor: View {
     /// Persist the host (add or update). Returns success; sets `error` on failure.
     @discardableResult
     private func save() -> Bool {
+        let secret = currentSecret()
         let ok: Bool
         if let editing {
-            ok = store.update(editing, nickname: nickname, host: host, username: trimmedUser, privateKeyPEM: keyPEM)
+            // nil secret = keep the stored one (blank field on edit).
+            ok = store.update(editing, nickname: nickname, host: host, username: trimmedUser, secret: secret)
+        } else if let secret {
+            ok = store.add(nickname: nickname, host: host, username: trimmedUser, secret: secret)
         } else {
-            ok = store.add(nickname: nickname, host: host, username: trimmedUser, privateKeyPEM: trimmedKey)
+            ok = false  // add needs a secret; canSave already prevents this — defensive.
         }
-        if !ok { error = "Couldn't save this host. Check the fields (a private key is required) and try again." }
+        if !ok { error = "Couldn't save this host. Check the fields (a key or password is required) and try again." }
         return ok
     }
 
     private func saveAndConnect() {
         guard let ep = endpoint, save() else { return }
-        // Add mode requires a key, so it is in hand here — connect straight away.
-        onConnect(SSHCredentials(host: ep.host, port: ep.port, username: trimmedUser,
-                                 privateKeyPEM: trimmedKey, remoteSocketPath: ""))
+        // Add mode requires the secret, so it is in hand here — connect straight away.
+        let creds: SSHCredentials
+        switch authKind {
+        case .key:
+            creds = SSHCredentials(host: ep.host, port: ep.port, username: trimmedUser,
+                                   privateKeyPEM: trimmedKey, remoteSocketPath: "")
+        case .password:
+            creds = SSHCredentials(host: ep.host, port: ep.port, username: trimmedUser,
+                                   password: password, remoteSocketPath: "")
+        }
+        onConnect(creds)
         dismiss()
     }
 
@@ -131,6 +161,31 @@ struct HostEditor: View {
         HStack {
             Text(label).font(Typography.app(15)).foregroundStyle(Palette.textDim)
             TextField(placeholder, text: text)
+                .multilineTextAlignment(.trailing)
+                .textInputAutocapitalization(.never).autocorrectionDisabled()
+                .font(Typography.machine(15)).foregroundStyle(Palette.text)
+        }
+        .padding(.horizontal, 16).padding(.vertical, 14)
+        .background(Palette.surface).clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+
+    /// Choose how this host authenticates. Switching hides/shows the key vs password row.
+    private var authPicker: some View {
+        Picker("Auth", selection: $authKind) {
+            Text("Key").tag(SavedAuthKind.key)
+            Text("Password").tag(SavedAuthKind.password)
+        }
+        .pickerStyle(.segmented)
+        .padding(.vertical, 2)
+    }
+
+    /// The password field. A SecureField masks the value, so unlike the key it is safe
+    /// to enter inline; on edit it starts blank and the stored password is kept unless a
+    /// new one is typed. Stored in the Keychain (device-only), same as the key.
+    private var passwordRow: some View {
+        HStack {
+            Text("Password").font(Typography.app(15)).foregroundStyle(Palette.textDim)
+            SecureField(editing == nil ? "password" : "saved · type to replace", text: $password)
                 .multilineTextAlignment(.trailing)
                 .textInputAutocapitalization(.never).autocorrectionDisabled()
                 .font(Typography.machine(15)).foregroundStyle(Palette.text)

--- a/App/SavedHosts.swift
+++ b/App/SavedHosts.swift
@@ -1,10 +1,23 @@
 import Foundation
 import Security
 
+/// Which credential a saved host authenticates with.
+enum SavedAuthKind: String, Codable {
+    case key
+    case password
+}
+
+/// The secret half of a saved host, routed to the matching Keychain store by the
+/// store's add/update. Keeps one code path for both auth kinds.
+enum HostSecret {
+    case key(String)
+    case password(String)
+}
+
 /// A saved connection target for one-tap reconnect. Holds ONLY the non-secret
-/// fields (host — which may include ":port" — and username). The private key is
-/// NEVER stored here; it lives in the Keychain (`KeychainCredentialStore`), keyed
-/// by `id`. So the on-disk (UserDefaults) list can be read without exposing a key.
+/// fields (host — which may include ":port" — and username). The private key or
+/// password is NEVER stored here; it lives in the Keychain (`KeychainCredentialStore`),
+/// keyed by `id`. So the on-disk (UserDefaults) list can be read without exposing a secret.
 struct SavedHost: Codable, Identifiable, Hashable {
     let id: UUID
     var host: String
@@ -12,6 +25,13 @@ struct SavedHost: Codable, Identifiable, Hashable {
     /// Optional friendly label ("My Mac"). Legacy saved hosts predate this field, so it
     /// is OPTIONAL — old JSON without the key decodes to `nil` (no migration needed).
     var nickname: String?
+    /// Which credential this host uses. OPTIONAL for migration exactly like `nickname`:
+    /// JSON written before password auth has no `authKind`, decodes to nil, and resolves
+    /// to `.key` via `auth` — so every legacy host stays key-based.
+    var authKind: SavedAuthKind?
+
+    /// The resolved auth kind for callers — a legacy (nil) host is key-based.
+    var auth: SavedAuthKind { authKind ?? .key }
 
     /// The primary display label: the nickname if set, else the host itself.
     var label: String {
@@ -29,6 +49,9 @@ final class SavedHostsStore: ObservableObject {
 
     private let defaultsKey = "dev.herdr.savedHosts.v1"
     private let keychain = KeychainCredentialStore(service: "dev.herdr.credentials")
+    /// A host's password lives in its own Keychain service so a host's key and
+    /// password never collide on the same account id. Same device-only discipline.
+    private let passwordKeychain = KeychainCredentialStore(service: "dev.herdr.credentials.password")
 
     @Published private(set) var hosts: [SavedHost]
 
@@ -41,44 +64,76 @@ final class SavedHostsStore: ObservableObject {
         }
     }
 
-    /// Adds a NEW saved host (its own id) and stores its key in the Keychain. Returns
-    /// false — WITHOUT recording the host — if a required field is missing or the key
-    /// could not be persisted, so the UI never offers a one-tap host it cannot open.
+    /// Adds a NEW saved host (its own id) and stores its secret (key or password) in
+    /// the Keychain. Returns false — WITHOUT recording the host — if a required field
+    /// is missing or the secret could not be persisted, so the UI never offers a
+    /// one-tap host it cannot open.
     @discardableResult
-    func add(nickname: String, host: String, username: String, privateKeyPEM: String) -> Bool {
+    func add(nickname: String, host: String, username: String, secret: HostSecret) -> Bool {
         let h = host.trimmingCharacters(in: .whitespacesAndNewlines)
         let u = username.trimmingCharacters(in: .whitespacesAndNewlines)
         let n = nickname.trimmingCharacters(in: .whitespacesAndNewlines)
-        let key = privateKeyPEM.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !h.isEmpty, !u.isEmpty, !key.isEmpty else { return false }
+        guard !h.isEmpty, !u.isEmpty else { return false }
         let id = UUID()
-        // Persist the key FIRST; only record the host if the key actually stuck.
-        guard keychain.save(account: id.uuidString, secret: key) else { return false }
-        hosts.insert(SavedHost(id: id, host: h, username: u, nickname: n.isEmpty ? nil : n), at: 0)
+        // Persist the secret FIRST; only record the host if it actually stuck.
+        let kind: SavedAuthKind
+        switch secret {
+        case .key(let pem):
+            let key = pem.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !key.isEmpty, keychain.save(account: id.uuidString, secret: key) else { return false }
+            kind = .key
+        case .password(let password):
+            // A password is NOT trimmed — leading/trailing spaces can be significant.
+            guard !password.isEmpty,
+                  passwordKeychain.save(account: id.uuidString, secret: password) else { return false }
+            kind = .password
+        }
+        hosts.insert(
+            SavedHost(id: id, host: h, username: u, nickname: n.isEmpty ? nil : n, authKind: kind),
+            at: 0)
         persist()
         return true
     }
 
     /// Updates an existing saved host IN PLACE (by id): host / username / nickname, and
-    /// the private key only when `privateKeyPEM` is non-empty (empty = keep the current
-    /// key, so an edit never forces re-entering it). Returns false without changing
-    /// anything if a required field is missing or a provided key fails to persist.
+    /// the secret only when `secret` is non-nil (nil = keep the current one, so an edit
+    /// never forces re-entering it). Switching auth kind drops the now-stale other
+    /// secret. Returns false without changing anything if a required field is missing
+    /// or a provided secret fails to persist.
     @discardableResult
-    func update(_ existing: SavedHost, nickname: String, host: String, username: String, privateKeyPEM: String) -> Bool {
+    func update(_ existing: SavedHost, nickname: String, host: String, username: String, secret: HostSecret?) -> Bool {
         let h = host.trimmingCharacters(in: .whitespacesAndNewlines)
         let u = username.trimmingCharacters(in: .whitespacesAndNewlines)
         let n = nickname.trimmingCharacters(in: .whitespacesAndNewlines)
-        let key = privateKeyPEM.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !h.isEmpty, !u.isEmpty else { return false }
         guard let i = hosts.firstIndex(where: { $0.id == existing.id }) else { return false }
-        // Replace the key only if a new one was entered; a failed persist aborts the whole
-        // update so the record never drifts out of lockstep with the Keychain.
-        if !key.isEmpty {
-            guard keychain.save(account: existing.id.uuidString, secret: key) else { return false }
+        var newKind = existing.auth
+        // Replace the secret only if a new one was entered; a failed persist aborts the
+        // whole update so the record never drifts out of lockstep with the Keychain.
+        if let secret {
+            switch secret {
+            case .key(let pem):
+                let key = pem.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !key.isEmpty,
+                      keychain.save(account: existing.id.uuidString, secret: key) else { return false }
+                newKind = .key
+            case .password(let password):
+                guard !password.isEmpty,
+                      passwordKeychain.save(account: existing.id.uuidString, secret: password) else { return false }
+                newKind = .password
+            }
+            // Auth kind changed → best-effort drop the stale secret from the other store.
+            if newKind != existing.auth {
+                switch existing.auth {
+                case .key: _ = keychain.delete(account: existing.id.uuidString)
+                case .password: _ = passwordKeychain.delete(account: existing.id.uuidString)
+                }
+            }
         }
         hosts[i].host = h
         hosts[i].username = u
         hosts[i].nickname = n.isEmpty ? nil : n
+        hosts[i].authKind = newKind
         persist()
         return true
     }
@@ -87,13 +142,18 @@ final class SavedHostsStore: ObservableObject {
     /// — the caller must treat that as "cannot reconnect", not "empty key".
     func key(for host: SavedHost) -> String? { keychain.load(account: host.id.uuidString) }
 
-    /// Removes a saved host. Deletes the KEY first and drops the host record ONLY if
-    /// the key is confirmed gone — a failed Keychain delete must not leave the private
-    /// key orphaned while the host vanishes from the UI. Returns whether it removed;
-    /// on false the row stays put (a visible "it didn't remove") so the user can retry.
+    /// The password for a saved host, from the Keychain. Nil if missing/unreadable.
+    func password(for host: SavedHost) -> String? { passwordKeychain.load(account: host.id.uuidString) }
+
+    /// Removes a saved host. Deletes the secret from BOTH stores first and drops the
+    /// host record ONLY if both confirm it is gone — a failed Keychain delete must not
+    /// leave a secret orphaned while the host vanishes from the UI. Each delete returns
+    /// true on errSecItemNotFound, so a host with only one secret still deletes cleanly.
+    /// Returns whether it removed; on false the row stays put so the user can retry.
     @discardableResult
     func delete(_ host: SavedHost) -> Bool {
-        guard keychain.delete(account: host.id.uuidString) else { return false }
+        guard keychain.delete(account: host.id.uuidString),
+              passwordKeychain.delete(account: host.id.uuidString) else { return false }
         hosts.removeAll { $0.id == host.id }
         persist()
         return true

--- a/Sources/HerdrKit/CitadelTransport.swift
+++ b/Sources/HerdrKit/CitadelTransport.swift
@@ -112,20 +112,36 @@ public actor CitadelTransport: HerdrTransport {
     }
 
     private func makeConnection() async throws -> SSHClient {
-        let privateKey = try Curve25519.Signing.PrivateKey(
-            sshEd25519: Data(credentials.privateKeyPEM.utf8),
-            decryptionKey: credentials.passphrase.map { Data($0.utf8) }
-        )
+        let method: SSHAuthenticationMethod
+        switch credentials.auth {
+        case .privateKey(let pem, let passphrase):
+            let privateKey = try Curve25519.Signing.PrivateKey(
+                sshEd25519: Data(pem.utf8),
+                decryptionKey: passphrase.map { Data($0.utf8) }
+            )
+            method = .ed25519(username: credentials.username, privateKey: privateKey)
+        case .password(let password):
+            method = .passwordBased(username: credentials.username, password: password)
+        }
         // A client that resolves after a concurrent close() is reaped by the
         // generation check in connectedClient() (the only publisher of `self.client`),
         // so no cancellation handling is needed here.
-        return try await SSHClient.connect(
-            host: credentials.host,
-            port: Int(credentials.port),
-            authenticationMethod: .ed25519(username: credentials.username, privateKey: privateKey),
-            hostKeyValidator: hostKeyValidator,
-            reconnect: .never
-        )
+        do {
+            return try await SSHClient.connect(
+                host: credentials.host,
+                port: Int(credentials.port),
+                authenticationMethod: method,
+                hostKeyValidator: hostKeyValidator,
+                reconnect: .never
+            )
+        } catch SSHClientError.unsupportedPasswordAuthentication {
+            // The server offers no password auth (e.g. `PasswordAuthentication no`).
+            throw TransportError.passwordAuthUnsupported(host: credentials.host)
+        } catch SSHClientError.allAuthenticationOptionsFailed {
+            // Wrong password / rejected key. Host-key rejection is thrown by the
+            // validator, not caught here, so it keeps its dedicated recovery path.
+            throw TransportError.authenticationFailed(host: credentials.host)
+        }
     }
 
     /// Conservative ceiling on the full command line, well under the kernel's

--- a/Sources/HerdrKit/Transport.swift
+++ b/Sources/HerdrKit/Transport.swift
@@ -15,20 +15,26 @@ public struct SSHCredentials: Sendable {
     public var host: String
     public var port: UInt16
     public var username: String
-    /// PEM private key bytes. Held in memory and handed to the SSH stack
-    /// directly — never written to disk and never referenced by path, so the key
-    /// material's lifetime is the caller's to control rather than the
-    /// filesystem's.
-    public var privateKeyPEM: String
-    /// Optional public key bytes. Unused by the pure-Swift transport (nio-ssh
-    /// derives it from the private key); retained for source compatibility.
-    public var publicKeyPEM: String?
-    public var passphrase: String?
+    /// How to authenticate to the host. Either method's secret is held in memory
+    /// and handed to the SSH stack directly — never written to disk, never
+    /// referenced by path — so its lifetime is the caller's, not the filesystem's.
+    public var auth: Auth
     /// Vestigial under the pure-Swift transport: the server-side `api-bridge`
     /// resolves the API socket itself, so `CitadelTransport` ignores this. Kept
     /// so existing call sites compile; pruning it is a follow-up.
     public var remoteSocketPath: String
 
+    /// The two SSH auth methods herdr offers. `Equatable` for tests; the secrets
+    /// live only here and in the Keychain on the client.
+    public enum Auth: Sendable, Equatable {
+        /// PEM private key bytes, plus an optional passphrase for an encrypted key.
+        case privateKey(pem: String, passphrase: String?)
+        /// A plaintext password, offered to the server's password authentication.
+        case password(String)
+    }
+
+    /// Key-based auth. Signature preserved so existing call sites are unchanged;
+    /// `publicKeyPEM` is accepted and ignored (nio-ssh derives it from the key).
     public init(
         host: String,
         port: UInt16 = 22,
@@ -41,9 +47,22 @@ public struct SSHCredentials: Sendable {
         self.host = host
         self.port = port
         self.username = username
-        self.privateKeyPEM = privateKeyPEM
-        self.publicKeyPEM = publicKeyPEM
-        self.passphrase = passphrase
+        self.auth = .privateKey(pem: privateKeyPEM, passphrase: passphrase)
+        self.remoteSocketPath = remoteSocketPath
+    }
+
+    /// Password-based auth. Disambiguated from the key init by the `password:` label.
+    public init(
+        host: String,
+        port: UInt16 = 22,
+        username: String,
+        password: String,
+        remoteSocketPath: String
+    ) {
+        self.host = host
+        self.port = port
+        self.username = username
+        self.auth = .password(password)
         self.remoteSocketPath = remoteSocketPath
     }
 }
@@ -88,6 +107,13 @@ public enum TransportError: Error, CustomStringConvertible {
     /// The api-bridge (or the remote shell) produced no reply on stdout but wrote
     /// to stderr — surfaced rather than handed back as an empty, undecodable line.
     case bridgeFailed(stderr: String)
+    /// A password connection was attempted against a server that does not offer
+    /// password authentication (e.g. `PasswordAuthentication no`). Distinct from a
+    /// wrong password and from a host-key mismatch.
+    case passwordAuthUnsupported(host: String)
+    /// The server rejected the credentials — a wrong password, or a key it would
+    /// not accept.
+    case authenticationFailed(host: String)
 
     public var description: String {
         switch self {
@@ -102,6 +128,10 @@ public enum TransportError: Error, CustomStringConvertible {
             return "host key for \(h) rejected: \(fp) does not match the pinned key"
         case .bridgeFailed(let stderr):
             return "api-bridge produced no reply; stderr: \(stderr)"
+        case .passwordAuthUnsupported(let h):
+            return "\(h) does not offer password authentication — use a key instead"
+        case .authenticationFailed(let h):
+            return "authentication to \(h) failed — check the password or key"
         }
     }
 }

--- a/Tests/HerdrKitTests/SSHCredentialsAuthTests.swift
+++ b/Tests/HerdrKitTests/SSHCredentialsAuthTests.swift
@@ -1,0 +1,30 @@
+import XCTest
+
+@testable import HerdrKit
+
+/// The auth-kind discriminator on `SSHCredentials`: each init must map to the
+/// right `Auth` case, since `CitadelTransport.makeConnection` branches on it to
+/// choose `.ed25519` vs `.passwordBased`. (The `SSHAuthenticationMethod` Citadel
+/// builds is opaque, so the actual wiring is proven by the gated live tests; this
+/// pins the routing decision that selects it.)
+final class SSHCredentialsAuthTests: XCTestCase {
+    func testKeyInitMapsToPrivateKeyAuth() {
+        let creds = SSHCredentials(
+            host: "h", port: 2222, username: "root",
+            privateKeyPEM: "PEM", passphrase: "secret", remoteSocketPath: "")
+        XCTAssertEqual(creds.auth, .privateKey(pem: "PEM", passphrase: "secret"))
+    }
+
+    func testKeyInitWithoutPassphraseHasNilPassphrase() {
+        let creds = SSHCredentials(
+            host: "h", username: "root", privateKeyPEM: "PEM", remoteSocketPath: "")
+        XCTAssertEqual(creds.auth, .privateKey(pem: "PEM", passphrase: nil))
+    }
+
+    func testPasswordInitMapsToPasswordAuth() {
+        let creds = SSHCredentials(
+            host: "h", port: 22, username: "root",
+            password: "hunter2", remoteSocketPath: "")
+        XCTAssertEqual(creds.auth, .password("hunter2"))
+    }
+}


### PR DESCRIPTION
Add a **Key / Password** toggle to the host editor. `SSHCredentials` gains an `Auth` enum (`.privateKey` / `.password`) with a new `password:` init (the key init is unchanged); `CitadelTransport` branches to `.passwordBased` (Citadel 0.12.1 — no dep bump) and maps the two Citadel auth errors to distinct `TransportError` cases (password-unsupported vs authentication-failed), leaving host-key rejection on its own recovery path.

Saved hosts carry an optional `authKind` (legacy rows decode as `.key`) and store the password in its own device-only Keychain service; add/update/delete route both secrets in lockstep. `SecureField` masks the password (so, unlike the key, it can be shown inline).

Built with the Swift toolchain; **3 HerdrKit unit tests** cover the auth discriminator. On-device: connect to a password-only sshd; a key-only server surfaces `passwordAuthUnsupported`.

refs #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)