### PR TITLE
fix(terminal): repaint on server-driven resize — stop overdraw

### DIFF
--- a/App/LiveTerminalView.swift
+++ b/App/LiveTerminalView.swift
@@ -439,6 +439,12 @@ struct LiveTerminalView: UIViewRepresentable {
                 relockPending = true            // hold off ALL sendPTYSize until the release lands
                 let pending = Self.geometryReleaseTask[paneID]
                 Task { @MainActor [weak self] in
+                    // Re-fronting a keep-mounted pane whose geometry changed while hidden can leave
+                    // stale/overlapping cells visible until the resize round-trip lands — repaint now
+                    // (main-actor Task, so the @MainActor forceFullRepaint is called safely).
+                    if let self, let view = self.view, self.foreground, !self.stopped {
+                        self.forceFullRepaint(view)
+                    }
                     await pending?.value        // let any committed lock:false land FIRST
                     guard let self, self.foreground, !self.stopped,
                           self.myGeometryGeneration == gen else { return }   // a newer hide/show superseded us
@@ -645,6 +651,23 @@ struct LiveTerminalView: UIViewRepresentable {
         @MainActor
         private func resizeEmulator(cols: Int, rows: Int, in view: ReadOnlyTerminalView) {
             view.getTerminal().resize(cols: max(4, cols), rows: max(2, rows))
+            // A server-driven resize reflows the emulator grid but — unlike a `.data` feed —
+            // never triggers the view to repaint, so the next feed can paint new cells OVER stale
+            // ones (the "overdraw" bug that previously only a manual refresh cleared). Force a
+            // display-only full repaint at the new geometry. Purely display-side (see helper).
+            forceFullRepaint(view)
+        }
+
+        /// Repaint the entire visible grid from the current buffer, without changing content or
+        /// clearing. `updateFullScreen()` marks every row dirty (no content change); `setNeedsDisplay()`
+        /// drives the iOS view's `draw(_:)` over the full bounds, which renders cells from the buffer
+        /// via CoreText. Both are public SwiftTerm / UIKit APIs. DISPLAY-ONLY — never calls
+        /// `set_pty_size` and never touches `desiredCols`/`lastSentCols`/`relockPending`, so the PTY
+        /// width-lock is untouched.
+        @MainActor
+        private func forceFullRepaint(_ view: ReadOnlyTerminalView) {
+            view.getTerminal().updateFullScreen()
+            view.setNeedsDisplay()
         }
 
         /// The view laid out (first appearance, rotation, keyboard) and computed a


### PR DESCRIPTION
## Problem
Sometimes the terminal draws **new content on top of old** (overlapping, unreadable) until a manual refresh. Root cause: a **server-driven** PTY resize flows through `Coordinator.resizeEmulator` (`App/LiveTerminalView.swift`), which calls `getTerminal().resize(...)` but **never repaints the view**. When the server changes geometry without the phone's pixels changing (a co-viewing desktop reasserts its width; the agent runs `resize`/`stty`; a keep-mounted pane re-fronts), the emulator reflows while the view keeps the old rows — the next `.data` feed then paints over stale cells. Manual refresh only worked because it rebuilds the whole view (`.id(streamGen)`).

## Fix (display-only, no clear)
Force a full repaint at the one resize choke point: `getTerminal().updateFullScreen()` (public: mark all rows dirty) + `view.setNeedsDisplay()` (UIKit public: the iOS view renders in `override public func draw(_:)`, so this repaints the whole grid from the buffer). Called at the end of `resizeEmulator` (covers `.started`/`.reset`/`.resize`; the only repaint for a bare `.resize`) and on keep-mounted re-front. Not a clear — repaints existing content, never blanks. Both APIs verified public against SwiftTerm 1.15.0.

## Scope / safety
- App-only, single file (+23). No daemon/HerdrKit/protocol change.
- PTY width-lock untouched (stays inside `resizeEmulator`, which is `set_pty_size`-free; never touches desiredCols/lastSentCols/relockPending/setPTYSize).
- iPhone / read-only path unchanged (pure display refresh).

Verification: buildbox compiles + scroll/ccscroll/paging receipts stay green; on-sim receipt = a bare server-driven resize shows no overdraw without manual refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)