### PR TITLE
fix(reply): hardware Return in the reply box submits (stays focused)

### DIFF
--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -2379,6 +2379,14 @@ struct TerminalPaneContent: View {
                 .onChange(of: reply) { oldValue, newValue in
                     handleReplyChange(old: oldValue, new: newValue)
                 }
+                .submitLabel(.send)
+                // Hardware Return submits, exactly like tapping the send arrow. Guarded by
+                // `canSend` (mirrors the arrow's `.disabled(!canSend)`) so an empty/whitespace box
+                // is a true no-op and a fast second Return can't double-fire mid-send. Re-assert
+                // focus so the box stays ready for the next line — SwiftUI otherwise drops first
+                // responder on submit, which would hand key focus back to the terminal
+                // (wantsTerminalKeyFocus = isForeground && !replyFocused).
+                .onSubmit { if canSend { sendTapped() }; replyFocused = true }
             // Dictate into the reply (on-device). isActive: isForeground stops the mic
             // if this pane stops being the front one (no hot mic behind a hidden pane);
             // onStart disarms any pending ctrl chord and `replyDictating` suppresses the


### PR DESCRIPTION
## What
When typing in the reply box with a hardware keyboard, pressing **Return now sends** (it previously just ended editing — a single-line SwiftUI `TextField` with no submit handler). Follow-up to the iPad hardware-keyboard feature (build 67).

## How
On the reply `TextField`:
```swift
.submitLabel(.send)
.onSubmit { if canSend { sendTapped() }; replyFocused = true }
```
- `sendTapped()` is the exact same path as tapping the send arrow (`send(.submitText(reply))` → InputRouter → agent.prompt / pane.send_text).
- Guarded by **`canSend`** (`!reply.trimmed.isEmpty && !sending && !replyDictating`, mirroring the arrow's `.disabled(!canSend)`), so an empty/whitespace box is a true no-op (no refusal flash) and a fast second Return can't double-fire mid-send.
- **`replyFocused = true`** keeps focus in the box for the next line (owner's choice — chat-style). SwiftUI otherwise drops first responder on submit, which would hand key focus back to the terminal via `wantsTerminalKeyFocus = isForeground && !replyFocused`.
- No interaction with sticky-Ctrl (Return is a submit, not a char append) or the saved-prompts menu (only shown when empty, where `canSend` is false).

## Scope
App-only, single file (`App/HerdrApp.swift`). No daemon/HerdrKit/protocol change. iPhone unchanged.

Note: the separate typing-**lag** on direct terminal input is architectural (per-keystroke remote process spawn) and is tracked as jerryfane/herdr#62 for a later daemon-side persistent input channel — deliberately out of scope here.

Verification: buildbox compiles + existing receipts green; on-device — reply box + hardware keyboard: type + Return sends, box clears and stays focused, empty Return does nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)