### PR TITLE
feat(accounts): Accounts settings view + swap subscription

### DIFF
--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -869,6 +869,10 @@ struct TerminalHomeView: View {
     private static let agentListPollInterval: UInt64 = 5_000_000_000
 
     @State private var agents: [AgentInfo] = []
+    /// The credential accounts (subscriptions), for the per-agent "Swap subscription"
+    /// submenu. Refreshed alongside `agents` in `load()`; a stale list is fine (the
+    /// worst case is offering a swap that no-ops or fails loudly, never a wrong swap).
+    @State private var accounts: [CredentialAccount] = []
     @State private var error: String?
     @State private var loading = true
     @State private var rejectedFingerprint: String?
@@ -1608,6 +1612,36 @@ struct TerminalHomeView: View {
                         Button {
                             restartCandidate = row
                         } label: { Label("Restart agent", systemImage: "arrow.clockwise") }
+                        // Swap = restart the agent onto a DIFFERENT credential account
+                        // of the same kind (an agent runs only on its own kind's
+                        // subscriptions). Shown only when the daemon reported at least
+                        // one same-kind account; we can't tell which one it's on now,
+                        // so the list may include the current account — swapping to it
+                        // is a harmless no-op restart, not a wrong swap.
+                        let swapTargets = accounts.filter { $0.kind == row.info.agent }
+                        if !swapTargets.isEmpty {
+                            Menu {
+                                ForEach(swapTargets) { acct in
+                                    Button {
+                                        Task {
+                                            do {
+                                                try await client.restartAgent(
+                                                    target: row.info.paneID, account: acct.id)
+                                                await load()
+                                            } catch let e {
+                                                // `\(e)` surfaces the APIError's
+                                                // "code: message"; `.localizedDescription`
+                                                // would bridge to a useless generic string.
+                                                error = "couldn't swap \(row.title): \(e)"
+                                            }
+                                        }
+                                    } label: {
+                                        Label(acct.label + (acct.active ? "" : " (exhausted)"),
+                                              systemImage: "person.crop.circle")
+                                    }
+                                }
+                            } label: { Label("Swap subscription", systemImage: "arrow.left.arrow.right") }
+                        }
                     }
                 }
             }
@@ -1827,6 +1861,11 @@ struct TerminalHomeView: View {
         do {
             let fetched = try await client.agentList()
             agents = fetched
+            // Refresh the account roster for the swap submenu. Best-effort and
+            // stale-preserving: only overwrite on a successful fetch, so a transient
+            // failure — or an older daemon without `accounts.list` — keeps the
+            // last-good list rather than blanking the submenu mid-session.
+            if let fetchedAccounts = try? await client.accountsList() { accounts = fetchedAccounts }
             error = nil
             rejectedFingerprint = nil
             trustFailed = false
@@ -2796,12 +2835,13 @@ struct TerminalPaneContent: View {
 /// A jump target within Settings. The iPad sidebar index uses it to scroll the detail pane's
 /// SettingsView to a section; iPhone tabs and modal presentations leave it nil (no scrolling).
 enum SettingsSection: Hashable, CaseIterable {
-    case connection, federation, notify, trouble, help, about
+    case connection, federation, accounts, notify, trouble, help, about
 
     var label: String {
         switch self {
         case .connection: return "Connection"
         case .federation: return "Federation"
+        case .accounts:   return "Accounts"
         case .notify:     return "Notifications"
         case .trouble:    return "Troubleshooting"
         case .help:       return "Help"
@@ -2813,6 +2853,7 @@ enum SettingsSection: Hashable, CaseIterable {
         switch self {
         case .connection: return "wifi"
         case .federation: return "point.3.connected.trianglepath.dotted"
+        case .accounts:   return "key.horizontal"
         case .notify:     return "bell"
         case .trouble:    return "wrench.and.screwdriver"
         case .help:       return "questionmark.circle"
@@ -2903,6 +2944,13 @@ struct SettingsView: View {
     @AppStorage("notify.finishes") private var notifyFinishes = false
     @AppStorage("notify.gram") private var notifyGram = true
     @State private var copied = false
+    /// The credential accounts (subscriptions) for the Accounts section. Fetched by
+    /// this view itself (`.task` below) via the injected `client`, mirroring how the
+    /// Federation section derives from the injected agents. Empty until loaded, and
+    /// on an older daemon lacking `accounts.list` (the fetch is `try?`).
+    @State private var accounts: [CredentialAccount] = []
+    /// The "How accounts work" explainer alert, opened from the Accounts section.
+    @State private var showAccountsHelp = false
     /// The gestures tutorial, opened from the Help row (its persistent home now that
     /// it's no longer a tab). Presented as a child sheet over Settings.
     @State private var showGestures = false
@@ -2935,13 +2983,18 @@ struct SettingsView: View {
                         VStack(alignment: .leading, spacing: 0) {
                             connectionSection.id(SettingsSection.connection)
                             federationSection.id(SettingsSection.federation)
+                            accountsSection.id(SettingsSection.accounts)
                             notifySection.id(SettingsSection.notify)
                             troubleSection.id(SettingsSection.trouble)
                             helpSection.id(SettingsSection.help)
                             supportSection
                             aboutSection.id(SettingsSection.about)
-                            versionFooter
-                            githubFooter
+                            // Grouped so the top-level builder stays at/under SwiftUI's
+                            // 10-child ViewBuilder ceiling now that Accounts is a child.
+                            Group {
+                                versionFooter
+                                githubFooter
+                            }
                         }
                         .padding(.bottom, 16)
                     }
@@ -2968,6 +3021,18 @@ struct SettingsView: View {
         // Load the tip products when Settings opens. No-ops after a successful load;
         // re-tries after a prior failure, so products created in ASC later appear.
         .task { await tipStore.loadProducts() }
+        // Fetch the credential accounts for the Accounts section when Settings opens.
+        // `try?` so an older daemon without `accounts.list` (or a transient failure)
+        // just leaves the section empty rather than surfacing an error here.
+        .task { accounts = (try? await client.accountsList()) ?? [] }
+        // The "How accounts work" explainer — accounts are configured on the box, not
+        // in the app, so this points there rather than offering an in-app add flow.
+        .alert("How accounts work", isPresented: $showAccountsHelp) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text("Subscriptions are configured on your home box with the herdr CLI. "
+                + "Each agent runs on one; swap it from the agent's menu on the Agents tab.")
+        }
         // Keep the notify section's permission state honest: on open, and again when the
         // app returns to the foreground (the user may have flipped it in iOS Settings).
         .onAppear { refreshNotifyAuth() }
@@ -3099,6 +3164,142 @@ struct SettingsView: View {
         case .reachable:
             Circle().fill(Palette.done).frame(width: 8, height: 8)
                 .accessibilityLabel(Text("reachable"))
+        }
+    }
+
+    // MARK: Accounts (credential subscriptions)
+
+    /// The credential accounts (subscriptions) configured on the home box — one row
+    /// per account with its kind identity, status, and usage. Mirrors
+    /// `federationSection`: a section label, a rounded/stroked card of `accountRow`s
+    /// (or an empty explainer), and a trailing "How accounts work" info row. Accounts
+    /// are set up on the box, so there is no in-app add flow — the info row explains.
+    @ViewBuilder
+    private var accountsSection: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            sectionLabel("ACCOUNTS")
+            if accounts.isEmpty {
+                accountsEmpty
+            } else {
+                VStack(spacing: 0) {
+                    ForEach(Array(accounts.enumerated()), id: \.element.id) { index, account in
+                        accountRow(account)
+                        if index < accounts.count - 1 { rowDivider }
+                    }
+                }
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+                .overlay(RoundedRectangle(cornerRadius: 12).stroke(Palette.hairline, lineWidth: 1))
+                .padding(.horizontal, 16).padding(.top, 10)
+            }
+            richActionRow("How accounts work", systemImage: "info.circle",
+                          subtitle: "Subscriptions are set up on your home box") {
+                showAccountsHelp = true
+            }
+        }
+    }
+
+    /// No accounts reported (an older daemon, or none configured). Explainer copy in
+    /// the section body rather than a bare empty card — mirrors `federationEmpty`.
+    private var accountsEmpty: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("No accounts configured.")
+                .font(Typography.app(13)).foregroundStyle(Palette.textDim)
+            Text("Subscriptions set up on your home box appear here.")
+                .font(Typography.app(13)).foregroundStyle(Palette.textFaint)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 16).padding(.vertical, 14)
+        .overlay(RoundedRectangle(cornerRadius: 12).stroke(Palette.hairline, lineWidth: 1))
+        .padding(.horizontal, 16).padding(.top, 10)
+    }
+
+    /// One account: an identity chip keyed on the KIND (the same gradient+glyph the
+    /// agent cards use, so an account reads as the same family as the agents that run
+    /// on it), the label as title, a "kind · plan" subtitle, and a trailing usage +
+    /// status view. Mirrors `peerRow`.
+    private func accountRow(_ account: CredentialAccount) -> some View {
+        HStack(spacing: 12) {
+            ZStack {
+                RoundedRectangle(cornerRadius: 10).fill(AgentIdentity.gradient(for: account.kind))
+                    .frame(width: 40, height: 40)
+                Text(AgentIdentity.glyph(for: account.kind))
+                    .font(Typography.app(18, .bold)).foregroundStyle(.white)
+            }
+            VStack(alignment: .leading, spacing: 3) {
+                Text(account.label)
+                    .font(Typography.app(15, .semibold)).foregroundStyle(Palette.text).lineLimit(1)
+                Text(accountSubtitle(account))
+                    .font(Typography.app(13)).foregroundStyle(Palette.textDim).lineLimit(1)
+            }
+            Spacer(minLength: 8)
+            accountTrailing(account)
+        }
+        .padding(.horizontal, 16).padding(.vertical, 12)
+    }
+
+    /// "kind" or "kind · plan" — the plan/tier name folds into the subtitle so the
+    /// trailing view can stay the meter+status. Nothing extra when usage is absent.
+    private func accountSubtitle(_ account: CredentialAccount) -> String {
+        var parts: [String] = [account.kind]
+        if let plan = account.usage?.plan ?? account.usage?.tier, !plan.isEmpty {
+            parts.append(plan)
+        }
+        return parts.joined(separator: " · ")
+    }
+
+    /// The trailing status/usage cluster: the usage meter(s) when a percent is
+    /// reported, then the status indicator — a green dot when active, a red
+    /// "exhausted" pill when not (colour = meaning, like the agent status badges).
+    @ViewBuilder
+    private func accountTrailing(_ account: CredentialAccount) -> some View {
+        HStack(spacing: 10) {
+            if let usage = account.usage, usage.primaryUsedPercent != nil {
+                VStack(alignment: .trailing, spacing: 4) {
+                    if let primary = usage.primaryUsedPercent {
+                        usageMeter(percent: primary, window: "5h")
+                    }
+                    if let secondary = usage.secondaryUsedPercent {
+                        usageMeter(percent: secondary, window: "wk")
+                    }
+                }
+            }
+            if account.active {
+                Circle().fill(Palette.done).frame(width: 8, height: 8)
+                    .accessibilityLabel(Text("active"))
+            } else {
+                Text("exhausted")
+                    .font(Typography.app(11, .semibold)).foregroundStyle(Palette.died)
+                    .padding(.horizontal, 8).padding(.vertical, 3)
+                    .background(Capsule().fill(Palette.died.opacity(0.12)))
+                    .overlay(Capsule().stroke(Palette.died.opacity(0.5), lineWidth: 1))
+                    .accessibilityLabel(Text("exhausted"))
+            }
+        }
+    }
+
+    /// A tiny usage bar + "NN% · <window>" readout. The bar fills proportional to use
+    /// and shifts green→amber→red as it nears the cap (colour = meaning).
+    private func usageMeter(percent: Double, window: String) -> some View {
+        let clamped = max(0.0, min(100.0, percent))
+        let fill = CGFloat(max(2.0, 34.0 * clamped / 100.0))
+        return HStack(spacing: 6) {
+            ZStack(alignment: .leading) {
+                Capsule().fill(Palette.hairline).frame(width: 34, height: 4)
+                Capsule().fill(usageColor(clamped)).frame(width: fill, height: 4)
+            }
+            Text("\(Int(clamped.rounded()))% · \(window)")
+                .font(Typography.machine(11)).foregroundStyle(Palette.textDim).fixedSize()
+        }
+    }
+
+    /// Usage colour by headroom: comfortable green, amber as it tightens, red at the
+    /// cap. The same meaning-carrying palette as the agent status badges.
+    private func usageColor(_ percent: Double) -> Color {
+        switch percent {
+        case ..<75:  return Palette.done
+        case ..<95:  return Palette.waiting
+        default:     return Palette.died
         }
     }
 
@@ -3630,6 +3831,7 @@ struct MockTransport: HerdrTransport {
         // ccscroll receipt: any request may carry an SGR wheel event the app sent
         // (via sendText); the driver scrolls the stand-in Claude Code if so.
         ccDriver?.received(requestLine)
+        if requestLine.contains("accounts.list") { return Self.accountsList }
         if requestLine.contains("agent.list") { return Self.agentList }
         if requestLine.contains("agent.read") { return backfill ? Self.backfillRead() : Self.agentRead }
         if requestLine.contains("gram.list") { return Self.gramList }
@@ -3722,6 +3924,19 @@ struct MockTransport: HerdrTransport {
     static let demoLivePaneIDs: Set<String> = [
         "w1:p1", "w1:p2", "w2:p2", "w3:p1", "w3:p2", "w4:p1", "w4:p2",
     ]
+
+    /// `accounts.list` for the Settings mock render: two claude accounts (one active
+    /// with usage, one exhausted), a codex account with tier-only usage, and a kimi
+    /// account with none. Byte-identical to MockWireFixtures.accountsList in the
+    /// tests, where it is machine-checked to decode. If you change one, change both.
+    static let accountsList = #"""
+    {"id":"mock","result":{"type":"accounts_list","accounts":[
+      {"id":"acc-claude-1","kind":"claude","label":"Claude Max (work)","active":true,"usage":{"primary_used_percent":42,"secondary_used_percent":68,"resets_at":"2026-08-20T18:00:00Z","plan":"Max"}},
+      {"id":"acc-claude-2","kind":"claude","label":"Claude Pro (personal)","active":false,"usage":{"primary_used_percent":100,"secondary_used_percent":100,"plan":"Pro"}},
+      {"id":"acc-codex-1","kind":"codex","label":"Codex (team)","active":true,"usage":{"tier":"Plus"}},
+      {"id":"acc-kimi-1","kind":"kimi","label":"Kimi","active":true}
+    ]}}
+    """#
 
     static let agentRead = #"""
     {"id":"mock","result":{"read":{"pane_id":"w1:p1","text":"$ herdr agent attach jarvis\n\n> Ran 146 tests, 0 failures\n> Edited SessionRecoveryTests.swift  +18 -4\n\nRun `swift test` with -Xswiftc -warnings-as-errors?\n  1. yes\n  2. no, skip it\n>\n\n[demo data - mock render mode, no live connection]","truncated":false,"source":"recent_unwrapped","format":"text"}}}

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -888,6 +888,15 @@ struct TerminalHomeView: View {
     /// dialog). Set from the agent card's context menu; a restart interrupts a
     /// busy agent's turn, so it is confirmed before firing.
     @State private var restartCandidate: AgentRow?
+    /// A pending "Swap subscription" confirmation: which agent, and the target
+    /// account. A swap IS a full restart (kills + --resume) onto a different
+    /// credential account, so it interrupts a busy turn exactly like the plain
+    /// restart above — and is confirmed before firing for the same reason.
+    private struct PendingSwap {
+        let row: AgentRow
+        let account: CredentialAccount
+    }
+    @State private var swapCandidate: PendingSwap?
     @State private var activeCover: ActiveCover?
     /// The selected bottom tab (Agents / Gram / Settings). Terminal is NOT a tab — it
     /// fronts a keep-mounted pane OVER the tabs (see PaneKeepAliveContainer). Gram and
@@ -1472,6 +1481,36 @@ struct TerminalHomeView: View {
                     "Interrupts \(row.title)'s current turn. Its session is preserved and reopened with --resume."
                 )
             }
+            .confirmationDialog(
+                "Swap subscription?",
+                isPresented: Binding(
+                    get: { swapCandidate != nil },
+                    set: { if !$0 { swapCandidate = nil } }
+                ),
+                presenting: swapCandidate
+            ) { cand in
+                Button("Swap", role: .destructive) {
+                    let target = cand.row.info.paneID
+                    let title = cand.row.title
+                    let accountID = cand.account.id
+                    Task {
+                        do {
+                            try await client.restartAgent(target: target, account: accountID)
+                            await load()
+                        } catch let e {
+                            // `\(e)` surfaces the APIError's "code: message"
+                            // (CustomStringConvertible); `.localizedDescription`
+                            // would bridge to a useless generic NSError string.
+                            error = "couldn't swap \(title): \(e)"
+                        }
+                    }
+                }
+                Button("Cancel", role: .cancel) {}
+            } message: { cand in
+                Text(
+                    "Switches \(cand.row.title) to \(cand.account.label) and restarts it — this interrupts its current turn. The session is reopened with --resume on the new subscription."
+                )
+            }
         }
     }
 
@@ -1616,25 +1655,17 @@ struct TerminalHomeView: View {
                         // of the same kind (an agent runs only on its own kind's
                         // subscriptions). Shown only when the daemon reported at least
                         // one same-kind account; we can't tell which one it's on now,
-                        // so the list may include the current account — swapping to it
-                        // is a harmless no-op restart, not a wrong swap.
+                        // so the list may include the current account. Picking an
+                        // account does NOT fire immediately — it stages a confirmation
+                        // (swapCandidate), because a swap is a full turn-interrupting
+                        // restart, and even swapping to the current account restarts
+                        // (interrupts) the agent rather than being a no-op.
                         let swapTargets = accounts.filter { $0.kind == row.info.agent }
                         if !swapTargets.isEmpty {
                             Menu {
                                 ForEach(swapTargets) { acct in
                                     Button {
-                                        Task {
-                                            do {
-                                                try await client.restartAgent(
-                                                    target: row.info.paneID, account: acct.id)
-                                                await load()
-                                            } catch let e {
-                                                // `\(e)` surfaces the APIError's
-                                                // "code: message"; `.localizedDescription`
-                                                // would bridge to a useless generic string.
-                                                error = "couldn't swap \(row.title): \(e)"
-                                            }
-                                        }
+                                        swapCandidate = PendingSwap(row: row, account: acct)
                                     } label: {
                                         Label(acct.label + (acct.active ? "" : " (exhausted)"),
                                               systemImage: "person.crop.circle")

--- a/Sources/HerdrKit/HerdrClient.swift
+++ b/Sources/HerdrKit/HerdrClient.swift
@@ -59,6 +59,15 @@ public actor HerdrClient {
         try await call("agent.list", EmptyParams(), as: AgentListResult.self).agents
     }
 
+    /// Every credential account (subscription) the daemon knows about, for the
+    /// Settings → Accounts list and the per-agent "Swap subscription" menu. Mirrors
+    /// `agentList()`: a small parameterless JSON query. THROWS the server's
+    /// `APIError` on an older daemon that lacks the method, so callers that want a
+    /// quiet degrade use `try?`.
+    public func accountsList() async throws -> [CredentialAccount] {
+        try await call("accounts.list", EmptyParams(), as: AccountsListResult.self).accounts
+    }
+
     /// The complete pane set, as a value that carries its own provenance.
     ///
     /// `SessionRecovery.observe` takes this rather than `[AgentInfo]` because an
@@ -535,18 +544,40 @@ public actor HerdrClient {
         let target: String
     }
 
+    /// `agent.restart` params. `account` is the credential-account id to swap the
+    /// agent onto; it is OMITTED when nil (a plain in-place restart) via the custom
+    /// `encode`, so a no-account restart sends exactly the old `{ target }` payload
+    /// and an older daemon is unaffected. Mirrors the server's optional/skip-if-none.
+    struct AgentRestartParams: Encodable {
+        let target: String
+        let account: String?
+
+        enum CodingKeys: String, CodingKey {
+            case target, account
+        }
+
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(target, forKey: .target)
+            try container.encodeIfPresent(account, forKey: .account)
+        }
+    }
+
     struct AgentInfoResult: Decodable {
         let agent: AgentInfo
     }
 
     /// Restarts an agent in place: the daemon kills its harness process and
     /// reopens the SAME session with `--resume`, keeping the pane and identity.
-    /// `target` is the pane id (or agent name). Throws when the agent has no
+    /// `target` is the pane id (or agent name). Passing `account` reopens the
+    /// session on that credential subscription instead (the "swap subscription"
+    /// action); nil keeps the current account. Throws when the agent has no
     /// resumable session (`no_resumable_session` — not a herdr-launched agent, or
     /// none reported). Returns the restarted agent.
     @discardableResult
-    public func restartAgent(target: String) async throws -> AgentInfo {
-        try await call("agent.restart", AgentTargetParams(target: target), as: AgentInfoResult.self)
+    public func restartAgent(target: String, account: String? = nil) async throws -> AgentInfo {
+        try await call("agent.restart", AgentRestartParams(target: target, account: account),
+                       as: AgentInfoResult.self)
             .agent
     }
 

--- a/Sources/HerdrKit/Wire.swift
+++ b/Sources/HerdrKit/Wire.swift
@@ -139,6 +139,46 @@ struct AgentListResult: Decodable {
     let agents: [AgentInfo]
 }
 
+// MARK: - Accounts (credential subscriptions)
+
+/// One credential account (subscription) the daemon knows about — the app half of
+/// "multiple subscriptions per harness + swap". Mirrors the server's `AccountInfo`
+/// (`accounts.list` → `{ accounts: [AccountInfo] }`) BYTE-FOR-BYTE.
+///
+/// `kind` carries the SAME strings as `AgentInfo.agent` (claude/codex/kimi), so an
+/// agent may swap only among accounts whose `kind == agent.agent`. `usage` is
+/// omitted by the server when it has no usage data, so it decodes to nil.
+public struct CredentialAccount: Decodable, Equatable, Sendable, Identifiable {
+    public let id: String
+    public let kind: String
+    public let label: String
+    public let active: Bool
+    public let usage: AccountUsage?
+}
+
+/// A credential account's usage snapshot. EVERY field is optional — the server
+/// omits any it cannot report, so a bare `{}` (or a missing `usage`) is valid and
+/// must decode without failing. `primaryUsedPercent`/`secondaryUsedPercent` are the
+/// two rolling windows (e.g. Claude's 5-hour and weekly); `plan`/`tier` are the
+/// human plan name when there is no percent.
+public struct AccountUsage: Decodable, Equatable, Sendable {
+    public let primaryUsedPercent: Double?
+    public let secondaryUsedPercent: Double?
+    public let resetsAt: String?
+    public let plan: String?
+    public let tier: String?
+    enum CodingKeys: String, CodingKey {
+        case primaryUsedPercent = "primary_used_percent"
+        case secondaryUsedPercent = "secondary_used_percent"
+        case resetsAt = "resets_at"
+        case plan, tier
+    }
+}
+
+struct AccountsListResult: Decodable {
+    let accounts: [CredentialAccount]
+}
+
 // MARK: - Reads
 
 public enum ReadSource: String, Codable, Sendable {

--- a/Tests/HerdrKitTests/MockWireFixtureTests.swift
+++ b/Tests/HerdrKitTests/MockWireFixtureTests.swift
@@ -11,6 +11,7 @@ final class MockWireFixtureTests: XCTestCase {
     /// A canned-response transport standing in for MockTransport.
     private struct FixtureTransport: HerdrTransport {
         func roundTrip(_ requestLine: String) async throws -> String {
+            if requestLine.contains("accounts.list") { return MockWireFixtures.accountsList }
             if requestLine.contains("agent.list") { return MockWireFixtures.agentList }
             if requestLine.contains("agent.read") { return MockWireFixtures.agentRead }
             if requestLine.contains("gram.list") { return MockWireFixtures.gramList }
@@ -203,6 +204,75 @@ final class MockWireFixtureTests: XCTestCase {
                              "an invalid base64 payload must be rejected")
     }
 
+    /// The `accounts.list` fixture must decode through the real client path — the
+    /// only Linux-runnable check on the new `CredentialAccount`/`AccountUsage` wire
+    /// models (the SwiftUI Accounts section can't be compiled here). Covers a full
+    /// usage block (both percents + plan + resets_at), an exhausted account
+    /// (active:false, 100%), tier-only usage (no percent), and no usage at all —
+    /// each optional field must decode to nil rather than fail.
+    func testMockAccountsListDecodes() async throws {
+        let client = HerdrClient(transport: FixtureTransport())
+        let accounts = try await client.accountsList()
+        XCTAssertEqual(accounts.count, 4, "accounts.list fixture did not decode to 4 accounts")
+
+        // Full usage block on an active Claude Max account.
+        let first = try XCTUnwrap(accounts.first)
+        XCTAssertEqual(first.id, "acc-claude-1")
+        XCTAssertEqual(first.kind, "claude", "kind is the AgentInfo.agent string the swap menu filters on")
+        XCTAssertEqual(first.label, "Claude Max (work)")
+        XCTAssertTrue(first.active)
+        XCTAssertEqual(first.usage?.primaryUsedPercent, 42)
+        XCTAssertEqual(first.usage?.secondaryUsedPercent, 68)
+        XCTAssertEqual(first.usage?.resetsAt, "2026-08-20T18:00:00Z")
+        XCTAssertEqual(first.usage?.plan, "Max")
+
+        // Exhausted: active:false drives the red "exhausted" pill; percents at 100.
+        let exhausted = try XCTUnwrap(accounts.first { $0.id == "acc-claude-2" })
+        XCTAssertFalse(exhausted.active)
+        XCTAssertEqual(exhausted.usage?.primaryUsedPercent, 100)
+
+        // Tier-only usage: no percent → nil percents, tier text present.
+        let codex = try XCTUnwrap(accounts.first { $0.id == "acc-codex-1" })
+        XCTAssertNil(codex.usage?.primaryUsedPercent, "no primary_used_percent must decode to nil, not 0")
+        XCTAssertEqual(codex.usage?.tier, "Plus")
+
+        // No usage object at all → nil, not a decode failure.
+        let kimi = try XCTUnwrap(accounts.first { $0.id == "acc-kimi-1" })
+        XCTAssertNil(kimi.usage, "an omitted usage must decode to nil")
+
+        // The swap menu filters same-kind: two claude accounts here.
+        XCTAssertEqual(accounts.filter { $0.kind == "claude" }.count, 2,
+                       "the per-agent swap submenu offers the same-kind accounts")
+    }
+
+    /// `agent.restart` gained an optional `account` (the swap id). The param must
+    /// OMIT `account` when nil so a plain restart sends the old `{ target }` payload
+    /// (an older daemon is unaffected), and INCLUDE it — snake-free key `account` —
+    /// when swapping. Asserts the encoded request line directly.
+    func testRestartAccountParamOmittedWhenNilPresentWhenSet() async throws {
+        final class Capture: HerdrTransport, @unchecked Sendable {
+            var lastLine = ""
+            func roundTrip(_ requestLine: String) async throws -> String {
+                lastLine = requestLine
+                return #"{"id":"x","result":{"type":"agent_restarted","agent":{"pane_id":"w1:p1"}}}"#
+            }
+            func stream(_ requestLine: String) -> AsyncThrowingStream<String, Error> {
+                AsyncThrowingStream { $0.finish() }
+            }
+        }
+        let capture = Capture()
+        let client = HerdrClient(transport: capture)
+
+        _ = try await client.restartAgent(target: "w1:p1")
+        XCTAssertTrue(capture.lastLine.contains("\"target\":\"w1:p1\""), "target must be sent")
+        XCTAssertFalse(capture.lastLine.contains("account"),
+                       "a no-account restart must not send an account key: \(capture.lastLine)")
+
+        _ = try await client.restartAgent(target: "w1:p1", account: "acc-claude-2")
+        XCTAssertTrue(capture.lastLine.contains("\"account\":\"acc-claude-2\""),
+                      "swapping must send the account id: \(capture.lastLine)")
+    }
+
     /// The `gram.list` fixture must decode through the real client path, and the
     /// GramMessage flags the Gram page renders on (unread, open-queue, grabbed,
     /// direct) must resolve correctly. Optional fields (`to`, `grabbed_by`) are
@@ -339,6 +409,19 @@ enum MockWireFixtures {
 
     static let agentRead = #"""
     {"id":"mock","result":{"read":{"pane_id":"w1:p1","text":"$ herdr agent attach jarvis\n\n> Ran 146 tests, 0 failures\n> Edited SessionRecoveryTests.swift  +18 -4\n\nRun `swift test` with -Xswiftc -warnings-as-errors?\n  1. yes\n  2. no, skip it\n>\n\n[demo data - mock render mode, no live connection]","truncated":false,"source":"recent_unwrapped","format":"text"}}}
+    """#
+
+    /// An `accounts.list` owner view: two claude accounts (one active-with-usage, one
+    /// exhausted), a codex account with tier-only usage (no percent), and a kimi
+    /// account with no usage at all. Exercises every optionality of AccountUsage. Keep
+    /// in sync with the App's MockTransport.accountsList.
+    static let accountsList = #"""
+    {"id":"mock","result":{"type":"accounts_list","accounts":[
+      {"id":"acc-claude-1","kind":"claude","label":"Claude Max (work)","active":true,"usage":{"primary_used_percent":42,"secondary_used_percent":68,"resets_at":"2026-08-20T18:00:00Z","plan":"Max"}},
+      {"id":"acc-claude-2","kind":"claude","label":"Claude Pro (personal)","active":false,"usage":{"primary_used_percent":100,"secondary_used_percent":100,"plan":"Pro"}},
+      {"id":"acc-codex-1","kind":"codex","label":"Codex (team)","active":true,"usage":{"tier":"Plus"}},
+      {"id":"acc-kimi-1","kind":"kimi","label":"Kimi","active":true}
+    ]}}
     """#
 
     /// A `gram.list` owner view: unread + read agent->owner messages, an unclaimed


### PR DESCRIPTION
## What
App half of the credential/account feature (#142; daemon = herdr #87). A Settings → Accounts section listing each configured account with status + best-effort usage, and a per-agent **Swap subscription** submenu.

## How
- **Wire** (machine-verified on Linux): `CredentialAccount{id,kind,label,active,usage?}` + `AccountUsage` (all optional, snake_case CodingKeys) + `AccountsListResult` — matches the daemon `accounts.list` byte-for-byte (a shared MockTransport fixture asserts it).
- **Client**: `accountsList()`; `restartAgent(target:account:)` sends `account` only when set (`encodeIfPresent`) so a no-account restart is byte-identical to #141.
- **Settings**: Accounts section mirroring Federation — per-account rows (identity chip, kind/plan subtitle, usage meters for Codex / tier for Claude / status, green-active vs red-exhausted badge). Self-loads via `.task`.
- **Swap**: in the agent context menu (after Restart), a `Menu` of same-kind accounts (`kind == agent.agent`) → `restartAgent(account:)`. Errors via `\(e)` (the file convention). The app only ever sees labels/status/usage — never a credential.

## Testing
- **HerdrKit is pure-Swift and builds on Linux** — I ran `swift test` (272 pass) + 2 new: `testMockAccountsListDecodes` (all usage optionality) and `testRestartAccountParamOmittedWhenNilPresentWhenSet` (the encode contract). Wire/client half is machine-verified.
- **SwiftUI half → CI `check (macos-latest)` is the gate** (can't compile locally). Written carefully; flagged for compiler confirmation: the SettingsView ViewBuilder child count (footers wrapped in a `Group` for headroom), the `let`+`if` inside the `.contextMenu` builder, `String == String?` in the swap filter, and the `usageColor` `Double` range `switch`.
- Pre-existing unrelated failure `ReadmeLayoutTests.testEveryFileTheReadmeNamesExists` fails on the clean base too (not mine).

Pairs with herdr #87; ships via TestFlight after the daemon deploys. refs #142
