### PR TITLE
feat(settings): show the daemon commit + gate the update button on a real mismatch

### DIFF
--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -3845,10 +3845,13 @@ struct SettingsView: View {
                         .lineLimit(1).truncationMode(.middle)
                     Spacer(minLength: 0)
                 }
-                // The connected daemon's own version (distinct from the app version in the footer).
-                // Only shown once `server.staged_update` has answered — absent on an older daemon.
+                // The connected daemon's own version + commit (distinct from the app version in the
+                // footer). Only shown once `server.staged_update` has answered — absent on an older
+                // daemon. The version is static across commits, so the sha is what identifies the
+                // build; a daemon too old to report it shows just the version.
                 if let running = stagedUpdate?.runningVersion {
-                    Text("herdr daemon \(running)")
+                    Text(stagedUpdate?.runningSha.map { "herdr daemon \(running) · \($0)" }
+                        ?? "herdr daemon \(running)")
                         .font(Typography.machine(12)).foregroundStyle(Palette.textFaint)
                 }
             }
@@ -3858,8 +3861,10 @@ struct SettingsView: View {
         }
     }
 
-    /// True when the connected daemon has a newer build staged and ready to activate.
-    private var daemonUpdateAvailable: Bool { stagedUpdate?.staged != nil }
+    /// True when the connected daemon has a newer build staged and ready to activate — a staged
+    /// build whose sha differs from what's running (HerdrKit's `updateAvailable`), so a stale/equal
+    /// manifest never shows a phantom update.
+    private var daemonUpdateAvailable: Bool { stagedUpdate?.updateAvailable ?? false }
 
     /// Shown only when the daemon has a staged self-update: an icon chip + "Update available" + the
     /// staged build's id/date, then an "Update & restart" action (a spinner replaces it while the

--- a/Sources/HerdrKit/Wire.swift
+++ b/Sources/HerdrKit/Wire.swift
@@ -603,12 +603,14 @@ public struct PanePtySize: Decodable, Sendable, Equatable {
 /// nil when nothing is staged. Mirrors `ResponseResult::StagedUpdate`
 /// (`src/api/schema/response.rs`); the internally-tagged `type` key is ignored on decode.
 ///
-/// Note: the running daemon reports only a version string (no sha), and the version is static
-/// across commits, so "an update is available" is exactly `staged != nil` — the build step only
-/// writes a manifest for a genuinely newer build and the daemon clears it once applied.
+/// The version string is static across commits (`0.8.0`), so `runningSha` — the running binary's
+/// short git commit — is what actually identifies the build. An update is available when a build is
+/// staged whose `sha` differs from `runningSha` (see `updateAvailable`). `runningSha` is nil on an
+/// older daemon that predates the sha-reporting change.
 public struct StagedUpdate: Decodable, Sendable, Equatable {
     public let runningVersion: String
     public let runningProtocol: Int
+    public let runningSha: String?
     public let staged: Staged?
 
     /// The pre-staged build the daemon would activate on apply. `path` is intentionally not on the
@@ -623,10 +625,20 @@ public struct StagedUpdate: Decodable, Sendable, Equatable {
         }
     }
 
+    /// True when a staged build exists that differs from what's running. When the daemon reports its
+    /// commit (`runningSha`), require the shas to differ so a stale/equal manifest never shows a
+    /// phantom update; on an older daemon (no `runningSha`) fall back to "a build is staged".
+    public var updateAvailable: Bool {
+        guard let staged else { return false }
+        guard let runningSha else { return true }
+        return staged.sha != runningSha
+    }
+
     enum CodingKeys: String, CodingKey {
         case staged
         case runningVersion = "running_version"
         case runningProtocol = "running_protocol"
+        case runningSha = "running_sha"
     }
 }
 

--- a/Tests/HerdrKitTests/StagedUpdateTests.swift
+++ b/Tests/HerdrKitTests/StagedUpdateTests.swift
@@ -62,4 +62,39 @@ final class StagedUpdateTests: XCTestCase {
         let data = try JSONSerialization.data(withJSONObject: ["type": "ok"])
         XCTAssertNoThrow(try JSONDecoder().decode(OkAck.self, from: data))
     }
+
+    /// `running_sha` decodes to `runningSha` — the field that actually identifies the build (version
+    /// is static). Omitted on an older daemon → nil.
+    func testDecodesRunningSha() throws {
+        let withSha = try decodeStaged([
+            "type": "staged_update", "running_version": "0.8.0", "running_protocol": 20,
+            "running_sha": "b3e34990",
+        ])
+        XCTAssertEqual(withSha.runningSha, "b3e34990")
+        let without = try decodeStaged([
+            "type": "staged_update", "running_version": "0.8.0", "running_protocol": 20,
+        ])
+        XCTAssertNil(without.runningSha, "an older daemon omits running_sha")
+    }
+
+    /// `updateAvailable` is the button gate: true only when a staged build differs from what's
+    /// running. Nothing staged → false; a staged sha equal to running → false (no phantom); a
+    /// different staged sha → true; and with no running_sha (older daemon) it falls back to
+    /// "a build is staged".
+    func testUpdateAvailableComparesShas() throws {
+        func make(runningSha: String?, stagedSha: String?) throws -> StagedUpdate {
+            var obj: [String: Any] = [
+                "type": "staged_update", "running_version": "0.8.0", "running_protocol": 20,
+            ]
+            if let runningSha { obj["running_sha"] = runningSha }
+            if let stagedSha {
+                obj["staged"] = ["version": "0.8.0", "sha": stagedSha, "built_at": "2026-08-24T00:00:00Z"]
+            }
+            return try decodeStaged(obj)
+        }
+        XCTAssertFalse(try make(runningSha: "aaa", stagedSha: nil).updateAvailable, "nothing staged → false")
+        XCTAssertFalse(try make(runningSha: "aaa", stagedSha: "aaa").updateAvailable, "same sha → false (no phantom)")
+        XCTAssertTrue(try make(runningSha: "aaa", stagedSha: "bbb").updateAvailable, "different sha → true")
+        XCTAssertTrue(try make(runningSha: nil, stagedSha: "bbb").updateAvailable, "no running_sha → fall back to staged-present")
+    }
 }


### PR DESCRIPTION
Pairs with herdr fork **#106** (`server.staged_update` now returns `running_sha`). Makes "am I on the fork's latest commit?" answerable in the app.

- **HerdrKit `Wire.StagedUpdate`**: adds `runningSha` (`running_sha`). New `updateAvailable` compares `staged.sha` to `runningSha` — true only when they differ; falls back to "a build is staged" on an older daemon that omits `running_sha`.
- **Settings → Machines → Connection card**: shows **"herdr daemon 0.8.0 · b3e34990"** when the sha is reported (plain version otherwise — graceful before the daemon deploy).
- **Update callout** now gates on `updateAvailable`, so a stale/equal manifest never shows a phantom update.
- Tests: `running_sha` decode + the `updateAvailable` sha comparison (HerdrKit, green on Linux).

Degrades cleanly before the daemon deploy: `runningSha` nil → no sha shown, and the button falls back to staged-present. Lights up fully once #106 is merged + deployed.
