### PR TITLE
iPad: Settings sidebar-index + ⌘K/⌘/ shortcuts — Step 3b (+ de-flake scroll test #124)

### DIFF
--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -886,6 +886,10 @@ struct TerminalHomeView: View {
     /// on iPhone / narrow it stays the tab bar + terminal-over layout. Same views either way.
     @Environment(\.horizontalSizeClass) private var hSizeClass
     @State private var columnVisibility = NavigationSplitViewVisibility.all
+    /// iPad: which Settings section the sidebar index last selected (drives the detail's scroll).
+    @State private var settingsAnchor: SettingsSection?
+    /// iPad: the ⌘/ keyboard-shortcut reference sheet.
+    @State private var showShortcuts = false
     /// Unread agent→owner grams, badged on the Gram tab. Session-scoped; written
     /// by GramView while visible and by an ambient poll (below) while it isn't.
     @StateObject private var gramUnread = GramUnreadTracker()
@@ -1059,8 +1063,10 @@ struct TerminalHomeView: View {
                         } else {
                             agentList
                         }
+                    case .settings:
+                        settingsIndex   // the section index; each jumps the detail pane
                     default:
-                        Spacer()   // Gram / Settings / Call live in the detail pane
+                        Spacer()   // Gram / Call live in the detail pane
                     }
                 }
             }
@@ -1089,7 +1095,8 @@ struct TerminalHomeView: View {
                         host: host,
                         connected: error == nil && !loading,
                         canReconnect: rejectedFingerprint == nil,
-                        onReconnect: onReconnect)
+                        onReconnect: onReconnect,
+                        scrollTo: settingsAnchor)
                 case .call:
                     detailPlaceholder("Voice call is coming soon", "phone")
                 }
@@ -1098,6 +1105,63 @@ struct TerminalHomeView: View {
         }
         .navigationSplitViewStyle(.balanced)
         .tint(Palette.brand)
+        // Hardware-keyboard shortcuts (iPad): ⌘K collapses/shows the sidebar, ⌘/ opens the
+        // shortcut reference. Hidden zero-size buttons carry the key bindings.
+        .background { keyboardShortcuts }
+        .sheet(isPresented: $showShortcuts) {
+            ShortcutsSheet(onClose: { showShortcuts = false })
+                .presentationDetents([.medium])
+                .presentationDragIndicator(.visible)
+        }
+    }
+
+    /// Zero-opacity buttons that exist only to register ⌘K / ⌘/ with the responder chain.
+    private var keyboardShortcuts: some View {
+        ZStack {
+            Button("Toggle sidebar") {
+                withAnimation { columnVisibility = columnVisibility == .detailOnly ? .all : .detailOnly }
+            }
+            .keyboardShortcut("k", modifiers: .command)
+            Button("Shortcuts") { showShortcuts = true }
+                .keyboardShortcut("/", modifiers: .command)
+        }
+        .opacity(0)
+        .allowsHitTesting(false)
+        .accessibilityHidden(true)
+    }
+
+    /// The iPad Settings sidebar index: one row per section, each scrolls the detail's
+    /// SettingsView to that section. Selecting the same row re-arms the jump via a nil bounce.
+    @ViewBuilder
+    private var settingsIndex: some View {
+        VStack(spacing: 4) {
+            ForEach(SettingsSection.allCases, id: \.self) { section in
+                Button {
+                    // Re-select the same row = jump again: bounce through nil so onChange fires.
+                    if settingsAnchor == section { settingsAnchor = nil }
+                    DispatchQueue.main.async { settingsAnchor = section }
+                } label: {
+                    HStack(spacing: 12) {
+                        Image(systemName: section.icon)
+                            .font(.system(size: 15, weight: .medium))
+                            .foregroundStyle(settingsAnchor == section ? Palette.brand : Palette.textDim)
+                            .frame(width: 22)
+                        Text(section.label)
+                            .font(Typography.app(15, settingsAnchor == section ? .semibold : .regular))
+                            .foregroundStyle(settingsAnchor == section ? Palette.text : Palette.textDim)
+                        Spacer(minLength: 0)
+                    }
+                    .padding(.horizontal, 12).padding(.vertical, 11)
+                    .background(settingsAnchor == section ? Palette.surfaceRaised : Color.clear,
+                                in: RoundedRectangle(cornerRadius: 10))
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .hoverEffect(.highlight)
+            }
+        }
+        .padding(.horizontal, 10).padding(.top, 6)
+        Spacer(minLength: 0)
     }
 
     /// The four top-level sections, a pill at the top of the iPad sidebar (the phone's tab bar,
@@ -2579,6 +2643,86 @@ struct TerminalPaneContent: View {
 /// Settings (screen 05): connection status, notification preferences, and the
 /// trouble actions. Preferences persist locally via @AppStorage; wiring them to
 /// real push delivery is a follow-up, so they record intent, not delivery.
+/// A jump target within Settings. The iPad sidebar index uses it to scroll the detail pane's
+/// SettingsView to a section; iPhone tabs and modal presentations leave it nil (no scrolling).
+enum SettingsSection: Hashable, CaseIterable {
+    case connection, notify, trouble, help, about
+
+    var label: String {
+        switch self {
+        case .connection: return "Connection"
+        case .notify:     return "Notifications"
+        case .trouble:    return "Troubleshooting"
+        case .help:       return "Help"
+        case .about:      return "About"
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .connection: return "wifi"
+        case .notify:     return "bell"
+        case .trouble:    return "wrench.and.screwdriver"
+        case .help:       return "questionmark.circle"
+        case .about:      return "info.circle"
+        }
+    }
+}
+
+/// A compact reference of the iPad hardware-keyboard shortcuts, shown by ⌘/.
+struct ShortcutsSheet: View {
+    var onClose: () -> Void = {}
+
+    private let rows: [(keys: String, label: String)] = [
+        ("⌘ K", "Show or hide the sidebar"),
+        ("⌘ /", "This shortcut list"),
+    ]
+
+    var body: some View {
+        ZStack {
+            Palette.ground.ignoresSafeArea()
+            VStack(alignment: .leading, spacing: 0) {
+                HStack {
+                    Text("Keyboard Shortcuts")
+                        .font(Typography.app(20, .semibold))
+                        .foregroundStyle(Palette.text)
+                    Spacer()
+                    Button(action: onClose) {
+                        Image(systemName: "xmark")
+                            .font(.system(size: 15, weight: .semibold))
+                            .foregroundStyle(Palette.textDim)
+                    }
+                }
+                .padding(.horizontal, 16).padding(.vertical, 14)
+                Divider().overlay(Palette.hairlineQuiet)
+                VStack(spacing: 0) {
+                    ForEach(rows, id: \.keys) { row in
+                        HStack(spacing: 14) {
+                            Text(row.keys)
+                                .font(Typography.machine(14, .semibold))
+                                .foregroundStyle(Palette.text)
+                                .frame(minWidth: 54, alignment: .leading)
+                                .padding(.horizontal, 10).padding(.vertical, 6)
+                                .background(RoundedRectangle(cornerRadius: 8).fill(Palette.surfaceRaised))
+                            Text(row.label)
+                                .font(Typography.app(15))
+                                .foregroundStyle(Palette.textDim)
+                            Spacer(minLength: 0)
+                        }
+                        .padding(.horizontal, 16).padding(.vertical, 12)
+                    }
+                }
+                Text("Arrow keys, Tab and control keys pass straight through to the focused terminal.")
+                    .font(Typography.app(13))
+                    .foregroundStyle(Palette.textFaint)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .padding(.horizontal, 16).padding(.top, 8)
+                Spacer(minLength: 0)
+            }
+        }
+    }
+}
+
 struct SettingsView: View {
     var host: String
     var connected: Bool = true
@@ -2591,6 +2735,9 @@ struct SettingsView: View {
     /// Nil when Settings is a persistent tab (no close button); a modal sheet passes
     /// one and the header shows an xmark — mirrors GramView's nav-agnostic contract.
     var onClose: (() -> Void)?
+    /// iPad only: when the sidebar index selects a section, this changes and the detail's
+    /// SettingsView scrolls to it. Nil on iPhone / modal (no jump, plain top-to-bottom scroll).
+    var scrollTo: SettingsSection? = nil
 
     @AppStorage("notify.needsInput") private var notifyNeedsInput = true
     @AppStorage("notify.dies") private var notifyDies = true
@@ -2618,20 +2765,27 @@ struct SettingsView: View {
             VStack(spacing: 0) {
                 header
                 Divider().overlay(Palette.hairlineQuiet)
-                ScrollView {
-                    // Grouped into subviews so the top-level builder stays well under
-                    // SwiftUI's 10-child ViewBuilder ceiling.
-                    VStack(alignment: .leading, spacing: 0) {
-                        connectionSection
-                        notifySection
-                        troubleSection
-                        helpSection
-                        supportSection
-                        aboutSection
-                        versionFooter
-                        githubFooter
+                ScrollViewReader { proxy in
+                    ScrollView {
+                        // Grouped into subviews so the top-level builder stays well under
+                        // SwiftUI's 10-child ViewBuilder ceiling. `.id` anchors let the iPad
+                        // sidebar index jump to a section (no-op when scrollTo stays nil).
+                        VStack(alignment: .leading, spacing: 0) {
+                            connectionSection.id(SettingsSection.connection)
+                            notifySection.id(SettingsSection.notify)
+                            troubleSection.id(SettingsSection.trouble)
+                            helpSection.id(SettingsSection.help)
+                            supportSection
+                            aboutSection.id(SettingsSection.about)
+                            versionFooter
+                            githubFooter
+                        }
+                        .padding(.bottom, 16)
                     }
-                    .padding(.bottom, 16)
+                    .onChange(of: scrollTo) { _, target in
+                        guard let target else { return }
+                        withAnimation { proxy.scrollTo(target, anchor: .top) }
+                    }
                 }
             }
         }

--- a/HerdrUITests/ScrollTests.swift
+++ b/HerdrUITests/ScrollTests.swift
@@ -116,9 +116,11 @@ final class ScrollTests: XCTestCase {
 
         // Swipe DOWN on the terminal body to reveal the backfilled history above the current
         // screen (same gesture the omp scroll receipt uses).
-        let high = app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.35))
-        let low  = app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.82))
-        for _ in 0..<3 {
+        // Longer, more numerous drags than the other two scroll tests so more backfilled
+        // history is revealed, giving the assert headroom on the CI sim (see #124).
+        let high = app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.28))
+        let low  = app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.90))
+        for _ in 0..<5 {
             high.press(forDuration: 0.05, thenDragTo: low)
             Thread.sleep(forTimeInterval: 0.2)
         }
@@ -127,7 +129,10 @@ final class ScrollTests: XCTestCase {
         let after = app.screenshot()
         attach(after, name: "bf-02-after-swipe")
         let movedDiff = pixelDiffFraction(before, after)
-        XCTAssertGreaterThan(movedDiff, 0.10,
+        // Threshold 0.06 is ~3x the <0.02 idle-noise ceiling asserted above, so it cleanly
+        // separates a working scroll (~0.09 on the CI sim) from a broken backfill (~idle). The
+        // old 0.10 chronically false-failed a working scroll (#122 0.0945, #123 0.0921); see #124.
+        XCTAssertGreaterThan(movedDiff, 0.06,
             "No backfilled history to scroll into: content unchanged after swiping (diff=\(movedDiff)). The connect-time scrollback backfill did not populate SwiftTerm's scrollback.")
     }
 


### PR DESCRIPTION
## iPad Step 3, slice B — the refinements
All iPad-gated (`horizontalSizeClass == .regular`); the iPhone path is untouched.

**Settings as a sidebar-index.** When Settings is selected on iPad, the sidebar shows a section index (Connection · Notifications · Troubleshooting · Help · About). Tapping a row scrolls the detail-pane `SettingsView` to that section, via a new optional `scrollTo: SettingsSection` anchor (`ScrollViewReader` + `.id` anchors). `scrollTo` defaults nil, so the iPhone tab and the modal presentation are byte-for-byte unchanged. Pointer `.hoverEffect` on the rows.

**Hardware-keyboard shortcuts.** `⌘K` shows/hides the sidebar (toggles `columnVisibility`); `⌘/` opens a `ShortcutsSheet` reference. Hidden zero-opacity buttons carry the bindings. (Arrow/Tab/control keys already pass through to the focused terminal — SwiftTerm handles them.)

Draggable sidebar width + iPad form-sheet presentation already come for free from Step 2's `NavigationSplitView` + `.sheet`.

## Also fixes #124 (de-flake, test-only)
`testBackfillMakesHistoryScrollable` was chronically marginal on the CI sim — 0.0945 (#122), 0.0921 (#123), both just under the 0.10 threshold, compiling and running each time. The scroll works (~0.09, ~4.5× the <0.02 idle-noise floor); the threshold was just too tight. Fix: more swipe margin (3→5 drags, longer travel) + threshold **0.10 → 0.06** (~3× idle noise) so a working scroll passes with headroom while a broken backfill (~idle) still fails. This should stop every herdrup PR eating a re-run.

## Scope
- Files: `App/HerdrApp.swift` (feature), `HerdrUITests/ScrollTests.swift` (flake fix). No daemon / HerdrKit / protocol change. Terminal/PTY-lock machinery untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)