### PR TITLE
fix: open a saved Gram message's attachment on demand

### DIFF
--- a/App/GramView.swift
+++ b/App/GramView.swift
@@ -376,7 +376,12 @@ struct GramView: View {
             ScrollView {
                 LazyVStack(spacing: 10) {
                     ForEach(savedGrams.saved) { s in
-                        SavedGramRow(saved: s, onUnsave: { savedGrams.remove(s.id) })
+                        SavedGramRow(
+                            saved: s,
+                            isDownloadingFile: downloadingFileFor == s.id,
+                            onOpenFile: { openFile(id: s.id) },
+                            onUnsave: { savedGrams.remove(s.id) }
+                        )
                     }
                 }
                 .padding(16)
@@ -435,7 +440,7 @@ struct GramView: View {
                             message: message,
                             isDownloadingFile: downloadingFileFor == message.id,
                             isSaved: savedGrams.isSaved(message.id),
-                            onOpenFile: { openFile(message) },
+                            onOpenFile: { openFile(id: message.id) },
                             onToggleSave: { savedGrams.toggle(message) },
                             onDelete: { delete(message) }
                         )
@@ -1042,13 +1047,13 @@ struct GramView: View {
 
     /// Download a message's file to a temp URL and present it in QuickLook (which
     /// offers the system share action to save it).
-    private func openFile(_ message: GramMessage) {
+    private func openFile(id: String) {
         guard downloadingFileFor == nil else { return }
-        downloadingFileFor = message.id
+        downloadingFileFor = id
         openFileTask = Task {
             defer { downloadingFileFor = nil }
             do {
-                let (name, mime, data) = try await client.gramGetFile(id: message.id)
+                let (name, mime, data) = try await client.gramGetFile(id: id)
                 // The page went away mid-download (task cancelled in .onDisappear): stop
                 // before writing any temp file, so a late completion can't strand one.
                 if Task.isCancelled { return }

--- a/App/SavedGramStore.swift
+++ b/App/SavedGramStore.swift
@@ -8,6 +8,23 @@ import HerdrKit
 /// re-fetch (only whole-list `gramList` + on-demand `gramGetFile`), so an id-only bookmark
 /// would orphan the moment the original is deleted. The file BYTES are never copied (they can
 /// be up to 100 MiB and are fetched on demand); we only note whether the original had a file.
+/// The metadata of a saved message's attachment — enough to show a chip and re-fetch the bytes
+/// on demand via `gramGetFile(id:)`. A local Codable mirror of HerdrKit's `GramFile` (which is
+/// Decodable-only). The bytes are NOT stored (they can be up to 100 MiB); they're fetched when
+/// the chip is tapped, which works while the original message still exists on the server.
+struct SavedGramFile: Codable, Hashable {
+    let name: String
+    let size: UInt64
+    let mime: String
+
+    var displaySize: String {
+        let b = Double(size)
+        if b < 1024 { return "\(size) B" }
+        if b < 1024 * 1024 { return String(format: "%.0f KB", b / 1024) }
+        return String(format: "%.1f MB", b / (1024 * 1024))
+    }
+}
+
 struct SavedGram: Codable, Identifiable, Hashable {
     let id: String
     var text: String
@@ -15,7 +32,9 @@ struct SavedGram: Codable, Identifiable, Hashable {
     /// direction == .agentToOwner — so the saved copy can render the same avatar/side.
     var fromAgent: Bool
     var createdUnixMs: UInt64
-    var hasFile: Bool
+    /// The attachment's metadata, if any (bytes fetched on demand). Optional so a pre-existing
+    /// saved entry (which stored only a `hasFile` flag) still decodes cleanly, to `nil`.
+    var file: SavedGramFile?
 
     var createdAt: Date { Date(timeIntervalSince1970: Double(createdUnixMs) / 1000) }
 }
@@ -57,7 +76,7 @@ final class SavedGramStore: ObservableObject {
                 from: message.from,
                 fromAgent: message.isFromAgent,
                 createdUnixMs: message.createdUnixMs,
-                hasFile: message.file != nil
+                file: message.file.map { SavedGramFile(name: $0.name, size: $0.size, mime: $0.mime) }
             )
             saved.append(copy)
             saved.sort { $0.createdUnixMs > $1.createdUnixMs }
@@ -84,6 +103,8 @@ final class SavedGramStore: ObservableObject {
 /// saved attachment shows only a note (its original may already be gone from the server).
 struct SavedGramRow: View {
     let saved: SavedGram
+    var isDownloadingFile: Bool
+    var onOpenFile: () -> Void
     var onUnsave: () -> Void
 
     var body: some View {
@@ -112,16 +133,42 @@ struct SavedGramRow: View {
                     .textSelection(.enabled)
                     .fixedSize(horizontal: false, vertical: true)
             }
-            if saved.hasFile {
-                Label("had an attachment", systemImage: "paperclip")
-                    .font(Typography.machine(11))
-                    .foregroundStyle(Palette.textFaint)
+            if let file = saved.file {
+                fileChip(file)
             }
         }
         .padding(12)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(RoundedRectangle(cornerRadius: 12).fill(Palette.card))
         .overlay(RoundedRectangle(cornerRadius: 12).stroke(Palette.hairlineQuiet, lineWidth: 1))
+    }
+
+    /// A tappable chip that fetches the attachment from the server on demand (`gramGetFile`) and
+    /// previews it — works while the original message still exists (it fails gracefully if the
+    /// owner has since deleted it, since the bytes were never copied locally).
+    private func fileChip(_ file: SavedGramFile) -> some View {
+        Button(action: onOpenFile) {
+            HStack(spacing: 8) {
+                if isDownloadingFile {
+                    ProgressView().controlSize(.mini).tint(Palette.textDim)
+                } else {
+                    Image(systemName: "paperclip").font(.system(size: 13, weight: .semibold))
+                        .foregroundStyle(Palette.textDim)
+                }
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(file.name).font(Typography.app(12, .medium)).foregroundStyle(Palette.text).lineLimit(1)
+                    Text(file.displaySize).font(Typography.machine(10)).foregroundStyle(Palette.textFaint)
+                }
+                Spacer(minLength: 0)
+                Image(systemName: "arrow.down.circle").font(.system(size: 13)).foregroundStyle(Palette.textFaint)
+            }
+            .padding(.horizontal, 10).padding(.vertical, 8)
+            .background(RoundedRectangle(cornerRadius: 9).fill(Palette.surfaceRaised))
+            .overlay(RoundedRectangle(cornerRadius: 9).stroke(Palette.hairline, lineWidth: 1))
+        }
+        .buttonStyle(.plain)
+        .disabled(isDownloadingFile)
+        .padding(.top, 2)
     }
 
     /// Compact relative age ("now" / "5m" / "3h" / "2d"), matching the inbox row's terse style.


### PR DESCRIPTION
Follow-up to #118. A saved Gram message with an attachment showed only a "had an attachment" note — you couldn't view the file.

## Fix
- Store the attachment's **metadata** (`name/size/mime`, a local Codable mirror of `GramFile` which is Decodable-only) in the saved copy, instead of a bare `hasFile` flag.
- Render it as a **tappable chip** in the Saved section that fetches the bytes **on demand** via `gramGetFile(id:)` and previews them (QuickLook / the in-app web viewer) — reusing the inbox's exact path (`openFile` refactored to take an `id`).
- Bytes are still **not** copied locally (gram files can be up to 100 MiB), so opening works while the original message still exists and fails gracefully once it's deleted.
- Backward-compatible: `file` is optional, so saved entries from build 59 (which stored only `hasFile`) decode to `nil` — re-save to attach the chip.

App-only; no daemon/HerdrKit/protocol change.

## Verify
Save a Gram message that has an attachment → open the **Saved** section → tap the file chip → the attachment downloads and previews, same as in the inbox.