### PR TITLE
feat(settings): account setup guide + email + left-edge swipe-back

### DIFF
--- a/App/AccountsSetupView.swift
+++ b/App/AccountsSetupView.swift
@@ -1,0 +1,154 @@
+import SwiftUI
+
+/// A short guide for adding another subscription (account) on the home box — what
+/// the Accounts section in Settings links to when you tap "How to set up accounts".
+/// Accounts are login folders on the box, not in the app; this teaches the four
+/// steps that make a new subscription show up here and become swappable from an
+/// agent's menu. Presented as a `.large` sheet, mirroring `FederationSetupView`
+/// (same `onClose` contract, header, cards, footer).
+struct AccountsSetupView: View {
+    var onClose: () -> Void
+
+    /// One setup step: the SF Symbol hinting the action, what you do, and why.
+    private struct Step: Identifiable {
+        let symbol: String
+        let title: String
+        let detail: String
+        var id: String { title }
+    }
+
+    private static let steps: [Step] = [
+        .init(symbol: "folder.badge.plus",
+              title: "Make a folder for it",
+              detail: "Each subscription lives in its own config-home folder on your box — e.g. ~/.codex-work or ~/.claude-2. One folder per account keeps their logins separate."),
+        .init(symbol: "person.badge.key",
+              title: "Log in pointed at that folder",
+              detail: "Run the harness with its config-home env var set, then sign in (see the commands below). That writes the login into the folder, not your default one."),
+        .init(symbol: "doc.badge.gearshape",
+              title: "Register it in your config",
+              detail: "Add an [[accounts]] block to ~/.config/herdr/config.toml with an id, kind, label, and config_dir (the folder path)."),
+        .init(symbol: "arrow.clockwise",
+              title: "Reload — no restart",
+              detail: "Run herdr server reload-config on the home box. The account appears here, and each agent's menu lets you swap onto it."),
+    ]
+
+    /// The per-harness login commands step 2 describes, as a mono chip.
+    private static let loginSnippet = """
+    # Codex
+    CODEX_HOME=~/.codex-work codex
+    # Claude (then /login)
+    CLAUDE_CONFIG_DIR=~/.claude-2 claude
+    # Kimi
+    KIMI_CODE_HOME=~/.kimi-work kimi
+    """
+
+    /// The [[accounts]] stanza step 3 describes.
+    private static let configSnippet = """
+    [[accounts]]
+    id = "codex-work"
+    kind = "codex"
+    label = "Codex · work"
+    config_dir = "/root/.codex-work"
+    """
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider().overlay(Palette.hairlineQuiet)
+            ScrollView {
+                VStack(spacing: 10) {
+                    ForEach(Self.steps) { row(for: $0) }
+                    monoCard(caption: "Log in pointed at the folder", body: Self.loginSnippet)
+                    monoCard(caption: "~/.config/herdr/config.toml", body: Self.configSnippet)
+                    monoCard(caption: "Then, on the home box", body: "herdr server reload-config")
+                }
+                .padding(.horizontal, 16)
+                .padding(.top, 14)
+                .padding(.bottom, 12)
+            }
+            footer
+        }
+        .background(Palette.ground.ignoresSafeArea())
+    }
+
+    private var header: some View {
+        HStack(spacing: 10) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Set up an account")
+                    .font(Typography.app(20, .semibold))
+                    .foregroundStyle(Palette.text)
+                Text("Add another subscription on your box")
+                    .font(Typography.app(12))
+                    .foregroundStyle(Palette.textFaint)
+            }
+            Spacer(minLength: 0)
+            Button(action: onClose) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 15, weight: .medium))
+                    .foregroundStyle(Palette.textDim)
+                    .frame(width: 36, height: 36)
+                    .background(Palette.surface)
+                    .clipShape(Circle())
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.top, 8)
+        .padding(.bottom, 10)
+    }
+
+    private func row(for step: Step) -> some View {
+        HStack(spacing: 14) {
+            Image(systemName: step.symbol)
+                .font(.system(size: 18, weight: .medium))
+                .foregroundStyle(Palette.brand)
+                .frame(width: 44, height: 44)
+                .background(RoundedRectangle(cornerRadius: 12).fill(Palette.surfaceRaised))
+            VStack(alignment: .leading, spacing: 3) {
+                Text(step.title)
+                    .font(Typography.app(15, .semibold))
+                    .foregroundStyle(Palette.text)
+                Text(step.detail)
+                    .font(Typography.app(13))
+                    .foregroundStyle(Palette.textDim)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(RoundedRectangle(cornerRadius: 14).fill(Palette.surface))
+    }
+
+    /// A captioned mono chip (matches FederationSetupView's config/reload cards).
+    private func monoCard(caption: String, body: String) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(caption)
+                .font(Typography.app(12, .semibold))
+                .foregroundStyle(Palette.textFaint)
+            Text(body)
+                .font(Typography.machine(13))
+                .foregroundStyle(Palette.text)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(12)
+                .background(RoundedRectangle(cornerRadius: 8).fill(Palette.surfaceRaised))
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(12)
+        .background(RoundedRectangle(cornerRadius: 14).fill(Palette.surface))
+    }
+
+    private var footer: some View {
+        Button(action: onClose) {
+            Text("Got it")
+                .font(Typography.app(15, .semibold))
+                .foregroundStyle(Palette.textDim)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 10)
+        }
+        .padding(.horizontal, 16)
+        .padding(.top, 8)
+        .padding(.bottom, 12)
+        .background(Palette.ground)
+    }
+}

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -2970,6 +2970,18 @@ private struct SettingsBackButton: View {
     }
 }
 
+/// Left-edge swipe-back for a pushed Settings detail screen. Holds its OWN
+/// `@Environment(\.dismiss)` — like `SettingsBackButton` — so the swipe pops
+/// exactly the NavigationStack push it sits under, not the enclosing tab/sheet.
+/// Reuses the app's window-level `EdgeSwipeBack` recognizer (the same one the
+/// terminal pane uses), which works even though the nav bar is hidden.
+private struct DetailSwipeBack: View {
+    @Environment(\.dismiss) private var dismiss
+    var body: some View {
+        EdgeSwipeBack { dismiss() }
+    }
+}
+
 struct SettingsView: View {
     let client: HerdrClient
     /// Live agents, mirrored in from the home view exactly like GramView's — the
@@ -3001,8 +3013,8 @@ struct SettingsView: View {
     /// Federation section derives from the injected agents. Empty until loaded, and
     /// on an older daemon lacking `accounts.list` (the fetch is `try?`).
     @State private var accounts: [CredentialAccount] = []
-    /// The "How accounts work" explainer alert, opened from the Accounts section.
-    @State private var showAccountsHelp = false
+    /// The "how to set up accounts" guide sheet, opened from the Accounts section.
+    @State private var showAccountsSetup = false
     /// The gestures tutorial, opened from the Help row (its persistent home now that
     /// it's no longer a tab). Presented as a child sheet over Settings.
     @State private var showGestures = false
@@ -3054,13 +3066,12 @@ struct SettingsView: View {
         // `try?` so an older daemon without `accounts.list` (or a transient failure)
         // just leaves the section empty rather than surfacing an error here.
         .task { accounts = (try? await client.accountsList()) ?? [] }
-        // The "How accounts work" explainer — accounts are configured on the box, not
-        // in the app, so this points there rather than offering an in-app add flow.
-        .alert("How accounts work", isPresented: $showAccountsHelp) {
-            Button("OK", role: .cancel) {}
-        } message: {
-            Text("Subscriptions are configured on your home box with the herdr CLI. "
-                + "Each agent runs on one; swap it from the agent's menu on the Agents tab.")
+        // "How to set up accounts" — a step-by-step guide for adding another
+        // subscription on the box (accounts live there, not in the app).
+        .sheet(isPresented: $showAccountsSetup) {
+            AccountsSetupView(onClose: { showAccountsSetup = false })
+                .presentationDetents([.large])
+                .presentationDragIndicator(.visible)
         }
         // Keep the notify section's permission state honest: on open, and again when the
         // app returns to the foreground (the user may have flipped it in iOS Settings).
@@ -3189,6 +3200,10 @@ struct SettingsView: View {
             }
         }
         .toolbar(.hidden, for: .navigationBar)
+        // Hiding the nav bar kills UIKit's default interactive-pop, so re-add a
+        // left-edge swipe-back on pushed detail screens (iPhone). iPad's split
+        // view is the nav (showBack:false), so no gesture there.
+        .overlay { if showBack { DetailSwipeBack() } }
     }
 
     /// The detail header: an optional circular back button, then a title in the app
@@ -3552,9 +3567,9 @@ struct SettingsView: View {
                 .overlay(RoundedRectangle(cornerRadius: 12).stroke(Palette.hairline, lineWidth: 1))
                 .padding(.horizontal, 16).padding(.top, 10)
             }
-            richActionRow("How accounts work", systemImage: "info.circle",
-                          subtitle: "Subscriptions are set up on your home box") {
-                showAccountsHelp = true
+            richActionRow("How to set up accounts", systemImage: "plus.circle",
+                          subtitle: "Add another subscription on your box") {
+                showAccountsSetup = true
             }
         }
     }
@@ -3592,6 +3607,10 @@ struct SettingsView: View {
                     .font(Typography.app(15, .semibold)).foregroundStyle(Palette.text).lineLimit(1)
                 Text(accountSubtitle(account))
                     .font(Typography.app(13)).foregroundStyle(Palette.textDim).lineLimit(1)
+                if let email = account.email, !email.isEmpty {
+                    Text(email)
+                        .font(Typography.machine(11)).foregroundStyle(Palette.textFaint).lineLimit(1)
+                }
             }
             Spacer(minLength: 8)
             accountTrailing(account)
@@ -4324,9 +4343,9 @@ struct MockTransport: HerdrTransport {
     /// tests, where it is machine-checked to decode. If you change one, change both.
     static let accountsList = #"""
     {"id":"mock","result":{"type":"accounts_list","accounts":[
-      {"id":"acc-claude-1","kind":"claude","label":"Claude Max (work)","active":true,"usage":{"source":"live","windows":[{"label":"5h","used_percent":42,"resets_at":"2026-08-20T18:00:00Z","status":"ok"},{"label":"weekly","used_percent":68,"status":"ok"}],"primary_used_percent":42,"secondary_used_percent":68,"resets_at":"2026-08-20T18:00:00Z","plan":"Max"}},
-      {"id":"acc-claude-2","kind":"claude","label":"Claude Pro (personal)","active":false,"usage":{"primary_used_percent":100,"secondary_used_percent":100,"plan":"Pro"}},
-      {"id":"acc-codex-1","kind":"codex","label":"Codex (team)","active":true,"usage":{"tier":"Plus"}},
+      {"id":"acc-claude-1","kind":"claude","label":"Claude Max (work)","active":true,"email":"work@example.com","usage":{"source":"live","windows":[{"label":"5h","used_percent":42,"resets_at":"2026-08-20T18:00:00Z","status":"ok"},{"label":"weekly","used_percent":68,"status":"ok"}],"primary_used_percent":42,"secondary_used_percent":68,"resets_at":"2026-08-20T18:00:00Z","plan":"Max"}},
+      {"id":"acc-claude-2","kind":"claude","label":"Claude Pro (personal)","active":false,"email":"personal@example.com","usage":{"primary_used_percent":100,"secondary_used_percent":100,"plan":"Pro"}},
+      {"id":"acc-codex-1","kind":"codex","label":"Codex (team)","active":true,"email":"team@example.com","usage":{"tier":"Plus"}},
       {"id":"acc-kimi-1","kind":"kimi","label":"Kimi","active":true}
     ]}}
     """#

--- a/Sources/HerdrKit/Wire.swift
+++ b/Sources/HerdrKit/Wire.swift
@@ -153,6 +153,9 @@ public struct CredentialAccount: Decodable, Equatable, Sendable, Identifiable {
     public let kind: String
     public let label: String
     public let active: Bool
+    /// The account's login email, when the daemon can derive it. Optional → an
+    /// older daemon that omits it decodes to nil. Identity only, never a secret.
+    public let email: String?
     public let usage: AccountUsage?
 }
 

--- a/Tests/HerdrKitTests/MockWireFixtureTests.swift
+++ b/Tests/HerdrKitTests/MockWireFixtureTests.swift
@@ -221,6 +221,7 @@ final class MockWireFixtureTests: XCTestCase {
         XCTAssertEqual(first.kind, "claude", "kind is the AgentInfo.agent string the swap menu filters on")
         XCTAssertEqual(first.label, "Claude Max (work)")
         XCTAssertTrue(first.active)
+        XCTAssertEqual(first.email, "work@example.com", "account email decodes")
         XCTAssertEqual(first.usage?.primaryUsedPercent, 42)
         XCTAssertEqual(first.usage?.secondaryUsedPercent, 68)
         XCTAssertEqual(first.usage?.resetsAt, "2026-08-20T18:00:00Z")
@@ -248,8 +249,9 @@ final class MockWireFixtureTests: XCTestCase {
         XCTAssertNil(codex.usage?.primaryUsedPercent, "no primary_used_percent must decode to nil, not 0")
         XCTAssertEqual(codex.usage?.tier, "Plus")
 
-        // No usage object at all → nil, not a decode failure.
+        // No usage object at all → nil, not a decode failure. Also no email → nil.
         let kimi = try XCTUnwrap(accounts.first { $0.id == "acc-kimi-1" })
+        XCTAssertNil(kimi.email, "an omitted email must decode to nil")
         XCTAssertNil(kimi.usage, "an omitted usage must decode to nil")
 
         // The swap menu filters same-kind: two claude accounts here.
@@ -429,9 +431,9 @@ enum MockWireFixtures {
     /// in sync with the App's MockTransport.accountsList.
     static let accountsList = #"""
     {"id":"mock","result":{"type":"accounts_list","accounts":[
-      {"id":"acc-claude-1","kind":"claude","label":"Claude Max (work)","active":true,"usage":{"source":"live","windows":[{"label":"5h","used_percent":42,"resets_at":"2026-08-20T18:00:00Z","status":"ok"},{"label":"weekly","used_percent":68,"status":"ok"}],"primary_used_percent":42,"secondary_used_percent":68,"resets_at":"2026-08-20T18:00:00Z","plan":"Max"}},
-      {"id":"acc-claude-2","kind":"claude","label":"Claude Pro (personal)","active":false,"usage":{"primary_used_percent":100,"secondary_used_percent":100,"plan":"Pro"}},
-      {"id":"acc-codex-1","kind":"codex","label":"Codex (team)","active":true,"usage":{"tier":"Plus"}},
+      {"id":"acc-claude-1","kind":"claude","label":"Claude Max (work)","active":true,"email":"work@example.com","usage":{"source":"live","windows":[{"label":"5h","used_percent":42,"resets_at":"2026-08-20T18:00:00Z","status":"ok"},{"label":"weekly","used_percent":68,"status":"ok"}],"primary_used_percent":42,"secondary_used_percent":68,"resets_at":"2026-08-20T18:00:00Z","plan":"Max"}},
+      {"id":"acc-claude-2","kind":"claude","label":"Claude Pro (personal)","active":false,"email":"personal@example.com","usage":{"primary_used_percent":100,"secondary_used_percent":100,"plan":"Pro"}},
+      {"id":"acc-codex-1","kind":"codex","label":"Codex (team)","active":true,"email":"team@example.com","usage":{"tier":"Plus"}},
       {"id":"acc-kimi-1","kind":"kimi","label":"Kimi","active":true}
     ]}}
     """#


### PR DESCRIPTION
## What (refs #144, owner follow-ups)
Four Settings refinements, pairs with daemon jerryfane/herdr #90.

1. **Setup guide** — the Accounts "How accounts work" info alert is now a real **"How to set up accounts"** guide sheet (new `AccountsSetupView`, mirrors `FederationSetupView`): the four-step manual flow (make a folder → log in pointed at it → add `[[accounts]]` to `config.toml` → `reload-config`) with per-harness login + config mono chips.
2. **Email** — each account's email renders under its subtitle in `accountRow` (from the new daemon `AccountInfo.email`; `CredentialAccount` gains an optional `email` that an older daemon omits → nil).
3. **Codex weekly label** — daemon-side (in #90); the app passes `window.label` through verbatim, so Codex now shows "weekly" not "5h".
4. **Left→right swipe-back** — the redesign hides the nav bar (disabling UIKit's interactive-pop), so pushed detail screens got no swipe-back. Re-added by attaching the app's **existing window-level `EdgeSwipeBack`** (the terminal's) via `DetailSwipeBack` (holds its own `dismiss`, like `SettingsBackButton`) as an overlay on `detailScaffold`. iPad split (showBack:false) unaffected.

## Verification
HerdrKit `swift test` green (email decodes; kimi email → nil; back-compat intact). `swiftc -parse` clean on the changed App files. **App/*.swift type-checks only on macOS CI — this build-and-uitest run is the first real compile.** Mock fixture kept byte-identical to the test fixture (both now carry email).

🤖 Generated with [Claude Code](https://claude.com/claude-code)