### PR TITLE
fix(gram): dismiss the composer keyboard after sending

### DIFF
--- a/App/GramView.swift
+++ b/App/GramView.swift
@@ -46,6 +46,10 @@ struct GramView: View {
     @State private var phase: LoadPhase = .loading
     @State private var recipient: Recipient = .queue
     @State private var draft: String = ""
+    /// Focus of the composer field. Bound so a successful send can resign it —
+    /// the composer is a multiline (`axis: .vertical`) field with no Return-to-send,
+    /// so without this the keyboard has no way to drop and it hides the tab bar.
+    @FocusState private var composerFocused: Bool
     /// True while dictating into the composer, so the field is disabled (typing can't be
     /// overwritten by the next partial) while the live transcript still appends.
     @State private var draftDictating = false
@@ -455,9 +459,13 @@ struct GramView: View {
 
     // MARK: - Content
 
-    @ViewBuilder
     private var content: some View {
-        if showingSaved { savedContent } else { inboxContent }
+        Group {
+            if showingSaved { savedContent } else { inboxContent }
+        }
+        // Let a drag on the message feed dismiss the keyboard too, so the composer
+        // never gets stuck covering the tab bar with no way out.
+        .scrollDismissesKeyboard(.interactively)
     }
 
     /// The Saved section: locally-kept copies of bookmarked messages. Rendered from the local
@@ -717,6 +725,7 @@ struct GramView: View {
                     .font(Typography.app(15))
                     .foregroundStyle(Palette.text)
                     .tint(Palette.text)
+                    .focused($composerFocused)
                     .lineLimit(1...5)
                     .padding(.horizontal, 12)
                     .padding(.vertical, 9)
@@ -936,6 +945,9 @@ struct GramView: View {
         // A file with no caption is fine; an empty text-only message is not.
         guard (!text.isEmpty || !files.isEmpty), !sending else { return }
         sending = true
+        // Drop the keyboard the moment the message is committed, so the composer
+        // stops covering the tab bar (the field has no Return-to-send to resign it).
+        composerFocused = false
         defer {
             sending = false
             uploading = false


### PR DESCRIPTION
Owner-reported: after sending a message on the Gram tab, the text input keeps the keyboard up, covering the bottom tab bar — with no way to dismiss it short of force-quitting and relaunching the app.

## Cause
The Gram composer is a multiline `TextField(..., axis: .vertical)` (`GramView.swift`). It had **no `@FocusState`** binding, and a multiline field has **no Return-to-send** to resign first responder. `send()` cleared `draft` but nothing dropped the keyboard, and the feed had no scroll-to-dismiss — so once focused, the keyboard was effectively stuck up, hiding the tab bar.

## Fix
- Bind the field to a new `@FocusState composerFocused` and set it `false` the instant a send commits (`send()`), so the keyboard drops and the tab bar returns right after you send.
- Add `.scrollDismissesKeyboard(.interactively)` to the message feed (`content`) so a drag can dismiss the keyboard at any time too.

Small, composer-only change; no send/upload/poll behavior touched.

## Verify
- CI `build-and-uitest`.
- Manual: focus the Gram composer (keyboard up, tab bar hidden) → tap send → keyboard drops, tab bar visible. Also: with the keyboard up, drag the message feed → keyboard dismisses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)