### PR TITLE
feat: make links in Gram messages tappable

### DIFF
--- a/App/GramView.swift
+++ b/App/GramView.swift
@@ -1241,9 +1241,10 @@ private struct GramRow: View {
                     .buttonStyle(.plain)
                 }
                 if !message.text.isEmpty {
-                    Text(message.text)
+                    Text(linkified(message.text))
                         .font(Typography.app(14))
                         .foregroundStyle(Palette.textDim)
+                        .tint(Palette.brand)
                         .fixedSize(horizontal: false, vertical: true)
                 }
                 if let file = message.file {

--- a/App/LinkText.swift
+++ b/App/LinkText.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+/// Detects URLs in a plain string and returns an `AttributedString` with them as tappable link
+/// runs, styled with a tint + underline. SwiftUI's `Text` does NOT auto-link a plain `String`, so
+/// Gram message bodies run through this to make links clickable (a tap opens the URL via the
+/// `openURL` environment). Bare URLs, `https://…`, and `www.…` are all detected by NSDataDetector.
+func linkified(_ text: String, tint: Color = Palette.brand) -> AttributedString {
+    let ns = NSMutableAttributedString(string: text)
+    if let detector = try? NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue) {
+        let full = NSRange(location: 0, length: (text as NSString).length)
+        detector.enumerateMatches(in: text, range: full) { match, _, _ in
+            guard let match, let url = match.url else { return }
+            ns.addAttribute(.link, value: url, range: match.range)
+        }
+    }
+    var attributed = AttributedString(ns)
+    // Tint the detected link runs so they read as links; the `.link` attribute makes the tap open
+    // the URL regardless. Non-URL text keeps whatever the surrounding Text sets.
+    for run in attributed.runs where run.link != nil {
+        attributed[run.range].foregroundColor = tint
+    }
+    return attributed
+}

--- a/App/SavedGramStore.swift
+++ b/App/SavedGramStore.swift
@@ -127,9 +127,10 @@ struct SavedGramRow: View {
                 .buttonStyle(.plain)
             }
             if !saved.text.isEmpty {
-                Text(saved.text)
+                Text(linkified(saved.text))
                     .font(Typography.app(14))
                     .foregroundStyle(Palette.textDim)
+                    .tint(Palette.brand)
                     .textSelection(.enabled)
                     .fixedSize(horizontal: false, vertical: true)
             }


### PR DESCRIPTION
Gram message bodies were a plain `Text(String)`, which SwiftUI does not auto-link.

## Change
- New `App/LinkText.swift`: `linkified(_:tint:)` — `NSDataDetector(.link)` over the text → an `AttributedString` with `.link` runs, tinted brand. Detects `https://…`, bare `example.com`, and `www.…`.
- Applied at the two Gram message-text sites: `GramRow` (inbox) and `SavedGramRow` (Saved). Tapping a URL opens it (via `openURL`); the `.tint` + link color mark it.
- Long-press still shows Copy/Save/Delete (the row's only gesture is the context menu); plain text is unaffected.

App-only; no daemon/HerdrKit/protocol change.

## Verify
A Gram or Saved message containing a URL shows it tinted; tapping opens the browser; long-press still gives the menu; non-URL text is unchanged.