### PR TITLE
style(ui): remove em dashes from user-facing copy

### DIFF
--- a/App/AccountsSetupView.swift
+++ b/App/AccountsSetupView.swift
@@ -20,7 +20,7 @@ struct AccountsSetupView: View {
     private static let steps: [Step] = [
         .init(symbol: "folder.badge.plus",
               title: "Make a folder for it",
-              detail: "Each subscription lives in its own config-home folder on your box — e.g. ~/.codex-work or ~/.claude-2. One folder per account keeps their logins separate."),
+              detail: "Each subscription lives in its own config-home folder on your box, e.g. ~/.codex-work or ~/.claude-2. One folder per account keeps their logins separate."),
         .init(symbol: "person.badge.key",
               title: "Log in pointed at that folder",
               detail: "Run the harness with its config-home env var set, then sign in (see the commands below). That writes the login into the folder, not your default one."),
@@ -28,7 +28,7 @@ struct AccountsSetupView: View {
               title: "Register it in your config",
               detail: "Add an [[accounts]] block to ~/.config/herdr/config.toml with an id, kind, label, and config_dir (the folder path)."),
         .init(symbol: "arrow.clockwise",
-              title: "Reload — no restart",
+              title: "Reload, no restart",
               detail: "Run herdr server reload-config on the home box. The account appears here, and each agent's menu lets you swap onto it."),
     ]
 

--- a/App/FederationSetupView.swift
+++ b/App/FederationSetupView.swift
@@ -21,7 +21,7 @@ struct FederationSetupView: View {
     private static let steps: [Step] = [
         .init(symbol: "arrow.down.circle",
               title: "Install the herdr fork",
-              detail: "On the machine, install the jerryfane/herdr fork — it has the api-bridge the home box connects through. Official herdr does not."),
+              detail: "On the machine, install the jerryfane/herdr fork; it has the api-bridge the home box connects through. Official herdr does not."),
         .init(symbol: "network",
               title: "Put it on your network",
               detail: "Join it to your Tailscale tailnet (or any address your home box can reach) and authorize your home box's SSH key."),
@@ -29,7 +29,7 @@ struct FederationSetupView: View {
               title: "Add it to your config",
               detail: "Add a peer to ~/.config/herdr/config.toml: an alias and ssh://user@host."),
         .init(symbol: "arrow.clockwise",
-              title: "Reload — no restart",
+              title: "Reload, no restart",
               detail: "Run herdr server reload-config on the home box. The machine's agents appear here; no restart needed."),
     ]
 

--- a/App/GesturesHelpView.swift
+++ b/App/GesturesHelpView.swift
@@ -39,7 +39,7 @@ struct GesturesHelpView: View {
               detail: "Stops it."),
         .init(symbol: "trash",
               title: "Press and hold a message in Gram",
-              detail: "Deletes it — and its file — for good."),
+              detail: "Deletes it, and its file, for good."),
         .init(symbol: "arrow.clockwise",
               title: "Pull down in Gram",
               detail: "Refreshes the messages."),

--- a/App/GramView.swift
+++ b/App/GramView.swift
@@ -913,7 +913,7 @@ struct GramView: View {
                 phase = .unavailable(
                     "Gram isn't available on this server yet, or the messages couldn't load.")
             } else {
-                refreshNote = "Refresh failed — showing the last loaded messages."
+                refreshNote = "Refresh failed. Showing the last loaded messages."
             }
         }
     }
@@ -1014,7 +1014,7 @@ struct GramView: View {
         attachedFiles = remaining
         if let failure {
             sendError = sentCount > 0
-                ? "Sent \(sentCount) of \(files.count) — \(failure)"
+                ? "Sent \(sentCount) of \(files.count). \(failure)"
                 : failure
         }
     }
@@ -1028,7 +1028,7 @@ struct GramView: View {
         if let bad { parts.append(bad) }
         if capped > 0 { parts.append("\(capped) over the \(Self.maxAttachments)-file limit") }
         guard !parts.isEmpty else { return nil }
-        return "Skipped — " + parts.joined(separator: "; ") + "."
+        return "Skipped: " + parts.joined(separator: "; ") + "."
     }
 
     /// Read picked files into memory (each bounded by the server's size cap) so each

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -538,7 +538,7 @@ struct ConnectView: View {
     // Two faint captions: what the connection is, and where the key lives.
     private var captions: some View {
         VStack(spacing: 8) {
-            Text("Connects privately over your Tailscale network — nothing is exposed to the public internet.")
+            Text("Connects privately over your Tailscale network. Nothing is exposed to the public internet.")
                 .font(Typography.machine(12)).foregroundStyle(Palette.textFaint)
                 .multilineTextAlignment(.center)
             Text("Your key or password stays in this device's Keychain, never uploaded.")
@@ -848,7 +848,7 @@ struct NewAgentView: View {
                         errorMessage = "couldn't start the agent: \(startError)"
                     } catch {
                         errorMessage = "couldn't start the agent (\(startError)); also failed to "
-                            + "clean up the empty pane (\(error)) — it may need closing manually"
+                            + "clean up the empty pane (\(error)). It may need closing manually"
                     }
                 } else {
                     errorMessage = "couldn't create the pane: \(startError)"
@@ -1546,7 +1546,7 @@ struct TerminalHomeView: View {
                 Button("Cancel", role: .cancel) {}
             } message: { cand in
                 Text(
-                    "Switches \(cand.row.title) to \(cand.account.label) and restarts it — this interrupts its current turn. The session is reopened with --resume on the new subscription."
+                    "Switches \(cand.row.title) to \(cand.account.label) and restarts it. This interrupts its current turn. The session is reopened with --resume on the new subscription."
                 )
             }
         }
@@ -1849,7 +1849,7 @@ struct TerminalHomeView: View {
                     Button("trust this key & reconnect") { trustFailed = !onTrustHostKey(fingerprint) }
                         .font(Typography.app(15, .semibold)).foregroundStyle(Palette.died)
                     if trustFailed {
-                        Text("could not save the verified key to the keychain — not reconnecting. try again.")
+                        Text("could not save the verified key to the keychain; not reconnecting. try again.")
                             .font(Typography.app(12)).foregroundStyle(Palette.died).multilineTextAlignment(.center)
                     }
                 }
@@ -1887,7 +1887,7 @@ struct TerminalHomeView: View {
                 .font(Typography.app(20, .bold)).foregroundStyle(Palette.text)
                 .multilineTextAlignment(.center)
             Text(herdrIncompatibleBuild
-                 ? "Herdrup runs the herdr daemon on your machine over SSH. The herdr on this host can't run the app bridge — it's too old, or isn't the jerryfane/herdr fork. Update or install the fork, then reconnect."
+                 ? "Herdrup runs the herdr daemon on your machine over SSH. The herdr on this host can't run the app bridge. It's too old, or isn't the jerryfane/herdr fork. Update or install the fork, then reconnect."
                  : "Herdrup runs the herdr daemon on your machine over SSH. It isn't installed yet. Install the jerryfane/herdr fork, then reconnect.")
                 .font(Typography.app(14)).foregroundStyle(Palette.textDim)
                 .multilineTextAlignment(.center)
@@ -2507,9 +2507,9 @@ struct TerminalPaneContent: View {
                 _ = try await client.prompt(pane: pane, text: "/tui default",
                                             waitUntil: HerdrClient.anyAgentStatus, timeoutMs: 6000)
                 tuiClassicPrompted = true
-                actionNote = "Switched — Claude Code will open in smooth-scroll mode from now on"
+                actionNote = "Switched. Claude Code will open in smooth-scroll mode from now on"
             } catch {
-                actionNote = "Couldn't switch — tap Switch to try again"
+                actionNote = "Couldn't switch. Tap Switch to try again"
             }
         }
     }
@@ -2807,11 +2807,11 @@ struct TerminalPaneContent: View {
         case "agent_input_pending":
             return "answer the on-screen prompt first (use the keys), then send"
         case "agent_not_ready":
-            return "agent not ready — try again"
+            return "agent not ready, try again"
         case "agent_prompt_not_received":
-            return "not delivered — try again"
+            return "not delivered, try again"
         case "timeout":
-            return "sent — awaiting confirmation"
+            return "sent, awaiting confirmation"
         default:
             return "send failed: \(error)"
         }
@@ -2896,7 +2896,7 @@ struct TerminalPaneContent: View {
                 // the reply bar is fully usable and a manual Send goes through the normal
                 // path. The typed task stays in the field for one tap.
                 pendingPrefill = false
-                actionNote = "couldn't auto-send — tap Send to deliver it"
+                actionNote = "couldn't auto-send, tap Send to deliver it"
                 return
             }
             try? await Task.sleep(nanoseconds: 1_500_000_000)
@@ -3176,7 +3176,7 @@ struct SettingsView: View {
                         bulkResult = "Moved all \(moved) agent\(moved == 1 ? "" : "s") to \(label)."
                     } else {
                         bulkResult = "Moved \(moved) of \(total). \(failed) couldn't be moved"
-                            + (lastError.map { " — \($0)" } ?? "") + "."
+                            + (lastError.map { ": \($0)" } ?? "") + "."
                     }
                     accounts = (try? await client.accountsList()) ?? []
                 }
@@ -3185,7 +3185,7 @@ struct SettingsView: View {
         } message: { account in
             let n = agents.filter { $0.agent == account.kind }.count
             Text("Restarts \(n) \(account.kind.capitalized) agent\(n == 1 ? "" : "s") onto "
-                + "\(account.label) — this interrupts each one's current turn. "
+                + "\(account.label). This interrupts each one's current turn. "
                 + "Sessions reopen with --resume.")
         }
         .alert(
@@ -4131,7 +4131,7 @@ struct SettingsView: View {
     private var supportFeedback: some View {
         switch tipStore.purchaseState {
         case .thankYou:
-            Text("Thank you — it means a lot.")
+            Text("Thank you, it means a lot.")
                 .font(Typography.app(12, .medium)).foregroundStyle(Palette.done)
                 .padding(.horizontal, 20).padding(.top, 8)
         case .failed(let message):
@@ -4187,8 +4187,8 @@ struct SettingsView: View {
     /// design's one-line stance. Version + build come from the bundle (MARKETING_VERSION
     /// / CFBundleVersion), so they track the shipped build, not a hardcoded string.
     private var versionFooter: some View {
-        let short = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "—"
-        let build = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "—"
+        let short = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "-"
+        let build = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "-"
         return VStack(spacing: 4) {
             Text("herdrup mobile \(short) (\(build))")
                 .font(Typography.machine(12)).foregroundStyle(Palette.textFaint)
@@ -4289,7 +4289,7 @@ struct SettingsView: View {
     private func copyDiagnostics() {
         // Host + app version only — never anything sensitive (no key, ever).
         let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "?"
-        UIPasteboard.general.string = "herdr-ios \(version) — host \(host)"
+        UIPasteboard.general.string = "herdr-ios \(version), host \(host)"
         copied = true
         // Revert the confirmation so a second copy gives feedback.
         Task { try? await Task.sleep(nanoseconds: 2_000_000_000); copied = false }
@@ -4484,7 +4484,7 @@ struct MockTransport: HerdrTransport {
         for i in 1...200 {
             body += String(format: "SCROLLTEST line %03d  the quick brown fox jumps over the lazy dog\r\n", i)
         }
-        body += "SCROLLTEST end — swipe down to reveal earlier lines"
+        body += "SCROLLTEST end, swipe down to reveal earlier lines"
         let b64 = Data(body.utf8).base64EncodedString()
         return "{\"stream\":\"pane.bytes\",\"frame\":\"reset\",\"seq\":0,\"epoch\":7,\"cols\":80,\"rows\":24,\"data_b64\":\"\(b64)\"}"
     }
@@ -4499,7 +4499,7 @@ struct MockTransport: HerdrTransport {
         for i in 1...1000 {
             body += String(format: "BACKFILL line %04d  the quick brown fox jumps over the lazy dog\r\n", i)
         }
-        body += "BACKFILL end — swipe down to reveal earlier lines"
+        body += "BACKFILL end, swipe down to reveal earlier lines"
         let payload: [String: Any] = ["id": "mock", "result": ["read": [
             "pane_id": "w1:p1", "text": body, "truncated": false,
             "source": "recent", "format": "ansi"]]]
@@ -4556,7 +4556,7 @@ struct MockTransport: HerdrTransport {
       {"id":"g2","direction":"owner_to_agent","from":"owner","text":"Anyone free to triage the failing CI?","created_unix_ms":1723000004000,"read_by_owner":true},
       {"id":"g3","direction":"owner_to_agent","from":"owner","text":"Rebase the vetrina branch onto main.","grabbed_by":"herdr-app","grabbed_unix_ms":1723000004500,"created_unix_ms":1723000003000,"read_by_owner":true},
       {"id":"g4","direction":"owner_to_agent","from":"owner","to":"clientloop","text":"Ship the Amigo POC scaffold today.","created_unix_ms":1723000002000,"read_by_owner":true},
-      {"id":"g5","direction":"agent_to_owner","from":"vetrina","text":"Deployed vetrina.dev — it is live.","created_unix_ms":1723000001000,"read_by_owner":true,"file":{"name":"vetrina-live.png","size":48213,"mime":"image/png","sha256":"9f2c0a1b7d3e4f5061728394a5b6c7d8e9f0a1b2c3d4e5f60718293a4b5c6d7e"}}
+      {"id":"g5","direction":"agent_to_owner","from":"vetrina","text":"Deployed vetrina.dev, it is live.","created_unix_ms":1723000001000,"read_by_owner":true,"file":{"name":"vetrina-live.png","size":48213,"mime":"image/png","sha256":"9f2c0a1b7d3e4f5061728394a5b6c7d8e9f0a1b2c3d4e5f60718293a4b5c6d7e"}}
     ]}}
     """#
 

--- a/App/HostEditor.swift
+++ b/App/HostEditor.swift
@@ -227,7 +227,7 @@ struct HostEditor: View {
             ZStack {
                 Palette.ground.ignoresSafeArea()
                 VStack(alignment: .leading, spacing: 14) {
-                    Text("Copy your ed25519 private key (PEM) to the clipboard, then paste it here. It is stored in the Keychain (device-only) and sent over the SSH connection — it is never displayed, so it can't appear in a screenshot.")
+                    Text("Copy your ed25519 private key (PEM) to the clipboard, then paste it here. It is stored in the Keychain (device-only) and sent over the SSH connection; it is never displayed, so it can't appear in a screenshot.")
                         .font(Typography.app(13)).foregroundStyle(Palette.textDim)
 
                     Button { pasteKeyFromClipboard() } label: {
@@ -271,7 +271,7 @@ struct HostEditor: View {
     private func pasteKeyFromClipboard() {
         guard let s = UIPasteboard.general.string?.trimmingCharacters(in: .whitespacesAndNewlines),
               !s.isEmpty else {
-            keyError = "Nothing to paste — copy your private key to the clipboard first."
+            keyError = "Nothing to paste. Copy your private key to the clipboard first."
             return
         }
         guard s.contains("PRIVATE KEY") else {

--- a/App/LiveTerminalView.swift
+++ b/App/LiveTerminalView.swift
@@ -708,7 +708,7 @@ struct LiveTerminalView: UIViewRepresentable {
             let capped = min(20.0, 0.5 * pow(2.0, Double(max(0, reconnectAttempts - 1))))  // 0.5,1,2,4,8,16,20
             let delay = capped * Double.random(in: 0.6...1.0)                               // full-ish jitter
             if let view {
-                let notice = "\r\n\u{1b}[2m— \(reason); reconnecting…\u{1b}[0m\r\n"
+                let notice = "\r\n\u{1b}[2m\(reason); reconnecting…\u{1b}[0m\r\n"
                 view.feed(byteArray: [UInt8](notice.utf8)[...])
             }
             reconnectTask = Task { @MainActor [weak self] in
@@ -1157,7 +1157,7 @@ struct LiveTerminalView: UIViewRepresentable {
         /// `handleScrollPan`, which sends wheel/arrow scroll INTO the agent.)
         private static let clearSequence = [UInt8]("\u{1b}[2J\u{1b}[H".utf8)
         /// The dim terminated marker shown when the process exits.
-        private static let exitedNotice = [UInt8]("\r\n\u{1b}[2m— process exited —\u{1b}[0m\r\n".utf8)
+        private static let exitedNotice = [UInt8]("\r\n\u{1b}[2mprocess exited\u{1b}[0m\r\n".utf8)
 
         private static func color(_ hex: UInt32) -> UIColor {
             UIColor(

--- a/Sources/HerdrKit/InputIntent.swift
+++ b/Sources/HerdrKit/InputIntent.swift
@@ -122,7 +122,7 @@ public struct InputRouter: Sendable {
             // Characters: Swift clusters "\r\n" into ONE grapheme that equals
             // neither "\n" nor "\r", so a Character scan would wave CRLF through.
             guard !text.unicodeScalars.contains(where: { $0 == "\n" || $0 == "\r" }) else {
-                return .refused(reason: "newline not allowed here — press Enter to submit")
+                return .refused(reason: "newline not allowed here; press Enter to submit")
             }
             return .text(pane: pane, text)
 

--- a/Sources/HerdrKit/Transport.swift
+++ b/Sources/HerdrKit/Transport.swift
@@ -144,11 +144,11 @@ public enum TransportError: Error, CustomStringConvertible {
         case .herdrNotInstalled(let h):
             return "herdr is not installed on \(h)"
         case .herdrIncompatible(let h):
-            return "the herdr on \(h) is too old or isn't the fork — update it (or install the fork) and reconnect"
+            return "the herdr on \(h) is too old or isn't the fork. Update it (or install the fork) and reconnect"
         case .passwordAuthUnsupported(let h):
-            return "\(h) does not offer password authentication — use a key instead"
+            return "\(h) does not offer password authentication; use a key instead"
         case .authenticationFailed(let h):
-            return "authentication to \(h) failed — check the password or key"
+            return "authentication to \(h) failed. Check the password or key"
         }
     }
 }


### PR DESCRIPTION
Owner request: remove all em dashes from the app's visible text.

Scope: **user-facing strings only** (what shows in the app) — labels, setup guidance, error/status messages, terminal notices, the tip-jar line, and the version-fallback glyph. Each em dash is rewritten with natural punctuation (comma / period / semicolon / colon) tuned to the sentence, not a blanket hyphen. Code comments are intentionally left untouched (not visible in the app; confirmed with the owner).

- 9 files, 34 strings, symmetric edits (no behavior change).
- Verified: zero em dashes remain in any non-comment string literal (grep), all files parse, HerdrKit builds + tests green (the 1 `ReadmeLayoutTests` failure is pre-existing on main, unrelated).

## Verify
- CI `build-and-uitest`.
- Spot-check in the app: Accounts/Federation setup sheets, the connect error/guidance screens, Gram status lines, the tip-jar "thank you", the Tailscale privacy line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)