### PR TITLE
fix: guide the user to install herdr when the daemon is absent

### DIFF
--- a/App/ForkNoticeView.swift
+++ b/App/ForkNoticeView.swift
@@ -50,17 +50,7 @@ struct ForkNoticeView: View {
             Spacer(minLength: 0)
             VStack(spacing: 8) {
                 // Primary action: send them to the fork's install instructions.
-                Link(destination: URL(string: "https://github.com/jerryfane/herdr")!) {
-                    HStack(spacing: 6) {
-                        Text("Install instructions")
-                        Image(systemName: "arrow.up.right").font(.system(size: 12, weight: .semibold))
-                    }
-                    .font(Typography.app(16, .semibold))
-                    .foregroundStyle(Palette.ground)
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, 14)
-                    .background(RoundedRectangle(cornerRadius: 14).fill(Palette.text))
-                }
+                InstallInstructionsLink()
                 // Never a lockout: dismissing is always one tap away.
                 Button(action: onDismiss) {
                     Text("Continue anyway")
@@ -93,5 +83,31 @@ struct ForkNoticeView: View {
         .padding(12)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(RoundedRectangle(cornerRadius: 14).fill(Palette.surface))
+    }
+}
+
+/// The shared primary action that opens the fork's install instructions on GitHub.
+/// One source of truth for the URL and the button styling, reused by `ForkNoticeView`
+/// (the "wrong daemon" notice) and the no-herdr install-guidance screen in
+/// `TerminalHomeView.errorView`, so the two "daemon not ready" states point at the
+/// same place with the same affordance.
+struct InstallInstructionsLink: View {
+    /// Button label. The two call sites word it slightly differently: the fork notice
+    /// says "Install instructions"; the no-herdr screen, where a copy-paste command
+    /// already sits above, says "Full install instructions".
+    var label: String = "Install instructions"
+
+    var body: some View {
+        Link(destination: URL(string: "https://github.com/jerryfane/herdr")!) {
+            HStack(spacing: 6) {
+                Text(label)
+                Image(systemName: "arrow.up.right").font(.system(size: 12, weight: .semibold))
+            }
+            .font(Typography.app(16, .semibold))
+            .foregroundStyle(Palette.ground)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 14)
+            .background(RoundedRectangle(cornerRadius: 14).fill(Palette.text))
+        }
     }
 }

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -864,6 +864,12 @@ struct TerminalHomeView: View {
     @State private var loading = true
     @State private var rejectedFingerprint: String?
     @State private var trustFailed = false
+    /// Set when the connect failed because herdr is not installed on the host
+    /// (`TransportError.herdrNotInstalled`). Drives the install-guidance branch in
+    /// `errorView` instead of surfacing the raw stderr. Reset at the start of each load.
+    @State private var herdrMissing = false
+    /// Latches the "Copied ✓" state on the install-command copy button.
+    @State private var installCmdCopied = false
     @State private var search = ""
     @State private var activeCover: ActiveCover?
     /// The selected bottom tab (Agents / Gram / Settings). Terminal is NOT a tab — it
@@ -1445,35 +1451,96 @@ struct TerminalHomeView: View {
     private func errorView(_ error: String) -> some View {
         Spacer()
         VStack(spacing: 14) {
-            Text(error).font(Typography.machine(13)).foregroundStyle(Palette.died)
-                .multilineTextAlignment(.center)
-            if let fingerprint = rejectedFingerprint {
-                VStack(spacing: 8) {
-                    Text("the host key changed. the server now presents:")
-                        .font(Typography.app(12)).foregroundStyle(Palette.textDim)
-                    Text(fingerprint).font(Typography.machine(11)).foregroundStyle(Palette.text)
-                        .textSelection(.enabled).multilineTextAlignment(.center)
-                    Text("trust it ONLY if this exactly matches the key you verified out of band.")
-                        .font(Typography.app(12)).foregroundStyle(Palette.textDim).multilineTextAlignment(.center)
+            // A connect that failed because herdr is not installed gets its OWN
+            // recovery screen (heading + install command + instructions link),
+            // not the raw stderr — a brand-new user has no way to read the shell
+            // diagnostic and know they need to go install the fork.
+            if herdrMissing {
+                herdrInstallGuidance
+            } else {
+                Text(error).font(Typography.machine(13)).foregroundStyle(Palette.died)
+                    .multilineTextAlignment(.center)
+                if let fingerprint = rejectedFingerprint {
+                    VStack(spacing: 8) {
+                        Text("the host key changed. the server now presents:")
+                            .font(Typography.app(12)).foregroundStyle(Palette.textDim)
+                        Text(fingerprint).font(Typography.machine(11)).foregroundStyle(Palette.text)
+                            .textSelection(.enabled).multilineTextAlignment(.center)
+                        Text("trust it ONLY if this exactly matches the key you verified out of band.")
+                            .font(Typography.app(12)).foregroundStyle(Palette.textDim).multilineTextAlignment(.center)
+                    }
+                    Button("trust this key & reconnect") { trustFailed = !onTrustHostKey(fingerprint) }
+                        .font(Typography.app(15, .semibold)).foregroundStyle(Palette.died)
+                    if trustFailed {
+                        Text("could not save the verified key to the keychain — not reconnecting. try again.")
+                            .font(Typography.app(12)).foregroundStyle(Palette.died).multilineTextAlignment(.center)
+                    }
                 }
-                Button("trust this key & reconnect") { trustFailed = !onTrustHostKey(fingerprint) }
-                    .font(Typography.app(15, .semibold)).foregroundStyle(Palette.died)
-                if trustFailed {
-                    Text("could not save the verified key to the keychain — not reconnecting. try again.")
-                        .font(Typography.app(12)).foregroundStyle(Palette.died).multilineTextAlignment(.center)
+                // Plain retry ONLY for non-host-key errors. After a host-key
+                // rejection a bare reconnect could first-contact-trust whatever key
+                // next appears (bypassing the fingerprint the user must verify), so
+                // the only routes then are "trust this key" above or disconnect.
+                if rejectedFingerprint == nil {
+                    Button("retry") { Task { await load() } }
+                        .font(Typography.app(15, .semibold)).foregroundStyle(Palette.text)
                 }
-            }
-            // Plain retry ONLY for non-host-key errors. After a host-key
-            // rejection a bare reconnect could first-contact-trust whatever key
-            // next appears (bypassing the fingerprint the user must verify), so
-            // the only routes then are "trust this key" above or disconnect.
-            if rejectedFingerprint == nil {
-                Button("retry") { Task { await load() } }
-                    .font(Typography.app(15, .semibold)).foregroundStyle(Palette.text)
             }
         }
         .padding(24)
         Spacer()
+    }
+
+    /// The one-liner that installs the fork on the remote machine, condensed from
+    /// the onboarding doc's happy path (clone, build, install to `~/.local/bin`).
+    /// `install -D` creates the parent dir, so no separate `mkdir` step is needed.
+    private static let herdrInstallCommand =
+        "git clone https://github.com/jerryfane/herdr && cd herdr && "
+        + "cargo build --release && "
+        + "install -D -m 0755 target/release/herdr ~/.local/bin/herdr"
+
+    /// Shown in place of the raw stderr when the connect failed because herdr is not
+    /// installed (`herdrMissing`). Mirrors `ForkNoticeView`'s language and reuses the
+    /// Gram setup card's command-box + Copy idiom, plus the shared install link.
+    @ViewBuilder private var herdrInstallGuidance: some View {
+        Image(systemName: "arrow.triangle.branch")
+            .font(.system(size: 34, weight: .regular))
+            .foregroundStyle(Palette.waiting)
+        VStack(spacing: 8) {
+            Text("herdr isn't installed here")
+                .font(Typography.app(20, .bold)).foregroundStyle(Palette.text)
+                .multilineTextAlignment(.center)
+            Text("Herdrup runs the herdr daemon on your machine over SSH. It isn't installed yet. Install the jerryfane/herdr fork, then reconnect.")
+                .font(Typography.app(14)).foregroundStyle(Palette.textDim)
+                .multilineTextAlignment(.center)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        // Copy box: run this on the machine, then reconnect.
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Run this on your machine, then reconnect:")
+                .font(Typography.app(13)).foregroundStyle(Palette.textDim)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            Text(Self.herdrInstallCommand)
+                .font(Typography.machine(11)).foregroundStyle(Palette.textDim)
+                .textSelection(.enabled)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(10)
+                .background(RoundedRectangle(cornerRadius: 8).fill(Palette.groundMachine))
+            Button {
+                UIPasteboard.general.string = Self.herdrInstallCommand
+                installCmdCopied = true
+            } label: {
+                Text(installCmdCopied ? "Copied ✓" : "Copy command")
+                    .font(Typography.app(13, .semibold)).foregroundStyle(Palette.ground)
+                    .frame(maxWidth: .infinity).padding(.vertical, 9)
+                    .background(RoundedRectangle(cornerRadius: 9).fill(Palette.text))
+            }
+        }
+        .padding(.top, 4)
+        // Full instructions (every install variant) + retry once it's installed.
+        InstallInstructionsLink(label: "Full install instructions")
+        Button("retry") { Task { await load() } }
+            .font(Typography.app(15, .semibold)).foregroundStyle(Palette.text)
+            .padding(.top, 2)
     }
 
     @MainActor
@@ -1489,6 +1556,7 @@ struct TerminalHomeView: View {
             error = nil
             rejectedFingerprint = nil
             trustFailed = false
+            herdrMissing = false
             // Prune keep-mounted panes whose agent is gone (Stopped / vanished) so no dead
             // terminal lingers warm — but only a slot that was ONCE seen live and has now
             // vanished (never a still-booting spawn pane, which is absent by design while its
@@ -1501,9 +1569,14 @@ struct TerminalHomeView: View {
             openGramIfPending()              // a cold-launch gram tap opens the Gram page once loaded
         } catch {
             let rejected: String?
-            if let transportError = error as? TransportError,
-               case .hostKeyRejected(_, let fingerprint) = transportError {
-                rejected = fingerprint
+            var notInstalled = false
+            if let transportError = error as? TransportError {
+                if case .hostKeyRejected(_, let fingerprint) = transportError {
+                    rejected = fingerprint
+                } else {
+                    rejected = nil
+                    if case .herdrNotInstalled = transportError { notInstalled = true }
+                }
             } else {
                 rejected = nil
             }
@@ -1514,6 +1587,9 @@ struct TerminalHomeView: View {
             if agents.isEmpty || rejected != nil {
                 self.error = "\(error)"
                 rejectedFingerprint = rejected
+                // Only when this is the surfaced error do we drive the install-guidance
+                // branch; a no-herdr connect always has an empty list, so it surfaces here.
+                herdrMissing = notInstalled
             }
             // DROP a pending deep-link this failed load couldn't service, rather than leave it armed:
             // a push targets a just-now event, so firing it after some much-later successful load would

--- a/Sources/HerdrKit/CitadelTransport.swift
+++ b/Sources/HerdrKit/CitadelTransport.swift
@@ -159,16 +159,39 @@ public actor CitadelTransport: HerdrTransport {
         Data(requestLine.utf8).base64EncodedString()
     }
 
+    /// Sentinel the exec wrapper prints to stderr when herdr is absent (see
+    /// `herdrPathResolution`). `classifyBridgeFailure` matches it to raise
+    /// `.herdrNotInstalled` rather than a generic `.bridgeFailed`. A fixed ASCII
+    /// token, deliberately NOT the shell's locale-dependent "not found" wording.
+    static let herdrNotInstalledSentinel = "__HERDR_NOT_INSTALLED__"
+
     /// Resolves herdr on the remote host: prefer `PATH`, fall back to the
-    /// standard `~/.local/bin` install location.
+    /// standard `~/.local/bin` install location — then GUARD that the resolved
+    /// path is actually executable before exec'ing it.
     ///
     /// A non-interactive SSH exec runs a NON-login shell, whose `PATH` does not
     /// include `~/.local/bin` — where herdr installs by default — so a bare
     /// `herdr api-bridge` fails with "command not found". A live round-trip
     /// caught exactly this. This mirrors herdr's own remote wrapper
     /// (src/remote/unix.rs: `command -v herdr`, else `$HOME/.local/bin/herdr`).
+    ///
+    /// The `[ -x "$HERDR" ]` guard separates "herdr is not installed at all" from
+    /// every other bridge failure: when neither PATH nor the fallback path holds an
+    /// executable, it prints `herdrNotInstalledSentinel` and exits BEFORE exec, so
+    /// `classifyBridgeFailure` can raise `.herdrNotInstalled` and the client can
+    /// offer install guidance instead of surfacing a raw stderr line.
     static let herdrPathResolution =
-        #"HERDR=$(command -v herdr || echo "$HOME/.local/bin/herdr"); exec "$HERDR" api-bridge "#
+        #"HERDR=$(command -v herdr || echo "$HOME/.local/bin/herdr"); [ -x "$HERDR" ] || { echo \#(herdrNotInstalledSentinel) >&2; exit 127; }; exec "$HERDR" api-bridge "#
+
+    /// Classifies an empty-stdout bridge failure. When herdr is absent the exec
+    /// wrapper prints `herdrNotInstalledSentinel` (see `herdrPathResolution`), so a
+    /// stderr carrying it becomes `.herdrNotInstalled(host:)`; anything else stays a
+    /// generic `.bridgeFailed(stderr:)`. Pure, so it is host-testable without SSH.
+    static func classifyBridgeFailure(stderr: String, host: String) -> TransportError {
+        stderr.contains(herdrNotInstalledSentinel)
+            ? .herdrNotInstalled(host: host)
+            : .bridgeFailed(stderr: stderr)
+    }
 
     /// The full exec command line: resolve herdr, then run
     /// `api-bridge <base64(requestLine)>`. base64 so no JSON metacharacter needs
@@ -208,7 +231,7 @@ public actor CitadelTransport: HerdrTransport {
         if lines.hasRemainder { return lines.flush() }   // a reply that lacked a trailing newline
         // Empty stdout: surface the bridge/remote diagnostic rather than handing
         // the caller an empty string it can only fail to decode.
-        if !stderr.isEmpty { throw TransportError.bridgeFailed(stderr: stderr) }
+        if !stderr.isEmpty { throw Self.classifyBridgeFailure(stderr: stderr, host: credentials.host) }
         throw TransportError.closedBeforeResponse
     }
 

--- a/Sources/HerdrKit/Transport.swift
+++ b/Sources/HerdrKit/Transport.swift
@@ -107,6 +107,13 @@ public enum TransportError: Error, CustomStringConvertible {
     /// The api-bridge (or the remote shell) produced no reply on stdout but wrote
     /// to stderr — surfaced rather than handed back as an empty, undecodable line.
     case bridgeFailed(stderr: String)
+    /// herdr is not installed on the host: neither on `PATH` nor at the default
+    /// `~/.local/bin/herdr`, so the api-bridge command line has no executable to
+    /// run. Distinguished from a generic `bridgeFailed` by an explicit sentinel the
+    /// exec wrapper emits (not by matching the shell's locale-specific "not found"
+    /// text), so the client can guide the user to install it rather than showing a
+    /// raw stderr line.
+    case herdrNotInstalled(host: String)
     /// A password connection was attempted against a server that does not offer
     /// password authentication (e.g. `PasswordAuthentication no`). Distinct from a
     /// wrong password and from a host-key mismatch.
@@ -128,6 +135,8 @@ public enum TransportError: Error, CustomStringConvertible {
             return "host key for \(h) rejected: \(fp) does not match the pinned key"
         case .bridgeFailed(let stderr):
             return "api-bridge produced no reply; stderr: \(stderr)"
+        case .herdrNotInstalled(let h):
+            return "herdr is not installed on \(h)"
         case .passwordAuthUnsupported(let h):
             return "\(h) does not offer password authentication — use a key instead"
         case .authenticationFailed(let h):

--- a/Tests/HerdrKitTests/CitadelTransportTests.swift
+++ b/Tests/HerdrKitTests/CitadelTransportTests.swift
@@ -109,4 +109,57 @@ final class CitadelTransportTests: XCTestCase {
         // A normal request is well under and does not throw.
         XCTAssertNoThrow(try CitadelTransport.bridgeCommand(for: #"{"id":"1","method":"agent.list"}"#))
     }
+
+    // MARK: - "herdr not installed" detection
+
+    /// AXIS: the exec wrapper guards that the resolved herdr path is executable and,
+    /// when it is not, emits the sentinel and exits BEFORE `exec`. This is what lets
+    /// the client tell "herdr is not installed" apart from every other bridge failure
+    /// and show install guidance instead of a raw stderr line. Pins the guard so it
+    /// cannot be silently dropped back to an unconditional `exec`.
+    func testBridgeCommandGuardsHerdrExecutableWithSentinel() throws {
+        let command = try CitadelTransport.bridgeCommand(for: #"{"id":"1","method":"agent.list"}"#)
+
+        XCTAssertTrue(command.contains(#"[ -x "$HERDR" ]"#),
+                      "the command does not guard that the resolved herdr path is executable")
+        XCTAssertTrue(command.contains(CitadelTransport.herdrNotInstalledSentinel),
+                      "the command does not emit the not-installed sentinel")
+        // The guard must run BEFORE exec, otherwise exec of a missing file wins and
+        // the sentinel is never printed.
+        let guardIndex = try XCTUnwrap(command.range(of: #"[ -x "$HERDR" ]"#)?.lowerBound)
+        let execIndex = try XCTUnwrap(command.range(of: #"exec "$HERDR""#)?.lowerBound)
+        XCTAssertLessThan(guardIndex, execIndex, "the executable guard runs after exec, so it never fires")
+        // The installed path is unchanged: it still runs api-bridge.
+        XCTAssertTrue(command.contains(" api-bridge "),
+                      "the command no longer invokes the api-bridge subcommand for the installed path")
+    }
+
+    /// A stderr carrying the sentinel classifies as `.herdrNotInstalled(host:)`,
+    /// carrying the host through for the client's guidance copy.
+    func testClassifyBridgeFailureDetectsMissingHerdr() {
+        let stderr = "bash: line 1: \(CitadelTransport.herdrNotInstalledSentinel)\n"
+        let error = CitadelTransport.classifyBridgeFailure(stderr: stderr, host: "box.example")
+        guard case TransportError.herdrNotInstalled(let host) = error else {
+            return XCTFail("expected .herdrNotInstalled, got \(error)")
+        }
+        XCTAssertEqual(host, "box.example", "the host was not carried through")
+    }
+
+    /// Any OTHER stderr stays a generic `.bridgeFailed` — the sentinel is the only
+    /// signal that promotes it, so an unrelated failure is never mislabelled as
+    /// "herdr not installed" (which would wrongly tell the user to reinstall).
+    func testClassifyBridgeFailurePassesThroughUnrelatedStderr() {
+        let stderr = "api-bridge: permission denied while opening the control socket\n"
+        let error = CitadelTransport.classifyBridgeFailure(stderr: stderr, host: "box.example")
+        guard case TransportError.bridgeFailed(let passed) = error else {
+            return XCTFail("expected .bridgeFailed, got \(error)")
+        }
+        XCTAssertEqual(passed, stderr, "the original stderr was not preserved")
+    }
+
+    /// The description names the host so the surfaced error is legible on its own.
+    func testHerdrNotInstalledDescriptionNamesHost() {
+        let error = TransportError.herdrNotInstalled(host: "box.example")
+        XCTAssertEqual(error.description, "herdr is not installed on box.example")
+    }
 }


### PR DESCRIPTION
## What

Closes the last onboarding dead end. When the app connects over SSH to a machine that has **no herdr installed at all**, the `api-bridge` exec fails, and the app showed the raw shell diagnostic (`api-bridge produced no reply; stderr: …/herdr: No such file or directory`) plus a bare **retry**. A brand-new user had no way to know they needed to go install the fork.

The other two "not ready" states already hand over the fix (`ForkNoticeView` for a base/official daemon; the Gram setup card for a missing skill). This fills the third.

## How

**Detect it precisely (client-side, no daemon change).** The SSH exec wrapper now guards `[ -x "$HERDR" ]` and, when neither `PATH` nor `~/.local/bin` holds an executable, prints a fixed sentinel (`__HERDR_NOT_INSTALLED__`) and exits **before** `exec`. `CitadelTransport.classifyBridgeFailure` turns that into a distinct `TransportError.herdrNotInstalled(host:)` instead of a generic `bridgeFailed`. Using an explicit sentinel — not the shell's locale-specific "not found" text — means an unrelated failure is never mislabelled as "reinstall herdr".

**Show install guidance.** `TerminalHomeView.errorView` gets a branch (driven by a new `herdrMissing` state set in `load()`'s catch) that replaces the raw stderr with: a heading, a **copy-paste build-from-source command** (reusing the Gram setup card's command-box + Copy idiom), a shared **"Full install instructions"** link, and **retry** once it's installed.

**Reuse over new code.** The install-instructions link is extracted into a shared `InstallInstructionsLink` view, now used by both `ForkNoticeView` and the new screen, so both "daemon not ready" states point at the same place with the same affordance.

## Scope

Entirely client-side. **No daemon/fork change, no redeploy, no `PROTOCOL_VERSION` bump** — the exec wrapper is client-emitted shell. `ForkNoticeView` (wrong-daemon) and the Gram setup card (no-skill) are untouched; the host-key-rejection recovery path is untouched.

## Tests

New `HerdrKit` unit tests (Linux-buildable, all green):
- the wrapper carries the `[ -x … ]` guard + sentinel, the guard runs before `exec`, and the installed path still runs `api-bridge`;
- `classifyBridgeFailure`: sentinel stderr → `.herdrNotInstalled`, other stderr → `.bridgeFailed`;
- `.herdrNotInstalled` description names the host.

`swift test` (full HerdrKit suite) passes except one **pre-existing, unrelated** failure on `main` (`ReadmeLayoutTests` — a malformed `README.md` layout row at line 70, present before this branch).

## Verify on device

Connect to a host with no herdr on `PATH` and no `~/.local/bin/herdr` → the install-guidance screen shows (heading + copy box + link + retry), not a raw stderr line. Tap **Copy command** → clipboard holds the one-liner. Install herdr there, tap **retry** → connects. Regression: a host with the fork connects normally; a base/official herdr still shows the existing `ForkNoticeView`.