### PR TITLE
fix(connect): explain when the host's herdr can't run the app bridge

### DIFF
--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -891,6 +891,11 @@ struct TerminalHomeView: View {
     /// (`TransportError.herdrNotInstalled`). Drives the install-guidance branch in
     /// `errorView` instead of surfacing the raw stderr. Reset at the start of each load.
     @State private var herdrMissing = false
+    /// When `herdrMissing` was triggered because the host's herdr is present but too
+    /// old / not the fork (`TransportError.herdrIncompatible`) rather than absent.
+    /// Only swaps the guidance heading/subtitle; the fix (install/update the fork) is
+    /// the same, so it reuses the same recovery screen.
+    @State private var herdrIncompatibleBuild = false
     /// Latches the "Copied ✓" state on the install-command copy button.
     @State private var installCmdCopied = false
     @State private var search = ""
@@ -1878,10 +1883,12 @@ struct TerminalHomeView: View {
             .font(.system(size: 34, weight: .regular))
             .foregroundStyle(Palette.waiting)
         VStack(spacing: 8) {
-            Text("herdr isn't installed here")
+            Text(herdrIncompatibleBuild ? "herdr here is too old" : "herdr isn't installed here")
                 .font(Typography.app(20, .bold)).foregroundStyle(Palette.text)
                 .multilineTextAlignment(.center)
-            Text("Herdrup runs the herdr daemon on your machine over SSH. It isn't installed yet. Install the jerryfane/herdr fork, then reconnect.")
+            Text(herdrIncompatibleBuild
+                 ? "Herdrup runs the herdr daemon on your machine over SSH. The herdr on this host can't run the app bridge — it's too old, or isn't the jerryfane/herdr fork. Update or install the fork, then reconnect."
+                 : "Herdrup runs the herdr daemon on your machine over SSH. It isn't installed yet. Install the jerryfane/herdr fork, then reconnect.")
                 .font(Typography.app(14)).foregroundStyle(Palette.textDim)
                 .multilineTextAlignment(.center)
                 .fixedSize(horizontal: false, vertical: true)
@@ -1947,12 +1954,20 @@ struct TerminalHomeView: View {
         } catch {
             let rejected: String?
             var notInstalled = false
+            var incompatibleBuild = false
             if let transportError = error as? TransportError {
                 if case .hostKeyRejected(_, let fingerprint) = transportError {
                     rejected = fingerprint
                 } else {
                     rejected = nil
                     if case .herdrNotInstalled = transportError { notInstalled = true }
+                    // herdr is present but can't run the app bridge (too old / not the
+                    // fork). Same recovery screen — the remedy is install/update the fork
+                    // — with a heading that fits (see `herdrInstallGuidance`).
+                    if case .herdrIncompatible = transportError {
+                        notInstalled = true
+                        incompatibleBuild = true
+                    }
                 }
             } else {
                 rejected = nil
@@ -1967,6 +1982,7 @@ struct TerminalHomeView: View {
                 // Only when this is the surfaced error do we drive the install-guidance
                 // branch; a no-herdr connect always has an empty list, so it surfaces here.
                 herdrMissing = notInstalled
+                herdrIncompatibleBuild = incompatibleBuild
             }
             // DROP a pending deep-link this failed load couldn't service, rather than leave it armed:
             // a push targets a just-now event, so firing it after some much-later successful load would

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -1941,6 +1941,7 @@ struct TerminalHomeView: View {
             rejectedFingerprint = nil
             trustFailed = false
             herdrMissing = false
+            herdrIncompatibleBuild = false
             // Prune keep-mounted panes whose agent is gone (Stopped / vanished) so no dead
             // terminal lingers warm — but only a slot that was ONCE seen live and has now
             // vanished (never a still-booting spawn pane, which is absent by design while its

--- a/Sources/HerdrKit/CitadelTransport.swift
+++ b/Sources/HerdrKit/CitadelTransport.swift
@@ -193,7 +193,11 @@ public actor CitadelTransport: HerdrTransport {
     static func classifyBridgeFailure(stderr: String, exitCode: Int, host: String) -> TransportError {
         if stderr.contains(herdrNotInstalledSentinel) { return .herdrNotInstalled(host: host) }
         // clap's usage-error exit code. The only thing the wrapper runs is
-        // `herdr api-bridge`, so exit 2 means herdr is there but can't run the app.
+        // `herdr api-bridge`, so exit 2 almost always means herdr is there but can't run
+        // the app. TRADE-OFF: a fork that HAS api-bridge but exits 2 for an unrelated
+        // usage error is mis-badged "incompatible" — accepted, because the guidance is
+        // non-destructive advice and the alternative is the raw exit code; matching on
+        // clap's stderr text instead would re-couple to a fragile, version-specific string.
         if exitCode == 2 { return .herdrIncompatible(host: host) }
         return .bridgeFailed(stderr: stderr)
     }
@@ -217,11 +221,24 @@ public actor CitadelTransport: HerdrTransport {
     public func roundTrip(_ requestLine: String) async throws -> String {
         let client = try await connectedClient()
         let output = try await client.executeCommandStream(try Self.bridgeCommand(for: requestLine))
+        return try await Self.parseBridgeOutput(output, host: credentials.host)
+    }
 
-        // One request, one reply line. Accumulate RAW bytes and decode UTF-8 only
-        // at newline boundaries: decoding each SSH channel-data chunk on its own
-        // (String(buffer:)) turns a multi-byte scalar split across a chunk boundary
-        // into U+FFFD, silently corrupting the reply.
+    /// Consumes the api-bridge exec output stream into its single reply line, or throws
+    /// a classified `TransportError`. Extracted from `roundTrip` for ONE reason: to make
+    /// the reachability of the exit-code classification testable. Citadel throws
+    /// `CommandFailed` at EOF on ANY non-zero exit, so the `do/catch` MUST enclose the
+    /// throwing loop or the raw "command failed, exit code N" escapes and the
+    /// not-installed / incompatible guidance is never reached. `SSHClient` itself is not
+    /// injectable, but a test can feed this a fake `AsyncThrowingStream` that finishes
+    /// `throwing:` a `RemoteExitError`, binding that the catch is present AND scoped.
+    static func parseBridgeOutput(
+        _ output: AsyncThrowingStream<ExecCommandOutput, Error>, host: String
+    ) async throws -> String {
+        // One request, one reply line. Accumulate RAW bytes and decode UTF-8 only at
+        // newline boundaries: decoding each SSH channel-data chunk on its own
+        // (String(buffer:)) turns a multi-byte scalar split across a chunk boundary into
+        // U+FFFD, silently corrupting the reply.
         var lines = LineAccumulator()
         var stderr = ""
         do {
@@ -233,22 +250,21 @@ public actor CitadelTransport: HerdrTransport {
                     stderr += String(buffer: buffer)  // diagnostic text; a lossy decode is fine here
                 }
             }
-        } catch let failure as SSHClient.CommandFailed {
+        } catch let failure as RemoteExitError {
             // A non-zero remote exit: Citadel throws `CommandFailed` at EOF instead of
             // ending the stream, so this catch is the ONLY place the exit status is
             // visible — without it the raw "command failed, exit code N" escapes and the
-            // not-installed / incompatible guidance below is never reached. A reply may
-            // still have arrived first (returned above); reaching here means it did not.
+            // not-installed / incompatible guidance is never reached. A reply may still
+            // have arrived first (returned above); reaching here means it did not.
             if lines.hasRemainder { return lines.flush() }
-            throw Self.classifyBridgeFailure(
-                stderr: stderr, exitCode: failure.exitCode, host: credentials.host)
+            throw classifyBridgeFailure(stderr: stderr, exitCode: failure.remoteExitCode, host: host)
         }
         // Channel closed on exit 0 without a newline-terminated reply.
         if lines.hasRemainder { return lines.flush() }   // a reply that lacked a trailing newline
         // Empty stdout: surface the bridge/remote diagnostic rather than handing
         // the caller an empty string it can only fail to decode.
         if !stderr.isEmpty {
-            throw Self.classifyBridgeFailure(stderr: stderr, exitCode: 0, host: credentials.host)
+            throw classifyBridgeFailure(stderr: stderr, exitCode: 0, host: host)
         }
         throw TransportError.closedBeforeResponse
     }
@@ -284,7 +300,7 @@ public actor CitadelTransport: HerdrTransport {
                 } catch is CancellationError {
                     await connection.close()
                     continuation.finish()
-                } catch let failure as SSHClient.CommandFailed {
+                } catch let failure as RemoteExitError {
                     // Same non-zero-exit mapping as `roundTrip`, so a pane stream against
                     // an incompatible/absent herdr fails legibly instead of as a raw
                     // CommandFailed. This path accumulates no stderr, so classify by code
@@ -293,7 +309,7 @@ public actor CitadelTransport: HerdrTransport {
                     await connection.close()
                     continuation.finish(
                         throwing: Self.classifyBridgeFailure(
-                            stderr: "", exitCode: failure.exitCode, host: self.credentials.host))
+                            stderr: "", exitCode: failure.remoteExitCode, host: self.credentials.host))
                 } catch {
                     await connection.close()
                     continuation.finish(throwing: error)
@@ -398,4 +414,17 @@ actor StreamConnection {
         client = nil
         try? await held?.close()
     }
+}
+
+/// A remote command's non-zero exit, abstracted so `parseBridgeOutput`'s classification
+/// path is unit-testable. A test cannot construct Citadel's `SSHClient.CommandFailed`
+/// (its memberwise initialiser is internal to that module), so `parseBridgeOutput`
+/// catches THIS protocol instead of the concrete type; the test injects its own
+/// conforming error through a fake stream. Citadel's error conforms below.
+protocol RemoteExitError: Error {
+    var remoteExitCode: Int { get }
+}
+
+extension SSHClient.CommandFailed: RemoteExitError {
+    var remoteExitCode: Int { exitCode }
 }

--- a/Sources/HerdrKit/CitadelTransport.swift
+++ b/Sources/HerdrKit/CitadelTransport.swift
@@ -183,14 +183,19 @@ public actor CitadelTransport: HerdrTransport {
     static let herdrPathResolution =
         #"HERDR=$(command -v herdr || echo "$HOME/.local/bin/herdr"); [ -x "$HERDR" ] || { echo \#(herdrNotInstalledSentinel) >&2; exit 127; }; exec "$HERDR" api-bridge "#
 
-    /// Classifies an empty-stdout bridge failure. When herdr is absent the exec
-    /// wrapper prints `herdrNotInstalledSentinel` (see `herdrPathResolution`), so a
-    /// stderr carrying it becomes `.herdrNotInstalled(host:)`; anything else stays a
-    /// generic `.bridgeFailed(stderr:)`. Pure, so it is host-testable without SSH.
-    static func classifyBridgeFailure(stderr: String, host: String) -> TransportError {
-        stderr.contains(herdrNotInstalledSentinel)
-            ? .herdrNotInstalled(host: host)
-            : .bridgeFailed(stderr: stderr)
+    /// Classifies a bridge failure from its stderr and the remote EXIT CODE. When
+    /// herdr is absent the exec wrapper prints `herdrNotInstalledSentinel` (see
+    /// `herdrPathResolution`) → `.herdrNotInstalled(host:)`. When herdr IS present but
+    /// does not understand the `api-bridge` subcommand — an upstream build, or a fork
+    /// too old to have it — its arg-parser (clap) rejects the subcommand and exits
+    /// with code 2 → `.herdrIncompatible(host:)`. Anything else stays a generic
+    /// `.bridgeFailed(stderr:)`. Pure, so it is host-testable without SSH.
+    static func classifyBridgeFailure(stderr: String, exitCode: Int, host: String) -> TransportError {
+        if stderr.contains(herdrNotInstalledSentinel) { return .herdrNotInstalled(host: host) }
+        // clap's usage-error exit code. The only thing the wrapper runs is
+        // `herdr api-bridge`, so exit 2 means herdr is there but can't run the app.
+        if exitCode == 2 { return .herdrIncompatible(host: host) }
+        return .bridgeFailed(stderr: stderr)
     }
 
     /// The full exec command line: resolve herdr, then run
@@ -219,19 +224,32 @@ public actor CitadelTransport: HerdrTransport {
         // into U+FFFD, silently corrupting the reply.
         var lines = LineAccumulator()
         var stderr = ""
-        for try await chunk in output {
-            switch chunk {
-            case .stdout(let buffer):
-                if let first = lines.append(buffer).first { return first }
-            case .stderr(let buffer):
-                stderr += String(buffer: buffer)  // diagnostic text; a lossy decode is fine here
+        do {
+            for try await chunk in output {
+                switch chunk {
+                case .stdout(let buffer):
+                    if let first = lines.append(buffer).first { return first }
+                case .stderr(let buffer):
+                    stderr += String(buffer: buffer)  // diagnostic text; a lossy decode is fine here
+                }
             }
+        } catch let failure as SSHClient.CommandFailed {
+            // A non-zero remote exit: Citadel throws `CommandFailed` at EOF instead of
+            // ending the stream, so this catch is the ONLY place the exit status is
+            // visible — without it the raw "command failed, exit code N" escapes and the
+            // not-installed / incompatible guidance below is never reached. A reply may
+            // still have arrived first (returned above); reaching here means it did not.
+            if lines.hasRemainder { return lines.flush() }
+            throw Self.classifyBridgeFailure(
+                stderr: stderr, exitCode: failure.exitCode, host: credentials.host)
         }
-        // Channel closed without a newline-terminated reply.
+        // Channel closed on exit 0 without a newline-terminated reply.
         if lines.hasRemainder { return lines.flush() }   // a reply that lacked a trailing newline
         // Empty stdout: surface the bridge/remote diagnostic rather than handing
         // the caller an empty string it can only fail to decode.
-        if !stderr.isEmpty { throw Self.classifyBridgeFailure(stderr: stderr, host: credentials.host) }
+        if !stderr.isEmpty {
+            throw Self.classifyBridgeFailure(stderr: stderr, exitCode: 0, host: credentials.host)
+        }
         throw TransportError.closedBeforeResponse
     }
 
@@ -266,6 +284,16 @@ public actor CitadelTransport: HerdrTransport {
                 } catch is CancellationError {
                     await connection.close()
                     continuation.finish()
+                } catch let failure as SSHClient.CommandFailed {
+                    // Same non-zero-exit mapping as `roundTrip`, so a pane stream against
+                    // an incompatible/absent herdr fails legibly instead of as a raw
+                    // CommandFailed. This path accumulates no stderr, so classify by code
+                    // (exit 2 → incompatible); the sentinel case is caught by roundTrip
+                    // on the initial connect before any stream is opened.
+                    await connection.close()
+                    continuation.finish(
+                        throwing: Self.classifyBridgeFailure(
+                            stderr: "", exitCode: failure.exitCode, host: self.credentials.host))
                 } catch {
                     await connection.close()
                     continuation.finish(throwing: error)

--- a/Sources/HerdrKit/Transport.swift
+++ b/Sources/HerdrKit/Transport.swift
@@ -114,6 +114,12 @@ public enum TransportError: Error, CustomStringConvertible {
     /// text), so the client can guide the user to install it rather than showing a
     /// raw stderr line.
     case herdrNotInstalled(host: String)
+    /// herdr IS installed on the host, but it does not understand the `api-bridge`
+    /// subcommand the app drives — an upstream/official build, or a fork too old to
+    /// have it. Its arg-parser exits with code 2, which `classifyBridgeFailure` maps
+    /// here so the client can say "update / install the fork" rather than showing a
+    /// raw "command failed, exit code 2".
+    case herdrIncompatible(host: String)
     /// A password connection was attempted against a server that does not offer
     /// password authentication (e.g. `PasswordAuthentication no`). Distinct from a
     /// wrong password and from a host-key mismatch.
@@ -137,6 +143,8 @@ public enum TransportError: Error, CustomStringConvertible {
             return "api-bridge produced no reply; stderr: \(stderr)"
         case .herdrNotInstalled(let h):
             return "herdr is not installed on \(h)"
+        case .herdrIncompatible(let h):
+            return "the herdr on \(h) is too old or isn't the fork — update it (or install the fork) and reconnect"
         case .passwordAuthUnsupported(let h):
             return "\(h) does not offer password authentication — use a key instead"
         case .authenticationFailed(let h):

--- a/Tests/HerdrKitTests/CitadelTransportTests.swift
+++ b/Tests/HerdrKitTests/CitadelTransportTests.swift
@@ -138,11 +138,38 @@ final class CitadelTransportTests: XCTestCase {
     /// carrying the host through for the client's guidance copy.
     func testClassifyBridgeFailureDetectsMissingHerdr() {
         let stderr = "bash: line 1: \(CitadelTransport.herdrNotInstalledSentinel)\n"
-        let error = CitadelTransport.classifyBridgeFailure(stderr: stderr, host: "box.example")
+        // The not-installed wrapper exits 127, but the sentinel wins regardless of code.
+        let error = CitadelTransport.classifyBridgeFailure(
+            stderr: stderr, exitCode: 127, host: "box.example")
         guard case TransportError.herdrNotInstalled(let host) = error else {
             return XCTFail("expected .herdrNotInstalled, got \(error)")
         }
         XCTAssertEqual(host, "box.example", "the host was not carried through")
+    }
+
+    /// Exit code 2 (clap's usage error for an unknown subcommand) with no sentinel
+    /// means herdr is present but doesn't understand `api-bridge` — too old, or not
+    /// the fork. It classifies as `.herdrIncompatible(host:)` so the client can say
+    /// "update / install the fork" instead of showing "command failed, exit code 2".
+    func testClassifyBridgeFailureExitTwoIsIncompatible() {
+        let stderr = "error: unrecognized subcommand 'api-bridge'\n"
+        let error = CitadelTransport.classifyBridgeFailure(
+            stderr: stderr, exitCode: 2, host: "box.example")
+        guard case TransportError.herdrIncompatible(let host) = error else {
+            return XCTFail("expected .herdrIncompatible, got \(error)")
+        }
+        XCTAssertEqual(host, "box.example", "the host was not carried through")
+    }
+
+    /// The sentinel outranks the exit code: an absent herdr must read as
+    /// not-installed even though its wrapper also exits non-zero.
+    func testClassifyBridgeFailureSentinelBeatsExitCode() {
+        let stderr = "\(CitadelTransport.herdrNotInstalledSentinel)\n"
+        let error = CitadelTransport.classifyBridgeFailure(
+            stderr: stderr, exitCode: 2, host: "box.example")
+        guard case TransportError.herdrNotInstalled = error else {
+            return XCTFail("expected .herdrNotInstalled, got \(error)")
+        }
     }
 
     /// Any OTHER stderr stays a generic `.bridgeFailed` — the sentinel is the only
@@ -150,7 +177,9 @@ final class CitadelTransportTests: XCTestCase {
     /// "herdr not installed" (which would wrongly tell the user to reinstall).
     func testClassifyBridgeFailurePassesThroughUnrelatedStderr() {
         let stderr = "api-bridge: permission denied while opening the control socket\n"
-        let error = CitadelTransport.classifyBridgeFailure(stderr: stderr, host: "box.example")
+        // A non-2, non-sentinel failure (e.g. exit 1) stays a generic bridge failure.
+        let error = CitadelTransport.classifyBridgeFailure(
+            stderr: stderr, exitCode: 1, host: "box.example")
         guard case TransportError.bridgeFailed(let passed) = error else {
             return XCTFail("expected .bridgeFailed, got \(error)")
         }

--- a/Tests/HerdrKitTests/CitadelTransportTests.swift
+++ b/Tests/HerdrKitTests/CitadelTransportTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 import Foundation
 import NIOCore
+import Citadel
 @testable import HerdrKit
 
 final class CitadelTransportTests: XCTestCase {
@@ -190,5 +191,89 @@ final class CitadelTransportTests: XCTestCase {
     func testHerdrNotInstalledDescriptionNamesHost() {
         let error = TransportError.herdrNotInstalled(host: "box.example")
         XCTAssertEqual(error.description, "herdr is not installed on box.example")
+    }
+
+    // MARK: - parseBridgeOutput reachability (the do/catch WIRING, not the pure classifier)
+
+    /// A fake non-zero exit the test can inject — `SSHClient.CommandFailed`'s init is
+    /// internal to Citadel, so `parseBridgeOutput` catches the `RemoteExitError` protocol
+    /// (which `CommandFailed` conforms to) and this stands in for it here.
+    private struct FakeExit: RemoteExitError { let remoteExitCode: Int }
+
+    /// Builds the exec output stream a test wants: some stdout/stderr, then either a
+    /// clean finish or a `throwing:` finish (what Citadel does on non-zero exit).
+    private func bridgeStream(
+        stdout: [String] = [], stderr: [String] = [], finishThrowing: Error? = nil
+    ) -> AsyncThrowingStream<ExecCommandOutput, Error> {
+        AsyncThrowingStream { continuation in
+            for s in stdout { continuation.yield(.stdout(ByteBuffer(string: s))) }
+            for s in stderr { continuation.yield(.stderr(ByteBuffer(string: s))) }
+            if let finishThrowing { continuation.finish(throwing: finishThrowing) }
+            else { continuation.finish() }
+        }
+    }
+
+    /// THE REACHABILITY TEST. A stream that finishes `throwing:` a non-zero exit (as
+    /// Citadel does) must be classified, not rethrown raw. Deleting or mis-scoping the
+    /// do/catch in `parseBridgeOutput` reintroduces the raw "command failed, exit code 2"
+    /// bug — this fails then, where the pure-classifier tests stay green.
+    func testParseBridgeOutputExitTwoRethrowsIncompatible() async {
+        let stream = bridgeStream(
+            stderr: ["error: unrecognized subcommand 'api-bridge'\n"],
+            finishThrowing: FakeExit(remoteExitCode: 2))
+        do {
+            _ = try await CitadelTransport.parseBridgeOutput(stream, host: "box.example")
+            XCTFail("expected a throw")
+        } catch let error as TransportError {
+            guard case .herdrIncompatible(let host) = error else {
+                return XCTFail("expected .herdrIncompatible, got \(error)")
+            }
+            XCTAssertEqual(host, "box.example")
+        } catch {
+            XCTFail("raw \(error) escaped — the do/catch is gone or mis-scoped")
+        }
+    }
+
+    /// The sentinel path through the SAME throwing-stream wiring: absent herdr exits 127
+    /// but its sentinel wins, and it must be classified, not rethrown raw.
+    func testParseBridgeOutputSentinelRethrowsNotInstalled() async {
+        let stream = bridgeStream(
+            stderr: ["\(CitadelTransport.herdrNotInstalledSentinel)\n"],
+            finishThrowing: FakeExit(remoteExitCode: 127))
+        do {
+            _ = try await CitadelTransport.parseBridgeOutput(stream, host: "box.example")
+            XCTFail("expected a throw")
+        } catch let error as TransportError {
+            guard case .herdrNotInstalled = error else {
+                return XCTFail("expected .herdrNotInstalled, got \(error)")
+            }
+        } catch {
+            XCTFail("raw \(error) escaped — the do/catch is gone or mis-scoped")
+        }
+    }
+
+    /// A reply that arrived before a non-zero exit is RETURNED, not overridden by the
+    /// exit classification — guards the `lines.first` early-return / `hasRemainder` order.
+    func testParseBridgeOutputReturnsReplyBeforeNonZeroExit() async throws {
+        let stream = bridgeStream(
+            stdout: ["{\"ok\":true}\n"],
+            finishThrowing: FakeExit(remoteExitCode: 1))
+        let reply = try await CitadelTransport.parseBridgeOutput(stream, host: "box.example")
+        XCTAssertEqual(reply, "{\"ok\":true}")
+    }
+
+    /// A clean exit-0 close with no reply surfaces `.closedBeforeResponse`, not a hang.
+    func testParseBridgeOutputCleanCloseWithoutReply() async {
+        let stream = bridgeStream()
+        do {
+            _ = try await CitadelTransport.parseBridgeOutput(stream, host: "box.example")
+            XCTFail("expected a throw")
+        } catch let error as TransportError {
+            guard case .closedBeforeResponse = error else {
+                return XCTFail("expected .closedBeforeResponse, got \(error)")
+            }
+        } catch {
+            XCTFail("unexpected \(error)")
+        }
     }
 }


### PR DESCRIPTION
Owner-reported: connecting to a friend's host (password auth) showed the raw **"command failed exit code 2"**.

## Cause
Auth/connection succeed; the app then execs `herdr api-bridge` on the host. `api-bridge` is a **fork** command — a host with upstream/official herdr, or a fork too old to have it, makes herdr's arg-parser reject the subcommand and **exit 2** (clap's usage-error code).

The ugly message is a second bug: `CitadelTransport.roundTrip` had **no catch** around its output loop, so Citadel's `SSHClient.CommandFailed` (thrown on *any* non-zero exit) propagated raw and the existing `classifyBridgeFailure` was unreachable. That also meant the **"herdr not installed"** guidance (exit 127) was silently unreachable for the same reason.

## Fix (app-only, no daemon change)
- `CitadelTransport`: catch `SSHClient.CommandFailed` in `roundTrip` (and the `stream` path) and classify by stderr + exit code — not-installed sentinel → `.herdrNotInstalled` (restored); **exit 2 → new `.herdrIncompatible`**; else → `.bridgeFailed`.
- `Transport.swift`: new `TransportError.herdrIncompatible(host:)` with a clear description.
- `HerdrApp.swift`: the connect recovery screen now shows install/update-the-fork guidance for both absent **and** incompatible herdr, with a heading that fits ("herdr here is too old" vs "herdr isn't installed here"). Reuses the existing `herdrInstallGuidance` screen.
- Tests: sentinel/127 → not-installed; exit 2 → incompatible; other → bridgeFailed; sentinel-beats-exit-code. HerdrKit `swift test` green (all 4 classifier cases).

## Verify
- CI `build-and-uitest`.
- Manual: connect to a host with upstream/old herdr → "herdr here is too old / update the fork" screen, not "exit code 2"; host with no herdr → install screen (now actually reached); host with current fork → normal success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)