### PR TITLE
feat(terminal): restart agent — context-menu action that resumes in place

### DIFF
--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -880,6 +880,10 @@ struct TerminalHomeView: View {
     /// Latches the "Copied ✓" state on the install-command copy button.
     @State private var installCmdCopied = false
     @State private var search = ""
+    /// The agent a pending "Restart agent" confirmation is about (nil = no
+    /// dialog). Set from the agent card's context menu; a restart interrupts a
+    /// busy agent's turn, so it is confirmed before firing.
+    @State private var restartCandidate: AgentRow?
     @State private var activeCover: ActiveCover?
     /// The selected bottom tab (Agents / Gram / Settings). Terminal is NOT a tab — it
     /// fronts a keep-mounted pane OVER the tabs (see PaneKeepAliveContainer). Gram and
@@ -1434,6 +1438,32 @@ struct TerminalHomeView: View {
             // full-screen (the pane overlay covers it too; this animates it away and
             // guards against the bar drawing over the overlay on some iOS versions).
             .toolbar(frontID != nil ? .hidden : .automatic, for: .tabBar)
+            .confirmationDialog(
+                "Restart agent?",
+                isPresented: Binding(
+                    get: { restartCandidate != nil },
+                    set: { if !$0 { restartCandidate = nil } }
+                ),
+                presenting: restartCandidate
+            ) { row in
+                Button("Restart", role: .destructive) {
+                    let target = row.info.paneID
+                    let title = row.title
+                    Task {
+                        do {
+                            try await client.restartAgent(target: target)
+                            await load()
+                        } catch let e {
+                            error = "couldn't restart \(title): \(e.localizedDescription)"
+                        }
+                    }
+                }
+                Button("Cancel", role: .cancel) {}
+            } message: { row in
+                Text(
+                    "Interrupts \(row.title)'s current turn. Its session is preserved and reopened with --resume."
+                )
+            }
         }
     }
 
@@ -1565,6 +1595,12 @@ struct TerminalHomeView: View {
                                 }
                             }
                         } label: { Label("Stop agent", systemImage: "stop.circle") }
+                        // Restart = close the agent's session and reopen it with
+                        // --resume in place (keeps the pane). It interrupts a busy
+                        // agent's turn, so it routes through a confirmation.
+                        Button {
+                            restartCandidate = row
+                        } label: { Label("Restart agent", systemImage: "arrow.clockwise") }
                     }
                 }
             }

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -1454,7 +1454,11 @@ struct TerminalHomeView: View {
                             try await client.restartAgent(target: target)
                             await load()
                         } catch let e {
-                            error = "couldn't restart \(title): \(e.localizedDescription)"
+                            // Interpolate the APIError directly ("code: message",
+                            // via CustomStringConvertible) — `.localizedDescription`
+                            // bridges through NSError to a useless generic string,
+                            // hiding the daemon's `no_resumable_session`.
+                            error = "couldn't restart \(title): \(e)"
                         }
                     }
                 }
@@ -1591,7 +1595,10 @@ struct TerminalHomeView: View {
                                     try await client.closePane(paneID: row.info.paneID)
                                     await load()
                                 } catch let e {
-                                    error = "couldn't stop \(row.title): \(e.localizedDescription)"
+                                    // `\(e)` surfaces the APIError's "code: message"
+                                    // (CustomStringConvertible); `.localizedDescription`
+                                    // would bridge to a useless generic NSError string.
+                                    error = "couldn't stop \(row.title): \(e)"
                                 }
                             }
                         } label: { Label("Stop agent", systemImage: "stop.circle") }

--- a/Sources/HerdrKit/HerdrClient.swift
+++ b/Sources/HerdrKit/HerdrClient.swift
@@ -531,6 +531,25 @@ public actor HerdrClient {
         _ = try await call("pane.close", PaneTarget(paneID: paneID), as: JSONNull.self)
     }
 
+    struct AgentTargetParams: Encodable {
+        let target: String
+    }
+
+    struct AgentInfoResult: Decodable {
+        let agent: AgentInfo
+    }
+
+    /// Restarts an agent in place: the daemon kills its harness process and
+    /// reopens the SAME session with `--resume`, keeping the pane and identity.
+    /// `target` is the pane id (or agent name). Throws when the agent has no
+    /// resumable session (`no_resumable_session` — not a herdr-launched agent, or
+    /// none reported). Returns the restarted agent.
+    @discardableResult
+    public func restartAgent(target: String) async throws -> AgentInfo {
+        try await call("agent.restart", AgentTargetParams(target: target), as: AgentInfoResult.self)
+            .agent
+    }
+
     /// True when `pane` reports an agent WITH a composer — the observable proxy for
     /// "a prompt will land NOW". This is the STRICTER new-agent PRE-FILL gate
     /// (`InputRouter.isPromptable(for:)`), deliberately NOT the reply-routing gate


### PR DESCRIPTION
## What

The app half of the agent-restart feature (daemon: herdr #86): a "Restart agent" action on each agent card's context menu.

## How

- Beside the existing "Stop agent", a new **"Restart agent"** button (`arrow.clockwise`) calls the new daemon `agent.restart`, which kills the agent's harness process and reopens its session with `--resume` **in place** — the pane and identity are kept.
- Restarting interrupts a busy agent's turn, so it routes through a **confirmation dialog** ("Interrupts its current turn. Its session is preserved and reopened with --resume.").
- A `no_resumable_session` error (not a herdr-launched agent, or none reported) surfaces inline, mirroring the existing "couldn't stop" error.
- Client: `restartAgent(target:)` mirrors `closePane`; it decodes the `agent.restart` response (`AgentInfo`) via a small `AgentInfoResult`.

## Testing

Cannot compile locally (macOS/Xcode only) — **CI `check (macos-latest)` is the gate.** Verified by reading: no symbol collisions (`AgentTargetParams`/`AgentInfoResult` defined once); `AgentRow.info.paneID` / `.title` are what the Stop button already uses; `client` is a non-optional `let` in `TerminalHomeView`; `catch let e` avoids the `@State error` name clash; `AgentRow` is `Identifiable` (valid for `confirmationDialog(presenting:)`).

Pairs with the daemon `agent.restart` (herdr #86); ships via TestFlight after that deploys. Complements herdrup#87.
