### PR TITLE
feat(settings): daemon self-update — version, update banner, one-tap update & restart

### DIFF
--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -3217,6 +3217,18 @@ struct SettingsView: View {
     /// into a dead end. Refreshed on appear and on foreground (after a Settings trip).
     @State private var notifyAuth: UNAuthorizationStatus = .notDetermined
     @Environment(\.scenePhase) private var scenePhase
+    /// The connected daemon's version + any staged self-update, from `server.staged_update`.
+    /// Fetched by this view (`.task` below) with `try?`, so a daemon too old to know the method
+    /// (or a transient failure) simply leaves it nil — the version line and update callout then
+    /// don't render, exactly the pre-fork/older-daemon degrade the notify + accounts rows use.
+    @State private var stagedUpdate: StagedUpdate?
+    /// The "Update & restart the daemon?" confirmation (the apply restarts the daemon in place).
+    @State private var showUpdateConfirm = false
+    /// True while `server.apply_staged_update` is in flight and we re-poll for the swap to land.
+    @State private var applyingUpdate = false
+    /// The apply outcome, shown in an alert (nil = no alert). Distinguishes a clean update, a
+    /// partial disk-stale warning, a rolled-back failure, and an unconfirmed "still restarting".
+    @State private var updateResult: String?
 
     var body: some View {
         Group {
@@ -3251,6 +3263,9 @@ struct SettingsView: View {
         // `try?` so an older daemon without `accounts.list` (or a transient failure)
         // just leaves the section empty rather than surfacing an error here.
         .task { accounts = (try? await client.accountsList()) ?? [] }
+        // Fetch the daemon version + any staged self-update. `try?` so an older daemon without
+        // `server.staged_update` leaves it nil (version line + update callout simply absent).
+        .task { stagedUpdate = try? await client.stagedUpdate() }
         // "How to set up accounts" — a step-by-step guide for adding another
         // subscription on the box (accounts live there, not in the app).
         .sheet(isPresented: $showAccountsSetup) {
@@ -3315,6 +3330,32 @@ struct SettingsView: View {
                 set: { if !$0 { bulkResult = nil } }
             ),
             presenting: bulkResult
+        ) { _ in
+            Button("OK", role: .cancel) {}
+        } message: { result in
+            Text(result)
+        }
+        // Update & restart: confirm (it restarts the daemon in place — agents keep running via
+        // live-handoff), then apply and re-poll for the swap to land.
+        .confirmationDialog(
+            "Update & restart the daemon?",
+            isPresented: $showUpdateConfirm
+        ) {
+            Button("Update & restart") { applyUpdate() }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            if let staged = stagedUpdate?.staged {
+                Text("Swaps the daemon to build \(staged.sha) and restarts it in place. Your "
+                    + "agents keep running — their sessions are preserved across the restart.")
+            }
+        }
+        .alert(
+            "Daemon update",
+            isPresented: Binding(
+                get: { updateResult != nil },
+                set: { if !$0 { updateResult = nil } }
+            ),
+            presenting: updateResult
         ) { _ in
             Button("OK", role: .cancel) {}
         } message: { result in
@@ -3485,11 +3526,33 @@ struct SettingsView: View {
                 }
                 rowDivider
                 glanceMachinesRow
+                if daemonUpdateAvailable {
+                    rowDivider
+                    glanceUpdateRow
+                }
             }
             .clipShape(RoundedRectangle(cornerRadius: 12))
             .overlay(RoundedRectangle(cornerRadius: 12).stroke(Palette.hairline, lineWidth: 1))
             .padding(.horizontal, 16).padding(.top, 10)
         }
+    }
+
+    /// A quiet shortcut into Machines when the daemon has a staged update — the section that owns
+    /// the "Update & restart" action is one tap away (mirrors `glanceExhaustedRow`).
+    private var glanceUpdateRow: some View {
+        NavigationLink(value: SettingsSection.machines) {
+            HStack(spacing: 10) {
+                Circle().fill(Palette.waiting).frame(width: 8, height: 8)
+                Text("Daemon update available")
+                    .font(Typography.app(14)).foregroundStyle(Palette.textDim).lineLimit(1)
+                Spacer(minLength: 0)
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 12, weight: .semibold)).foregroundStyle(Palette.textFaint)
+            }
+            .padding(.horizontal, 16).padding(.vertical, 13)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
     }
 
     private var glanceConnectionRow: some View {
@@ -3574,6 +3637,13 @@ struct SettingsView: View {
     }
 
     @ViewBuilder private var manageMachinesTrailing: some View {
+        if daemonUpdateAvailable {
+            Text("Update")
+                .font(Typography.app(11, .semibold)).foregroundStyle(Palette.waiting)
+                .padding(.horizontal, 8).padding(.vertical, 3)
+                .background(Capsule().fill(Palette.waiting.opacity(0.12)))
+                .overlay(Capsule().stroke(Palette.waiting.opacity(0.5), lineWidth: 1))
+        }
         Text("\(agents.count) agent\(agents.count == 1 ? "" : "s")")
             .font(Typography.machine(12)).foregroundStyle(Palette.textDim)
         Circle().fill(machinesReachability.color).frame(width: 8, height: 8)
@@ -3689,17 +3759,118 @@ struct SettingsView: View {
     private var connectionSection: some View {
         VStack(alignment: .leading, spacing: 0) {
             sectionLabel("CONNECTION")
-            HStack(spacing: 10) {
-                Circle().fill(connected ? Palette.done : Palette.died).frame(width: 8, height: 8)
-                Text(connected ? "Connected" : "Disconnected")
-                    .font(Typography.app(15, .semibold)).foregroundStyle(Palette.text).layoutPriority(1)
-                Text(host).font(Typography.machine(13)).foregroundStyle(Palette.textFaint)
-                    .lineLimit(1).truncationMode(.middle)
-                Spacer(minLength: 0)
+            VStack(alignment: .leading, spacing: 6) {
+                HStack(spacing: 10) {
+                    Circle().fill(connected ? Palette.done : Palette.died).frame(width: 8, height: 8)
+                    Text(connected ? "Connected" : "Disconnected")
+                        .font(Typography.app(15, .semibold)).foregroundStyle(Palette.text).layoutPriority(1)
+                    Text(host).font(Typography.machine(13)).foregroundStyle(Palette.textFaint)
+                        .lineLimit(1).truncationMode(.middle)
+                    Spacer(minLength: 0)
+                }
+                // The connected daemon's own version (distinct from the app version in the footer).
+                // Only shown once `server.staged_update` has answered — absent on an older daemon.
+                if let running = stagedUpdate?.runningVersion {
+                    Text("herdr daemon \(running)")
+                        .font(Typography.machine(12)).foregroundStyle(Palette.textFaint)
+                }
             }
             .rowShell()
             .padding(.horizontal, 16).padding(.top, 10)   // align with the toggle/action rows
+            daemonUpdateCallout
         }
+    }
+
+    /// True when the connected daemon has a newer build staged and ready to activate.
+    private var daemonUpdateAvailable: Bool { stagedUpdate?.staged != nil }
+
+    /// Shown only when the daemon has a staged self-update: an icon chip + "Update available" + the
+    /// staged build's id/date, then an "Update & restart" action (a spinner replaces it while the
+    /// apply is in flight). Mirrors `notifyInfoRow`'s callout shape, in its own hairline card.
+    @ViewBuilder
+    private var daemonUpdateCallout: some View {
+        if let staged = stagedUpdate?.staged {
+            HStack(alignment: .top, spacing: 10) {
+                Image(systemName: "arrow.down.circle")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(Palette.waiting)
+                    .frame(width: 26, height: 26)
+                    .background(Circle().fill(Palette.surfaceRaised))
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Update available")
+                        .font(Typography.app(13, .semibold)).foregroundStyle(Palette.textDim)
+                    Text("Build \(staged.sha) · staged \(String(staged.builtAt.prefix(10)))")
+                        .font(Typography.app(12)).foregroundStyle(Palette.textFaint)
+                        .fixedSize(horizontal: false, vertical: true)
+                    if applyingUpdate {
+                        HStack(spacing: 6) {
+                            ProgressView().controlSize(.small).tint(Palette.textDim)
+                            Text("Updating & restarting…")
+                                .font(Typography.app(13, .semibold)).foregroundStyle(Palette.textDim)
+                        }
+                        .padding(.top, 2)
+                    } else {
+                        Button("Update & restart") { showUpdateConfirm = true }
+                            .font(Typography.app(13, .semibold)).foregroundStyle(Palette.text)
+                            .padding(.top, 2)
+                    }
+                }
+                Spacer(minLength: 0)
+            }
+            .rowShell()
+            .padding(.horizontal, 16).padding(.top, 10)
+        }
+    }
+
+    /// Activate the staged build. The daemon swaps its binary and re-execs via live-handoff, so the
+    /// one-shot apply call may return the `ok` ack OR drop mid-handoff — both mean "restart under
+    /// way", so we then re-poll `stagedUpdate()` until the applied build clears its staged manifest.
+    /// A server `APIError` is a real verdict, not a dropped socket, and is surfaced distinctly:
+    /// `apply_staged_update_disk_stale` = running-new/disk-old (a warning); anything else = the
+    /// handoff rolled back and the OLD build is still serving.
+    private func applyUpdate() {
+        guard !applyingUpdate else { return }
+        applyingUpdate = true
+        Task {
+            do {
+                try await client.applyStagedUpdate()
+            } catch let apiError as APIError {
+                applyingUpdate = false
+                if apiError.code == "apply_staged_update_disk_stale" {
+                    updateResult = "Updated, with a warning: the new build is running, but the daemon "
+                        + "couldn't update its on-disk copy, so a full restart would fall back to the "
+                        + "old build until re-applied."
+                } else {
+                    updateResult = "Update failed: \(apiError). Your daemon is unchanged and still "
+                        + "running the current build."
+                }
+                if let refreshed = try? await client.stagedUpdate() { stagedUpdate = refreshed }
+                return
+            } catch {
+                // Transport dropped mid-handoff — expected: the daemon replaced itself before it
+                // could answer on the single-shot socket. Fall through to confirm by re-polling.
+            }
+            let confirmed = await confirmUpdateApplied()
+            applyingUpdate = false
+            // Only overwrite on a SUCCESSFUL read: a failed read here means the daemon is still
+            // mid-restart, and blanking the state would wrongly hide the banner. The next `.task`
+            // (on the view reappearing) re-fetches the true state once the daemon is back.
+            if let refreshed = try? await client.stagedUpdate() { stagedUpdate = refreshed }
+            updateResult = confirmed
+                ? "Updated. The daemon restarted on the new build; your agents kept running."
+                : "Update sent — the daemon may still be restarting. Reopen Settings in a moment to "
+                    + "confirm the new build."
+        }
+    }
+
+    /// Poll `stagedUpdate()` until the applied build has cleared its staged manifest (`staged ==
+    /// nil`), tolerating the brief window where the daemon is mid-handoff and the socket refuses.
+    private func confirmUpdateApplied() async -> Bool {
+        for _ in 0..<12 {   // ~12 × 2s = 24s, comfortably past a few-second handoff
+            try? await Task.sleep(nanoseconds: 2_000_000_000)
+            if let current = try? await client.stagedUpdate(), current.staged == nil { return true }
+        }
+        return false
     }
 
     /// The remote machines (federation peers) whose agents this home box lists —

--- a/Sources/HerdrKit/HerdrClient.swift
+++ b/Sources/HerdrKit/HerdrClient.swift
@@ -68,6 +68,25 @@ public actor HerdrClient {
         try await call("accounts.list", EmptyParams(), as: AccountsListResult.self).accounts
     }
 
+    /// The running daemon's version/protocol plus any staged update the fleet build step pre-staged
+    /// (`server.staged_update`). Parameterless read; THROWS the server's `APIError` on a daemon too
+    /// old to know the method, so callers that want a quiet degrade use `try?` (mirrors
+    /// `accountsList`). `staged` is nil when nothing is staged.
+    public func stagedUpdate() async throws -> StagedUpdate {
+        try await call("server.staged_update", EmptyParams(), as: StagedUpdate.self)
+    }
+
+    /// Activate the staged build (`server.apply_staged_update`): the daemon swaps its binary and
+    /// re-execs via live-handoff, keeping agent panes alive. Because the daemon replaces ITSELF, the
+    /// single-shot command socket may return the `ok` ack OR drop mid-handoff (a thrown transport
+    /// error); callers treat a transport drop here as "restart in progress" and re-poll
+    /// `stagedUpdate()`. Distinct server errors surface as thrown `APIError`:
+    /// `apply_staged_update_failed` (handoff rolled back — the OLD build is still serving) and
+    /// `apply_staged_update_disk_stale` (new build running, but the on-disk path was not updated).
+    public func applyStagedUpdate() async throws {
+        _ = try await call("server.apply_staged_update", EmptyParams(), as: OkAck.self)
+    }
+
     /// The complete pane set, as a value that carries its own provenance.
     ///
     /// `SessionRecovery.observe` takes this rather than `[AgentInfo]` because an

--- a/Sources/HerdrKit/Wire.swift
+++ b/Sources/HerdrKit/Wire.swift
@@ -595,3 +595,43 @@ public struct PanePtySize: Decodable, Sendable, Equatable {
         case cols, rows, locked
     }
 }
+
+// MARK: - Server / staged self-update (server.staged_update / server.apply_staged_update)
+
+/// Result of `server.staged_update` (`type: "staged_update"`): the running daemon's version and
+/// protocol, plus the staged build when a build step has pre-staged a newer binary — `staged` is
+/// nil when nothing is staged. Mirrors `ResponseResult::StagedUpdate`
+/// (`src/api/schema/response.rs`); the internally-tagged `type` key is ignored on decode.
+///
+/// Note: the running daemon reports only a version string (no sha), and the version is static
+/// across commits, so "an update is available" is exactly `staged != nil` — the build step only
+/// writes a manifest for a genuinely newer build and the daemon clears it once applied.
+public struct StagedUpdate: Decodable, Sendable, Equatable {
+    public let runningVersion: String
+    public let runningProtocol: Int
+    public let staged: Staged?
+
+    /// The pre-staged build the daemon would activate on apply. `path` is intentionally not on the
+    /// wire (the daemon never exposes it), so it is absent here too.
+    public struct Staged: Decodable, Sendable, Equatable {
+        public let version: String
+        public let sha: String
+        public let builtAt: String
+        enum CodingKeys: String, CodingKey {
+            case version, sha
+            case builtAt = "built_at"
+        }
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case staged
+        case runningVersion = "running_version"
+        case runningProtocol = "running_protocol"
+    }
+}
+
+/// Ack of a `server.apply_staged_update` that returned cleanly (`type: "ok"`). Decoded as an empty
+/// object (the `type` tag is ignored). The apply re-execs the daemon via live-handoff, so the
+/// one-shot command socket may instead DROP mid-apply — callers treat both a returned ack and a
+/// transport drop as "restart initiated" and then re-poll `stagedUpdate()`.
+struct OkAck: Decodable, Sendable {}

--- a/Tests/HerdrKitTests/StagedUpdateTests.swift
+++ b/Tests/HerdrKitTests/StagedUpdateTests.swift
@@ -1,0 +1,65 @@
+import XCTest
+@testable import HerdrKit
+
+/// Decode tests for `server.staged_update` / `server.apply_staged_update` wire types. The JSON is
+/// built the way the daemon serializes `ResponseResult` — internally tagged with a `type` key and
+/// snake_case fields — so a wrong CodingKey or a missed tag-ignore fails here rather than on-device.
+final class StagedUpdateTests: XCTestCase {
+
+    private func decodeStaged(_ obj: [String: Any]) throws -> StagedUpdate {
+        let data = try JSONSerialization.data(withJSONObject: obj)
+        return try JSONDecoder().decode(StagedUpdate.self, from: data)
+    }
+
+    /// A staged build present: nested object decodes, snake_case → camelCase maps, and the
+    /// internally-tagged `type` key is ignored (it has no field on the struct).
+    func testDecodesStagedUpdateWithAStagedBuild() throws {
+        let update = try decodeStaged([
+            "type": "staged_update",
+            "running_version": "0.8.0",
+            "running_protocol": 20,
+            "staged": [
+                "version": "0.8.0",
+                "sha": "b3e34990",
+                "built_at": "2026-08-23T18:43:06Z",
+            ],
+        ])
+        XCTAssertEqual(update.runningVersion, "0.8.0")
+        XCTAssertEqual(update.runningProtocol, 20)
+        XCTAssertEqual(update.staged?.version, "0.8.0")
+        XCTAssertEqual(update.staged?.sha, "b3e34990")
+        XCTAssertEqual(update.staged?.builtAt, "2026-08-23T18:43:06Z",
+                       "built_at must map to builtAt — a wrong CodingKey fails here")
+    }
+
+    /// Nothing staged: the daemon omits `staged` (it is `skip_serializing_if = Option::is_none`), so
+    /// `staged` decodes to nil. This is the "no update available" state the UI keys off.
+    func testDecodesStagedUpdateWithNothingStaged() throws {
+        let update = try decodeStaged([
+            "type": "staged_update",
+            "running_version": "0.8.0",
+            "running_protocol": 20,
+        ])
+        XCTAssertNil(update.staged, "an omitted staged object is 'no update available'")
+        XCTAssertEqual(update.runningVersion, "0.8.0")
+    }
+
+    /// The full wire path: `{ id, result: { type: staged_update, ... } }` unwraps through
+    /// `ResultEnvelope`, exactly as `HerdrClient.call(as: StagedUpdate.self)` does.
+    func testDecodesThroughResultEnvelopeLikeTheClient() throws {
+        let line = #"""
+        {"id":"herdrkit:server.staged_update:1","result":{"type":"staged_update",\#
+        "running_version":"0.8.0","running_protocol":20,\#
+        "staged":{"version":"0.8.0","sha":"b3e34990","built_at":"2026-08-23T18:43:06Z"}}}
+        """#
+        let env = try JSONDecoder().decode(ResultEnvelope<StagedUpdate>.self, from: Data(line.utf8))
+        XCTAssertEqual(env.result.staged?.sha, "b3e34990")
+    }
+
+    /// A clean apply returns `{ type: "ok" }`; `OkAck` decodes it by ignoring the tag. (The apply may
+    /// instead throw a transport error when the daemon drops mid-handoff — that path is the caller's.)
+    func testOkAckDecodesTheApplyAcknowledgement() throws {
+        let data = try JSONSerialization.data(withJSONObject: ["type": "ok"])
+        XCTAssertNoThrow(try JSONDecoder().decode(OkAck.self, from: data))
+    }
+}


### PR DESCRIPTION
Adds the **app half** of the Phase 2 daemon self-update flow. The daemon half is merged and dormant on the herdr fork (`server.staged_update` read + `server.apply_staged_update` apply, activated via live-handoff so agent panes survive the restart); this wires the app to it.

## HerdrKit (Linux-testable)
Two methods on the existing single-shot command socket, following the `accountsList()` shape:
- `stagedUpdate() → server.staged_update` — the running daemon version/protocol plus any pre-staged newer build (`staged` is nil when nothing is staged). Degrades quietly with `try?` on a daemon too old to know the method.
- `applyStagedUpdate() → server.apply_staged_update` — activates the staged build. The daemon replaces **itself**, so the one-shot call may return the `ok` ack or drop mid-handoff; a dropped socket is treated as "restart under way".

Wire types `StagedUpdate` / `OkAck` mirror the internally-tagged (`type`) `ResponseResult` variants.

## App (Settings → Machines)
- The **CONNECTION** card now shows the connected daemon's version (distinct from the app version in the footer).
- When a build is staged, an **"Update available"** callout (modeled on `notifyInfoRow`) offers **"Update & restart"**: confirmation → apply → re-poll `stagedUpdate()` until the applied build clears its manifest.
- Outcome handling: a transport drop mid-handoff = "restart under way"; a server `APIError` is a real verdict — `apply_staged_update_disk_stale` surfaces as a distinct *warning* (new build running, on-disk copy stale), anything else as a rolled-back *failure* (old build still serving).
- Discoverability: an at-a-glance shortcut row + a Machines-row "Update" badge, both gated on a staged build.
- **Inert on an older daemon**: the staged read returns nil → neither the version line nor any update affordance renders (so nothing changes on the current live daemon or in screenshot/mock mode).

## Tests
`StagedUpdateTests` (HerdrKit, green on Linux): decode with/without a staged build, through the result envelope like the client, and the `ok` ack. The apply state-machine's on-device proof is the post-bootstrap end-to-end (read → Apply → agents survive → manifest cleared), consistent with how the daemon apply was validated.

## Sequencing
App-visible only after the one-time **bootstrap deploy** of the merged daemon chain (`b3e34990`) carries `server.staged_update`/`apply_staged_update` live; until then `stagedUpdate()` returns nil and the UI stays hidden. The producer side (build-&-stage tooling that writes the manifest) is already built and proven.

Note: pre-existing `ReadmeLayoutTests` failure on `main` (a README layout-grammar row) is unrelated to this change.
