### PR TITLE
feat(terminal): adjustable font size + copy actions

### DIFF
--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -890,6 +890,9 @@ struct TerminalHomeView: View {
     @State private var settingsAnchor: SettingsSection?
     /// iPad: the ⌘/ keyboard-shortcut reference sheet.
     @State private var showShortcuts = false
+    /// Terminal font size preference (points), shared app-wide via UserDefaults with the
+    /// per-pane ⋯ control; driven here by ⌘+ / ⌘- / ⌘0 (Mac + hardware keyboard).
+    @AppStorage("terminal.fontSize") private var terminalFontSize: Double = 12.5
     /// Unread agent→owner grams, badged on the Gram tab. Session-scoped; written
     /// by GramView while visible and by an ambient poll (below) while it isn't.
     @StateObject private var gramUnread = GramUnreadTracker()
@@ -1124,6 +1127,14 @@ struct TerminalHomeView: View {
             .keyboardShortcut("k", modifiers: .command)
             Button("Shortcuts") { showShortcuts = true }
                 .keyboardShortcut("/", modifiers: .command)
+            // Terminal font zoom (Mac + hardware keyboard). ⌘+ registers from "=" (its
+            // unshifted key), ⌘- shrinks, ⌘0 resets — the standard zoom idiom.
+            Button("Zoom in") { terminalFontSize = min(terminalFontSize + 1, 24) }
+                .keyboardShortcut("=", modifiers: .command)
+            Button("Zoom out") { terminalFontSize = max(terminalFontSize - 1, 9) }
+                .keyboardShortcut("-", modifiers: .command)
+            Button("Reset zoom") { terminalFontSize = 12.5 }
+                .keyboardShortcut("0", modifiers: .command)
         }
         .opacity(0)
         .allowsHitTesting(false)
@@ -1926,6 +1937,10 @@ struct TerminalPaneContent: View {
     /// the LiveTerminalView (new Coordinator → a fresh pane.stream over a new connection, re-seeded
     /// from the current server state). Useful when the stream has gone stale or its connection dropped.
     @State private var streamGen = 0
+    /// Terminal font size preference (points), app-wide via UserDefaults. Read here to
+    /// drive `LiveTerminalView.fontSize` (applied in-place, no view recreation) and
+    /// mutated by ⌘± and the ⋯ "Text size" control. Clamped to [9, 24].
+    @AppStorage("terminal.fontSize") private var terminalFontSize: Double = 12.5
     /// App foreground/background phase. On return to `.active` the front pane's
     /// live `pane.stream` has stalled (no network while backgrounded) and
     /// reconnects from the live tail, missing output produced while away — so we
@@ -2042,7 +2057,8 @@ struct TerminalPaneContent: View {
                                  // drive the PTY directly — but yield focus while the reply field is
                                  // focused, and never on iPhone (the terminal can't become first
                                  // responder there, so this is inert).
-                                 wantsTerminalKeyFocus: isForeground && !replyFocused)
+                                 wantsTerminalKeyFocus: isForeground && !replyFocused,
+                                 fontSize: CGFloat(terminalFontSize))
                     // Reconnect on refresh: a new id re-creates the view → fresh stream/connection.
                     .id(streamGen)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -2173,6 +2189,33 @@ struct TerminalPaneContent: View {
     /// at a glance without opening the menu.
     private var agentActionsMenu: some View {
         Menu {
+            Section {
+                Button {
+                    Task {
+                        if let out = try? await client.read(pane: paneID, source: .visible, format: .text) {
+                            UIPasteboard.general.string = out.text
+                        }
+                    }
+                } label: { Label("Copy screen", systemImage: "doc.on.doc") }
+                Button {
+                    Task {
+                        if let out = try? await client.read(pane: paneID, source: .recentUnwrapped, format: .text) {
+                            UIPasteboard.general.string = out.text
+                        }
+                    }
+                } label: { Label("Copy recent output", systemImage: "doc.on.clipboard") }
+            }
+            Section("Text size") {
+                Button {
+                    terminalFontSize = min(terminalFontSize + 1, 24)
+                } label: { Label("Increase", systemImage: "textformat.size.larger") }
+                Button {
+                    terminalFontSize = max(terminalFontSize - 1, 9)
+                } label: { Label("Decrease", systemImage: "textformat.size.smaller") }
+                Button {
+                    terminalFontSize = 12.5
+                } label: { Label("Reset", systemImage: "arrow.counterclockwise") }
+            }
             Button {
                 mute.toggle(paneID)
             } label: {
@@ -2716,6 +2759,9 @@ struct ShortcutsSheet: View {
     private let rows: [(keys: String, label: String)] = [
         ("⌘ K", "Show or hide the sidebar"),
         ("⌘ /", "This shortcut list"),
+        ("⌘ +", "Increase terminal font size"),
+        ("⌘ −", "Decrease terminal font size"),
+        ("⌘ 0", "Reset terminal font size"),
     ]
 
     var body: some View {

--- a/App/LiveTerminalView.swift
+++ b/App/LiveTerminalView.swift
@@ -62,11 +62,17 @@ struct LiveTerminalView: UIViewRepresentable {
     /// on iPhone the terminal cannot become first responder, so this is inert (see
     /// `ReadOnlyTerminalView.keyDriveEnabled`). Refreshed on every update.
     var wantsTerminalKeyFocus: Bool = false
+    /// Terminal font size in points (the `terminal.fontSize` preference). Applied
+    /// in-place via `Coordinator.applyFont` when it changes — re-lays-out the grid,
+    /// no view recreation.
+    var fontSize: CGFloat = 12.5
 
     func makeCoordinator() -> Coordinator { Coordinator(client: client, paneID: paneID) }
 
     func makeUIView(context: Context) -> ReadOnlyTerminalView {
-        let view = ReadOnlyTerminalView(frame: .zero, font: Coordinator.paneFont)
+        context.coordinator.paneFontSize =
+            min(max(fontSize, Coordinator.minFontSize), Coordinator.maxFontSize)
+        let view = ReadOnlyTerminalView(frame: .zero, font: context.coordinator.paneFont)
         context.coordinator.onNavigate = onNavigate
         context.coordinator.attach(view)
         return view
@@ -83,6 +89,7 @@ struct LiveTerminalView: UIViewRepresentable {
         } else if uiView.isFirstResponder {
             uiView.resignFirstResponder()
         }
+        context.coordinator.applyFont(size: fontSize)
     }
 
     static func dismantleUIView(_ uiView: ReadOnlyTerminalView, coordinator: Coordinator) {
@@ -247,10 +254,28 @@ struct LiveTerminalView: UIViewRepresentable {
         /// IBM Plex Mono (the design's MACHINE voice) at the pane size, falling back
         /// to the system monospace if the bundled face is unavailable. The
         /// PostScript name matches `DesignSystem.Typography`'s mono regular cut.
-        static let paneFontSize: CGFloat = 12.5
-        static let paneFont: UIFont =
+        static let minFontSize: CGFloat = 9
+        static let maxFontSize: CGFloat = 24
+        static let defaultFontSize: CGFloat = 12.5
+        /// Terminal font size in points, driven by the `terminal.fontSize` preference.
+        /// Instance (not static) so it can change at runtime: setting `view.font` from
+        /// `applyFont` flows through SwiftTerm's resetFont → resize → sizeChanged →
+        /// sendPTYSize, which re-locks the PTY at the new column count.
+        var paneFontSize: CGFloat = 12.5
+        var paneFont: UIFont {
             UIFont(name: "IBMPlexMono", size: paneFontSize)
-            ?? UIFont.monospacedSystemFont(ofSize: paneFontSize, weight: .regular)
+                ?? UIFont.monospacedSystemFont(ofSize: paneFontSize, weight: .regular)
+        }
+
+        /// Apply a new terminal font size (clamped to [minFontSize, maxFontSize]).
+        /// A no-op if unchanged; otherwise setting `view.font` drives the full
+        /// re-layout (cell recompute → grid resize → sizeChanged → sendPTYSize).
+        func applyFont(size: CGFloat) {
+            let clamped = min(max(size, Self.minFontSize), Self.maxFontSize)
+            guard clamped != paneFontSize else { return }
+            paneFontSize = clamped
+            view?.font = paneFont
+        }
 
         /// Scrollback backfill — so scrolling up shows output produced BEFORE this connection
         /// (open/refresh only seeds the current screen otherwise). On each connect we fetch the
@@ -535,7 +560,7 @@ struct LiveTerminalView: UIViewRepresentable {
         // MARK: styling (the design's machine voice)
 
         private func style(_ view: ReadOnlyTerminalView) {
-            view.font = Self.paneFont
+            view.font = paneFont
             // groundMachine #0B0D1C behind, ink #EEF0F7 text, working-blue caret —
             // the same tokens `DesignSystem.Palette` uses, so the terminal is the
             // one darker ground the design calls for.
@@ -790,7 +815,7 @@ struct LiveTerminalView: UIViewRepresentable {
             // deferred re-lock re-sends at the LIVE grid once the release lands.
             guard foreground, !relockPending else { return }
             guard resizeTask == nil else { return }   // a drain is running; it re-reads `desired`
-            let cell = Self.cellPixels()
+            let cell = cellPixels()
             resizeTask = Task { @MainActor [weak self] in
                 // `self.foreground` in the condition: if this pane is backgrounded mid-drain (a
                 // keep-mounted hide), STOP driving `lock:true` — a hidden pane must never re-pin a
@@ -829,7 +854,7 @@ struct LiveTerminalView: UIViewRepresentable {
         }
 
         /// Cell size from the actual mono font — the DPI hint the server stores.
-        private static func cellPixels() -> (width: UInt32, height: UInt32) {
+        private func cellPixels() -> (width: UInt32, height: UInt32) {
             let attrs: [NSAttributedString.Key: Any] = [.font: paneFont]
             let advance = ("W" as NSString).size(withAttributes: attrs).width
             let lineHeight = paneFont.lineHeight
@@ -971,7 +996,7 @@ struct LiveTerminalView: UIViewRepresentable {
             case .changed:
                 scrollAccum += gr.translation(in: view).y
                 gr.setTranslation(.zero, in: view)
-                let line = max(1, Self.paneFont.lineHeight)
+                let line = max(1, paneFont.lineHeight)
                 let ticks = Int(scrollAccum / line)
                 guard ticks != 0 else { return }
                 // Pace the wheel: a MOUSE-MODE agent (Claude Code) accelerates its own
@@ -1015,8 +1040,8 @@ struct LiveTerminalView: UIViewRepresentable {
                 // understand these; a documented limit of the private protocol, not a
                 // runtime bug.
                 let code = up ? 64 : 65
-                let cw = ("W" as NSString).size(withAttributes: [.font: Self.paneFont]).width
-                let ch = Self.paneFont.lineHeight
+                let cw = ("W" as NSString).size(withAttributes: [.font: paneFont]).width
+                let ch = paneFont.lineHeight
                 let col = max(1, min(Int(point.x / max(1, cw)) + 1, max(1, term.cols)))
                 let row = max(1, min(Int(point.y / max(1, ch)) + 1, max(1, term.rows)))
                 seq = String(repeating: "\u{1b}[<\(code);\(col);\(row)M", count: count)


### PR DESCRIPTION
Two owner-requested gaps hit while running Herdrup on **macOS** (build 71): the terminal font is fixed at 12.5pt with no way to change it, and there's no easy way to select/copy terminal text. Both fixes are **app-only — no daemon change or redeploy.**

## Feature 1 — adjustable terminal font size
- New `@AppStorage("terminal.fontSize")` preference (persisted, clamped 9–24pt).
- `LiveTerminalView`'s font is now dynamic: `Coordinator.applyFont(size:)` sets `view.font`, which flows through SwiftTerm `resetFont → resize → sizeChanged → sendPTYSize` — the exact path a rotation already uses, so the PTY re-locks at the new column count and the agent's TUI reflows. No new PTY plumbing.
- **Correctness:** `cellPixels()` (the server DPI hint) is now an instance method reading the *live* font, so the cell-pixel hint tracks the grid instead of a hardcoded 12.5pt.
- **Controls:** `⌘+` / `⌘-` / `⌘0` (Mac + hardware keyboard, registered in `keyboardShortcuts`, documented in `ShortcutsSheet`) **and** the header `⋯` menu's *Text size* Increase / Decrease / Reset — so touch-only iPhone/iPad users get it too.

## Feature 2 (Tier 1) — copy actions
The header `⋯` menu gains two entries, both via the existing `agent.read` → `UIPasteboard`:
- **Copy screen** — `source=visible`.
- **Copy recent output** — `source=recent_unwrapped`.

Works on Mac, iPad and iPhone immediately; no gesture or first-responder change.

## Deferred to a fast-follow (own verification pass)
Native precise drag-selection (relaxes the read-only first-responder invariant + touches the gesture stack) and pinch-to-zoom. This PR is the low-risk, all-platform half.

## Verification
Swift can't be built on Linux — relying on CI (compile + UITests on macOS) here, then on-device via TestFlight:
- Font: `⌘+/-/0` resize the grid and the TUI reflows to the new column count; `⋯` Text size on touch; background a pane → change size → re-show renders correctly; columns match the emulator (no `cellPixels()` desync).
- Copy: `⋯` Copy screen / Copy recent output land text on the clipboard on all three platforms.

---
**Provenance:** owner's in-session feature requests (terminal font too small on Mac + wanting easy select/copy across Mac/iPhone/iPad), plan approved via plan mode → `/root/.claude/plans/so-r-u-working-quizzical-valiant.md`. herdr-app seat.