### PR TITLE
fix(input): answer agent plan/question menus from the app

### DIFF
--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -2918,8 +2918,11 @@ struct TerminalPaneContent: View {
     /// non-delivery.
     private static func promptFailureNote(for error: APIError) -> String {
         switch error.code {
-        case "agent_input_pending":
-            return "answer the on-screen prompt first (use the keys), then send"
+        case "agent_blocked", "agent_input_pending":
+            // The agent is showing a menu (plan-approval / question). Routing normally
+            // switches to raw keys when this is detected; if a send still races the
+            // status here, tell the reader they can type the answer or use the keycaps.
+            return "agent is asking — type your answer or use the keys, then Enter"
         case "agent_not_ready":
             return "agent not ready, try again"
         case "agent_prompt_not_received":
@@ -2959,7 +2962,10 @@ struct TerminalPaneContent: View {
         let sameNamedAgent = live.name != nil && live.name == agent?.name
         let priorWasIntent = agent.map { router.mode(for: $0) == .intent } ?? false
         let liveLostComposer = sameNamedAgent && router.mode(for: live) != .intent
-        if priorWasIntent && liveLostComposer { return }
+        // A genuine MENU/blocked state is NOT a transient composer hiccup — adopt it so
+        // the app can drive the menu with raw keys (answer a plan-approval / AskUserQuestion).
+        // Only hold the prior intent agent for a true composer blip (composer nil, not blocked).
+        if priorWasIntent && liveLostComposer && !live.isAwaitingMenuInput { return }
         agent = live
     }
 

--- a/Sources/HerdrKit/InputIntent.swift
+++ b/Sources/HerdrKit/InputIntent.swift
@@ -77,6 +77,13 @@ public struct InputRouter: Sendable {
     /// task warrants holding out for a confirmed composer.)
     public func mode(for agent: AgentInfo) -> InputMode {
         guard agent.agent != nil else { return .rawKeys }
+        // A named agent showing an interactive MENU (plan-approval / AskUserQuestion) is
+        // `blocked` / input_pending: `agent.prompt` is rejected there ("agent is blocked
+        // and requires interactive input"). Route input as raw keys instead — typed chars
+        // land in the menu's free-text field via `pane.send_text` (which the daemon accepts
+        // while blocked) and Enter/arrows navigate via the keycaps. When the menu clears,
+        // the agent goes back to `.intent`. See herdrup #157-follow-up / the answer-menus fix.
+        if agent.isAwaitingMenuInput { return .rawKeys }
         return .intent
     }
 

--- a/Sources/HerdrKit/Wire.swift
+++ b/Sources/HerdrKit/Wire.swift
@@ -76,6 +76,14 @@ public struct CompletedTurn: Decodable, Equatable, Sendable {
 public struct AgentInfo: Decodable, Equatable, Sendable, Identifiable {
     public let agent: String?
     public let agentStatus: String?
+    /// Set when the agent is showing an interactive prompt/menu that needs an
+    /// on-screen choice (a plan-approval or an AskUserQuestion) rather than a chat
+    /// prompt. `agent.prompt` is REJECTED while this is true (or `agentStatus ==
+    /// "blocked"`), so the app must drive the pane with raw keys / `pane.send_text`
+    /// instead. `inputPromptKind` is the menu kind ("select" / "confirm"). Decoded
+    /// leniently — absent on an older server.
+    public let inputPending: Bool?
+    public let inputPromptKind: String?
     public let name: String?
     public let paneID: String
     public let tabID: String?
@@ -112,6 +120,11 @@ public struct AgentInfo: Decodable, Equatable, Sendable, Identifiable {
 
     public var isWorking: Bool { agentStatus == "working" }
 
+    /// The agent is showing an interactive menu / permission prompt (plan-approval or
+    /// AskUserQuestion) that must be answered on-screen. `agent.prompt` is refused in
+    /// this state, so the app routes input as raw keys / `pane.send_text` instead.
+    public var isAwaitingMenuInput: Bool { agentStatus == "blocked" || inputPending == true }
+
     /// A remote (federated) agent whose owning machine is currently unreachable.
     /// Its `agentStatus` is a stale last-known value, so the UI must render it as
     /// offline rather than as a live status. Unknown reachability strings (a newer
@@ -121,6 +134,8 @@ public struct AgentInfo: Decodable, Equatable, Sendable, Identifiable {
     enum CodingKeys: String, CodingKey {
         case agent, name, composer, revision, turn, cwd, focused, reachability
         case agentStatus = "agent_status"
+        case inputPending = "input_pending"
+        case inputPromptKind = "input_prompt_kind"
         case paneID = "pane_id"
         case tabID = "tab_id"
         case workspaceID = "workspace_id"

--- a/Tests/HerdrKitTests/InputIntentTests.swift
+++ b/Tests/HerdrKitTests/InputIntentTests.swift
@@ -9,6 +9,15 @@ private func makeAgent(pane: String, agent: String?, hasComposer: Bool) throws -
     return try JSONDecoder().decode(ResultEnvelope<AgentListResult>.self, from: Data(json.utf8)).result.agents[0]
 }
 
+private func makeAgentWithStatus(pane: String, agent: String?, status: String?, inputPending: Bool?) throws -> AgentInfo {
+    var fields = ["\"pane_id\":\"\(pane)\""]
+    if let agent { fields.append("\"agent\":\"\(agent)\"") }
+    if let status { fields.append("\"agent_status\":\"\(status)\"") }
+    if let inputPending { fields.append("\"input_pending\":\(inputPending)") }
+    let json = "{\"id\":\"x\",\"result\":{\"agents\":[{\(fields.joined(separator: ","))}]}}"
+    return try JSONDecoder().decode(ResultEnvelope<AgentListResult>.self, from: Data(json.utf8)).result.agents[0]
+}
+
 final class InputRouterTests: XCTestCase {
     let router = InputRouter()
 
@@ -32,6 +41,39 @@ final class InputRouterTests: XCTestCase {
     /// and re-opens the never-submitted bug, so this assertion KILLs that mutation.)
     func testNamedAgentWithoutComposerStillRoutesAsIntent() throws {
         XCTAssertEqual(router.mode(for: try makeAgent(pane: "p1", agent: "claude", hasComposer: false)), .intent)
+    }
+
+    /// A named agent showing a MENU (blocked / input_pending — a plan-approval or an
+    /// AskUserQuestion) must route as rawKeys: agent.prompt is rejected while blocked, so a
+    /// typed answer has to go via pane.send_text into the menu's free-text field. Mutation
+    /// guard: dropping the isAwaitingMenuInput check returns .intent here → the reply hits
+    /// agent.prompt → "agent is blocked" (the reported bug).
+    func testBlockedAgentRoutesAsRawKeysSoMenusAreAnswerable() throws {
+        let blocked = try makeAgentWithStatus(pane: "p1", agent: "claude", status: "blocked", inputPending: nil)
+        XCTAssertTrue(blocked.isAwaitingMenuInput)
+        XCTAssertEqual(router.mode(for: blocked), .rawKeys)
+        // A typed reply then plans to .text → pane.send_text (accepted while blocked).
+        XCTAssertEqual(
+            router.plan(action: .submitText("2"), pane: "p1", mode: router.mode(for: blocked)),
+            .text(pane: "p1", "2")
+        )
+        // input_pending without a "blocked" status also counts (enumerated-select menus).
+        let pending = try makeAgentWithStatus(pane: "p1", agent: "claude", status: "idle", inputPending: true)
+        XCTAssertEqual(router.mode(for: pending), .rawKeys)
+        // A working/idle agent with no menu still routes as intent (agent.prompt).
+        let working = try makeAgentWithStatus(pane: "p1", agent: "claude", status: "working", inputPending: false)
+        XCTAssertFalse(working.isAwaitingMenuInput)
+        XCTAssertEqual(router.mode(for: working), .intent)
+    }
+
+    func testAgentInfoDecodesInputPendingFields() throws {
+        let a = try makeAgentWithStatus(pane: "p1", agent: "claude", status: "blocked", inputPending: true)
+        XCTAssertEqual(a.inputPending, true)
+        XCTAssertEqual(a.agentStatus, "blocked")
+        // Absent on an older server → nil, still decodes.
+        let old = try makeAgent(pane: "p1", agent: "claude", hasComposer: true)
+        XCTAssertNil(old.inputPending)
+        XCTAssertFalse(old.isAwaitingMenuInput)
     }
 
     /// The pre-fill readiness gate stays STRICTER than routing on purpose: an


### PR DESCRIPTION
Fixes the owner-reported bug: you couldn't answer an agent's plan-approval / AskUserQuestion menu from the app — the input errored "agent is busy".

## Cause
When Claude Code shows a menu, the daemon marks the pane `blocked` / `input_pending` and **rejects `agent.prompt`** ("agent is blocked and requires interactive input"). But a typed reply for a *named* agent always routed through `agent.prompt` (`InputRouter.mode` returned `.intent` for any named agent, ignoring status). The app already receives `agentStatus == "blocked"` — it just ignored it.

## Fix (app-only, no daemon change)
- `mode(for:)` returns `.rawKeys` when the agent `isAwaitingMenuInput` (`agentStatus == "blocked"` or `input_pending`). A typed answer then plans to `.text` → `pane.send_text`, which the daemon **accepts while blocked** and which refuses newlines / never auto-submits — so it lands in the menu's free-text ("Other") field, and Enter/arrows still navigate via the keycaps.
- **`reresolveAgent`** no longer holds the prior `.intent` agent when the live one is genuinely awaiting menu input (only for a true composer blip) — otherwise the hold-guard would treat a real `blocked` menu as a transient composer loss and never adopt it (the naive fix's trap).
- Decode `input_pending` / `input_prompt_kind` on `AgentInfo` (daemon already sends them) to catch enumerated-select menus that aren't `blocked`.
- `promptFailureNote`: clear `agent_blocked` message for any send that races the status.

## Tests
`InputRouterTests` (HerdrKit, Linux, +2): a `blocked` (and an `input_pending`) named agent routes `.rawKeys` and a typed reply plans to `.text`; a working agent still `.intent`; `AgentInfo` decodes/omits `input_pending`. Mutation-verified (drop the routing → the menu test goes red). SwiftUI compiles in CI.