### PR TITLE
feat(agents): rename an agent or terminal from the long-press menu

### DIFF
--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -912,6 +912,20 @@ struct TerminalHomeView: View {
         let account: CredentialAccount
     }
     @State private var swapCandidate: PendingSwap?
+    /// A pending rename (nil = no sheet). An agent sets its daemon `name` (a resolvable mention
+    /// target — `herdr agent read <name>`); a terminal sets its pane `label` (shown in
+    /// `herdr pane list`) plus the app-local row label. Identifiable so it drives a `.sheet(item:)`.
+    private enum RenameTarget: Identifiable {
+        case agent(AgentRow)
+        case terminal(SavedTerminal)
+        var id: String {
+            switch self {
+            case .agent(let row): return "agent:\(row.info.paneID)"
+            case .terminal(let terminal): return "terminal:\(terminal.id.uuidString)"
+            }
+        }
+    }
+    @State private var renameTarget: RenameTarget?
     @State private var activeCover: ActiveCover?
     /// The selected bottom tab (Agents / Gram / Settings). Terminal is NOT a tab — it
     /// fronts a keep-mounted pane OVER the tabs (see PaneKeepAliveContainer). Gram and
@@ -1589,6 +1603,59 @@ struct TerminalHomeView: View {
                     "Switches \(cand.row.title) to \(cand.account.label) and restarts it. This interrupts its current turn. The session is reopened with --resume on the new subscription."
                 )
             }
+            .sheet(item: $renameTarget) { target in
+                renameSheet(for: target)
+            }
+        }
+    }
+
+    /// The rename form for an agent or a terminal. Agent names are coerced to the server grammar
+    /// (`AgentName.normalize`) and set daemon-side (`agent.rename`) so they resolve as mention
+    /// targets; the list refreshes via `load()`. Terminal names are free-form and dual-written —
+    /// `pane.rename` (daemon label, visible in `herdr pane list`) plus the app-local row label.
+    @ViewBuilder
+    private func renameSheet(for target: RenameTarget) -> some View {
+        switch target {
+        case .agent(let row):
+            RenameSheet(
+                title: "Rename agent",
+                fieldLabel: "AGENT NAME",
+                placeholder: "e.g. planner",
+                current: row.info.name ?? "",
+                footnote: "Lowercase letters, digits, - and _. Another agent can then read this one by name.",
+                normalize: AgentName.normalize
+            ) { newName in
+                let paneID = row.info.paneID
+                let title = row.title
+                Task {
+                    do {
+                        try await client.renameAgent(target: paneID, name: newName)
+                        await load()
+                    } catch let e {
+                        error = "couldn't rename \(title): \(e)"
+                    }
+                }
+            }
+        case .terminal(let terminal):
+            RenameSheet(
+                title: "Rename terminal",
+                fieldLabel: "TERMINAL NAME",
+                placeholder: "e.g. build logs",
+                current: terminal.label,
+                footnote: "Shows in herdr pane list, so you can tell an agent to check this terminal by name.",
+                normalize: { $0 }
+            ) { newLabel in
+                let paneID = terminal.paneID
+                let id = terminal.id
+                Task {
+                    do {
+                        try await client.renamePane(paneID: paneID, label: newLabel)
+                        terminalsStore.rename(id, to: newLabel)
+                    } catch let e {
+                        error = "couldn't rename terminal: \(e)"
+                    }
+                }
+            }
         }
     }
 
@@ -1717,6 +1784,11 @@ struct TerminalHomeView: View {
                     }
                     .buttonStyle(.plain)
                     .contextMenu {
+                        // Rename = set the pane's daemon `label` (shown in `herdr pane list`) so you
+                        // can tell an agent to check this terminal by name, + the app-local row label.
+                        Button {
+                            renameTarget = .terminal(terminal)
+                        } label: { Label("Rename", systemImage: "pencil") }
                         Button(role: .destructive) {
                             Task { await deleteTerminal(terminal) }
                         } label: { Label("Close terminal", systemImage: "xmark.circle") }
@@ -1797,6 +1869,11 @@ struct TerminalHomeView: View {
                                 }
                             }
                         } label: { Label("Stop agent", systemImage: "stop.circle") }
+                        // Rename = set the agent's daemon `name`, which becomes a resolvable
+                        // mention target (another agent can `herdr agent read <name>`).
+                        Button {
+                            renameTarget = .agent(row)
+                        } label: { Label("Rename", systemImage: "pencil") }
                         // Restart = close the agent's session and reopen it with
                         // --resume in place (keeps the pane). It interrupts a busy
                         // agent's turn, so it routes through a confirmation.
@@ -4584,6 +4661,84 @@ struct SettingsView: View {
         copied = true
         // Revert the confirmation so a second copy gives feedback.
         Task { try? await Task.sleep(nanoseconds: 2_000_000_000); copied = false }
+    }
+}
+
+/// A single-field rename form (agent name or terminal label), styled like `SavePromptSheet`.
+/// `normalize` coerces the input to the target's grammar — identity for a free-form terminal label,
+/// `AgentName.normalize` for an agent. It applies to the TRIMMED input, so what's shown as "saved as"
+/// is exactly what's sent. The preview line appears only when normalization changes the input (the
+/// agent case), so the user isn't surprised by "Build Logs" → "build-logs". Owns its own field state.
+struct RenameSheet: View {
+    let title: String
+    let fieldLabel: String
+    let placeholder: String
+    let current: String
+    let footnote: String
+    let normalize: (String) -> String
+    var onSave: (String) -> Void
+
+    @State private var value: String
+    @Environment(\.dismiss) private var dismiss
+
+    init(title: String, fieldLabel: String, placeholder: String, current: String, footnote: String,
+         normalize: @escaping (String) -> String, onSave: @escaping (String) -> Void) {
+        self.title = title
+        self.fieldLabel = fieldLabel
+        self.placeholder = placeholder
+        self.current = current
+        self.footnote = footnote
+        self.normalize = normalize
+        self.onSave = onSave
+        _value = State(initialValue: current)
+    }
+
+    private var trimmed: String { value.trimmingCharacters(in: .whitespacesAndNewlines) }
+    private var effective: String { normalize(trimmed) }
+    private var canSave: Bool { !trimmed.isEmpty && !effective.isEmpty }
+    private var showPreview: Bool { canSave && effective != trimmed }
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Palette.ground.ignoresSafeArea()
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 10) {
+                        Text(fieldLabel).font(Typography.microLabel).foregroundStyle(Palette.textFaint)
+                            .padding(.leading, 4)
+                        TextField(placeholder, text: $value)
+                            .textInputAutocapitalization(.never).autocorrectionDisabled()
+                            .font(Typography.app(15)).foregroundStyle(Palette.text)
+                            .padding(.horizontal, 16).padding(.vertical, 14)
+                            .background(Palette.surface).clipShape(RoundedRectangle(cornerRadius: 12))
+                        if showPreview {
+                            Text("Will be saved as \(effective)")
+                                .font(Typography.machine(12)).foregroundStyle(Palette.textDim)
+                                .padding(.leading, 4)
+                        }
+                        Text(footnote).font(Typography.app(12)).foregroundStyle(Palette.textFaint)
+                            .fixedSize(horizontal: false, vertical: true)
+                            .padding(.leading, 4).padding(.top, 2)
+                        Button {
+                            onSave(effective); dismiss()
+                        } label: {
+                            Text("Save").font(Typography.app(16, .semibold)).foregroundStyle(Palette.ground)
+                                .frame(maxWidth: .infinity).padding(.vertical, 14)
+                                .background(RoundedRectangle(cornerRadius: 14).fill(Palette.text))
+                        }
+                        .disabled(!canSave).opacity(canSave ? 1 : 0.5).padding(.top, 6)
+                    }
+                    .padding(20)
+                }
+            }
+            .navigationTitle(title)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }.foregroundStyle(Palette.textDim)
+                }
+            }
+        }
     }
 }
 

--- a/Sources/HerdrKit/HerdrClient.swift
+++ b/Sources/HerdrKit/HerdrClient.swift
@@ -600,6 +600,43 @@ public actor HerdrClient {
             .agent
     }
 
+    struct AgentRenameParams: Encodable {
+        let target: String
+        let name: String
+    }
+
+    /// Renames an agent (`agent.rename`): sets the agent's `name`, which becomes a
+    /// resolvable mention target daemon-side (`herdr agent read <name>` / another agent
+    /// prompting `<name>`). `target` is the pane id (or the current name). The server
+    /// enforces the name grammar `^[a-z][a-z0-9_-]{0,31}$`, so callers pass a name already
+    /// coerced by `AgentName.normalize`; it still THROWS `APIError` for a duplicate
+    /// (`agent_name_taken`) or an otherwise invalid name. Returns the updated agent.
+    @discardableResult
+    public func renameAgent(target: String, name: String) async throws -> AgentInfo {
+        try await call("agent.rename", AgentRenameParams(target: target, name: name),
+                       as: AgentInfoResult.self)
+            .agent
+    }
+
+    struct PaneRenameParams: Encodable {
+        let paneID: String
+        let label: String
+        enum CodingKeys: String, CodingKey {
+            case label
+            case paneID = "pane_id"
+        }
+    }
+
+    /// Renames a pane (`pane.rename`): sets the pane's manual `label`, which shows in
+    /// `pane.list` — so a plain terminal can be mentioned to an agent ("check the terminal
+    /// labelled <label>"; the agent lists panes, matches the label, then reads that pane).
+    /// Works on any pane, agent or not. The server trims the label. The returned pane is
+    /// ignored (callers keep the app-local label in sync separately).
+    public func renamePane(paneID: String, label: String) async throws {
+        _ = try await call("pane.rename", PaneRenameParams(paneID: paneID, label: label),
+                           as: PaneInfoResult.self)
+    }
+
     /// True when `pane` reports an agent WITH a composer — the observable proxy for
     /// "a prompt will land NOW". This is the STRICTER new-agent PRE-FILL gate
     /// (`InputRouter.isPromptable(for:)`), deliberately NOT the reply-routing gate

--- a/Tests/HerdrKitTests/RenameTests.swift
+++ b/Tests/HerdrKitTests/RenameTests.swift
@@ -1,0 +1,66 @@
+import XCTest
+@testable import HerdrKit
+
+/// The two rename client calls: renameAgent (agent.rename → ResponseResult::AgentInfo{agent}) and
+/// renamePane (pane.rename → ResponseResult::PaneInfo{pane}). Both the request encoding (method name
+/// + exact wire keys) and the response decoding are pinned against herdr's actual wire shapes, so a
+/// wrong key or transposed field fails here rather than on-device.
+final class RenameTests: XCTestCase {
+
+    /// Records the request line and replies with a canned response per method.
+    private final class CapturingTransport: HerdrTransport, @unchecked Sendable {
+        var lastRequest = ""
+        func roundTrip(_ requestLine: String) async throws -> String {
+            lastRequest = requestLine
+            if requestLine.contains("agent.rename") {
+                return #"{"id":"x","result":{"type":"agent_info","agent":{"pane_id":"w1:p1","name":"planner","agent":"claude","agent_status":"working"}}}"#
+            }
+            if requestLine.contains("pane.rename") {
+                return #"{"id":"x","result":{"type":"pane_info","pane":{"pane_id":"w1:p2","label":"build logs"}}}"#
+            }
+            return #"{"id":"x","result":{}}"#
+        }
+        func stream(_ requestLine: String) -> AsyncThrowingStream<String, Error> {
+            AsyncThrowingStream { $0.finish() }
+        }
+    }
+
+    func testRenameAgentSendsTargetAndNameAndDecodesTheAgent() async throws {
+        let t = CapturingTransport()
+        let agent = try await HerdrClient(transport: t).renameAgent(target: "w1:p1", name: "planner")
+
+        XCTAssertEqual(agent.displayName, "planner", "did not decode name from agent.rename's AgentInfo{agent}")
+        XCTAssertEqual(agent.paneID, "w1:p1")
+        XCTAssertTrue(t.lastRequest.contains(#""method":"agent.rename""#), "wrong method")
+        // Pin the key:value PAIRS so transposing target/name would fail.
+        XCTAssertTrue(t.lastRequest.contains(#""target":"w1:p1""#), "target/value not sent correctly")
+        XCTAssertTrue(t.lastRequest.contains(#""name":"planner""#), "name/value not sent correctly")
+    }
+
+    func testRenamePaneSendsSnakeCasePaneIDAndLabel() async throws {
+        let t = CapturingTransport()
+        try await HerdrClient(transport: t).renamePane(paneID: "w1:p2", label: "build logs")
+
+        XCTAssertTrue(t.lastRequest.contains(#""method":"pane.rename""#), "wrong method")
+        // The pane id must go out under the snake_case wire key the server expects.
+        XCTAssertTrue(t.lastRequest.contains(#""pane_id":"w1:p2""#), "pane_id must use the snake_case wire key")
+        XCTAssertTrue(t.lastRequest.contains(#""label":"build logs""#), "label/value not sent correctly")
+    }
+
+    /// AXIS: a duplicate/invalid name surfaces as a thrown APIError (agent_name_taken /
+    /// invalid_agent_name) — what the rename UI leans on to show the reason instead of failing silently.
+    func testRenameAgentServerErrorSurfacesAsAPIError() async throws {
+        struct ErrorTransport: HerdrTransport {
+            func roundTrip(_ r: String) async throws -> String {
+                #"{"id":"x","error":{"code":"agent_name_taken","message":"another agent already uses that name"}}"#
+            }
+            func stream(_ r: String) -> AsyncThrowingStream<String, Error> { AsyncThrowingStream { $0.finish() } }
+        }
+        do {
+            _ = try await HerdrClient(transport: ErrorTransport()).renameAgent(target: "w1:p1", name: "planner")
+            XCTFail("a duplicate-name rejection must throw, not return silently")
+        } catch let e as APIError {
+            XCTAssertEqual(e.code, "agent_name_taken")
+        }
+    }
+}


### PR DESCRIPTION
Rename an **agent** or a **terminal** from the agent list's long-press menu — so it's easy to tell an agent "check the output of the terminal called `<name>`".

Both rename verbs **already exist end-to-end in the live daemon** (`agent.rename`, `pane.rename` — verified in the running binary), so this is **app + client only, no daemon change, works against the daemon the app is connected to today**.

## HerdrKit (Linux-tested)
- `renameAgent(target:name:) → agent.rename` — sets the agent's daemon `name`, which is a **resolvable mention target** (`herdr agent read <name>` resolves by it). Name coerced to the server grammar via `AgentName.normalize`; surfaces `APIError` for `agent_name_taken` / `invalid_agent_name`.
- `renamePane(paneID:label:) → pane.rename` — sets the pane's manual `label`, shown in `herdr pane list`. (The label isn't a *directly* resolvable target yet — an agent finds it by listing panes and matching, then reads that pane. A future daemon tweak could make `pane read <label>` one step.)

## App (agent list long-press menus)
- **Agent** card → "Rename" → `renameAgent` → `load()` (the 5s poll also reflects it). Errors shown in the list's error line.
- **Terminal** row → "Rename" → **dual-write**: `renamePane` (daemon label → agent-visible) + `SavedTerminalsStore.rename` (app-local row label), kept in sync.
- New `RenameSheet` (single field, styled like `SavePromptSheet`): pre-filled with the current name, shows a normalized "saved as" preview when it differs (`Build Logs` → `build-logs`), free-form for terminals.

## Tests
`RenameTests` (HerdrKit, green on Linux) pin the wire shapes: `agent.rename` sends `{target,name}` and decodes `AgentInfo`; `pane.rename` sends `{pane_id,label}`; a duplicate-name rejection throws `APIError`. App UI compiles under CI (`build-and-uitest`, macOS).

Ships independently of the Phase-2 daemon-update chain.
