### PR TITLE
fix(terminal): shell keys via pane.send_text; smaller terminal affordance

### DIFF
--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -1605,7 +1605,12 @@ struct TerminalHomeView: View {
                     .frame(height: 15)
             }
             Spacer()
-            circleButton("plus") { activeCover = .newAgent }
+            HStack(spacing: 8) {
+                // Open a plain shell terminal — a small icon so agents stay the priority
+                // (the re-entry guard in createTerminal absorbs an eager double-tap).
+                circleButton("terminal") { Task { await createTerminal() } }
+                circleButton("plus") { activeCover = .newAgent }
+            }
         }
         .padding(.horizontal, 16).padding(.top, 8).padding(.bottom, 10)
     }
@@ -1648,12 +1653,6 @@ struct TerminalHomeView: View {
             searchField   // pinned above the scroll, as the mockup/Termius have it
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: 0) {
-                    // Terminals lead the list. Hidden during an agent search (the search
-                    // field filters agents, not shell terminals), so a search view stays
-                    // focused on its matches.
-                    if search.isEmpty {
-                        terminalsSection
-                    }
                     if agents.isEmpty {
                         emptyLine("no agents")
                     } else if visibleSections.isEmpty {
@@ -1664,6 +1663,12 @@ struct TerminalHomeView: View {
                         ForEach(visibleSections, id: \.group) { section in
                             sectionView(section.group, section.rows)
                         }
+                    }
+                    // Terminals sit BELOW the herd and only when you have some — agents
+                    // are the priority. Open one from the header's terminal button.
+                    // Hidden during an agent search (that filters agents, not shells).
+                    if search.isEmpty && !terminalsStore.terminals.isEmpty {
+                        terminalsSection
                     }
                 }
             }
@@ -1677,9 +1682,9 @@ struct TerminalHomeView: View {
 
     // MARK: terminals
 
-    /// The Terminals section: the user's opened shell panes (each reopens its live PTY) plus
-    /// a "New Terminal" row that splits a fresh shell. Always present so a terminal is one tap
-    /// away, even with no agents. Long-press a terminal to close it.
+    /// The Terminals section: the user's opened shell panes (each reopens its live PTY). Shown
+    /// below the agents and only when non-empty, so agents stay the priority. Open a new one
+    /// from the header's terminal button; long-press a row to close it.
     private var terminalsSection: some View {
         VStack(alignment: .leading, spacing: 6) {
             HStack(spacing: 8) {
@@ -1703,14 +1708,6 @@ struct TerminalHomeView: View {
                     } label: { Label("Close terminal", systemImage: "xmark.circle") }
                 }
             }
-
-            Button {
-                Task { await createTerminal() }
-            } label: {
-                newTerminalRow
-            }
-            .buttonStyle(.plain)
-            .disabled(creatingTerminal)
         }
     }
 
@@ -1729,23 +1726,6 @@ struct TerminalHomeView: View {
             Spacer()
             Image(systemName: "chevron.right")
                 .font(.system(size: 12, weight: .semibold)).foregroundStyle(Palette.textFaint)
-        }
-        .padding(.horizontal, 16).padding(.vertical, 10)
-        .contentShape(Rectangle())
-    }
-
-    private var newTerminalRow: some View {
-        HStack(spacing: 12) {
-            ZStack {
-                RoundedRectangle(cornerRadius: 10)
-                    .stroke(Palette.hairline, style: StrokeStyle(lineWidth: 1, dash: [4, 3]))
-                    .frame(width: 40, height: 40)
-                Image(systemName: creatingTerminal ? "ellipsis" : "plus")
-                    .font(.system(size: 16, weight: .semibold)).foregroundStyle(Palette.textDim)
-            }
-            Text(creatingTerminal ? "Opening…" : "New Terminal")
-                .font(Typography.app(16, .semibold)).foregroundStyle(Palette.textDim)
-            Spacer()
         }
         .padding(.horizontal, 16).padding(.vertical, 10)
         .contentShape(Rectangle())

--- a/Sources/HerdrKit/InputIntent.swift
+++ b/Sources/HerdrKit/InputIntent.swift
@@ -136,11 +136,49 @@ public struct InputRouter: Sendable {
             guard !seq.isEmpty else { return .refused(reason: "empty sequence") }
             return .rawText(pane: pane, seq)
 
-        case (.key(let k), _):
+        case (.key(let k), .rawKeys):
+            // A shell / TUI pane has no agent, so `agent.send_keys` (the `.keys`
+            // path) would be rejected `agent_not_found`. Deliver the key as its raw
+            // terminal byte sequence via `pane.send_text` instead — the same path
+            // the `^C` / Shift+Tab caps already use — so Return, arrows, esc, etc.
+            // reach the PTY. See herdrup #157 follow-up.
+            guard let bytes = Self.keyBytes(for: k) else {
+                return .refused(reason: "unsupported key \(k)")
+            }
+            return .rawText(pane: pane, bytes)
+
+        case (.key(let k), .intent):
+            // A named agent takes keys through `agent.send_keys` (dialog navigation),
+            // which the server verifies against the live pane.
             guard let canonical = Self.canonicalKey(k) else {
                 return .refused(reason: "unsupported key \(k)")
             }
             return .keys(pane: pane, [canonical])
+        }
+    }
+
+    /// The terminal byte sequence for an allowed named key, or nil if the name is
+    /// not one we send. Used to deliver a keycap to a pane with no agent (a shell /
+    /// TUI) as raw bytes via `pane.send_text`, since `agent.send_keys` needs an
+    /// agent. Enter is CR (`\r`) — the PTY line discipline turns it into a submit —
+    /// and the cursor/nav keys use the standard xterm sequences.
+    static func keyBytes(for raw: String) -> String? {
+        guard let canonical = canonicalKey(raw) else { return nil }
+        switch canonical {
+        case "Enter": return "\r"
+        case "Escape": return "\u{1b}"
+        case "Tab": return "\t"
+        case "Backspace": return "\u{7f}"
+        case "Space": return " "
+        case "Up": return "\u{1b}[A"
+        case "Down": return "\u{1b}[B"
+        case "Right": return "\u{1b}[C"
+        case "Left": return "\u{1b}[D"
+        case "Home": return "\u{1b}[H"
+        case "End": return "\u{1b}[F"
+        case "PageUp": return "\u{1b}[5~"
+        case "PageDown": return "\u{1b}[6~"
+        default: return nil
         }
     }
 

--- a/Tests/HerdrKitTests/InputIntentTests.swift
+++ b/Tests/HerdrKitTests/InputIntentTests.swift
@@ -86,10 +86,12 @@ final class InputRouterTests: XCTestCase {
         ) else { return XCTFail("expected literal text") }
         XCTAssertFalse(sent.contains("\n"), "typed text must not carry a newline")
         XCTAssertFalse(sent.contains("\r"), "typed text must not carry a carriage return")
-        // Submitting is a separate, explicit key.
+        // Submitting is a separate, explicit key — and on a shell (no agent) it goes
+        // as a raw CR via pane.send_text, NOT agent.send_keys (which would be rejected
+        // agent_not_found). herdrup #157 follow-up.
         XCTAssertEqual(
             router.plan(action: .key("Enter"), pane: "p1", mode: .rawKeys),
-            .keys(pane: "p1", ["Enter"])
+            .rawText(pane: "p1", "\r")
         )
     }
 
@@ -133,10 +135,34 @@ final class InputRouterTests: XCTestCase {
         }
     }
 
-    func testNavigationKeysWorkInBothModes() {
-        for mode in [InputMode.intent, .rawKeys] {
-            XCTAssertEqual(router.plan(action: .key("Up"), pane: "p1", mode: mode), .keys(pane: "p1", ["Up"]))
-            XCTAssertEqual(router.plan(action: .key("Enter"), pane: "p1", mode: mode), .keys(pane: "p1", ["Enter"]))
+    /// A named agent takes keys through agent.send_keys (dialog navigation, server-verified).
+    func testNamedKeysUseSendKeysInIntentMode() {
+        XCTAssertEqual(router.plan(action: .key("Up"), pane: "p1", mode: .intent), .keys(pane: "p1", ["Up"]))
+        XCTAssertEqual(router.plan(action: .key("Enter"), pane: "p1", mode: .intent), .keys(pane: "p1", ["Enter"]))
+    }
+
+    /// A shell/TUI pane (no agent) takes keys as raw terminal bytes via pane.send_text —
+    /// agent.send_keys there is rejected agent_not_found (the shipped #157 bug).
+    func testNamedKeysBecomeRawBytesInRawKeysMode() {
+        XCTAssertEqual(router.plan(action: .key("Enter"), pane: "p1", mode: .rawKeys), .rawText(pane: "p1", "\r"))
+        XCTAssertEqual(router.plan(action: .key("Up"), pane: "p1", mode: .rawKeys), .rawText(pane: "p1", "\u{1b}[A"))
+        XCTAssertEqual(router.plan(action: .key("Escape"), pane: "p1", mode: .rawKeys), .rawText(pane: "p1", "\u{1b}"))
+        XCTAssertEqual(router.plan(action: .key("Tab"), pane: "p1", mode: .rawKeys), .rawText(pane: "p1", "\t"))
+        // No .keys plan is ever produced in rawKeys mode (that path needs an agent).
+        if case .keys = router.plan(action: .key("Enter"), pane: "p1", mode: .rawKeys) {
+            XCTFail("rawKeys must never route a key through agent.send_keys")
+        }
+    }
+
+    func testKeyBytesCoversEveryAllowedKeyAndRejectsOthers() {
+        for name in InputRouter.allowed {
+            XCTAssertNotNil(InputRouter.keyBytes(for: name), "no bytes for allowed key \(name)")
+        }
+        XCTAssertEqual(InputRouter.keyBytes(for: "enter"), "\r", "name-matching is case-insensitive")
+        XCTAssertNil(InputRouter.keyBytes(for: "F13"))
+        // An unsupported key is refused in rawKeys too, not silently dropped.
+        guard case .refused = router.plan(action: .key("F13"), pane: "p1", mode: .rawKeys) else {
+            return XCTFail("unsupported key in rawKeys should be refused")
         }
     }
 


### PR DESCRIPTION
Follow-up to #157. Two fixes.

## 1. Bug: shell control keys failed with `agent_not_found`
Typing into a New Terminal worked, but **Return** (and esc / arrows / etc.) failed:
`send failed: agent_not_found: agent target …:p53 not found`. A `.key(name)` routed to `.keys` → `client.sendKeys` → **`agent.send_keys`**, which requires an agent — a shell pane has none. The terminal accepted input but couldn't submit a command.

**Fix** (`Sources/HerdrKit/InputIntent.swift`): split `InputRouter.plan`'s `.key` case by mode.
- `.rawKeys` (shell/TUI): the key becomes its terminal byte sequence via `.rawText` → `pane.send_text` (the path the `^C` / Shift-Tab caps already use). New `keyBytes(for:)` maps the `allowed` set (Enter→`\r`, arrows→`ESC[A..D`, esc/tab/home/end/page…).
- `.intent` (named agent): unchanged — still `agent.send_keys` for dialog navigation.

No dispatcher change (`.rawText` already routes to `sendText`).

## 2. UX: terminal was too prominent
Per owner feedback ("agents are the priority"): removed the pinned top "TERMINALS" section + its in-list "New Terminal" row. Creating a terminal is now a **small terminal icon in the header** (beside +), and open terminals render in a **compact section below the agents, only when non-empty**. Top of the list is always agents.

## Tests
`InputRouterTests` (updated + new, green on Linux): a shell `.key("Enter")` → `.rawText(pane,"\r")` and never `.keys`; arrows/esc/tab map correctly; `.intent` keys still `.keys`; `keyBytes` covers every `allowed` key and refuses others. Mutation-verified (revert the rawKeys split → the shell-key tests go red). The `.intent`/agent path is untouched. SwiftUI wiring compiles in CI.

_(Pre-existing `ReadmeLayoutTests` fails on Linux `swift test` on `main` too — a README-grammar quirk, unrelated; macOS CI is green.)_