### PR TITLE
fix(terminal): reseed the front pane on foreground to recover missed output (#62)

### DIFF
--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -1926,6 +1926,15 @@ struct TerminalPaneContent: View {
     /// the LiveTerminalView (new Coordinator → a fresh pane.stream over a new connection, re-seeded
     /// from the current server state). Useful when the stream has gone stale or its connection dropped.
     @State private var streamGen = 0
+    /// App foreground/background phase. On return to `.active` the front pane's
+    /// live `pane.stream` has stalled (no network while backgrounded) and
+    /// reconnects from the live tail, missing output produced while away — so we
+    /// reseed the front pane from durable scrollback (issue #62 follow-up).
+    @Environment(\.scenePhase) private var scenePhase
+    /// Set when the app actually goes `.background`, so the reseed on the next
+    /// `.active` fires only after a real background — not a transient `.inactive`
+    /// (Control Center / a notification banner), which would flash needlessly.
+    @State private var wasBackgrounded = false
     /// STICKY Ctrl modifier: tapping the `ctrl` cap arms it; the next character
     /// typed in the reply field is then sent as its control byte (and consumed, not
     /// added to the message), and the modifier disarms. See `handleReplyChange`.
@@ -2068,6 +2077,24 @@ struct TerminalPaneContent: View {
         // backgrounds so a hidden keep-mounted pane can't hold the software keyboard.
         .onChange(of: isForeground) { _, nowFront in
             if nowFront { Task { await refresh() } } else { replyFocused = false }
+        }
+        // When the app returns to the foreground after a real background, reseed the
+        // FRONT pane the same way the header refresh button does (bump streamGen →
+        // remount → startBackfill() reads the durable current screen + scrollback).
+        // Its live stream stalled while backgrounded and reconnects from the live
+        // tail, so output produced while away is otherwise lost until a manual
+        // refresh (issue #62 follow-up). Gated on isForeground so only the visible
+        // pane pays the reseed; hidden keep-mounted panes reseed when next front.
+        .onChange(of: scenePhase) { _, phase in
+            switch phase {
+            case .background:
+                wasBackgrounded = true
+            case .active:
+                if wasBackgrounded && isForeground { streamGen += 1 }
+                wasBackgrounded = false
+            default:
+                break
+            }
         }
     }
 


### PR DESCRIPTION
## Bug
After the app is backgrounded, the front terminal pane loses output produced while away: you see A (what was on screen) + C (output after return), **missing B** (the gap), until you tap the manual **refresh**. Owner-reported on build 69.

## Root cause (pre-existing `pane.stream` behavior, independent of the #62 input channel)
On foreground nothing reseeds. The front pane's live `pane.stream` stalls while backgrounded and, on return, reconnects via the watchdog **from the live tail** — the daemon reseeds only from the current visible screen and never replays the disconnected interval (`resume_from`/`epoch` are wired but v1-ignored; the output ring is torn down on detach). The reconnect path also skips the history backfill (the `didSeedOnce` gate). The durable grid+scrollback still holds A+B+C — which the **refresh button** reads by bumping `streamGen` → remount → `startBackfill()` → `client.read(source:.recent, ansi, 1000)`.

## Fix
Auto-run that exact recovery on foreground: when `scenePhase` returns to `.active` **after a real `.background`**, bump the front pane's `streamGen` (remount → `startBackfill` reseeds from `source=recent` = current screen + scrollback). 
- **Gated on `isForeground`** so only the visible pane pays the reseed; hidden keep-mounted panes reseed when next brought front.
- A `wasBackgrounded` flag skips a transient `.inactive` (Control Center / a notification banner) so it never flashes needlessly.
- Reuses the proven manual-refresh RPC — **no daemon change**.

## Verification
- CI compile + UI tests (this run).
- On device: open a pane producing periodic output, background ~30s, foreground → the full current output shows **without** tapping refresh; a Control-Center peek does **not** reseed.

refs #62