### PR TITLE
feat(federation): Settings section + peer list + setup guide; cap host-list width on iPad/macOS (#135, #136)

### DIFF
--- a/App/FederationSetupView.swift
+++ b/App/FederationSetupView.swift
@@ -1,0 +1,168 @@
+import SwiftUI
+
+/// A short guide for adding another machine to the herd — the setup the Federation
+/// section in Settings links to when you tap "How to add a machine". Federation lets
+/// your home box reach agents running on OTHER computers (over Tailscale / SSH) and
+/// list them here beside the local ones. This teaches the four steps that make a new
+/// machine's agents show up. Presented as a `.large` sheet with a swipe-down grabber,
+/// mirroring `GesturesHelpView` (same `onClose` contract, header, footer).
+struct FederationSetupView: View {
+    var onClose: () -> Void
+
+    /// One setup step: the SF Symbol hinting the action, what you do, and why.
+    /// Kept in one list so the guide and the real procedure stay together.
+    private struct Step: Identifiable {
+        let symbol: String
+        let title: String
+        let detail: String
+        var id: String { title }  // titles are unique + stable → stable ForEach identity
+    }
+
+    private static let steps: [Step] = [
+        .init(symbol: "arrow.down.circle",
+              title: "Install the herdr fork",
+              detail: "On the machine, install the jerryfane/herdr fork — it has the api-bridge the home box connects through. Official herdr does not."),
+        .init(symbol: "network",
+              title: "Put it on your network",
+              detail: "Join it to your Tailscale tailnet (or any address your home box can reach) and authorize your home box's SSH key."),
+        .init(symbol: "doc.badge.gearshape",
+              title: "Add it to your config",
+              detail: "Add a peer to ~/.config/herdr/config.toml: an alias and ssh://user@host."),
+        .init(symbol: "arrow.clockwise",
+              title: "Reload — no restart",
+              detail: "Run herdr server reload-config on the home box. The machine's agents appear here; no restart needed."),
+    ]
+
+    /// The config snippet the third step describes, shown as a mono chip.
+    private static let configSnippet = """
+    [[federation.peers]]
+    alias = "mac-studio"
+    endpoint = "ssh://user@mac-studio"
+    """
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider().overlay(Palette.hairlineQuiet)
+            ScrollView {
+                VStack(spacing: 10) {
+                    ForEach(Self.steps) { row(for: $0) }
+                    configCard
+                    reloadCard
+                }
+                .padding(.horizontal, 16)
+                .padding(.top, 14)
+                .padding(.bottom, 12)
+            }
+            footer
+        }
+        .background(Palette.ground.ignoresSafeArea())
+    }
+
+    private var header: some View {
+        HStack(spacing: 10) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Add a machine")
+                    .font(Typography.app(20, .semibold))
+                    .foregroundStyle(Palette.text)
+                Text("Connect another computer to the herd")
+                    .font(Typography.app(12))
+                    .foregroundStyle(Palette.textFaint)
+            }
+            Spacer(minLength: 0)
+            Button(action: onClose) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 15, weight: .medium))
+                    .foregroundStyle(Palette.textDim)
+                    .frame(width: 36, height: 36)
+                    .background(Palette.surface)
+                    .clipShape(Circle())
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.top, 8)
+        .padding(.bottom, 10)
+    }
+
+    private func row(for step: Step) -> some View {
+        HStack(spacing: 14) {
+            Image(systemName: step.symbol)
+                .font(.system(size: 18, weight: .medium))
+                .foregroundStyle(Palette.brand)
+                .frame(width: 44, height: 44)
+                .background(RoundedRectangle(cornerRadius: 12).fill(Palette.surfaceRaised))
+            VStack(alignment: .leading, spacing: 3) {
+                Text(step.title)
+                    .font(Typography.app(15, .semibold))
+                    .foregroundStyle(Palette.text)
+                Text(step.detail)
+                    .font(Typography.app(13))
+                    .foregroundStyle(Palette.textDim)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(RoundedRectangle(cornerRadius: 14).fill(Palette.surface))
+    }
+
+    /// The peer stanza to paste into config.toml — machine voice in a raised chip,
+    /// the same mono-chip idiom the shortcuts / keycap surfaces use.
+    private var configCard: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("~/.config/herdr/config.toml")
+                .font(Typography.app(12, .semibold))
+                .foregroundStyle(Palette.textFaint)
+            Text(Self.configSnippet)
+                .font(Typography.machine(13))
+                .foregroundStyle(Palette.text)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(12)
+                .background(RoundedRectangle(cornerRadius: 8).fill(Palette.surfaceRaised))
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(12)
+        .background(RoundedRectangle(cornerRadius: 14).fill(Palette.surface))
+    }
+
+    /// The reload command — the one step that makes the new peer's agents appear,
+    /// no restart. Same mono chip as the config snippet.
+    private var reloadCard: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Then, on the home box")
+                .font(Typography.app(12, .semibold))
+                .foregroundStyle(Palette.textFaint)
+            Text("herdr server reload-config")
+                .font(Typography.machine(13))
+                .foregroundStyle(Palette.text)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(12)
+                .background(RoundedRectangle(cornerRadius: 8).fill(Palette.surfaceRaised))
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(12)
+        .background(RoundedRectangle(cornerRadius: 14).fill(Palette.surface))
+    }
+
+    private var footer: some View {
+        VStack(spacing: 8) {
+            // Primary action: send them to the fork's install instructions (step 1),
+            // reusing the one shared install link the fork notice uses.
+            InstallInstructionsLink()
+            Button(action: onClose) {
+                Text("Got it")
+                    .font(Typography.app(15, .semibold))
+                    .foregroundStyle(Palette.textDim)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 10)
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.top, 8)
+        .padding(.bottom, 12)
+        .background(Palette.ground)
+    }
+}

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -296,7 +296,7 @@ struct RootView: View {
                                  agent: MockTransport.demoPaneAgent)
             }
         case .settings:
-            SettingsView(host: "mac.tail-scale.ts.net")
+            SettingsView(client: mockClient, agents: [], host: "mac.tail-scale.ts.net")
         case .newAgent:
             NewAgentView(client: mockClient,
                          initialFolder: "/root/herdr-ios", initialKind: "codex",
@@ -464,6 +464,9 @@ struct ConnectView: View {
                     captions
                 }
                 .padding(22)
+                // Cap + center the column on iPad/macOS so the host list doesn't
+                // stretch edge to edge; inert on iPhone (narrower than the cap).
+                .readableColumn()
             }
         }
         // Add / edit a host. Save & Connect (add) hands credentials up via onConnect.
@@ -1095,6 +1098,8 @@ struct TerminalHomeView: View {
                     GramView(client: client, agents: agents, unread: gramUnread)
                 case .settings:
                     SettingsView(
+                        client: client,
+                        agents: agents,
                         host: host,
                         connected: error == nil && !loading,
                         canReconnect: rejectedFingerprint == nil,
@@ -1239,6 +1244,8 @@ struct TerminalHomeView: View {
                     .badge(gramUnread.count == 0 ? nil : Text("\(gramUnread.count)"))
 
                 SettingsView(
+                    client: client,
+                    agents: agents,
                     host: host,
                     connected: error == nil && !loading,
                     // Withhold reconnect during a host-key rejection — reconnecting then
@@ -2743,11 +2750,12 @@ struct TerminalPaneContent: View {
 /// A jump target within Settings. The iPad sidebar index uses it to scroll the detail pane's
 /// SettingsView to a section; iPhone tabs and modal presentations leave it nil (no scrolling).
 enum SettingsSection: Hashable, CaseIterable {
-    case connection, notify, trouble, help, about
+    case connection, federation, notify, trouble, help, about
 
     var label: String {
         switch self {
         case .connection: return "Connection"
+        case .federation: return "Federation"
         case .notify:     return "Notifications"
         case .trouble:    return "Troubleshooting"
         case .help:       return "Help"
@@ -2758,6 +2766,7 @@ enum SettingsSection: Hashable, CaseIterable {
     var icon: String {
         switch self {
         case .connection: return "wifi"
+        case .federation: return "point.3.connected.trianglepath.dotted"
         case .notify:     return "bell"
         case .trouble:    return "wrench.and.screwdriver"
         case .help:       return "questionmark.circle"
@@ -2824,6 +2833,10 @@ struct ShortcutsSheet: View {
 }
 
 struct SettingsView: View {
+    let client: HerdrClient
+    /// Live agents, mirrored in from the home view exactly like GramView's — the
+    /// Federation section derives its remote-machine (peer) list from these.
+    let agents: [AgentInfo]
     var host: String
     var connected: Bool = true
     /// Whether "Reconnect now" is safe to offer. FALSE while the connection is in
@@ -2847,6 +2860,9 @@ struct SettingsView: View {
     /// The gestures tutorial, opened from the Help row (its persistent home now that
     /// it's no longer a tab). Presented as a child sheet over Settings.
     @State private var showGestures = false
+    /// The "add a machine" federation setup guide, opened from the Federation
+    /// section's "How to add a machine" row. A child sheet over Settings.
+    @State private var showFederationSetup = false
     /// The tip jar (StoreKit 2). Renders nothing until products load, so the section
     /// is invisible before the App Store Connect products exist.
     @ObservedObject private var tipStore = TipStore.shared
@@ -2872,6 +2888,7 @@ struct SettingsView: View {
                         // sidebar index jump to a section (no-op when scrollTo stays nil).
                         VStack(alignment: .leading, spacing: 0) {
                             connectionSection.id(SettingsSection.connection)
+                            federationSection.id(SettingsSection.federation)
                             notifySection.id(SettingsSection.notify)
                             troubleSection.id(SettingsSection.trouble)
                             helpSection.id(SettingsSection.help)
@@ -2893,6 +2910,12 @@ struct SettingsView: View {
         // reuse the same self-contained help view the first-run popup shows.
         .sheet(isPresented: $showGestures) {
             GesturesHelpView(onClose: { showGestures = false })
+                .presentationDetents([.large])
+                .presentationDragIndicator(.visible)
+        }
+        // The federation setup guide, opened from the Federation section.
+        .sheet(isPresented: $showFederationSetup) {
+            FederationSetupView(onClose: { showFederationSetup = false })
                 .presentationDetents([.large])
                 .presentationDragIndicator(.visible)
         }
@@ -2941,6 +2964,95 @@ struct SettingsView: View {
             }
             .rowShell()
             .padding(.horizontal, 16).padding(.top, 10)   // align with the toggle/action rows
+        }
+    }
+
+    /// The remote machines (federation peers) whose agents this home box lists —
+    /// one row per peer, derived from the injected `agents` (grouped by machineID,
+    /// reachability aggregated worst-case in HerdrKit's `PeerSummary`). Empty until
+    /// a machine running the herdr fork is added; the "How to add a machine" row
+    /// opens the setup guide.
+    @ViewBuilder
+    private var federationSection: some View {
+        let peers = PeerSummary.peerSummaries(from: agents)
+        VStack(alignment: .leading, spacing: 0) {
+            sectionLabel("FEDERATION")
+            if peers.isEmpty {
+                federationEmpty
+            } else {
+                VStack(spacing: 0) {
+                    ForEach(Array(peers.enumerated()), id: \.element.id) { index, peer in
+                        peerRow(peer)
+                        if index < peers.count - 1 { rowDivider }
+                    }
+                }
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+                .overlay(RoundedRectangle(cornerRadius: 12).stroke(Palette.hairline, lineWidth: 1))
+                .padding(.horizontal, 16).padding(.top, 10)
+            }
+            richActionRow("How to add a machine", systemImage: "plus.circle",
+                          subtitle: "Connect another computer to your home box") {
+                showFederationSetup = true
+            }
+        }
+    }
+
+    /// Local-only: no agent carries a machineID, so there are no remote peers yet.
+    /// Explainer copy in the section body rather than a bare empty card.
+    private var federationEmpty: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("No machines connected yet.")
+                .font(Typography.app(13)).foregroundStyle(Palette.textDim)
+            Text("Machines running an agent appear here.")
+                .font(Typography.app(13)).foregroundStyle(Palette.textFaint)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 16).padding(.vertical, 14)
+        .overlay(RoundedRectangle(cornerRadius: 12).stroke(Palette.hairline, lineWidth: 1))
+        .padding(.horizontal, 16).padding(.top, 10)
+    }
+
+    /// One peer: an identity chip keyed on the alias (the same gradient+glyph the
+    /// agent cards use), the alias, an "N agent(s)" line, and a reachability badge.
+    private func peerRow(_ peer: PeerSummary) -> some View {
+        HStack(spacing: 12) {
+            ZStack {
+                RoundedRectangle(cornerRadius: 10).fill(AgentIdentity.gradient(for: peer.alias))
+                    .frame(width: 40, height: 40)
+                Text(AgentIdentity.glyph(for: peer.alias))
+                    .font(Typography.app(18, .bold)).foregroundStyle(.white)
+            }
+            VStack(alignment: .leading, spacing: 3) {
+                Text(peer.alias)
+                    .font(Typography.app(15, .semibold)).foregroundStyle(Palette.text).lineLimit(1)
+                Text("\(peer.agentCount) agent\(peer.agentCount == 1 ? "" : "s")")
+                    .font(Typography.app(13)).foregroundStyle(Palette.textDim)
+            }
+            Spacer(minLength: 8)
+            peerBadge(peer.reachability)
+        }
+        .padding(.horizontal, 16).padding(.vertical, 12)
+    }
+
+    /// The peer's aggregate reachability as a badge. Offline reuses the agent list's
+    /// quiet `wifi.slash` square (faint ink — offline is quiet, not the stopped-red
+    /// alarm); degraded is an amber dot, reachable a quiet green dot.
+    @ViewBuilder
+    private func peerBadge(_ reachability: PeerReachability) -> some View {
+        switch reachability {
+        case .offline:
+            Image(systemName: "wifi.slash")
+                .font(.system(size: 11, weight: .bold)).foregroundStyle(Palette.textDim)
+                .frame(width: 26, height: 26)
+                .overlay(RoundedRectangle(cornerRadius: 7).stroke(Palette.textDim.opacity(0.55), lineWidth: 1.5))
+                .accessibilityLabel(Text("offline"))
+        case .degraded:
+            Circle().fill(Palette.waiting).frame(width: 8, height: 8)
+                .accessibilityLabel(Text("degraded"))
+        case .reachable:
+            Circle().fill(Palette.done).frame(width: 8, height: 8)
+                .accessibilityLabel(Text("reachable"))
         }
     }
 
@@ -3332,6 +3444,20 @@ struct SettingsView: View {
     }
 }
 
+/// Caps a column at a readable width and centers it. On a wide canvas (iPad /
+/// macOS) an edge-to-edge single column of cards drifts far past a comfortable
+/// measure; capping then re-expanding centers the capped column in the available
+/// space. On iPhone (narrower than the cap) it is inert — the inner cap never
+/// binds, so the layout is unchanged.
+private struct ReadableColumn: ViewModifier {
+    let cap: CGFloat
+    func body(content: Content) -> some View {
+        content
+            .frame(maxWidth: cap)
+            .frame(maxWidth: .infinity)
+    }
+}
+
 /// The kit's row shell: transparent fill, a 1px hairline border, and the tap
 /// shape confined to the card (so the outer gutter/gap is not a tap target).
 private extension View {
@@ -3341,6 +3467,12 @@ private extension View {
             .frame(maxWidth: .infinity, alignment: .leading)
             .overlay(RoundedRectangle(cornerRadius: 12).stroke(Palette.hairline, lineWidth: 1))
             .contentShape(RoundedRectangle(cornerRadius: 12))
+    }
+
+    /// Center + cap a column at a comfortable reading width on wide canvases;
+    /// inert on iPhone (narrower than `cap`). See `ReadableColumn`.
+    func readableColumn(_ cap: CGFloat = 560) -> some View {
+        modifier(ReadableColumn(cap: cap))
     }
 }
 

--- a/Sources/HerdrKit/Federation.swift
+++ b/Sources/HerdrKit/Federation.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+/// A peer's aggregate reachability, taken worst-case across its agents. The home
+/// box polls each remote agent's `reachability`; a machine is only as reachable as
+/// its least-reachable agent, so any `unreachable` agent makes the whole peer
+/// `.offline`, else any `degraded` makes it `.degraded`, else `.reachable`.
+///
+/// Unknown reachability strings (a newer server) read as reachable — the safe
+/// default is "not offline", matching `AgentInfo.isUnreachable`.
+public enum PeerReachability: Equatable, Sendable {
+    case reachable, degraded, offline
+}
+
+/// A remote machine (federation peer) as summarized from the agent list: one entry
+/// per distinct `machineID`, carrying how many of that peer's agents the home box
+/// currently lists and the aggregate reachability across them.
+///
+/// This is a PURE derivation from `[AgentInfo]` (no SwiftUI, no server call), so the
+/// grouping + aggregation rules are unit-tested on Linux like `AgentList`, and the
+/// Settings Federation section only renders what this decides.
+public struct PeerSummary: Equatable, Identifiable, Sendable {
+    /// The peer's alias — the shared `machineID` its agents carry (also the
+    /// `<alias>/…` prefix on their names/pane ids). Its identity here too.
+    public let alias: String
+    /// How many of this peer's agents are in the current list.
+    public let agentCount: Int
+    /// The aggregate reachability across this peer's agents (worst case wins).
+    public let reachability: PeerReachability
+
+    public var id: String { alias }
+
+    public init(alias: String, agentCount: Int, reachability: PeerReachability) {
+        self.alias = alias
+        self.agentCount = agentCount
+        self.reachability = reachability
+    }
+
+    /// Derive the remote-machine (peer) list from a flat agent list: keep only the
+    /// agents that carry a `machineID` (a remote/federated agent — a local agent
+    /// leaves it nil), group by that id, and aggregate reachability worst-case.
+    /// Sorted by alias so the list is stable between refreshes regardless of the
+    /// order the server answered in (the same churn `AgentList` guards against).
+    public static func peerSummaries(from agents: [AgentInfo]) -> [PeerSummary] {
+        let remote = agents.filter { $0.machineID != nil }
+        let byMachine = Dictionary(grouping: remote) { $0.machineID! }
+        return byMachine
+            .map { alias, group in
+                PeerSummary(
+                    alias: alias,
+                    agentCount: group.count,
+                    reachability: aggregateReachability(group))
+            }
+            .sorted { $0.alias < $1.alias }
+    }
+
+    /// Worst-case reachability across a peer's agents. Reads the RAW `reachability`
+    /// string (not the boolean `isUnreachable`, which only knows "unreachable"): any
+    /// `unreachable` agent → `.offline`, else any `degraded` → `.degraded`, else
+    /// `.reachable`. Unknown values read as reachable — the safe "not offline" default.
+    static func aggregateReachability(_ agents: [AgentInfo]) -> PeerReachability {
+        if agents.contains(where: { $0.reachability == "unreachable" }) { return .offline }
+        if agents.contains(where: { $0.reachability == "degraded" }) { return .degraded }
+        return .reachable
+    }
+}

--- a/Tests/HerdrKitTests/FederationTests.swift
+++ b/Tests/HerdrKitTests/FederationTests.swift
@@ -1,0 +1,100 @@
+import XCTest
+@testable import HerdrKit
+
+/// The pure peer-grouping derivation behind Settings' Federation section:
+/// `PeerSummary.peerSummaries(from:)` groups remote agents by machine and
+/// aggregates their reachability worst-case. Mirrors `AgentListTests`' honest
+/// fixture path — build the JSON, decode it — so a wrong CodingKey (machine_id /
+/// reachability) fails here rather than passing on an in-memory struct.
+final class FederationTests: XCTestCase {
+
+    /// Builds an AgentInfo through the decoder, so these tests exercise the same
+    /// wire path the app does. A remote agent carries `machine_id`; a local one
+    /// leaves it nil.
+    private func agent(
+        pane: String, machineID: String? = nil, reachability: String? = nil, status: String? = nil
+    ) throws -> AgentInfo {
+        var obj: [String: Any] = ["pane_id": pane]
+        if let machineID { obj["machine_id"] = machineID }
+        if let reachability { obj["reachability"] = reachability }
+        if let status { obj["agent_status"] = status }
+        let data = try JSONSerialization.data(withJSONObject: obj)
+        return try JSONDecoder().decode(AgentInfo.self, from: data)
+    }
+
+    /// Local agents (no machine_id) are not peers — only remote agents form the list.
+    func testLocalAgentsAreExcludedFromPeers() throws {
+        let peers = PeerSummary.peerSummaries(from: [
+            try agent(pane: "p1", status: "working"),                       // local
+            try agent(pane: "p2", status: "idle"),                          // local
+            try agent(pane: "mcb/p1", machineID: "mcb", reachability: "reachable"),
+        ])
+        XCTAssertEqual(peers.map(\.alias), ["mcb"],
+                       "a local agent (no machine_id) leaked into the peer list")
+        XCTAssertEqual(peers.first?.agentCount, 1, "only the one remote agent should be counted")
+    }
+
+    /// A peer with any "unreachable" agent aggregates to offline (worst case wins),
+    /// even alongside a reachable one — and both agents are still counted.
+    func testAnyUnreachableAgentMakesThePeerOffline() throws {
+        let peers = PeerSummary.peerSummaries(from: [
+            try agent(pane: "mcb/p1", machineID: "mcb", reachability: "reachable"),
+            try agent(pane: "mcb/p2", machineID: "mcb", reachability: "unreachable"),
+        ])
+        let peer = try XCTUnwrap(peers.first { $0.alias == "mcb" })
+        XCTAssertEqual(peer.agentCount, 2, "both of the peer's agents must be counted")
+        XCTAssertEqual(peer.reachability, .offline,
+                       "one unreachable agent must make the whole peer offline")
+    }
+
+    /// A peer with a "degraded" + a "reachable" agent (and no unreachable) aggregates
+    /// to degraded — not offline, and not reachable.
+    func testDegradedPlusReachableAggregatesToDegraded() throws {
+        let peers = PeerSummary.peerSummaries(from: [
+            try agent(pane: "air/p1", machineID: "air", reachability: "degraded"),
+            try agent(pane: "air/p2", machineID: "air", reachability: "reachable"),
+        ])
+        let peer = try XCTUnwrap(peers.first { $0.alias == "air" })
+        XCTAssertEqual(peer.agentCount, 2)
+        XCTAssertEqual(peer.reachability, .degraded,
+                       "a degraded agent (no unreachable) must make the peer degraded, not reachable")
+    }
+
+    /// All-reachable agents leave the peer reachable, and an unknown reachability
+    /// string (a newer server) reads as reachable — the safe "not offline" default.
+    func testAllReachableStaysReachable() throws {
+        let peers = PeerSummary.peerSummaries(from: [
+            try agent(pane: "box/p1", machineID: "box", reachability: "reachable"),
+            try agent(pane: "box/p2", machineID: "box", reachability: nil),
+            try agent(pane: "box/p3", machineID: "box", reachability: "some_future_state"),
+        ])
+        let peer = try XCTUnwrap(peers.first { $0.alias == "box" })
+        XCTAssertEqual(peer.agentCount, 3)
+        XCTAssertEqual(peer.reachability, .reachable,
+                       "no unreachable/degraded agent means the peer is reachable; an unknown "
+                       + "reachability string must read as reachable (the safe default)")
+    }
+
+    /// Multiple peers are grouped by machine_id, counted correctly, and returned in a
+    /// stable alias order regardless of the order the server answered in.
+    func testPeersAreGroupedCountedAndAliasSorted() throws {
+        let peers = PeerSummary.peerSummaries(from: [
+            try agent(pane: "zed/p1", machineID: "zed", reachability: "reachable"),
+            try agent(pane: "air/p1", machineID: "air", reachability: "reachable"),
+            try agent(pane: "air/p2", machineID: "air", reachability: "reachable"),
+            try agent(pane: "local", status: "idle"),   // excluded — no machine_id
+        ])
+        XCTAssertEqual(peers.map(\.alias), ["air", "zed"],
+                       "peers must be alias-sorted so the list is stable between refreshes")
+        XCTAssertEqual(peers.map(\.agentCount), [2, 1], "per-peer agent counts are wrong")
+    }
+
+    /// No remote agents → no peers, which is what drives the section's empty state.
+    func testNoRemoteAgentsYieldsNoPeers() throws {
+        let peers = PeerSummary.peerSummaries(from: [
+            try agent(pane: "p1", status: "working"),
+            try agent(pane: "p2", status: "idle"),
+        ])
+        XCTAssertTrue(peers.isEmpty, "with no machine_id anywhere there are no federation peers")
+    }
+}


### PR DESCRIPTION
Implements two logged issues (app-only SwiftUI, no daemon change), off `main` (has W7).

## #136 — cap host-list width on iPad/macOS
`ConnectView` was presented full-window, so the "Connect / saved hosts" column stretched edge-to-edge on wide screens. Adds a reusable `readableColumn(_ cap: CGFloat = 560)` `ViewModifier` (`.frame(maxWidth: cap).frame(maxWidth: .infinity)`) and applies it to `ConnectView`'s column. Inert on iPhone (narrower than the cap); centered + capped on iPad/macOS. **refs #136**

## #135 — Federation section in Settings
- **Wiring:** `SettingsView` now takes `client` + `agents`, threaded in exactly like `GramView` (all three call sites updated, incl. the DEBUG preview).
- **Peer list:** a new `federationSection` renders one row per remote machine, derived from the live agent list — grouped by `machineID`, reachability aggregated **worst-case** (any `unreachable` → offline, else any `degraded` → degraded, else reachable). Row = identity chip (keyed on alias) + alias + "N agents" + a reachability badge (reuses the W7 `wifi.slash` offline visual; amber `degraded`, green `reachable`). Local-only shows an explainer. New `case federation` on `SettingsSection` auto-wires the iPad sidebar.
- **Setup guide:** a "How to add a machine" row opens `FederationSetupView` (new, modeled on `GesturesHelpView`) — 4 steps (install the fork · Tailscale/SSH + authorize key · add `[[federation.peers]]` to config.toml · `herdr server reload-config`, no restart) with mono command chips.
- **Pure grouping in HerdrKit** (`Sources/HerdrKit/Federation.swift`: `PeerSummary`/`PeerReachability`/`peerSummaries(from:)`) + **unit tests** (`Tests/HerdrKitTests/FederationTests.swift`, decode-path fixtures: local excluded, worst-case aggregation, grouping/counts/alias-sort, unknown-string safety, empty). **refs #135**

### Known limitation (v1)
The peer list is derived from `agent.list`, which carries only agents — there is no `federation.peers` API — so a **configured-but-idle peer with zero agents is invisible**. Surfaced honestly in-view ("machines running an agent appear here"). Follow-up: a daemon `federation.peers` method (would also let the app add/remove peers directly, since the daemon already supports runtime reconcile via herdr PR #82).

### Note
Authored on Linux (the app is macOS/Xcode-only), so the SwiftUI was verified by mirroring existing idioms + checking every type/signature against source, not by a local compile — CI (macos-latest) is the compile gate. The HerdrKit half is pure Foundation and unit-tested.
