### PR TITLE
fix(voice): keep long dictation from losing its start (unbounded, accumulating)

### DIFF
--- a/App/VoiceInput.swift
+++ b/App/VoiceInput.swift
@@ -1,4 +1,5 @@
 import AVFoundation
+import HerdrKit
 import Speech
 import SwiftUI
 
@@ -26,11 +27,25 @@ final class SpeechDictator: ObservableObject {
 
     private let recognizer = SFSpeechRecognizer()  // the user's current locale
     private let engine = AVAudioEngine()
-    private var request: SFSpeechAudioBufferRecognitionRequest?
+    /// The recognition request the audio tap feeds. Held in a lock-guarded box because
+    /// the tap runs on an audio thread and the request is SWAPPED on every segment roll
+    /// (see `rollSegment`) while the engine + tap keep running uninterrupted.
+    private let box = RequestBox()
     private var task: SFSpeechRecognitionTask?
-    /// Bumped for every session and on every stop/finalize. An in-flight recognition
-    /// callback captures its generation and no-ops if it no longer matches, so a stale
-    /// callback from a finished session can't touch a newer one.
+    /// Finalized segments so far this session. Keeps the exposed `transcript` MONOTONIC —
+    /// it never loses its head when the recognizer re-segments near its ceiling.
+    private var accumulator = TranscriptAccumulator()
+    /// The current segment's latest best transcription, not yet committed.
+    private var lastPartial = ""
+    /// Rolls the recognition task over before `SFSpeechRecognizer`'s ~1-minute audio
+    /// ceiling, so it never reaches the window where it would drop earlier text.
+    private var rollTimer: Timer?
+    /// Seconds a single recognition task runs before we commit + restart it — under
+    /// Apple's ~60s ceiling with margin.
+    private let segmentSeconds: TimeInterval = 50
+    /// Bumped on every stop/finalize/roll. An in-flight recognition callback captures its
+    /// generation and no-ops if it no longer matches, so a stale callback from a retired
+    /// task can't touch a newer one.
     private var generation = 0
 
     var isRecording: Bool { state == .recording }
@@ -46,6 +61,8 @@ final class SpeechDictator: ObservableObject {
         // double-tap would otherwise install a SECOND tap on the input node (a crash) and
         // spawn a second recognition task.
         guard state != .requesting, state != .recording else { return }
+        accumulator.reset()
+        lastPartial = ""
         transcript = ""
         note = nil
         state = .requesting
@@ -107,49 +124,104 @@ final class SpeechDictator: ObservableObject {
         try session.setCategory(.record, mode: .measurement, options: .duckOthers)
         try session.setActive(true, options: .notifyOthersOnDeactivation)
 
-        let request = SFSpeechAudioBufferRecognitionRequest()
-        request.shouldReportPartialResults = true
-        request.requiresOnDeviceRecognition = true
-        self.request = request
-
-        generation &+= 1
-        let gen = generation
-
+        // The tap runs for the WHOLE dictation and feeds whatever request is current in
+        // the box; only the request + task are swapped on a segment roll, never the engine.
         let input = engine.inputNode
         let format = input.outputFormat(forBus: 0)
-        input.installTap(onBus: 0, bufferSize: 1024, format: format) { [weak request] buffer, _ in
-            request?.append(buffer)
+        let box = self.box
+        input.installTap(onBus: 0, bufferSize: 1024, format: format) { buffer, _ in
+            box.append(buffer)
         }
         engine.prepare()
         try engine.start()
         state = .recording
 
+        startSegment(recognizer: recognizer)
+        // Roll the recognition task over before SFSpeechRecognizer's ~1-minute ceiling, so
+        // it never reaches the window where it drops earlier text.
+        rollTimer = Timer.scheduledTimer(withTimeInterval: segmentSeconds, repeats: true) { [weak self] _ in
+            Task { @MainActor in self?.rollSegment() }
+        }
+    }
+
+    /// Begin one recognition segment: a fresh request + task on the already-running engine.
+    private func startSegment(recognizer: SFSpeechRecognizer) {
+        let request = SFSpeechAudioBufferRecognitionRequest()
+        request.shouldReportPartialResults = true
+        request.requiresOnDeviceRecognition = true
+        box.set(request)   // also ends the previous request, if any
+        lastPartial = ""
+
+        generation &+= 1
+        let gen = generation
         task = recognizer.recognitionTask(with: request) { [weak self] result, error in
             guard let self else { return }
             Task { @MainActor in
-                // Ignore a callback that belongs to a session we've already torn down.
+                // Ignore a callback from a retired task.
                 guard gen == self.generation, self.state == .recording else { return }
-                if let result { self.transcript = result.bestTranscription.formattedString }
-                if error != nil || (result?.isFinal ?? false) {
-                    self.generation &+= 1
-                    self.finishAudio()
-                    self.state = .idle
+                if let result {
+                    self.lastPartial = result.bestTranscription.formattedString
+                    self.transcript = self.accumulator.text(withPartial: self.lastPartial)
+                }
+                if result?.isFinal ?? false {
+                    // A segment finalized (a natural pause / the ceiling): keep its text and
+                    // start a fresh segment rather than ending — dictation CONTINUES.
+                    self.rollSegment()
+                } else if error != nil, self.state == .recording {
+                    // The task errored (commonly the ceiling); roll to a fresh one.
+                    self.rollSegment()
                 }
             }
         }
     }
 
+    /// Commit the current segment's text and start a fresh recognition task on the same
+    /// running engine, so recognition never hits its ceiling and the head is never lost.
+    private func rollSegment() {
+        guard state == .recording, let recognizer else { return }
+        accumulator.commit(lastPartial)
+        transcript = accumulator.committed
+        generation &+= 1     // retire the old task's callbacks before the new one starts
+        task?.cancel()
+        task = nil
+        startSegment(recognizer: recognizer)
+    }
+
     private func finishAudio() {
+        rollTimer?.invalidate()
+        rollTimer = nil
         engine.inputNode.removeTap(onBus: 0)
         if engine.isRunning { engine.stop() }
-        request?.endAudio()
+        // Keep the fully-dictated text: fold the last live partial into `committed` before
+        // tearing down (the field already shows it; this makes `transcript` self-consistent).
+        accumulator.commit(lastPartial)
+        transcript = accumulator.committed
+        lastPartial = ""
+        box.set(nil)   // ends the current request
         task?.cancel()
-        request = nil
         task = nil
         try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
     }
 
     private func teardown() { finishAudio() }
+}
+
+/// Thread-safe holder for the current recognition request. The audio tap (an audio thread)
+/// appends buffers through this while the main actor SWAPS the request on each segment roll.
+/// A single `NSLock` around one reference is enough — append and set never contend for long.
+private final class RequestBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var request: SFSpeechAudioBufferRecognitionRequest?
+    /// Install a new request (or nil to clear); ends the one it replaces so its recognizer
+    /// finalizes rather than leaking the audio pipeline.
+    func set(_ r: SFSpeechAudioBufferRecognitionRequest?) {
+        lock.lock(); let old = request; request = r; lock.unlock()
+        old?.endAudio()
+    }
+    func append(_ buffer: AVAudioPCMBuffer) {
+        lock.lock(); let r = request; lock.unlock()
+        r?.append(buffer)
+    }
 }
 
 /// A mic button that dictates into a bound text field. The recognized text is APPENDED

--- a/App/VoiceInput.swift
+++ b/App/VoiceInput.swift
@@ -37,6 +37,19 @@ final class SpeechDictator: ObservableObject {
     private var accumulator = TranscriptAccumulator()
     /// The current segment's latest best transcription, not yet committed.
     private var lastPartial = ""
+    /// A segment we rolled away from whose OWN final result has not landed yet: its last
+    /// partial is shown provisionally so the screen never flickers, then its full final (the
+    /// tail the old task keeps recognising after the swap) replaces it. Assumes one rolled
+    /// segment finalizes before the next ~50s roll — true given on-device finals arrive in
+    /// ~1s.
+    private var pending = ""
+    /// Generation of the segment whose text is in `pending`, so its own (non-active) final
+    /// commits exactly once and a rare pause-at-a-roll-boundary can't double-commit it.
+    private var pendingGen: Int?
+    /// Consecutive error-driven rolls with no successful result between them. Capped so a
+    /// PERSISTENT failure (asset evicted, dictation disabled mid-session) stops with a note
+    /// instead of churning new tasks forever.
+    private var errorRolls = 0
     /// Rolls the recognition task over before `SFSpeechRecognizer`'s ~1-minute audio
     /// ceiling, so it never reaches the window where it would drop earlier text.
     private var rollTimer: Timer?
@@ -63,6 +76,9 @@ final class SpeechDictator: ObservableObject {
         guard state != .requesting, state != .recording else { return }
         accumulator.reset()
         lastPartial = ""
+        pending = ""
+        pendingGen = nil
+        errorRolls = 0
         transcript = ""
         note = nil
         state = .requesting
@@ -132,24 +148,32 @@ final class SpeechDictator: ObservableObject {
         input.installTap(onBus: 0, bufferSize: 1024, format: format) { buffer, _ in
             box.append(buffer)
         }
+        // Ready the first request BEFORE the engine runs, so the very first audio buffers
+        // have a request to go to (the box is otherwise nil for a beat and drops them).
+        state = .recording
+        startSegment(recognizer: recognizer)
         engine.prepare()
         try engine.start()
-        state = .recording
 
-        startSegment(recognizer: recognizer)
-        // Roll the recognition task over before SFSpeechRecognizer's ~1-minute ceiling, so
-        // it never reaches the window where it drops earlier text.
+        // Roll the recognition task over before SFSpeechRecognizer's ~1-minute ceiling.
+        // segmentSeconds keeps ~10s of margin under it; that margin is a heuristic — the
+        // pure TranscriptAccumulator tests can't cover the driver committing before a
+        // within-segment shrink, so it's tuned conservatively.
         rollTimer = Timer.scheduledTimer(withTimeInterval: segmentSeconds, repeats: true) { [weak self] _ in
             Task { @MainActor in self?.rollSegment() }
         }
     }
 
     /// Begin one recognition segment: a fresh request + task on the already-running engine.
+    /// The OUTGOING task is NOT cancelled — `box.set` ends its request so it delivers a full
+    /// FINAL result (the tail it was still recognising after the swap), which the callback
+    /// commits. Cancelling would discard that final and re-introduce the per-roll boundary
+    /// loss this avoids.
     private func startSegment(recognizer: SFSpeechRecognizer) {
         let request = SFSpeechAudioBufferRecognitionRequest()
         request.shouldReportPartialResults = true
         request.requiresOnDeviceRecognition = true
-        box.set(request)   // also ends the previous request, if any
+        box.set(request)   // ends the previous request (it finalizes), routes audio here
         lastPartial = ""
 
         generation &+= 1
@@ -157,34 +181,68 @@ final class SpeechDictator: ObservableObject {
         task = recognizer.recognitionTask(with: request) { [weak self] result, error in
             guard let self else { return }
             Task { @MainActor in
-                // Ignore a callback from a retired task.
-                guard gen == self.generation, self.state == .recording else { return }
+                guard self.state == .recording else { return }
+                let isActive = (gen == self.generation)
                 if let result {
-                    self.lastPartial = result.bestTranscription.formattedString
-                    self.transcript = self.accumulator.text(withPartial: self.lastPartial)
-                }
-                if result?.isFinal ?? false {
-                    // A segment finalized (a natural pause / the ceiling): keep its text and
-                    // start a fresh segment rather than ending — dictation CONTINUES.
-                    self.rollSegment()
-                } else if error != nil, self.state == .recording {
-                    // The task errored (commonly the ceiling); roll to a fresh one.
-                    self.rollSegment()
+                    self.errorRolls = 0          // a result means we're making progress
+                    let text = result.bestTranscription.formattedString
+                    if result.isFinal {
+                        if isActive {
+                            // Active segment finalized on a natural pause: commit it and keep
+                            // going (a pause no longer stops dictation).
+                            if let pg = self.pendingGen, pg != gen {
+                                self.accumulator.commit(self.pending)   // an earlier provisional
+                            }
+                            self.pending = ""; self.pendingGen = nil
+                            self.accumulator.commit(text)
+                            self.lastPartial = ""
+                            self.transcript = self.accumulator.committed
+                            self.startSegment(recognizer: recognizer)
+                        } else if self.pendingGen == gen {
+                            // The segment we rolled away from delivered its FULL final (incl.
+                            // the tail): commit the whole thing, replacing its provisional.
+                            self.accumulator.commit(text)
+                            self.pending = ""; self.pendingGen = nil
+                            self.refreshTranscript()
+                        }
+                        // a non-active final for an already-committed segment: ignore.
+                    } else if isActive {
+                        self.lastPartial = text
+                        self.refreshTranscript()
+                    }
+                    // Partials from a non-active (finalizing) segment are ignored.
+                } else if error != nil, isActive {
+                    // Roll on error (routinely the ceiling), but CAP consecutive error-rolls
+                    // so a persistent failure stops with feedback instead of churning forever.
+                    self.errorRolls += 1
+                    if self.errorRolls >= 3 {
+                        self.note = "Dictation stopped. Tap the mic to start again."
+                        self.stop()
+                    } else {
+                        self.rollSegment()
+                    }
                 }
             }
         }
     }
 
-    /// Commit the current segment's text and start a fresh recognition task on the same
-    /// running engine, so recognition never hits its ceiling and the head is never lost.
+    /// Roll to a fresh segment before the recognizer's ceiling. The current segment's text is
+    /// kept on screen as `pending` (so nothing flickers) and its task is left to FINALIZE;
+    /// its full final commits in the callback above and supersedes the provisional.
     private func rollSegment() {
         guard state == .recording, let recognizer else { return }
-        accumulator.commit(lastPartial)
-        transcript = accumulator.committed
-        generation &+= 1     // retire the old task's callbacks before the new one starts
-        task?.cancel()
-        task = nil
-        startSegment(recognizer: recognizer)
+        let rolledGen = generation
+        pending = [pending, lastPartial].filter { !$0.isEmpty }.joined(separator: " ")
+        pendingGen = rolledGen
+        lastPartial = ""
+        startSegment(recognizer: recognizer)   // box.set ends the rolled request -> it finalizes
+    }
+
+    /// Rebuild the displayed transcript: committed + the provisional rolled segment + the
+    /// active partial. Never shorter than `committed`.
+    private func refreshTranscript() {
+        let tail = [pending, lastPartial].filter { !$0.isEmpty }.joined(separator: " ")
+        transcript = accumulator.text(withPartial: tail)
     }
 
     private func finishAudio() {
@@ -192,11 +250,14 @@ final class SpeechDictator: ObservableObject {
         rollTimer = nil
         engine.inputNode.removeTap(onBus: 0)
         if engine.isRunning { engine.stop() }
-        // Keep the fully-dictated text: fold the last live partial into `committed` before
-        // tearing down (the field already shows it; this makes `transcript` self-consistent).
-        accumulator.commit(lastPartial)
+        // Keep everything on screen: fold the provisional rolled segment AND the last live
+        // partial into `committed` before tearing down (makes `transcript` self-consistent).
+        let tail = [pending, lastPartial].filter { !$0.isEmpty }.joined(separator: " ")
+        if !tail.isEmpty { accumulator.commit(tail) }
         transcript = accumulator.committed
         lastPartial = ""
+        pending = ""
+        pendingGen = nil
         box.set(nil)   // ends the current request
         task?.cancel()
         task = nil

--- a/Sources/HerdrKit/TranscriptAccumulator.swift
+++ b/Sources/HerdrKit/TranscriptAccumulator.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+/// Keeps a dictation transcript MONOTONIC across the underlying recognizer's
+/// segment boundaries.
+///
+/// `SFSpeechRecognizer` hands back the CURRENT segment's best transcription each
+/// callback, and near its implicit ~1-minute ceiling it re-segments so that string
+/// SHRINKS — dropping its head. If the field is set straight from that latest partial,
+/// the earlier dictated text is lost. This type separates the finalized text
+/// (`committed`) from the in-progress `partial`: the exposed transcript is
+/// `committed` + `partial`, so it never falls below what was already committed. The
+/// dictation driver commits a segment (on a final result or a rolling restart) before
+/// the recognizer can drop it, then keeps going — making dictation effectively
+/// unbounded and loss-free.
+///
+/// Pure value type: no Speech/AVFoundation dependency, so it is unit-testable off-device.
+public struct TranscriptAccumulator: Equatable, Sendable {
+    /// The finalized text so far this session. Only ever grows (until `reset`).
+    public private(set) var committed: String = ""
+
+    public init() {}
+
+    /// The full transcript given the current in-progress `partial`: `committed`
+    /// joined to `partial` by a single space, skipping the space when either side is
+    /// empty. Never shorter than `committed`.
+    public func text(withPartial partial: String) -> String {
+        let p = partial.trimmingCharacters(in: .whitespacesAndNewlines)
+        if committed.isEmpty { return p }
+        if p.isEmpty { return committed }
+        return committed + " " + p
+    }
+
+    /// Fold the current `partial` into `committed` (idempotent for an empty partial).
+    /// After this, `text(withPartial: "")` returns the folded whole.
+    public mutating func commit(_ partial: String) {
+        committed = text(withPartial: partial)
+    }
+
+    /// Clear everything for a new dictation session.
+    public mutating func reset() {
+        committed = ""
+    }
+}

--- a/Tests/HerdrKitTests/TranscriptAccumulatorTests.swift
+++ b/Tests/HerdrKitTests/TranscriptAccumulatorTests.swift
@@ -1,0 +1,51 @@
+import XCTest
+@testable import HerdrKit
+
+final class TranscriptAccumulatorTests: XCTestCase {
+    func testEmptyStart() {
+        let acc = TranscriptAccumulator()
+        XCTAssertEqual(acc.committed, "")
+        XCTAssertEqual(acc.text(withPartial: ""), "")
+        XCTAssertEqual(acc.text(withPartial: "hello"), "hello")
+    }
+
+    func testCommitAccumulatesWithSingleSpaces() {
+        var acc = TranscriptAccumulator()
+        acc.commit("hello")
+        XCTAssertEqual(acc.committed, "hello")
+        XCTAssertEqual(acc.text(withPartial: "world"), "hello world")
+        acc.commit("world")
+        XCTAssertEqual(acc.committed, "hello world")
+        XCTAssertEqual(acc.text(withPartial: ""), "hello world")
+    }
+
+    /// THE BUG THIS FIXES: once text is committed, a SHORTER partial (the recognizer
+    /// re-segmenting near its ceiling) must not drop the earlier text.
+    func testShorterPartialNeverLosesCommitted() {
+        var acc = TranscriptAccumulator()
+        acc.commit("one two three four five")
+        // The recognizer's next window comes back as just "six" — the head must survive.
+        let text = acc.text(withPartial: "six")
+        XCTAssertEqual(text, "one two three four five six")
+        XCTAssertTrue(text.hasPrefix(acc.committed), "output fell below committed")
+        // An empty partial (a gap between segments) still returns everything committed.
+        XCTAssertEqual(acc.text(withPartial: ""), "one two three four five")
+    }
+
+    func testPartialWhitespaceIsTrimmed() {
+        var acc = TranscriptAccumulator()
+        acc.commit("hi")
+        XCTAssertEqual(acc.text(withPartial: "  there \n"), "hi there")
+        // Committing a whitespace-only partial is a no-op.
+        acc.commit("   ")
+        XCTAssertEqual(acc.committed, "hi")
+    }
+
+    func testResetClears() {
+        var acc = TranscriptAccumulator()
+        acc.commit("something")
+        acc.reset()
+        XCTAssertEqual(acc.committed, "")
+        XCTAssertEqual(acc.text(withPartial: "fresh"), "fresh")
+    }
+}


### PR DESCRIPTION
Owner: in voice mode, after dictating a while the EARLIER text disappears, leaving only the recent part.

## Cause
`SpeechDictator` set the field straight from the recognizer's latest `bestTranscription.formattedString`. On-device `SFSpeechRecognizer` re-segments near its implicit ~1-minute ceiling, so that string SHRINKS (drops its head) — overwriting the earlier dictated text. No explicit app limit exists.

## Fix
- New pure **`TranscriptAccumulator`** (HerdrKit, Linux-unit-tested) keeps the exposed transcript MONOTONIC: `committed` finalized text + current partial, never shorter than `committed`.
- `SpeechDictator` commits a segment (on `isFinal`, a ~50s roll timer, or an `error`) and starts a fresh request+task on the **same running engine** — a lock-guarded `RequestBox` lets the audio tap feed the swapped request. So the task never reaches the ceiling and the head is never lost. Dictation is now effectively unbounded.

## UX shift (intended)
A pause no longer auto-stops dictation (it commits the segment and continues); it stops on tap / background / going inactive. This is what makes long multi-sentence dictation work without losing the start.

## Verify
- HerdrKit `swift test` — 5 `TranscriptAccumulator` cases (monotonicity, join, shorter-partial-never-loses-committed, reset).
- CI `build-and-uitest`.
- Manual: dictate a continuous message >1 min — the beginning stays, nothing cuts at ~1 min; a mid-sentence pause no longer stops it; tap stop ends it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)