### PR TITLE
feat(terminal): open plain shell terminals from the Agents list

### DIFF
--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -975,6 +975,12 @@ struct TerminalHomeView: View {
     /// fragile "push while dismissing a cover" no longer applies — but the deferral is kept as
     /// cheap safety).
     @State private var pendingOpenSlot: PaneSlot?
+    /// The user's opened plain-shell terminals (a singleton, so it survives this view's
+    /// `.id(session)` remount). Shell panes never appear in `agent.list`, so the app tracks
+    /// them here to relist and reopen. See `SavedTerminalsStore`.
+    @ObservedObject private var terminalsStore = SavedTerminalsStore.shared
+    /// Re-entry guard while a `New Terminal` split is in flight (also dims the row).
+    @State private var creatingTerminal = false
     private static let maxLivePanes = 3
     // Only the quiet tail (idle) starts collapsed — the model forbids a
     // collapsed group from ever hiding something that wants attention.
@@ -1020,6 +1026,37 @@ struct TerminalHomeView: View {
         // open path (row tap, deep-link, spawn, swipe-paging) consistent.
         selectedTab = .agents
         frontID = slot.paneID
+    }
+
+    /// Open a fresh plain-shell terminal: `pane.split` with NO `agent.start` yields a booting
+    /// shell PTY (the same split the new-agent flow does, minus turning it into an agent).
+    /// Remember it (so it relists — a shell pane is absent from `agent.list` by construction)
+    /// and front it. The terminal drives the shell through the SAME pane-id path as any agent
+    /// pane: raw keystrokes + the control bar (see `TerminalPaneContent`, `InputRouter`).
+    private func createTerminal() async {
+        guard !creatingTerminal else { return }   // re-entry invariant, not just .disabled
+        creatingTerminal = true
+        defer { creatingTerminal = false }
+        do {
+            let paneID = try await client.splitPane(cwd: nil)
+            let terminal = terminalsStore.add(paneID: paneID)
+            open(PaneSlot(paneID: paneID, title: terminal.label, agent: nil,
+                          initialReply: "", siblings: []))
+        } catch let e {
+            // `\(e)` surfaces the APIError's "code: message" (CustomStringConvertible);
+            // `.localizedDescription` bridges to a useless generic NSError string.
+            error = "couldn't open a terminal: \(e)"
+        }
+    }
+
+    /// Close a terminal: end its shell pane server-side (best-effort — it may already have
+    /// exited), unmount any live slot, and forget it. Deleting is the user's intent, so a
+    /// close that fails (a gone pane) still forgets it rather than stranding a dead row.
+    private func deleteTerminal(_ terminal: SavedTerminal) async {
+        try? await client.closePane(paneID: terminal.paneID)
+        if frontID == terminal.paneID { frontID = nil }
+        slots.removeAll { $0.paneID == terminal.paneID }
+        terminalsStore.delete(terminal.id)
     }
 
     /// Front the pane a tapped push targeted (PushCenter.pendingPaneID), once the agent list has
@@ -1611,6 +1648,12 @@ struct TerminalHomeView: View {
             searchField   // pinned above the scroll, as the mockup/Termius have it
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: 0) {
+                    // Terminals lead the list. Hidden during an agent search (the search
+                    // field filters agents, not shell terminals), so a search view stays
+                    // focused on its matches.
+                    if search.isEmpty {
+                        terminalsSection
+                    }
                     if agents.isEmpty {
                         emptyLine("no agents")
                     } else if visibleSections.isEmpty {
@@ -1630,6 +1673,82 @@ struct TerminalHomeView: View {
     private func emptyLine(_ text: String) -> some View {
         Text(text).font(Typography.app(15)).foregroundStyle(Palette.textDim)
             .frame(maxWidth: .infinity).padding(.top, 44)
+    }
+
+    // MARK: terminals
+
+    /// The Terminals section: the user's opened shell panes (each reopens its live PTY) plus
+    /// a "New Terminal" row that splits a fresh shell. Always present so a terminal is one tap
+    /// away, even with no agents. Long-press a terminal to close it.
+    private var terminalsSection: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 8) {
+                Text("TERMINALS")
+                    .font(Typography.microLabel).tracking(1.2).foregroundStyle(Palette.textFaint)
+                Rectangle().fill(Palette.hairline).frame(height: 1)
+            }
+            .padding(.horizontal, 16).padding(.top, 10)
+
+            ForEach(terminalsStore.terminals) { terminal in
+                Button {
+                    open(PaneSlot(paneID: terminal.paneID, title: terminal.label, agent: nil,
+                                  initialReply: "", siblings: []))
+                } label: {
+                    terminalCard(terminal)
+                }
+                .buttonStyle(.plain)
+                .contextMenu {
+                    Button(role: .destructive) {
+                        Task { await deleteTerminal(terminal) }
+                    } label: { Label("Close terminal", systemImage: "xmark.circle") }
+                }
+            }
+
+            Button {
+                Task { await createTerminal() }
+            } label: {
+                newTerminalRow
+            }
+            .buttonStyle(.plain)
+            .disabled(creatingTerminal)
+        }
+    }
+
+    private func terminalCard(_ terminal: SavedTerminal) -> some View {
+        HStack(spacing: 12) {
+            ZStack {
+                RoundedRectangle(cornerRadius: 10).fill(Palette.surfaceRaised)
+                    .frame(width: 40, height: 40)
+                Image(systemName: "terminal")
+                    .font(.system(size: 17, weight: .semibold)).foregroundStyle(Palette.textDim)
+            }
+            VStack(alignment: .leading, spacing: 3) {
+                Text(terminal.label).font(Typography.app(16, .semibold)).foregroundStyle(Palette.text)
+                Text("shell").font(Typography.machine(12)).foregroundStyle(Palette.textFaint)
+            }
+            Spacer()
+            Image(systemName: "chevron.right")
+                .font(.system(size: 12, weight: .semibold)).foregroundStyle(Palette.textFaint)
+        }
+        .padding(.horizontal, 16).padding(.vertical, 10)
+        .contentShape(Rectangle())
+    }
+
+    private var newTerminalRow: some View {
+        HStack(spacing: 12) {
+            ZStack {
+                RoundedRectangle(cornerRadius: 10)
+                    .stroke(Palette.hairline, style: StrokeStyle(lineWidth: 1, dash: [4, 3]))
+                    .frame(width: 40, height: 40)
+                Image(systemName: creatingTerminal ? "ellipsis" : "plus")
+                    .font(.system(size: 16, weight: .semibold)).foregroundStyle(Palette.textDim)
+            }
+            Text(creatingTerminal ? "Opening…" : "New Terminal")
+                .font(Typography.app(16, .semibold)).foregroundStyle(Palette.textDim)
+            Spacer()
+        }
+        .padding(.horizontal, 16).padding(.vertical, 10)
+        .contentShape(Rectangle())
     }
 
     private func sectionView(_ group: AgentGroup, _ rows: [AgentRow]) -> some View {

--- a/App/SavedTerminalsStore.swift
+++ b/App/SavedTerminalsStore.swift
@@ -1,0 +1,56 @@
+import Combine
+import Foundation
+import HerdrKit
+
+/// Persists the terminals the user has opened (plain shell panes) as JSON in UserDefaults.
+///
+/// A shell pane created via `pane.split` (with no `agent.start`) never appears in
+/// `agent.list` — that census is agent-only — so the app must remember the panes it opened
+/// as terminals to relist and reopen them. Device-local and secret-free (a pane id + a
+/// label), so it needs no Keychain, mirroring `SavedPromptsStore`. A singleton
+/// `ObservableObject` so the Terminals section updates live as terminals are opened/closed.
+/// The pure list logic lives in HerdrKit's tested `SavedTerminals`.
+final class SavedTerminalsStore: ObservableObject {
+    static let shared = SavedTerminalsStore()
+
+    private let defaultsKey = "dev.herdr.savedTerminals.v1"
+    @Published private(set) var model: SavedTerminals
+
+    init() {
+        if let data = UserDefaults.standard.data(forKey: defaultsKey),
+           let decoded = try? JSONDecoder().decode(SavedTerminals.self, from: data) {
+            model = decoded
+        } else {
+            model = SavedTerminals()
+        }
+    }
+
+    var terminals: [SavedTerminal] { model.terminals }
+
+    /// Remember a freshly created terminal pane (auto-labeled "Terminal N"); returns it.
+    @discardableResult
+    func add(paneID: String) -> SavedTerminal {
+        let created = model.add(paneID: paneID, createdUnixMs: nowUnixMs())
+        persist()
+        return created
+    }
+
+    func delete(_ id: UUID) {
+        model.remove(id: id)
+        persist()
+    }
+
+    func rename(_ id: UUID, to label: String) {
+        model.rename(id: id, to: label)
+        persist()
+    }
+
+    private func nowUnixMs() -> UInt64 {
+        UInt64(Date().timeIntervalSince1970 * 1000)
+    }
+
+    private func persist() {
+        guard let data = try? JSONEncoder().encode(model) else { return }
+        UserDefaults.standard.set(data, forKey: defaultsKey)
+    }
+}

--- a/Sources/HerdrKit/SavedTerminals.swift
+++ b/Sources/HerdrKit/SavedTerminals.swift
@@ -1,0 +1,82 @@
+import Foundation
+
+/// One user-opened plain-shell terminal, remembered app-side.
+///
+/// A terminal created via `pane.split` (with no `agent.start`) is a plain shell pane.
+/// Such a pane never appears in `agent.list` — that census is agent-only by construction —
+/// so the app has to remember the panes it opened as terminals to relist and reopen them.
+/// This record is device-local and secret-free (just a pane id + a label), so it lives in
+/// UserDefaults as JSON, mirroring the other small stores in the app.
+public struct SavedTerminal: Codable, Identifiable, Hashable, Sendable {
+    public let id: UUID
+    /// The daemon pane id the shell runs in; the terminal reopens by streaming this.
+    public let paneID: String
+    /// User-facing label, e.g. "Terminal 1". Editable.
+    public var label: String
+    /// When it was opened (ms since epoch), for stable ordering.
+    public let createdUnixMs: UInt64
+
+    public init(id: UUID = UUID(), paneID: String, label: String, createdUnixMs: UInt64) {
+        self.id = id
+        self.paneID = paneID
+        self.label = label
+        self.createdUnixMs = createdUnixMs
+    }
+}
+
+/// The remembered terminals, with the pure add/remove/rename/relabel logic kept free of
+/// Combine/UserDefaults so it is unit-testable on any platform. The app wraps this in an
+/// `ObservableObject` that adds persistence (see `SavedTerminalsStore`).
+public struct SavedTerminals: Codable, Equatable, Sendable {
+    public private(set) var terminals: [SavedTerminal]
+
+    public init(terminals: [SavedTerminal] = []) {
+        self.terminals = terminals
+    }
+
+    /// Remember a freshly created terminal pane, auto-labeled with the lowest free
+    /// "Terminal N". Returns the added record. `id` is injectable for deterministic tests.
+    @discardableResult
+    public mutating func add(paneID: String, createdUnixMs: UInt64, id: UUID = UUID()) -> SavedTerminal {
+        let terminal = SavedTerminal(
+            id: id,
+            paneID: paneID,
+            label: Self.nextLabel(existing: terminals.map(\.label)),
+            createdUnixMs: createdUnixMs
+        )
+        terminals.append(terminal)
+        return terminal
+    }
+
+    public mutating func remove(id: UUID) {
+        terminals.removeAll { $0.id == id }
+    }
+
+    /// Forget any terminal backed by a given pane (e.g. after its shell exits and the
+    /// user dismisses it).
+    public mutating func removePane(_ paneID: String) {
+        terminals.removeAll { $0.paneID == paneID }
+    }
+
+    /// Rename a terminal. A blank label is refused (the auto-label stays).
+    public mutating func rename(id: UUID, to label: String) {
+        let trimmed = label.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, let index = terminals.firstIndex(where: { $0.id == id }) else { return }
+        terminals[index].label = trimmed
+    }
+
+    /// The next default label: "Terminal N" for the lowest positive `N` whose label is not
+    /// already taken, so deleting "Terminal 2" and adding again reuses 2 rather than climbing
+    /// forever. Custom (non-"Terminal N") labels are simply ignored by the numbering.
+    static func nextLabel(existing: [String], prefix: String = "Terminal ") -> String {
+        var used = Set<Int>()
+        for label in existing where label.hasPrefix(prefix) {
+            if let n = Int(label.dropFirst(prefix.count)), n > 0 {
+                used.insert(n)
+            }
+        }
+        var n = 1
+        while used.contains(n) { n += 1 }
+        return "\(prefix)\(n)"
+    }
+}

--- a/Tests/HerdrKitTests/SavedTerminalsTests.swift
+++ b/Tests/HerdrKitTests/SavedTerminalsTests.swift
@@ -1,0 +1,58 @@
+import XCTest
+@testable import HerdrKit
+
+final class SavedTerminalsTests: XCTestCase {
+    func testAddAutoLabelsSequentially() {
+        var store = SavedTerminals()
+        let a = store.add(paneID: "w:p1", createdUnixMs: 1)
+        let b = store.add(paneID: "w:p2", createdUnixMs: 2)
+        XCTAssertEqual(a.label, "Terminal 1")
+        XCTAssertEqual(b.label, "Terminal 2")
+        XCTAssertEqual(store.terminals.map(\.paneID), ["w:p1", "w:p2"])
+    }
+
+    func testDeleteThenAddReusesLowestFreeNumber() {
+        var store = SavedTerminals()
+        let a = store.add(paneID: "w:p1", createdUnixMs: 1) // Terminal 1
+        _ = store.add(paneID: "w:p2", createdUnixMs: 2)     // Terminal 2
+        store.remove(id: a.id)                              // free "Terminal 1"
+        let c = store.add(paneID: "w:p3", createdUnixMs: 3)
+        XCTAssertEqual(c.label, "Terminal 1", "should reuse the freed number, not climb to 3")
+    }
+
+    func testCustomLabelsAreIgnoredByNumbering() {
+        var store = SavedTerminals()
+        let a = store.add(paneID: "w:p1", createdUnixMs: 1) // Terminal 1
+        store.rename(id: a.id, to: "build box")
+        let b = store.add(paneID: "w:p2", createdUnixMs: 2)
+        XCTAssertEqual(b.label, "Terminal 1", "a custom-renamed terminal frees its old number")
+    }
+
+    func testRenameIgnoresBlankAndTrims() {
+        var store = SavedTerminals()
+        let a = store.add(paneID: "w:p1", createdUnixMs: 1)
+        store.rename(id: a.id, to: "   ")
+        XCTAssertEqual(store.terminals[0].label, "Terminal 1", "blank rename is refused")
+        store.rename(id: a.id, to: "  pi  ")
+        XCTAssertEqual(store.terminals[0].label, "pi", "label is trimmed")
+    }
+
+    func testRemovePaneForgetsByPaneID() {
+        var store = SavedTerminals()
+        _ = store.add(paneID: "w:p1", createdUnixMs: 1)
+        _ = store.add(paneID: "w:p2", createdUnixMs: 2)
+        store.removePane("w:p1")
+        XCTAssertEqual(store.terminals.map(\.paneID), ["w:p2"])
+    }
+
+    func testCodableRoundTrip() throws {
+        var store = SavedTerminals()
+        _ = store.add(paneID: "w:p1", createdUnixMs: 10, id: UUID())
+        let a = store.add(paneID: "w:p2", createdUnixMs: 20, id: UUID())
+        store.rename(id: a.id, to: "deploy")
+        let data = try JSONEncoder().encode(store)
+        let decoded = try JSONDecoder().decode(SavedTerminals.self, from: data)
+        XCTAssertEqual(decoded, store)
+        XCTAssertEqual(decoded.terminals.map(\.label), ["Terminal 1", "deploy"])
+    }
+}


### PR DESCRIPTION
Adds a way to open a real terminal and type commands directly — a "Terminals" section at the top of the Agents list with a **New Terminal** row.

## What it does
- **New Terminal** splits a fresh shell pane (`pane.split` with **no** `agent.start`) and opens it in the existing live terminal — full soft keyboard, control bar (Return / esc / arrows / ^C / tab), and hardware keyboard on iPad. It's the exact `pane`-id-driven path agent terminals use; `agent: nil` selects raw-keys input for free.
- Opened terminals appear in the **Terminals** section, labeled "Terminal 1/2/3…", and **persist across app restarts** (reconnect by streaming the pane).
- **Long-press → Close terminal** ends the shell pane; a shell that exits shows the existing exited state.

## Why the app has to track them
A shell pane never appears in `agent.list` — that census is agent-only by construction — so there's no server-side census to relist from. Opened terminals are remembered app-side in `SavedTerminalsStore` (UserDefaults JSON, secret-free), backed by the pure, tested `HerdrKit.SavedTerminals` model (auto-labeling, reuse-lowest-free-number, rename, codable).

## Scope
- **No daemon change** — every piece (`pane.split`, `pane.send_text` / input channel, `LiveTerminalView`, LRU keep-alive) already exists.
- Files: `Sources/HerdrKit/SavedTerminals.swift` (+ tests), `App/SavedTerminalsStore.swift`, and the Agents-screen wiring in `App/HerdrApp.swift` (Terminals section, `createTerminal`/`deleteTerminal`). iPad renders the same list, so one change covers both.

## Tests
`SavedTerminalsTests` (6, green on Linux): sequential auto-labels, delete-then-add reuses the freed number, custom labels free their number, blank-rename refused + trim, remove-by-pane, codable round-trip. The SwiftUI wiring compiles in CI (Linux can't build App/).