### PR TITLE
feat: save Gram messages + saved prompts in the reply bar

### DIFF
--- a/App/GramView.swift
+++ b/App/GramView.swift
@@ -56,6 +56,9 @@ struct GramView: View {
     /// A non-fatal refresh failure while messages are already shown.
     @State private var refreshNote: String?
     @State private var isLoading = false
+    /// Saved (bookmarked) Gram messages + whether the page is showing the Saved section.
+    @ObservedObject private var savedGrams = SavedGramStore.shared
+    @State private var showingSaved = false
     /// Messages with a mark-read in flight, so a re-`onAppear` (scroll) does not fire
     /// a duplicate `gram.mark_read`.
     @State private var markingRead: Set<String> = []
@@ -297,10 +300,10 @@ struct GramView: View {
 
     private var header: some View {
         HStack(spacing: 10) {
-            Text("Gram")
+            Text(showingSaved ? "Saved" : "Gram")
                 .font(Typography.app(20, .semibold))
                 .foregroundStyle(Palette.text)
-            if unreadCount > 0 {
+            if !showingSaved, unreadCount > 0 {
                 Text("\(unreadCount)")
                     .font(Typography.machine(11, .semibold))
                     .foregroundStyle(Palette.ground)
@@ -309,12 +312,22 @@ struct GramView: View {
                     .background(Capsule().fill(Palette.waiting))
             }
             Spacer()
+            // All / Saved toggle — a filled bookmark means the Saved section is showing.
             Button {
-                Task { await load(initial: false) }
+                withAnimation(.easeInOut(duration: 0.15)) { showingSaved.toggle() }
             } label: {
-                Image(systemName: "arrow.clockwise")
+                Image(systemName: showingSaved ? "bookmark.fill" : "bookmark")
                     .font(.system(size: 15, weight: .semibold))
-                    .foregroundStyle(Palette.textDim)
+                    .foregroundStyle(showingSaved ? Palette.brand : Palette.textDim)
+            }
+            if !showingSaved {
+                Button {
+                    Task { await load(initial: false) }
+                } label: {
+                    Image(systemName: "arrow.clockwise")
+                        .font(.system(size: 15, weight: .semibold))
+                        .foregroundStyle(Palette.textDim)
+                }
             }
             if let onClose {
                 Button(action: onClose) {
@@ -335,6 +348,44 @@ struct GramView: View {
 
     @ViewBuilder
     private var content: some View {
+        if showingSaved { savedContent } else { inboxContent }
+    }
+
+    /// The Saved section: locally-kept copies of bookmarked messages. Rendered from the local
+    /// store (independent of the poll), so a saved message survives even after the original is
+    /// deleted from the server.
+    @ViewBuilder
+    private var savedContent: some View {
+        if savedGrams.saved.isEmpty {
+            centered {
+                VStack(spacing: 8) {
+                    Image(systemName: "bookmark")
+                        .font(.system(size: 28))
+                        .foregroundStyle(Palette.textFaint)
+                    Text("No saved messages yet")
+                        .font(Typography.app(15, .medium))
+                        .foregroundStyle(Palette.textDim)
+                    Text("Tap the bookmark on a message to keep it here.")
+                        .font(Typography.app(13))
+                        .foregroundStyle(Palette.textFaint)
+                        .multilineTextAlignment(.center)
+                }
+                .padding(.horizontal, 32)
+            }
+        } else {
+            ScrollView {
+                LazyVStack(spacing: 10) {
+                    ForEach(savedGrams.saved) { s in
+                        SavedGramRow(saved: s, onUnsave: { savedGrams.remove(s.id) })
+                    }
+                }
+                .padding(16)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var inboxContent: some View {
         switch phase {
         case .loading:
             centered { ProgressView().tint(Palette.textDim) }
@@ -383,7 +434,9 @@ struct GramView: View {
                         GramRow(
                             message: message,
                             isDownloadingFile: downloadingFileFor == message.id,
+                            isSaved: savedGrams.isSaved(message.id),
                             onOpenFile: { openFile(message) },
+                            onToggleSave: { savedGrams.toggle(message) },
                             onDelete: { delete(message) }
                         )
                         .onAppear { markReadIfNeeded(message) }
@@ -1152,7 +1205,9 @@ struct GramView: View {
 private struct GramRow: View {
     let message: GramMessage
     var isDownloadingFile: Bool
+    var isSaved: Bool
     var onOpenFile: () -> Void
+    var onToggleSave: () -> Void
     var onDelete: () -> Void
 
     var body: some View {
@@ -1170,6 +1225,15 @@ private struct GramRow: View {
                     Text(age)
                         .font(Typography.machine(11))
                         .foregroundStyle(Palette.textFaint)
+                    // Small save/unsave tap target (the same action is also in the long-press menu).
+                    Button(action: onToggleSave) {
+                        Image(systemName: isSaved ? "bookmark.fill" : "bookmark")
+                            .font(.system(size: 12, weight: .semibold))
+                            .foregroundStyle(isSaved ? Palette.brand : Palette.textFaint)
+                            .frame(width: 22, height: 22)
+                            .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
                 }
                 if !message.text.isEmpty {
                     Text(message.text)
@@ -1202,6 +1266,9 @@ private struct GramRow: View {
                 } label: {
                     Label("Copy", systemImage: "doc.on.doc")
                 }
+            }
+            Button(action: onToggleSave) {
+                Label(isSaved ? "Unsave" : "Save", systemImage: isSaved ? "bookmark.slash" : "bookmark")
             }
             Button(role: .destructive, action: onDelete) {
                 Label("Delete", systemImage: "trash")

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -1722,6 +1722,11 @@ struct TerminalPaneContent: View {
     /// Per-agent push mute, toggled from the header's ⋯ menu (keyed by this pane's
     /// public id — the same id the push payload carries).
     @ObservedObject private var mute = MuteStore.shared
+    /// Saved prompts, shown from the reply bar when the input is empty (the send arrow would be
+    /// dead then). Tapping one inserts it and sends it via the normal path.
+    @ObservedObject private var savedPrompts = SavedPromptsStore.shared
+    /// Presents the "save a new prompt" sheet.
+    @State private var showSavePrompt = false
     @State private var sending = false
     @State private var actionNote: String?
     /// In-flight guard for the [Switch] banner action, so repeated taps don't queue multiple
@@ -2203,15 +2208,57 @@ struct TerminalPaneContent: View {
                 // isActive drops on autoDelivering so an in-flight dictation stops before
                 // the auto-deliver clears the reply, and it can't be started during either.
                 .disabled(sending || autoDelivering)
-            Button { sendTapped() } label: {
-                Image(systemName: "arrow.up").font(.system(size: 15, weight: .bold))
-                    .foregroundStyle(canSend ? Palette.ground : Palette.textFaint)
-                    .frame(width: 40, height: 40)
-                    .background(canSend ? Palette.text : Palette.surface).clipShape(Circle())
+            // When the input is EMPTY the send arrow is dead, so offer saved prompts in its
+            // place; otherwise the normal send arrow (same 40x40 circle, mutually exclusive
+            // by the same empty predicate `canSend` uses).
+            if reply.trimmingCharacters(in: .whitespaces).isEmpty {
+                savedPromptsButton
+            } else {
+                Button { sendTapped() } label: {
+                    Image(systemName: "arrow.up").font(.system(size: 15, weight: .bold))
+                        .foregroundStyle(canSend ? Palette.ground : Palette.textFaint)
+                        .frame(width: 40, height: 40)
+                        .background(canSend ? Palette.text : Palette.surface).clipShape(Circle())
+                }
+                .disabled(!canSend)
             }
-            .disabled(!canSend)
         }
         .padding(.horizontal, 12).padding(.top, 4).padding(.bottom, 8)
+        .sheet(isPresented: $showSavePrompt) {
+            SavePromptSheet { nick, txt in savedPrompts.add(nickname: nick, text: txt) }
+        }
+    }
+
+    /// Replaces the (dead) send arrow when the input is empty: a menu of saved prompts. Tap one
+    /// to insert + send it; "Save new prompt…" opens the editor; the submenu deletes.
+    private var savedPromptsButton: some View {
+        Menu {
+            ForEach(savedPrompts.prompts) { p in
+                Button { usePrompt(p) } label: { Label(p.label, systemImage: "text.quote") }
+            }
+            if !savedPrompts.prompts.isEmpty { Divider() }
+            Button { showSavePrompt = true } label: { Label("Save new prompt…", systemImage: "plus") }
+            if !savedPrompts.prompts.isEmpty {
+                Menu {
+                    ForEach(savedPrompts.prompts) { p in
+                        Button(role: .destructive) { savedPrompts.delete(p.id) } label: { Text(p.label) }
+                    }
+                } label: { Label("Delete a prompt", systemImage: "trash") }
+            }
+        } label: {
+            Image(systemName: "bookmark").font(.system(size: 15, weight: .semibold))
+                .foregroundStyle(Palette.textDim)
+                .frame(width: 40, height: 40)
+                .background(Palette.surface).clipShape(Circle())
+        }
+        .disabled(sending || autoDelivering)
+    }
+
+    /// Insert a saved prompt into the reply field and send it — the same path a typed reply
+    /// takes (`sendTapped` → mode-aware `send(.submitText)` → confirmed `agent.prompt`).
+    private func usePrompt(_ p: SavedPrompt) {
+        reply = p.text
+        sendTapped()
     }
 
     /// Routes a reader action through InputRouter, then executes the plan. A

--- a/App/SavedGramStore.swift
+++ b/App/SavedGramStore.swift
@@ -1,0 +1,135 @@
+import Foundation
+import Combine
+import SwiftUI
+import HerdrKit
+
+/// A locally-saved ("bookmarked") Gram message. A LOCAL COPY of the essentials — not just the
+/// id — because gram is a delete-for-good, server-rotated channel with no single-message
+/// re-fetch (only whole-list `gramList` + on-demand `gramGetFile`), so an id-only bookmark
+/// would orphan the moment the original is deleted. The file BYTES are never copied (they can
+/// be up to 100 MiB and are fetched on demand); we only note whether the original had a file.
+struct SavedGram: Codable, Identifiable, Hashable {
+    let id: String
+    var text: String
+    var from: String
+    /// direction == .agentToOwner — so the saved copy can render the same avatar/side.
+    var fromAgent: Bool
+    var createdUnixMs: UInt64
+    var hasFile: Bool
+
+    var createdAt: Date { Date(timeIntervalSince1970: Double(createdUnixMs) / 1000) }
+}
+
+/// Persists the owner's saved Gram messages as JSON in UserDefaults (device-local, secret-free),
+/// mirroring `SavedHostsStore` minus the Keychain. An in-memory `Set` of ids gives O(1)
+/// `isSaved` for the per-row bookmark toggle (the `MuteStore` idea). Singleton
+/// `ObservableObject` so the Gram view's bookmark icons and Saved section update live.
+final class SavedGramStore: ObservableObject {
+    static let shared = SavedGramStore()
+
+    private let defaultsKey = "dev.herdr.savedGrams.v1"
+    /// Newest-first, matching how the Gram list is shown.
+    @Published private(set) var saved: [SavedGram]
+    private var ids: Set<String>
+
+    init() {
+        let decoded: [SavedGram]
+        if let data = UserDefaults.standard.data(forKey: defaultsKey),
+           let d = try? JSONDecoder().decode([SavedGram].self, from: data) {
+            decoded = d
+        } else {
+            decoded = []
+        }
+        saved = decoded.sorted { $0.createdUnixMs > $1.createdUnixMs }
+        ids = Set(decoded.map(\.id))
+    }
+
+    func isSaved(_ id: String) -> Bool { ids.contains(id) }
+
+    /// Save a copy of the message, or un-save it if already saved.
+    func toggle(_ message: GramMessage) {
+        if ids.contains(message.id) {
+            remove(message.id)
+        } else {
+            let copy = SavedGram(
+                id: message.id,
+                text: message.text,
+                from: message.from,
+                fromAgent: message.isFromAgent,
+                createdUnixMs: message.createdUnixMs,
+                hasFile: message.file != nil
+            )
+            saved.append(copy)
+            saved.sort { $0.createdUnixMs > $1.createdUnixMs }
+            ids.insert(message.id)
+            persist()
+        }
+    }
+
+    func remove(_ id: String) {
+        guard ids.contains(id) else { return }
+        saved.removeAll { $0.id == id }
+        ids.remove(id)
+        persist()
+    }
+
+    private func persist() {
+        guard let data = try? JSONEncoder().encode(saved) else { return }
+        UserDefaults.standard.set(data, forKey: defaultsKey)
+    }
+}
+
+/// Renders a locally-saved Gram message (a `SavedGram` copy) in the Saved section, mirroring the
+/// inbox `GramRow` card. Read-only apart from the un-save bookmark; file bytes are not kept, so a
+/// saved attachment shows only a note (its original may already be gone from the server).
+struct SavedGramRow: View {
+    let saved: SavedGram
+    var onUnsave: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 6) {
+                Text(saved.fromAgent ? saved.from : "You")
+                    .font(Typography.app(13, .semibold))
+                    .foregroundStyle(Palette.text)
+                Spacer(minLength: 0)
+                Text(age)
+                    .font(Typography.machine(11))
+                    .foregroundStyle(Palette.textFaint)
+                Button(action: onUnsave) {
+                    Image(systemName: "bookmark.fill")
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(Palette.brand)
+                        .frame(width: 22, height: 22)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+            }
+            if !saved.text.isEmpty {
+                Text(saved.text)
+                    .font(Typography.app(14))
+                    .foregroundStyle(Palette.textDim)
+                    .textSelection(.enabled)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            if saved.hasFile {
+                Label("had an attachment", systemImage: "paperclip")
+                    .font(Typography.machine(11))
+                    .foregroundStyle(Palette.textFaint)
+            }
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(RoundedRectangle(cornerRadius: 12).fill(Palette.card))
+        .overlay(RoundedRectangle(cornerRadius: 12).stroke(Palette.hairlineQuiet, lineWidth: 1))
+    }
+
+    /// Compact relative age ("now" / "5m" / "3h" / "2d"), matching the inbox row's terse style.
+    private var age: String {
+        let secs = Date().timeIntervalSince(saved.createdAt)
+        if secs < 60 { return "now" }
+        if secs < 3600 { return "\(Int(secs / 60))m" }
+        if secs < 86400 { return "\(Int(secs / 3600))h" }
+        return "\(Int(secs / 86400))d"
+    }
+}

--- a/App/SavedPromptsStore.swift
+++ b/App/SavedPromptsStore.swift
@@ -1,0 +1,120 @@
+import Foundation
+import Combine
+import SwiftUI
+
+/// A reusable prompt the user can save and fire into an agent's reply bar with one tap.
+/// Just a nickname (the "surname") plus the prompt text — no secret — so it lives entirely
+/// in UserDefaults as JSON, mirroring `SavedHostsStore` minus the Keychain machinery.
+struct SavedPrompt: Codable, Identifiable, Hashable {
+    let id: UUID
+    var nickname: String
+    var text: String
+
+    init(id: UUID = UUID(), nickname: String, text: String) {
+        self.id = id
+        self.nickname = nickname
+        self.text = text
+    }
+
+    /// The display label: the nickname if set, else the prompt text itself
+    /// (mirrors `SavedHost.label`).
+    var label: String {
+        let n = nickname.trimmingCharacters(in: .whitespacesAndNewlines)
+        return n.isEmpty ? text : n
+    }
+}
+
+/// Persists the user's saved prompts as JSON in UserDefaults. Device-local and secret-free,
+/// so it needs none of `SavedHostsStore`'s Keychain half. A singleton `ObservableObject` so
+/// the reply bar's saved-prompts menu updates live as prompts are added or removed.
+final class SavedPromptsStore: ObservableObject {
+    static let shared = SavedPromptsStore()
+
+    private let defaultsKey = "dev.herdr.savedPrompts.v1"
+    @Published private(set) var prompts: [SavedPrompt]
+
+    init() {
+        if let data = UserDefaults.standard.data(forKey: defaultsKey),
+           let decoded = try? JSONDecoder().decode([SavedPrompt].self, from: data) {
+            prompts = decoded
+        } else {
+            prompts = []
+        }
+    }
+
+    /// Adds a new saved prompt. A blank text is refused (a promptless prompt is useless);
+    /// a blank nickname is allowed — `label` then falls back to the text.
+    func add(nickname: String, text: String) {
+        let t = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !t.isEmpty else { return }
+        prompts.append(SavedPrompt(nickname: nickname.trimmingCharacters(in: .whitespacesAndNewlines), text: t))
+        persist()
+    }
+
+    func delete(_ id: UUID) {
+        prompts.removeAll { $0.id == id }
+        persist()
+    }
+
+    private func persist() {
+        guard let data = try? JSONEncoder().encode(prompts) else { return }
+        UserDefaults.standard.set(data, forKey: defaultsKey)
+    }
+}
+
+/// A small form to save a new prompt: a nickname (the "surname") + the prompt text.
+/// Styled to match `HostEditor` — dark ground, surface fields, Geist app voice + Plex Mono
+/// for the prompt body. Owns its own state, so it opens blank each time.
+struct SavePromptSheet: View {
+    var onSave: (String, String) -> Void
+
+    @State private var nickname = ""
+    @State private var text = ""
+    @Environment(\.dismiss) private var dismiss
+
+    private var canSave: Bool { !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Palette.ground.ignoresSafeArea()
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 10) {
+                        Text("NICKNAME").font(Typography.microLabel).foregroundStyle(Palette.textFaint)
+                            .padding(.leading, 4)
+                        TextField("e.g. daily standup", text: $nickname)
+                            .textInputAutocapitalization(.never).autocorrectionDisabled()
+                            .font(Typography.app(15)).foregroundStyle(Palette.text)
+                            .padding(.horizontal, 16).padding(.vertical, 14)
+                            .background(Palette.surface).clipShape(RoundedRectangle(cornerRadius: 12))
+
+                        Text("PROMPT").font(Typography.microLabel).foregroundStyle(Palette.textFaint)
+                            .padding(.leading, 4).padding(.top, 6)
+                        TextField("what to send the agent…", text: $text, axis: .vertical)
+                            .lineLimit(3...10)
+                            .font(Typography.machine(14)).foregroundStyle(Palette.text)
+                            .padding(.horizontal, 16).padding(.vertical, 14)
+                            .background(Palette.surface).clipShape(RoundedRectangle(cornerRadius: 12))
+
+                        Button {
+                            onSave(nickname, text); dismiss()
+                        } label: {
+                            Text("Save prompt").font(Typography.app(16, .semibold)).foregroundStyle(Palette.ground)
+                                .frame(maxWidth: .infinity).padding(.vertical, 14)
+                                .background(RoundedRectangle(cornerRadius: 14).fill(Palette.text))
+                        }
+                        .disabled(!canSave).opacity(canSave ? 1 : 0.5).padding(.top, 6)
+                    }
+                    .padding(20)
+                }
+            }
+            .navigationTitle("Save prompt")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }.foregroundStyle(Palette.textDim)
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Two small **app-only** features (no daemon/HerdrKit/protocol change).

## 1. Save Gram messages
- A **bookmark icon** on each Gram message (and a **Save** item in the long-press menu) toggles saving.
- A **Saved section** — an **All/Saved bookmark toggle** in the Gram header — lists the saved messages.
- `SavedGramStore` persists **local copies** (`id, text, from, direction, createdUnixMs, hasFile` — never the file bytes) as JSON in `UserDefaults`. Rationale: gram is delete-for-good + server-rotated with no single-message re-fetch, so an id-only bookmark would orphan; local copies keep a saved message readable after the original is deleted.

## 2. Saved prompts (terminal reply bar)
- When the reply box is **empty**, the (dead) send arrow becomes a **saved-prompts button**.
- Tapping it opens a menu of saved prompts **by nickname** → tap one to **insert it and send it** (reuses `sendTapped()` → the normal mode-aware `agent.prompt` path, delivery-confirmed) → plus **"Save new prompt…"** (a small styled sheet) and a delete submenu.
- `SavedPromptsStore` mirrors `SavedHostsStore` minus the Keychain.

## Notes
- New stores follow the existing `MuteStore` / `SavedHostsStore` patterns; new `App/*.swift` are auto-included by the `App/` source glob (`project.yml`).
- No new send logic (reuses `sendTapped`); no prefill/`pendingPrefill` involvement.

## Verify on device
- **Gram:** tap the bookmark on a message → it fills; open the **Saved** section (header bookmark) → it's there; delete the original → the saved copy remains; un-save → it leaves Saved.
- **Reply bar:** open an agent terminal, empty the input → the send button becomes the saved-prompts icon; tap → the list shows prompts by nickname + "Save new prompt…"; tap a prompt → inserted and **sent**; save a new prompt → it appears; type something → the arrow send returns.