### PR TITLE
feat(agents): remote-agent reachability + offline badge (federation W7)

### DIFF
--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -1578,7 +1578,13 @@ struct TerminalHomeView: View {
                     .font(Typography.machine(12)).foregroundStyle(Palette.textDim).lineLimit(1)
             }
             Spacer(minLength: 8)
-            statusBadge(row.group)
+            // A remote agent whose machine is unreachable has a stale status, so
+            // it reads as offline rather than showing a misleading live badge.
+            if row.info.isUnreachable {
+                offlineBadge()
+            } else {
+                statusBadge(row.group)
+            }
         }
         .padding(12)
         .background(Palette.card)
@@ -1605,6 +1611,14 @@ struct TerminalHomeView: View {
     private func statusBadge(_ group: AgentGroup) -> some View {
         // The status is colour+shape; name it for VoiceOver too.
         badgeContent(group).accessibilityLabel(Text(group.label))
+    }
+
+    /// A remote agent whose owning machine is unreachable: its live status is a
+    /// stale last-known value, so show a muted "offline" mark, never a live badge.
+    /// The stopped SQUARE shape (gone, not a live state) but in faint ink, not the
+    /// stopped red — offline is quiet, not an alarm.
+    private func offlineBadge() -> some View {
+        badgeSquare("wifi.slash", Palette.textDim).accessibilityLabel(Text("offline"))
     }
 
     @ViewBuilder

--- a/Sources/HerdrKit/Wire.swift
+++ b/Sources/HerdrKit/Wire.swift
@@ -93,6 +93,15 @@ public struct AgentInfo: Decodable, Equatable, Sendable, Identifiable {
     public let turn: Int?
     public let turnEpoch: UInt64?
     public let lastCompletedTurn: CompletedTurn?
+    /// Federation (daemon W3+): for a remote agent, the owning peer's alias
+    /// (`machineID`, also carried as the `<alias>/…` prefix on `name`/`paneID`),
+    /// the peer's reachability as of the home's last poll, and the agent's
+    /// last-known status while its machine is unreachable. All absent on a local
+    /// agent or a non-federated server — decoded leniently, so an older or
+    /// non-federated server is unaffected.
+    public let machineID: String?
+    public let reachability: String?
+    public let lastKnownStatus: String?
 
     public var id: String { paneID }
 
@@ -103,8 +112,14 @@ public struct AgentInfo: Decodable, Equatable, Sendable, Identifiable {
 
     public var isWorking: Bool { agentStatus == "working" }
 
+    /// A remote (federated) agent whose owning machine is currently unreachable.
+    /// Its `agentStatus` is a stale last-known value, so the UI must render it as
+    /// offline rather than as a live status. Unknown reachability strings (a newer
+    /// server) read as reachable — the safe default is "not offline".
+    public var isUnreachable: Bool { reachability == "unreachable" }
+
     enum CodingKeys: String, CodingKey {
-        case agent, name, composer, revision, turn, cwd, focused
+        case agent, name, composer, revision, turn, cwd, focused, reachability
         case agentStatus = "agent_status"
         case paneID = "pane_id"
         case tabID = "tab_id"
@@ -115,6 +130,8 @@ public struct AgentInfo: Decodable, Equatable, Sendable, Identifiable {
         case stateChangeSeq = "state_change_seq"
         case turnEpoch = "turn_epoch"
         case lastCompletedTurn = "last_completed_turn"
+        case machineID = "machine_id"
+        case lastKnownStatus = "last_known_status"
     }
 }
 

--- a/Tests/HerdrKitTests/AgentListTests.swift
+++ b/Tests/HerdrKitTests/AgentListTests.swift
@@ -34,6 +34,45 @@ final class AgentListTests: XCTestCase {
                        + "— not paneID order p1<p2<p3")
     }
 
+    // MARK: - federation fields (daemon W3+)
+
+    /// A remote agent carries machine_id / reachability / last_known_status; they
+    /// decode through the same wire path, and only an `unreachable` agent surfaces
+    /// as offline. A local agent leaves them nil and is never offline. Building the
+    /// JSON keeps the keys honest — a wrong CodingKey would fail these.
+    func testFederationFieldsDecodeAndDriveOffline() throws {
+        let remote = try JSONDecoder().decode(
+            AgentInfo.self,
+            from: JSONSerialization.data(withJSONObject: [
+                "pane_id": "mcb-air/w1:p2",
+                "name": "mcb-air/build",
+                "agent_status": "idle",
+                "machine_id": "mcb-air",
+                "reachability": "unreachable",
+                "last_known_status": "working",
+            ]))
+        XCTAssertEqual(remote.machineID, "mcb-air")
+        XCTAssertEqual(remote.reachability, "unreachable")
+        XCTAssertEqual(remote.lastKnownStatus, "working")
+        XCTAssertTrue(remote.isUnreachable, "an unreachable agent must read as offline")
+
+        // A local agent has none of the federation fields, and is not offline.
+        let local = try agent(pane: "p1", status: "working")
+        XCTAssertNil(local.machineID)
+        XCTAssertNil(local.reachability)
+        XCTAssertNil(local.lastKnownStatus)
+        XCTAssertFalse(local.isUnreachable)
+
+        // Only "unreachable" is offline; reachable/degraded and any unknown newer
+        // value are treated as reachable (the safe default is "not offline").
+        for value in ["reachable", "degraded", "some_future_state"] {
+            let a = try JSONDecoder().decode(
+                AgentInfo.self,
+                from: JSONSerialization.data(withJSONObject: ["pane_id": "x", "reachability": value]))
+            XCTAssertFalse(a.isUnreachable, "reachability=\(value) must not read as offline")
+        }
+    }
+
     // MARK: - the three ways of not knowing
 
     /// AXIS: absent, indefinite and unrecognised are three different situations


### PR DESCRIPTION
## Federation W7 — remote-agent reachability in the app (final slice)

The **last** slice of the federation series (daemon W1–W6 merged in `jerryfane/herdr`; tracking issue **jerryfane/herdr#73**). The daemon now merges remote (federated) agents into `agent.list` with alias-prefixed names and three new fields — `machine_id`, `reachability`, `last_known_status`. This surfaces them in the app.

### Changes (small — the app was already prefix-safe)
Remote agents already appeared, opened, streamed, and drove for free, because the app treats `pane_id`/`name` as opaque strings end to end. The only real gap was **reachability**:

- **`AgentInfo`** (`Sources/HerdrKit/Wire.swift`) gains `machineID` / `reachability` / `lastKnownStatus` (all optional; decoded leniently via the same wire path, so a local agent or a non-federated/older server is unaffected), plus an `isUnreachable` helper. Unknown `reachability` values read as reachable — the safe default is *not* offline.
- **The agent card** (`App/HerdrApp.swift`) shows a muted **offline badge** (a faint `wifi.slash` square) in place of the status badge when a remote agent's machine is unreachable — so an offline agent never reads as a live idle/working status (its `agent_status` is a stale last-known value). The owning machine is already visible in the alias-prefixed title (`mcb-air/build`), so no separate machine chip is added.

### Design notes
- Production runs with `livePaneIDs == nil` (everything treated live), so an unreachable agent is **not** caught by the existing `.stopped`/liveness path — offline has to come from the new `reachability` field, which is exactly what drives the badge.
- Kept minimal: no full per-machine sectioning (the prefixed title already conveys the machine); can follow up if wanted.

### Verification
New HerdrKit decode test (`AgentListTests.testFederationFieldsDecodeAndDriveOffline`) decodes a remote agent with all three fields through the real JSON path, asserts the values + `isUnreachable`, and that reachable/degraded/unknown are not offline and a local agent leaves the fields nil. (Built and tested by CI — no Swift toolchain on the authoring box.)
