### PR TITLE
feat(terminal): per-viewer PTY width leases (#137) + federated key-drive input (#139)

### DIFF
--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -2079,7 +2079,10 @@ struct TerminalPaneContent: View {
                                  // focused, and never on iPhone (the terminal can't become first
                                  // responder there, so this is inert).
                                  wantsTerminalKeyFocus: isForeground && !replyFocused,
-                                 fontSize: CGFloat(terminalFontSize))
+                                 fontSize: CGFloat(terminalFontSize),
+                                 // A federated/remote pane routes key-drive input via pane.send_text
+                                 // (home can't proxy the persistent pane.input.stream channel). (#139)
+                                 isFederated: agent?.machineID != nil)
                     // Reconnect on refresh: a new id re-creates the view → fresh stream/connection.
                     .id(streamGen)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/App/LiveTerminalView.swift
+++ b/App/LiveTerminalView.swift
@@ -66,6 +66,11 @@ struct LiveTerminalView: UIViewRepresentable {
     /// in-place via `Coordinator.applyFont` when it changes — re-lays-out the grid,
     /// no view recreation.
     var fontSize: CGFloat = 12.5
+    /// Whether this pane's agent is federated/remote (`AgentInfo.machineID != nil`).
+    /// A federated pane routes key-drive input via `pane.send_text` (the home daemon
+    /// can't proxy the persistent `pane.input.stream` channel). Refreshed on every
+    /// update since the agent can resolve as federated after the view mounts. (#139)
+    var isFederated: Bool = false
 
     func makeCoordinator() -> Coordinator { Coordinator(client: client, paneID: paneID) }
 
@@ -74,12 +79,14 @@ struct LiveTerminalView: UIViewRepresentable {
             min(max(fontSize, Coordinator.minFontSize), Coordinator.maxFontSize)
         let view = ReadOnlyTerminalView(frame: .zero, font: context.coordinator.paneFont)
         context.coordinator.onNavigate = onNavigate
+        context.coordinator.isFederated = isFederated
         context.coordinator.attach(view)
         return view
     }
 
     func updateUIView(_ uiView: ReadOnlyTerminalView, context: Context) {
         context.coordinator.onNavigate = onNavigate
+        context.coordinator.isFederated = isFederated
         context.coordinator.setForeground(isForeground)
         // Drive terminal KEY focus from SwiftUI intent (iPad key-drive only). The resign is
         // gated on keyDriveEnabled so it manages ONLY key-drive focus: on iPhone/touch the view
@@ -159,6 +166,21 @@ struct LiveTerminalView: UIViewRepresentable {
     final class Coordinator: NSObject, TerminalViewDelegate, UIGestureRecognizerDelegate {
         private let client: HerdrClient
         private let paneID: String
+        /// Stable per-view identity for the daemon's PTY width-lease (#137). Generated
+        /// ONCE per Coordinator (= one view = one live `pane.stream`) and sent UNCHANGED
+        /// on BOTH this view's `pane.stream` open AND every `pane.set_pty_size` it makes,
+        /// so the lease taken by the resize is the one the daemon drops when this stream
+        /// closes. A fresh UUID per instance is deliberate: sharing one id across two
+        /// concurrent streams to a pane would let the FIRST close drop the shared lease
+        /// while the second is still open (JARVIS review finding #2 — premature shrink).
+        private let viewerID = UUID().uuidString
+        /// Whether this pane lives on a REMOTE (federated) machine (`AgentInfo.machineID
+        /// != nil`). The home daemon can route one-shot `pane.send_text` to a remote pane
+        /// (#84) but CANNOT proxy the persistent `pane.input.stream` duplex channel, so a
+        /// federated pane skips the channel and delivers every key-drive batch via
+        /// `sendText` (see `deliverInput`). Refreshed by `updateUIView` because the agent
+        /// can resolve as federated AFTER the view first mounts.
+        var isFederated = false
         private weak var view: ReadOnlyTerminalView?
         private var streamTask: Task<Void, Never>?
         /// The single serialized resize drain, if running. Only ever ONE at a time —
@@ -176,6 +198,15 @@ struct LiveTerminalView: UIViewRepresentable {
         /// set_pty_size). The drain stops once this equals `desired`.
         private var lastSentCols = 0
         private var lastSentRows = 0
+        /// The EFFECTIVE winsize the daemon actually applied, from the `set_pty_size`
+        /// response (#137). Under the width-lease arbiter this can EXCEED what this view
+        /// requested — a wider co-viewer's lease wins — so it is recorded for truth but
+        /// deliberately NOT fed back into `lastSent`: driving the drain toward the
+        /// arbiter's width would re-send forever, fighting the arbiter. The view still
+        /// RENDERS the applied (wider) grid because SwiftTerm reflows to the server cols
+        /// carried on the `pane.stream` itself; this is the coordinator's copy of that truth.
+        private var appliedCols = 0
+        private var appliedRows = 0
         /// Consecutive failures for the CURRENT target, so the drain's self-retry
         /// backs off and is capped; reset whenever a new target is requested.
         private var resizeRetries = 0
@@ -209,6 +240,20 @@ struct LiveTerminalView: UIViewRepresentable {
         /// No stream event (data, ping, resize) for this long → treat the stream as stuck and
         /// reconnect. 2.5× the server's 20s ping, so a single dropped ping is tolerated.
         private static let streamStuckTimeout: TimeInterval = 50
+
+        /// PTY width-lease heartbeat (#137). The daemon expires a viewer's lease on a
+        /// 5-minute TTL backstop (`DEFAULT_PTY_LEASE_TTL`), so a stable-size FOREGROUND
+        /// view — one that never fires a fresh `sizeChanged` — would silently lose its
+        /// lease. This task periodically re-asserts the current committed size (carrying
+        /// the same `viewerID`) to refresh the lease. Re-armed by `start()`, cancelled by
+        /// `stop()`. Backgrounded/relocking panes are skipped: they have no lease to keep.
+        private var heartbeatTask: Task<Void, Never>?
+        /// Lease TTL we request on every `lock:true` (`ttl_ms`). Explicit rather than the
+        /// server default so the refresh cadence below is provably under it.
+        private static let leaseTTLMillis: UInt64 = 300_000                 // 5 min
+        /// Lease-refresh cadence — comfortably under `leaseTTLMillis` so a single missed
+        /// beat can't lapse the lease (2 min refresh vs 5 min TTL).
+        private static let heartbeatIntervalNanos: UInt64 = 120_000_000_000  // 2 min
 
         /// Page-between-agents callback (see `LiveTerminalView.onNavigate`), refreshed
         /// by `updateUIView`. +1 = next agent, -1 = previous.
@@ -425,8 +470,10 @@ struct LiveTerminalView: UIViewRepresentable {
             keyboardObservers.removeAll()
             streamTask?.cancel()
             streamTask = nil
-            watchdogTask?.cancel()          // stop the heartbeat checker
+            watchdogTask?.cancel()          // stop the stream-stuck watchdog
             watchdogTask = nil
+            heartbeatTask?.cancel()         // stop the PTY width-lease keep-alive (#137)
+            heartbeatTask = nil
             reconnectTask?.cancel()         // cancel any pending backoff restart
             reconnectTask = nil
             backfillTask?.cancel()
@@ -468,6 +515,7 @@ struct LiveTerminalView: UIViewRepresentable {
             let client = self.client
             let pane = self.paneID
             let myGen = self.myGeometryGeneration
+            let viewerID = self.viewerID   // release THIS view's lease (#137), not the pane's
             // CHAIN releases: await the PREVIOUS entry first, so awaiting the newest release
             // transitively awaits every older one. Without this, overwriting the map here would
             // orphan an older ALREADY-committed lock:false (past its generation guard), and a later
@@ -483,7 +531,7 @@ struct LiveTerminalView: UIViewRepresentable {
                 // generation, `setForeground(true)` AWAITS this task before it re-locks.)
                 let current = await MainActor.run { Coordinator.geometryGeneration[pane] }
                 guard current == myGen else { return }
-                _ = try? await client.setPTYSize(pane: pane, cols: cols, rows: rows, lock: false)
+                _ = try? await client.setPTYSize(pane: pane, cols: cols, rows: rows, lock: false, viewerID: viewerID)
                 // Best-effort: drop our own registry entry once settled (no newer show/hide/attach
                 // bumped the generation). This only runs when the release actually SENT; a release
                 // that bailed on the generation guard above leaves the entry for the newer owner
@@ -590,10 +638,13 @@ struct LiveTerminalView: UIViewRepresentable {
             streamRunID &+= 1
             let myRun = streamRunID
             startWatchdog()
+            startHeartbeat()
             streamTask = Task { [weak self] in
                 guard let self else { return }
                 do {
-                    for try await event in self.client.streamTerminal(pane: self.paneID) {
+                    // Same viewerID as this view's set_pty_size: the daemon ties the
+                    // width-lease taken by the resize to THIS stream, dropping it on close.
+                    for try await event in self.client.streamTerminal(pane: self.paneID, viewerID: self.viewerID) {
                         if Task.isCancelled { return }
                         await self.handle(event)
                     }
@@ -618,6 +669,31 @@ struct LiveTerminalView: UIViewRepresentable {
                         self.scheduleReconnect("no response for \(Int(Self.streamStuckTimeout))s")
                         return   // scheduleReconnect → start() re-arms a fresh watchdog
                     }
+                }
+            }
+        }
+
+        /// PTY width-lease keep-alive (#137). A stable-size foreground view fires no fresh
+        /// `sizeChanged`, so without this its lease would lapse at the daemon's 5-minute TTL
+        /// and a co-viewing desktop would reclaim the width. Every `heartbeatIntervalNanos`
+        /// we re-assert the current COMMITTED size (defeating `sendPTYSize`'s dedup so the
+        /// same size actually re-sends), which the drain delivers as a fresh `lock:true`
+        /// carrying our `viewerID` + TTL. Only a FOREGROUND, non-relocking, idle-drain view
+        /// with a committed size refreshes: a hidden/relocking pane has already released its
+        /// lease (or is mid-retake) and must not re-pin, and skipping while a drain is in
+        /// flight preserves the "at most one set_pty_size in flight per pane" invariant.
+        private func startHeartbeat() {
+            heartbeatTask?.cancel()
+            heartbeatTask = Task { @MainActor [weak self] in
+                while !Task.isCancelled {
+                    try? await Task.sleep(nanoseconds: Self.heartbeatIntervalNanos)
+                    guard let self, !self.stopped else { return }
+                    guard self.foreground, !self.relockPending, self.resizeTask == nil,
+                          self.lastSentCols >= 4, self.lastSentRows >= 2 else { continue }
+                    let cols = self.lastSentCols, rows = self.lastSentRows
+                    self.lastSentCols = 0        // defeat sendPTYSize's dedup so the same size re-sends
+                    self.lastSentRows = 0
+                    self.sendPTYSize(cols: cols, rows: rows)
                 }
             }
         }
@@ -803,11 +879,20 @@ struct LiveTerminalView: UIViewRepresentable {
                     let c = self.desiredCols        // always drive toward the LATEST target
                     let r = self.desiredRows
                     do {
-                        _ = try await self.client.setPTYSize(
+                        // lock:true carries THIS view's viewerID + a lease TTL (#137): the
+                        // daemon width-lease is keyed on the viewerID and refreshed by every
+                        // such send (the heartbeat re-sends this same size under the TTL).
+                        let applied = try await self.client.setPTYSize(
                             pane: self.paneID, cols: c, rows: r,
-                            cellWidthPx: cell.width, cellHeightPx: cell.height, lock: true)
-                        self.lastSentCols = c        // confirmed
+                            cellWidthPx: cell.width, cellHeightPx: cell.height, lock: true,
+                            viewerID: self.viewerID, ttl: Self.leaseTTLMillis)
+                        self.lastSentCols = c        // confirmed: OUR request is committed
                         self.lastSentRows = r
+                        // The arbiter's EFFECTIVE size (a wider co-viewer can exceed our
+                        // request). Recorded for truth but NOT written back into lastSent —
+                        // converging the drain on it would re-send forever, fighting the arbiter.
+                        self.appliedCols = applied.cols
+                        self.appliedRows = applied.rows
                         self.resizeRetries = 0
                     } catch {
                         if Task.isCancelled { break }
@@ -885,6 +970,15 @@ struct LiveTerminalView: UIViewRepresentable {
         /// frames through one ordered writer.
         @MainActor
         private func deliverInput(_ batch: String) async {
+            // A federated (remote) pane can't host the persistent pane.input.stream duplex
+            // channel — the home daemon can't proxy it (channelSetupRejected) — so skip the
+            // channel entirely and route every batch through the federation-routable
+            // pane.send_text (#84). Order is still preserved: the single inputSendTask drain
+            // calls deliverInput serially. (#139)
+            if isFederated {
+                _ = try? await self.client.sendText(pane: self.paneID, text: batch)
+                return
+            }
             // Open the channel lazily on first use. An older daemon without
             // pane.input.stream makes start() throw, and we stay on send_text.
             if !inputChannelTried {

--- a/Sources/HerdrKit/HerdrClient.swift
+++ b/Sources/HerdrKit/HerdrClient.swift
@@ -616,7 +616,8 @@ public actor HerdrClient {
         pane: String,
         includeHistory: Bool = true,
         maxFrameBytes: Int? = nil,
-        scrollbackLines: Int? = nil
+        scrollbackLines: Int? = nil,
+        viewerID: String? = nil
     ) -> AsyncThrowingStream<TerminalStreamEvent, Error> {
         let encoder = JSONEncoder()
         let env = RequestEnvelope(
@@ -625,7 +626,8 @@ public actor HerdrClient {
             params: PaneStreamParams(
                 paneID: pane, includeHistory: includeHistory,
                 resumeFrom: nil, epoch: nil,
-                maxFrameBytes: maxFrameBytes, scrollbackLines: scrollbackLines)
+                maxFrameBytes: maxFrameBytes, scrollbackLines: scrollbackLines,
+                viewerID: viewerID)
         )
         guard let data = try? encoder.encode(env) else {
             return AsyncThrowingStream { $0.finish(throwing: TransportError.closedBeforeResponse) }
@@ -712,13 +714,16 @@ public actor HerdrClient {
         rows: Int,
         cellWidthPx: UInt32? = nil,
         cellHeightPx: UInt32? = nil,
-        lock: Bool = false
+        lock: Bool = false,
+        viewerID: String? = nil,
+        ttl: UInt64? = nil
     ) async throws -> PanePtySize {
         let clampedCols = min(max(cols, 4), Int(UInt16.max))
         let clampedRows = min(max(rows, 2), Int(UInt16.max))
         let params = PaneSetPtySizeParams(
             paneID: pane, cols: clampedCols, rows: clampedRows,
-            cellWidthPx: cellWidthPx, cellHeightPx: cellHeightPx, lock: lock)
+            cellWidthPx: cellWidthPx, cellHeightPx: cellHeightPx, lock: lock,
+            viewerID: viewerID, ttl: ttl)
         return try await call("pane.set_pty_size", params, as: PanePtySize.self)
     }
 }

--- a/Sources/HerdrKit/Wire.swift
+++ b/Sources/HerdrKit/Wire.swift
@@ -385,6 +385,13 @@ public struct PaneStreamParams: Encodable, Sendable {
     public let epoch: UInt64?
     public let maxFrameBytes: Int?
     public let scrollbackLines: Int?
+    /// Opaque per-view identity for the daemon's PTY width-lease bookkeeping (#137).
+    /// The daemon ties a viewer's width-lease liveness to its `pane.stream`: it drops
+    /// that viewer's lease when this stream closes. MUST be the SAME value the view
+    /// sends on its `pane.set_pty_size` (`PaneSetPtySizeParams.viewerID`) so the lease
+    /// taken there is the one released when this stream ends. Optional/omitted-when-nil:
+    /// an older daemon ignores it and a caller that doesn't lease leaves it nil.
+    public let viewerID: String?
 
     public init(
         paneID: String,
@@ -392,7 +399,8 @@ public struct PaneStreamParams: Encodable, Sendable {
         resumeFrom: UInt64? = nil,
         epoch: UInt64? = nil,
         maxFrameBytes: Int? = nil,
-        scrollbackLines: Int? = nil
+        scrollbackLines: Int? = nil,
+        viewerID: String? = nil
     ) {
         self.paneID = paneID
         self.includeHistory = includeHistory
@@ -400,6 +408,7 @@ public struct PaneStreamParams: Encodable, Sendable {
         self.epoch = epoch
         self.maxFrameBytes = maxFrameBytes
         self.scrollbackLines = scrollbackLines
+        self.viewerID = viewerID
     }
 
     enum CodingKeys: String, CodingKey {
@@ -409,6 +418,7 @@ public struct PaneStreamParams: Encodable, Sendable {
         case epoch
         case maxFrameBytes = "max_frame_bytes"
         case scrollbackLines = "scrollback_lines"
+        case viewerID = "viewer_id"
     }
 }
 
@@ -424,6 +434,18 @@ public struct PaneSetPtySizeParams: Encodable, Sendable {
     public let cellWidthPx: UInt32?
     public let cellHeightPx: UInt32?
     public let lock: Bool
+    /// Opaque per-view identity for the daemon's PTY width-lease (#137). The daemon
+    /// keys a viewer's width-lease on this: the WIDEST active viewer's geometry wins,
+    /// so a narrow viewer no longer shrinks a wider co-viewer. MUST equal the value
+    /// this view sends on its `pane.stream` open (`PaneStreamParams.viewerID`) — the
+    /// daemon drops this lease when that stream closes. Optional/omitted-when-nil so an
+    /// older daemon (and a non-leasing caller) is unaffected.
+    public let viewerID: String?
+    /// Lease time-to-live in milliseconds (#137). The daemon clamps to [1, 86_400_000]
+    /// and applies a 5-minute default (`DEFAULT_PTY_LEASE_TTL`) when omitted. A
+    /// foreground view re-sends within the TTL to keep its lease alive. Optional/
+    /// omitted-when-nil.
+    public let ttl: UInt64?
 
     public init(
         paneID: String,
@@ -431,7 +453,9 @@ public struct PaneSetPtySizeParams: Encodable, Sendable {
         rows: Int,
         cellWidthPx: UInt32? = nil,
         cellHeightPx: UInt32? = nil,
-        lock: Bool = false
+        lock: Bool = false,
+        viewerID: String? = nil,
+        ttl: UInt64? = nil
     ) {
         self.paneID = paneID
         self.cols = cols
@@ -439,6 +463,8 @@ public struct PaneSetPtySizeParams: Encodable, Sendable {
         self.cellWidthPx = cellWidthPx
         self.cellHeightPx = cellHeightPx
         self.lock = lock
+        self.viewerID = viewerID
+        self.ttl = ttl
     }
 
     enum CodingKeys: String, CodingKey {
@@ -446,6 +472,8 @@ public struct PaneSetPtySizeParams: Encodable, Sendable {
         case cols, rows, lock
         case cellWidthPx = "cell_width_px"
         case cellHeightPx = "cell_height_px"
+        case viewerID = "viewer_id"
+        case ttl = "ttl_ms"
     }
 }
 


### PR DESCRIPTION
## What

The app half of the two federated-terminal fixes — Slice 4 (#137, per-viewer width leases) and Slice 2 (#139, federated key-drive input). The daemon halves are merged (herdr #85 + #84).

## Slice 4 — #137 per-viewer width leases

The merged daemon change keys a PTY width-lease on an opaque `viewer_id`: the widest active viewer's geometry wins, and a viewer's lease is dropped when its `pane.stream` closes. This wires the app to that contract:

- **`viewerID`** — a stable `UUID().uuidString` on the **Coordinator** (the per-view object; the `LiveTerminalView` struct is recreated each render, so a struct-level `let` would mint a new id per render). Sent UNCHANGED on **both** the view's `pane.stream` open and every `pane.set_pty_size` it makes. A fresh id per view (one view = one live stream) is deliberate — sharing one id across two concurrent streams would let the first close drop the shared lease while the second is open (the daemon-review finding; premature shrink).
- **Wire/client**: optional `viewer_id` on `PaneStreamParams`; optional `viewer_id` + `ttl_ms` on `PaneSetPtySizeParams`; threaded through `streamTerminal(…, viewerID:)` and `setPTYSize(…, viewerID:, ttl:)`. Optional + omitted-when-nil (synthesized `encodeIfPresent`), so an older daemon is unaffected. `PanePtySize` response unchanged.
- **Heartbeat**: a stable-size foreground view fires no fresh `sizeChanged`, so a 2-minute heartbeat re-asserts the committed size (carrying the same viewerID) under the daemon's 5-minute lease TTL. Gated on foreground + not-relocking + idle-drain + a committed size, mirroring the existing `startWatchdog` task shape; cancelled in `stop()`.
- **Release-on-detach**: `releaseGeometryOwnership`'s `lock:false` carries the viewerID so the daemon drops *this* view's lease.
- **Applied size**: the `lock:true` response is captured (`appliedCols/Rows`) instead of discarded — the arbiter can apply a wider size than this view requested when a co-viewer wins. It is deliberately **not** fed back into the resize drain (that would re-send forever fighting the arbiter); the grid already reflows to the effective width via the stream's `resize` frames. *(These two properties are currently recorded-not-consumed — kept as the documented truth of the arbiter interaction; happy to drop them or wire a consumer per your call.)*

## Slice 2 — #139 federated key-drive input

A federated pane (`AgentInfo.machineID != nil`) can't host the persistent `pane.input.stream` duplex channel — the home daemon can't proxy it to the owning peer (`NIOSSHError.channelSetupRejected`). `deliverInput` now branches early for a federated pane and routes every key-drive batch through the federation-routable `pane.send_text` (merged #84). Order is preserved (the single `inputSendTask` drain calls `deliverInput` serially). Keybar control keys (S-Tab/^C/Ctrl) already route via `send_text`/`send_keys` and were already federation-safe — no change. The origin/main `deliverInput` already re-sends the batch via `send_text` when the channel can't confirm, so no fallback change was needed.

## Testing

- Cannot compile locally (macOS/Xcode only) — **CI `check (macos-latest)` is the gate.** Verified by reading: all referenced symbols exist with matching signatures; the heartbeat task mirrors the existing `startWatchdog` `Task { @MainActor }` pattern; `viewer_id`/`ttl_ms` CodingKeys match the daemon JSON; all production `setPTYSize`/`streamTerminal` call sites carry the same per-view viewerID (only mock-fixture tests use the nil default).
- No protocol version change (additive optional fields).

refs #137
refs #139
