### PR TITLE
fix: keep the compact Dynamic Island narrow (no timer in the notch pill)

### DIFF
--- a/HerdrWidgets/AgentLiveActivity.swift
+++ b/HerdrWidgets/AgentLiveActivity.swift
@@ -51,14 +51,14 @@ struct AgentLiveActivity: Widget {
             } compactLeading: {
                 StatusDot(status: context.state.status)
             } compactTrailing: {
-                // The action count wins the scarce compact slot; otherwise, a working
-                // session ticks its elapsed time here — the compact view's live motion.
+                // ONLY the count that demands action gets the scarce compact slot. A ticking
+                // timer here widened the notch pill (and kept growing as it counted up), so the
+                // working state stays a bare dot in the compact view; its live elapsed timer
+                // lives in the EXPANDED view and the lock screen, where width isn't constrained.
                 if context.state.needsYouCount > 0 {
                     Text("\(context.state.needsYouCount)")
                         .font(.caption2).bold()
                         .foregroundStyle(WidgetPalette.color(.needsYou))
-                } else if context.state.status == .working, let since = context.state.workingSince {
-                    WorkingTimer(since: since, font: .caption2)
                 }
             } minimal: {
                 StatusDot(status: context.state.status)

--- a/HerdrWidgets/AgentLiveActivity.swift
+++ b/HerdrWidgets/AgentLiveActivity.swift
@@ -34,7 +34,13 @@ struct AgentLiveActivity: Widget {
                             .font(.headline)
                             .foregroundStyle(WidgetPalette.text)
                             .lineLimit(1)
-                        if context.state.status == .working, let since = context.state.workingSince {
+                        // The ticking timer shows ONLY when exactly one agent is working, so it
+                        // unambiguously tracks THAT agent and stops the moment it finishes. The
+                        // Live Activity is one aggregate per machine, so with several agents working
+                        // a single "since" is meaningless (and the timer would appear to run on as
+                        // the busiest agent changes) — show the "N working" count instead.
+                        if context.state.status == .working, context.state.workingCount == 1,
+                           let since = context.state.workingSince {
                             HStack(spacing: 5) {
                                 Text("Working").font(.caption).foregroundStyle(WidgetPalette.color(.working))
                                 WorkingTimer(since: since, font: .caption)
@@ -89,8 +95,11 @@ private struct LockScreenView: View {
                     .font(.headline)
                     .foregroundStyle(WidgetPalette.text)
                     .lineLimit(1)
-                if state.status == .working, let since = state.workingSince {
-                    // The live ticking time IS the motion — the dot can't animate here.
+                // Timer ONLY for a single working agent (see the Dynamic Island note): it then
+                // tracks that agent and stops when it finishes. With several working, the "since"
+                // is ambiguous and looks like it never stops, so show the "N working" count. The
+                // live ticking time IS the motion here — the dot can't animate on a Live Activity.
+                if state.status == .working, state.workingCount == 1, let since = state.workingSince {
                     HStack(spacing: 5) {
                         Text("Working").font(.subheadline).foregroundStyle(WidgetPalette.color(.working))
                         WorkingTimer(since: since)


### PR DESCRIPTION
## What
The compact Dynamic Island pill was too wide while an agent worked. Cause: `compactTrailing` rendered the ticking `WorkingTimer` ("1:23"), which took horizontal space in the notch pill **and kept growing** as it counted up.

## Fix
Drop the timer from `compactTrailing` — the working state stays a bare status dot in the compact view. The live elapsed timer still shows in the **expanded** Dynamic Island and on the **lock screen**, where width isn't constrained.

App-only (widget), no daemon/protocol change. One-file change (`HerdrWidgets/AgentLiveActivity.swift`).

## Verify
On device: while an agent is working, the compact Dynamic Island (notch pill) is narrow — just the coloured dot, no ticking time. Long-press to expand → the "Working 1:23" timer is still there; the lock screen still ticks too.