### PR TITLE
feat(terminal): persistent pane.input.stream input channel (iPad typing latency, #62)

### DIFF
--- a/App/LiveTerminalView.swift
+++ b/App/LiveTerminalView.swift
@@ -415,6 +415,10 @@ struct LiveTerminalView: UIViewRepresentable {
             scrollSendTask = nil
             inputSendTask?.cancel()         // no forwarded keystroke can reach an exited/replaced pane
             inputSendTask = nil
+            if let channel = inputChannel { // tear down the persistent input channel (issue #62)
+                inputChannel = nil
+                Task { await channel.close() }
+            }
             for token in keyboardObservers { NotificationCenter.default.removeObserver(token) }
             keyboardObservers.removeAll()
             streamTask?.cancel()
@@ -853,6 +857,12 @@ struct LiveTerminalView: UIViewRepresentable {
         /// delegate callback); the drain hops to the main actor for the async `sendText`.
         private var pendingInput = ""
         private var inputSendTask: Task<Void, Never>?
+        /// Persistent input channel (issue #62): opened lazily on first key-drive
+        /// input, after which keystrokes ride one held SSH channel instead of a
+        /// fresh `send_text` exec per batch. nil = not yet tried, or the daemon
+        /// lacks the method / the channel died = `send_text` fallback.
+        private var inputChannel: PaneInputChannel?
+        private var inputChannelTried = false
         private func enqueueInput(_ s: String) {
             guard !s.isEmpty else { return }
             pendingInput += s
@@ -861,10 +871,43 @@ struct LiveTerminalView: UIViewRepresentable {
                 while let self, !self.stopped, !self.pendingInput.isEmpty {
                     let batch = self.pendingInput
                     self.pendingInput = ""
-                    _ = try? await self.client.sendText(pane: self.paneID, text: batch)
+                    await self.deliverInput(batch)
                 }
                 self?.inputSendTask = nil
             }
+        }
+
+        /// Delivers one input batch, preferring the persistent `pane.input.stream`
+        /// channel and falling back to per-call `sendText`. Order is preserved: the
+        /// single `inputSendTask` drain calls this serially, and the channel writes
+        /// frames through one ordered writer.
+        @MainActor
+        private func deliverInput(_ batch: String) async {
+            // Open the channel lazily on first use. An older daemon without
+            // pane.input.stream makes start() throw, and we stay on send_text.
+            if !inputChannelTried {
+                inputChannelTried = true
+                if let channel = await client.openPaneInput(pane: paneID) {
+                    do {
+                        try await channel.start()
+                        inputChannel = channel
+                    } catch {
+                        await channel.close()
+                        inputChannel = nil
+                    }
+                }
+            }
+            if let channel = inputChannel, await channel.send(batch) {
+                return
+            }
+            // Channel unavailable or died mid-session: drop it and fall back. A
+            // dropped channel is NOT re-opened here (no replay) — a fresh
+            // Coordinator on reconnect retries the open.
+            if let channel = inputChannel {
+                await channel.close()
+                inputChannel = nil
+            }
+            _ = try? await self.client.sendText(pane: self.paneID, text: batch)
         }
         func scrolled(source: TerminalView, position: Double) {}
         func setTerminalTitle(source: TerminalView, title: String) {}

--- a/Sources/HerdrKit/CitadelTransport.swift
+++ b/Sources/HerdrKit/CitadelTransport.swift
@@ -281,6 +281,21 @@ public actor CitadelTransport: HerdrTransport {
         }
     }
 
+    /// Opens a persistent input channel to one pane (issue #62): a dedicated SSH
+    /// exec channel running `herdr api-bridge --duplex`, over which
+    /// `PaneInputChannel` writes newline-delimited input frames to the daemon's
+    /// `pane.input.stream`. Uses its OWN connection (like `stream`) so input
+    /// backpressure never blocks the shared command socket or the pane.stream
+    /// firehose. `openLine` is the JSON `pane.input.stream` open request the
+    /// daemon's `--duplex` bridge reads first from stdin.
+    public nonisolated func openInputChannel(_ openLine: String) -> PaneInputChannel {
+        PaneInputChannel(
+            makeConnection: { try await self.makeConnection() },
+            command: Self.herdrPathResolution + "--duplex",
+            openLine: openLine
+        )
+    }
+
     /// Closes the held SSH connection. Idempotent.
     public func close() async {
         // Invalidate any in-flight connect so a handshake that resolves after this

--- a/Sources/HerdrKit/HerdrClient.swift
+++ b/Sources/HerdrKit/HerdrClient.swift
@@ -169,6 +169,23 @@ public actor HerdrClient {
         _ = try await call("pane.send_text", SendTextParams(paneID: pane, text: text), as: JSONNull.self)
     }
 
+    /// Opens a persistent `pane.input.stream` write channel for one pane (issue
+    /// #62), the write-side mirror of `streamTerminal`. Returns nil when the
+    /// transport cannot provide one (e.g. the in-memory test transport) — the
+    /// caller then uses per-call `sendText`. Feature detection is by ATTEMPT:
+    /// `PaneInputChannel.start()` throws against a daemon lacking the method (or an
+    /// older server), so the caller falls back on the throw.
+    public func openPaneInput(pane: String) -> PaneInputChannel? {
+        guard let citadel = transport as? CitadelTransport else { return nil }
+        let env = RequestEnvelope(
+            id: "herdrkit:pane.input.stream:\(pane)",
+            method: "pane.input.stream",
+            params: PaneInputStreamParams(paneID: pane)
+        )
+        guard let data = try? encoder.encode(env) else { return nil }
+        return citadel.openInputChannel(String(decoding: data, as: UTF8.self))
+    }
+
     struct RegisterDeviceParams: Encodable {
         let deviceToken: String
         let platform: String

--- a/Sources/HerdrKit/PaneInputChannel.swift
+++ b/Sources/HerdrKit/PaneInputChannel.swift
@@ -1,0 +1,202 @@
+import Foundation
+import Citadel
+import NIOCore
+
+/// A persistent, ordered input channel to ONE pane (herdr issue #62) — the
+/// write-side mirror of the `pane.stream` read firehose. Holds one SSH exec
+/// channel running `herdr api-bridge --duplex` open for the pane's lifetime and
+/// writes newline-delimited input frames to its stdin, instead of a fresh
+/// `herdr api-bridge` exec per keystroke (the remote fork/exec that dominates
+/// felt typing latency on the iPad hardware-keyboard path).
+///
+/// Built on Citadel's `withExec` (macOS 15+/iOS 17+), which — unlike
+/// `executeCommandStream`, whose output-only stream the command transport uses —
+/// exposes a WRITABLE stdin (`TTYStdinWriter`) over a no-PTY, 8-bit-safe RFC-4254
+/// exec channel. `withExec` is a SCOPED closure (the channel closes when it
+/// returns), so the channel runs inside a long-lived Task fed by an
+/// `AsyncStream<ByteBuffer>`; finishing that stream returns from the closure and
+/// closes the channel (the remote bridge then sees stdin EOF and exits).
+///
+/// Ordering is preserved by construction: a single writer drains one ordered
+/// stream to stdin. AT-MOST-ONCE, NO replay — on a drop the channel dies and the
+/// caller falls back to per-call `pane.send_text`; a lost keystroke is visible
+/// via the echo on `pane.stream` and retypable, whereas a duplicated Enter or
+/// Escape would be dangerous.
+public actor PaneInputChannel {
+    public enum ChannelError: Error, Equatable {
+        case unsupported
+        case closedBeforeAck
+        case remoteError(String)
+    }
+
+    private struct Frame: Encodable {
+        let seq: UInt64
+        let text: String
+    }
+
+    private struct WireErrorProbe: Decodable {
+        struct Body: Decodable {
+            let code: String?
+            let message: String?
+        }
+        let error: Body?
+    }
+
+    private let makeConnection: @Sendable () async throws -> SSHClient
+    private let command: String
+    private let openLine: String
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+
+    private var framesCont: AsyncStream<ByteBuffer>.Continuation?
+    private var runner: Task<Void, Never>?
+    private var client: SSHClient?
+    private var seq: UInt64 = 0
+    private var live = false
+
+    // The open handshake resolves exactly once: on the daemon's first stdout line
+    // (an ok ack, or an error line an old daemon returns for the unknown method),
+    // or when the channel dies before any line arrives. `openOutcome` buffers the
+    // result if it settles before `start()` parks its continuation.
+    private var openContinuation: CheckedContinuation<Void, Error>?
+    private var openOutcome: Result<Void, Error>?
+    private var openSettled = false
+
+    init(
+        makeConnection: @escaping @Sendable () async throws -> SSHClient,
+        command: String,
+        openLine: String
+    ) {
+        self.makeConnection = makeConnection
+        self.command = command
+        self.openLine = openLine
+    }
+
+    /// Opens the channel, writes the `pane.input.stream` open line, and awaits the
+    /// daemon's ack. Throws — so the caller falls back to per-call `send_text` —
+    /// if `withExec` is unavailable (macOS < 15; never on iOS 17), if the daemon
+    /// lacks the method (the open line returns an error), or on any transport
+    /// failure. On success the channel is live and `send` writes frames.
+    public func start() async throws {
+        guard #available(macOS 15.0, *) else { throw ChannelError.unsupported }
+
+        let (stream, cont) = AsyncStream<ByteBuffer>.makeStream()
+        framesCont = cont
+        // Single ordered writer: the open line goes first, then input frames.
+        cont.yield(ByteBuffer(string: openLine + "\n"))
+
+        runner = Task { [weak self] in
+            await self?.run(stream)
+        }
+
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            if let outcome = openOutcome {
+                continuation.resume(with: outcome)
+            } else {
+                openContinuation = continuation
+            }
+        }
+    }
+
+    /// Enqueues one input frame. Returns false when the channel is not live (the
+    /// caller then falls back to `send_text`). Fire-and-forget: never awaits an
+    /// ack — the real confirmation for a human is the echo on `pane.stream`.
+    @discardableResult
+    public func send(_ text: String) -> Bool {
+        guard live, let framesCont, !text.isEmpty else { return false }
+        seq &+= 1
+        guard let data = try? encoder.encode(Frame(seq: seq, text: text)) else { return false }
+        var buffer = ByteBuffer()
+        buffer.reserveCapacity(data.count + 1)
+        buffer.writeBytes(data)
+        buffer.writeInteger(UInt8(ascii: "\n"))
+        framesCont.yield(buffer)
+        return true
+    }
+
+    /// Tears the channel down: finishing the frame stream returns from `withExec`,
+    /// closing the SSH channel (the remote bridge then sees stdin EOF and exits).
+    public func close() {
+        live = false
+        framesCont?.finish()
+        framesCont = nil
+        runner?.cancel()
+    }
+
+    // MARK: - internals
+
+    @available(macOS 15.0, *)
+    private func run(_ frameStream: AsyncStream<ByteBuffer>) async {
+        do {
+            let client = try await makeConnection()
+            self.client = client
+            try await client.withExec(command) { [weak self] inbound, stdin in
+                let reader = Task { [weak self] in
+                    var accumulator = LineAccumulator()
+                    do {
+                        for try await chunk in inbound {
+                            guard case .stdout(let bytes) = chunk else { continue }
+                            for line in accumulator.append(bytes) {
+                                await self?.handleLine(line)
+                            }
+                        }
+                    } catch {
+                        // stdout closed/errored: the channel is done; the writer
+                        // loop below unwinds when its stream finishes.
+                    }
+                }
+                defer { reader.cancel() }
+                for await buffer in frameStream {
+                    try await stdin.write(buffer)
+                }
+            }
+            try? await client.close()
+        } catch {
+            // makeConnection / withExec failed before or during the channel.
+        }
+        settleOpen(.failure(ChannelError.closedBeforeAck))
+        markDead()
+    }
+
+    private func handleLine(_ line: String) {
+        if !openSettled {
+            if isErrorLine(line) {
+                settleOpen(.failure(ChannelError.remoteError(line)))
+                markDead()
+            } else {
+                live = true
+                settleOpen(.success(()))
+            }
+            return
+        }
+        // Post-ack lines are only the daemon's terminal error (or an ack for a
+        // frame that asked for one; v1 sends none). Any error line closes us.
+        if isErrorLine(line) {
+            markDead()
+        }
+    }
+
+    private func isErrorLine(_ line: String) -> Bool {
+        guard let data = line.data(using: .utf8),
+              let probe = try? decoder.decode(WireErrorProbe.self, from: data)
+        else { return false }
+        return probe.error != nil
+    }
+
+    private func settleOpen(_ result: Result<Void, Error>) {
+        guard !openSettled else { return }
+        openSettled = true
+        if let continuation = openContinuation {
+            openContinuation = nil
+            continuation.resume(with: result)
+        } else {
+            openOutcome = result
+        }
+    }
+
+    private func markDead() {
+        live = false
+        framesCont?.finish()
+        framesCont = nil
+    }
+}

--- a/Sources/HerdrKit/Wire.swift
+++ b/Sources/HerdrKit/Wire.swift
@@ -354,6 +354,13 @@ public enum TerminalStreamEvent: Sendable, Equatable {
 /// server defaults / resume hints (v1 ignores resume and always re-seeds). Nil
 /// optionals are omitted by the synthesized encoder, matching serde's
 /// `skip_serializing_if = "Option::is_none"`.
+/// Open params for the persistent `pane.input.stream` write channel (issue #62).
+public struct PaneInputStreamParams: Encodable, Sendable {
+    public let paneID: String
+    public init(paneID: String) { self.paneID = paneID }
+    enum CodingKeys: String, CodingKey { case paneID = "pane_id" }
+}
+
 public struct PaneStreamParams: Encodable, Sendable {
     public let paneID: String
     public let includeHistory: Bool


### PR DESCRIPTION
The **iOS half** of #62 — the client for the daemon's `pane.input.stream` (daemon merged jerryfane/herdr#64, live on the 0.8.0 fleet). Routes iPad hardware-keyboard keystrokes through **one held-open SSH channel** (`herdr api-bridge --duplex`) instead of a fresh `api-bridge` exec per keystroke — the remote fork/exec is what makes typing feel laggy. Echo already rides the persistent `pane.stream` firehose; only the send leg was per-call.

## How
- **`PaneInputChannel` (HerdrKit)** — built on Citadel `withExec` (0.12.1), which unlike `executeCommandStream` exposes a **writable stdin** over a no-PTY exec channel. The scoped closure runs inside a long-lived Task fed by one ordered `AsyncStream`, so a single writer preserves keystroke order. Guarded `if #available(macOS 15)` so the macOS-14 test target still compiles (iOS 17 always satisfies it).
- **`CitadelTransport.openInputChannel` / `HerdrClient.openPaneInput`** — the channel gets its **own** dedicated connection (like `stream`), so input backpressure never blocks the command socket or `pane.stream`.
- **`LiveTerminalView`** — the serialized `inputSendTask` drain prefers the channel and falls back to per-call `sendText` when it's unavailable or dies. **At-most-once, no replay** (a duplicated Enter is worse than a visibly-missing, retypable keystroke). Opened lazily on first key-drive input; torn down in `stop()`. **iPhone stays byte-for-byte read-only** — the `send()` `keyDriveEnabled`/`isFirstResponder` gate is untouched.
- **Feature-detected by attempt** — an older daemon without the method makes `start()` throw and the app stays on `send_text`; the live 0.8.0 fleet daemon advertises it.

## Validation
- Daemon side (jerryfane/herdr#64): 5 serve-loop unit tests + full `just check`; live-verified on the deployed 0.8.0 daemon (`pane.input.stream` open handshake returns `pane_not_found` for a bogus pane via `api-bridge --duplex` = wired end-to-end).
- iOS side: compiles + tests via this CI run; on-device typing-latency is the owner's TestFlight acceptance.

refs #62