### PR TITLE
fix: keep the agent list live with a periodic refresh

### DIFF
--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -859,6 +859,12 @@ struct TerminalHomeView: View {
     /// stopped section has something to show.
     var livePaneIDs: Set<String>? = nil
 
+    /// How often the connected agent list is re-fetched to stay live. agent.list is
+    /// a small JSON query (unlike a screen fetch), so a 5s floor is cheap even over a
+    /// forwarded SSH connection while keeping the list, header, and Live Activity in
+    /// step with the herd without a reconnect.
+    private static let agentListPollInterval: UInt64 = 5_000_000_000
+
     @State private var agents: [AgentInfo] = []
     @State private var error: String?
     @State private var loading = true
@@ -1081,7 +1087,23 @@ struct TerminalHomeView: View {
         // keeping these here fires load / fork-probe / first-run / deep-links ONCE per
         // connect (this view is .id(session)-scoped) rather than on every tab switch —
         // which otherwise re-showed the fork notice and cancelled an in-flight load.
-        .task { await load() }
+        //
+        // Load the agent list on connect, then keep it LIVE with a periodic refresh.
+        // Without the poll the list was fetched only once per connect (plus after a
+        // local spawn / close), so a server-side change — a new agent, a
+        // working → needs-you → exit transition, an agent that died — stayed invisible
+        // until the user reconnected to force a fresh load. agent.list is small JSON
+        // (cheap, unlike a screen fetch), and load() is stale-while-revalidate: a
+        // failed refresh keeps the last-good list rather than blanking it, and the
+        // spinner shows only while the list is empty. Still one .task, .id(session)-
+        // scoped, so tab switches never restart or duplicate it.
+        .task {
+            await load()
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: Self.agentListPollInterval)
+                await load()
+            }
+        }
         // Ambient unread-gram poll for the tab badge, running ONLY while the Gram
         // tab is not showing — GramView keeps its own 6s poll while visible and
         // writes the count on load / mark-read. Keyed on selectedTab so it


### PR DESCRIPTION
## What

The agent list could go stale and only refresh on **reconnect**. Reported on-device: "the agent list sometimes is not updated, and I have to reconnect to the host."

## Root cause

`agents` is set in exactly one place — `TerminalHomeView.load()` — which runs only:
- once per connect (`.task { await load() }`, `.id(session)`-scoped so tab switches don't re-fire it), and
- after a local **spawn / close / retry**.

There is **no periodic and no event-driven refresh**. `events.subscribe` exists in HerdrKit but is never wired up, and the front-pane live stream updates terminal *content*, not the list. So a server-side change — a new agent, a `working → needs-you → exit` transition, an agent that died — stayed invisible in the list (and the header + Live Activity, which derive from the same `agents`) until the user reconnected to force a fresh `load()`. That's the "sometimes": the list looks fresh right after an action, then drifts.

## Fix

Poll `agent.list` on a **5s** staleness floor while connected, mirroring the existing gram-unread poll and `load()`'s stale-while-revalidate semantics:
- `agent.list` is small JSON (cheap, unlike a screen fetch);
- a failed refresh keeps the last-good list (no blanking), and the spinner shows only while the list is empty (no mid-session flicker);
- the two post-load calls (`applyDeepLink`, `openGramIfPending`) are both guarded no-ops without a pending target and clear their flags when they act, so a 5s cadence can't cause a repeated jump.

Still **one** `.task`, `.id(session)`-scoped, so tab switches never restart or duplicate it. The interval is a single named constant (`agentListPollInterval`) for easy tuning.

## Scope

App-only. **No daemon/fork change, no redeploy, no protocol bump.** `load()` semantics are unchanged — this only calls it on a timer.

## Verify on device

With the app on the Agents list, start/stop an agent **from the machine** (not the app): the row's status updates within ~5s without reconnecting. Switch tabs and back: no duplicate spinner or reload. A brief network blip does not blank the list.