### PR TITLE
fix(terminals): scope saved terminals per host

### DIFF
--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -234,6 +234,7 @@ struct RootView: View {
                 client: client,
                 onDisconnect: { disconnect() },
                 host: credentials.host,
+                hostKey: HostKey.canonical(host: credentials.host, port: credentials.port),
                 onReconnect: { reconnect() },
                 onTrustHostKey: { fingerprint in trustAndReconnect(credentials, fingerprint: fingerprint) }
             )
@@ -864,6 +865,9 @@ struct TerminalHomeView: View {
     let client: HerdrClient
     var onDisconnect: () -> Void
     var host: String = ""   // shown in the Settings sheet's connection row
+    /// Canonical `host:port` key that scopes saved terminals to THIS connection (a terminal is a pane
+    /// on one daemon). Empty only in the DEBUG mock, which has no real terminals.
+    var hostKey: String = ""
     var onReconnect: () -> Void = {}
     var onTrustHostKey: (String) -> Bool
     /// The set of panes herdr still lists; anything absent is `stopped`. `nil`
@@ -1056,7 +1060,7 @@ struct TerminalHomeView: View {
         defer { creatingTerminal = false }
         do {
             let paneID = try await client.splitPane(cwd: nil)
-            let terminal = terminalsStore.add(paneID: paneID)
+            let terminal = terminalsStore.add(paneID: paneID, host: hostKey)
             open(PaneSlot(paneID: paneID, title: terminal.label, agent: nil,
                           initialReply: "", siblings: []))
         } catch let e {
@@ -1073,7 +1077,7 @@ struct TerminalHomeView: View {
         try? await client.closePane(paneID: terminal.paneID)
         if frontID == terminal.paneID { frontID = nil }
         slots.removeAll { $0.paneID == terminal.paneID }
-        terminalsStore.delete(terminal.id)
+        terminalsStore.delete(terminal.id, host: hostKey)
     }
 
     /// Front the pane a tapped push targeted (PushCenter.pendingPaneID), once the agent list has
@@ -1442,6 +1446,12 @@ struct TerminalHomeView: View {
             guard await client.probeFork() == .notFork else { return }
             if activeCover == nil { showForkNotice = true } else { pendingForkNotice = true }
         }
+        // One-time: fold any pre-per-host (global) terminal list into THIS host on first connect, so
+        // the owner keeps their named terminals on their main box. Idempotent — a no-op after the
+        // first migration and when there's nothing legacy pending.
+        .task(id: hostKey) {
+            if !hostKey.isEmpty { terminalsStore.migrateLegacyIfNeeded(host: hostKey) }
+        }
         // First launch: show the gestures tutorial once — but NOT over a pending push
         // deep-link (openGramIfPending / applyDeepLink would dismiss it to show Gram or
         // the pane, wasting the one-shot). Burn the seen-flag ONLY when we present.
@@ -1650,7 +1660,7 @@ struct TerminalHomeView: View {
                 Task {
                     do {
                         try await client.renamePane(paneID: paneID, label: newLabel)
-                        terminalsStore.rename(id, to: newLabel)
+                        terminalsStore.rename(id, to: newLabel, host: hostKey)
                     } catch let e {
                         error = "couldn't rename terminal: \(e)"
                     }
@@ -1737,7 +1747,7 @@ struct TerminalHomeView: View {
                     // Terminals sit BELOW the herd and only when you have some — agents
                     // are the priority. Open one from the header's terminal button.
                     // Hidden during an agent search (that filters agents, not shells).
-                    if search.isEmpty && !terminalsStore.terminals.isEmpty {
+                    if search.isEmpty && !terminalsStore.terminals(host: hostKey).isEmpty {
                         terminalsSection
                     }
                 }
@@ -1764,7 +1774,7 @@ struct TerminalHomeView: View {
                     // Count shown when collapsed (so the tally is legible while shut);
                     // expanded, the rows speak for themselves.
                     Text(terminalsCollapsed
-                        ? "TERMINALS · \(terminalsStore.terminals.count)" : "TERMINALS")
+                        ? "TERMINALS · \(terminalsStore.terminals(host: hostKey).count)" : "TERMINALS")
                         .font(Typography.microLabel).tracking(1.2).foregroundStyle(Palette.textFaint)
                     Image(systemName: terminalsCollapsed ? "chevron.right" : "chevron.down")
                         .font(.system(size: 9, weight: .semibold)).foregroundStyle(Palette.textFaint)
@@ -1775,7 +1785,7 @@ struct TerminalHomeView: View {
             .padding(.horizontal, 16).padding(.top, 10)
 
             if !terminalsCollapsed {
-                ForEach(terminalsStore.terminals) { terminal in
+                ForEach(terminalsStore.terminals(host: hostKey)) { terminal in
                     Button {
                         open(PaneSlot(paneID: terminal.paneID, title: terminal.label, agent: nil,
                                       initialReply: "", siblings: []))

--- a/App/SavedTerminalsStore.swift
+++ b/App/SavedTerminalsStore.swift
@@ -2,46 +2,70 @@ import Combine
 import Foundation
 import HerdrKit
 
-/// Persists the terminals the user has opened (plain shell panes) as JSON in UserDefaults.
+/// Persists the terminals the user has opened (plain shell panes) as JSON in UserDefaults,
+/// PARTITIONED BY HOST so each connected box shows only its own panes.
 ///
-/// A shell pane created via `pane.split` (with no `agent.start`) never appears in
-/// `agent.list` — that census is agent-only — so the app must remember the panes it opened
-/// as terminals to relist and reopen them. Device-local and secret-free (a pane id + a
-/// label), so it needs no Keychain, mirroring `SavedPromptsStore`. A singleton
-/// `ObservableObject` so the Terminals section updates live as terminals are opened/closed.
-/// The pure list logic lives in HerdrKit's tested `SavedTerminals`.
+/// A shell pane created via `pane.split` (with no `agent.start`) never appears in `agent.list` — that
+/// census is agent-only — so the app must remember the panes it opened as terminals to relist and
+/// reopen them. A terminal is a pane on ONE daemon, so the list must be scoped to the connected host;
+/// a single global list wrongly surfaced other hosts' panes. Device-local and secret-free (a pane id
+/// + a label), so it needs no Keychain. A singleton `ObservableObject` so the Terminals section
+/// updates live. The pure per-host list logic lives in HerdrKit's tested `HostScopedTerminals`.
 final class SavedTerminalsStore: ObservableObject {
     static let shared = SavedTerminalsStore()
 
-    private let defaultsKey = "dev.herdr.savedTerminals.v1"
-    @Published private(set) var model: SavedTerminals
+    private let defaultsKey = "dev.herdr.savedTerminals.v2"
+    private let legacyKey = "dev.herdr.savedTerminals.v1"
+    @Published private(set) var book: HostScopedTerminals
+    /// The pre-scoping flat list, held until the first host connects so it can inherit it (see
+    /// `migrateLegacyIfNeeded`). nil once consumed, or if there was nothing to migrate.
+    private var legacyPending: SavedTerminals?
 
     init() {
         if let data = UserDefaults.standard.data(forKey: defaultsKey),
-           let decoded = try? JSONDecoder().decode(SavedTerminals.self, from: data) {
-            model = decoded
+           let decoded = try? JSONDecoder().decode(HostScopedTerminals.self, from: data) {
+            book = decoded
         } else {
-            model = SavedTerminals()
+            book = HostScopedTerminals()
+            // First run on the per-host schema: keep the old global list to fold into whichever host
+            // connects first (preserves the owner's named terminals on their main box).
+            if let legacyData = UserDefaults.standard.data(forKey: legacyKey),
+               let legacy = try? JSONDecoder().decode(SavedTerminals.self, from: legacyData),
+               !legacy.terminals.isEmpty {
+                legacyPending = legacy
+            }
         }
     }
 
-    var terminals: [SavedTerminal] { model.terminals }
+    /// Call when a host connection is established (with its canonical key). Folds the legacy global
+    /// list into this host once, then never again — a no-op after the first call or when nothing is
+    /// pending. Retires the legacy blob so it can't re-migrate.
+    func migrateLegacyIfNeeded(host: String) {
+        guard let legacy = legacyPending else { return }
+        legacyPending = nil
+        if book.migrateLegacy(legacy, into: host) {
+            persist()
+        }
+        UserDefaults.standard.removeObject(forKey: legacyKey)
+    }
 
-    /// Remember a freshly created terminal pane (auto-labeled "Terminal N"); returns it.
+    func terminals(host: String) -> [SavedTerminal] { book.terminals(host: host) }
+
+    /// Remember a freshly created terminal pane (auto-labeled "Terminal N") on `host`; returns it.
     @discardableResult
-    func add(paneID: String) -> SavedTerminal {
-        let created = model.add(paneID: paneID, createdUnixMs: nowUnixMs())
+    func add(paneID: String, host: String) -> SavedTerminal {
+        let created = book.add(paneID: paneID, createdUnixMs: nowUnixMs(), host: host)
         persist()
         return created
     }
 
-    func delete(_ id: UUID) {
-        model.remove(id: id)
+    func delete(_ id: UUID, host: String) {
+        book.remove(id: id, host: host)
         persist()
     }
 
-    func rename(_ id: UUID, to label: String) {
-        model.rename(id: id, to: label)
+    func rename(_ id: UUID, to label: String, host: String) {
+        book.rename(id: id, to: label, host: host)
         persist()
     }
 
@@ -50,7 +74,7 @@ final class SavedTerminalsStore: ObservableObject {
     }
 
     private func persist() {
-        guard let data = try? JSONEncoder().encode(model) else { return }
+        guard let data = try? JSONEncoder().encode(book) else { return }
         UserDefaults.standard.set(data, forKey: defaultsKey)
     }
 }

--- a/Sources/HerdrKit/HostScopedTerminals.swift
+++ b/Sources/HerdrKit/HostScopedTerminals.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+/// A stable per-host bucket key for scoping app-side state to one SSH connection.
+public enum HostKey {
+    /// `host:port`, with the host lowercased and stripped of brackets + trailing dots so common
+    /// spellings of the same box share one bucket. This is NOT the pin-grade IPv6 canonicalization the
+    /// host-key policy uses — a rare IPv6 re-spelling here only splits a cosmetic terminal bucket,
+    /// never a security boundary, so the cheaper normalization is deliberate.
+    public static func canonical(host: String, port: UInt16) -> String {
+        var h = host.trimmingCharacters(in: .whitespaces)
+        if h.hasPrefix("[") && h.hasSuffix("]") { h = String(h.dropFirst().dropLast()) }
+        h = h.lowercased()
+        while h.hasSuffix(".") { h.removeLast() }
+        return "\(h):\(port)"
+    }
+}
+
+/// Saved terminals partitioned by host, so each connected host shows only its OWN terminals. A
+/// terminal is a pane on one daemon, so a single global list wrongly surfaces another host's panes
+/// (the phantom-terminal bug). The per-host add/remove/rename logic stays in `SavedTerminals`; this
+/// just buckets it by an opaque host key. Codable so the app persists it in UserDefaults.
+public struct HostScopedTerminals: Codable, Equatable, Sendable {
+    private var byHost: [String: SavedTerminals]
+
+    public init(byHost: [String: SavedTerminals] = [:]) {
+        self.byHost = byHost
+    }
+
+    public func terminals(host: String) -> [SavedTerminal] {
+        byHost[host]?.terminals ?? []
+    }
+
+    @discardableResult
+    public mutating func add(
+        paneID: String, createdUnixMs: UInt64, host: String, id: UUID = UUID()
+    ) -> SavedTerminal {
+        var list = byHost[host] ?? SavedTerminals()
+        let created = list.add(paneID: paneID, createdUnixMs: createdUnixMs, id: id)
+        byHost[host] = list
+        return created
+    }
+
+    public mutating func remove(id: UUID, host: String) {
+        guard var list = byHost[host] else { return }
+        list.remove(id: id)
+        byHost[host] = list
+    }
+
+    public mutating func rename(id: UUID, to label: String, host: String) {
+        guard var list = byHost[host] else { return }
+        list.rename(id: id, to: label)
+        byHost[host] = list
+    }
+
+    /// One-time legacy migration: fold a pre-scoping flat list into `host`'s bucket, but ONLY when
+    /// that host has no bucket yet — so the first host connected after the upgrade inherits the
+    /// owner's existing terminals (their main box), and every host stays isolated thereafter. Returns
+    /// true if it folded, so the caller can retire the legacy blob.
+    @discardableResult
+    public mutating func migrateLegacy(_ legacy: SavedTerminals, into host: String) -> Bool {
+        guard byHost[host] == nil, !legacy.terminals.isEmpty else { return false }
+        byHost[host] = legacy
+        return true
+    }
+}

--- a/Tests/HerdrKitTests/HostScopedTerminalsTests.swift
+++ b/Tests/HerdrKitTests/HostScopedTerminalsTests.swift
@@ -1,0 +1,71 @@
+import XCTest
+@testable import HerdrKit
+
+/// Per-host scoping of saved terminals: each host key keeps its own list (the phantom-terminal fix),
+/// and the one-time legacy migration folds a pre-scoping flat list into the first host only.
+final class HostScopedTerminalsTests: XCTestCase {
+
+    func testTwoHostsKeepSeparateLists() {
+        var book = HostScopedTerminals()
+        book.add(paneID: "wA:p1", createdUnixMs: 1, host: "a:22")
+        book.add(paneID: "wB:p1", createdUnixMs: 2, host: "b:22")
+
+        XCTAssertEqual(book.terminals(host: "a:22").map(\.paneID), ["wA:p1"])
+        XCTAssertEqual(book.terminals(host: "b:22").map(\.paneID), ["wB:p1"],
+                       "host B must not see host A's terminal")
+        XCTAssertTrue(book.terminals(host: "c:22").isEmpty, "an unseen host has no terminals")
+    }
+
+    func testRemoveAndRenameAreScopedToTheHost() {
+        var book = HostScopedTerminals()
+        let a = book.add(paneID: "wA:p1", createdUnixMs: 1, host: "a:22")
+        book.add(paneID: "wB:p1", createdUnixMs: 2, host: "b:22")
+
+        book.rename(id: a.id, to: "build logs", host: "a:22")
+        XCTAssertEqual(book.terminals(host: "a:22").first?.label, "build logs")
+
+        // Deleting on the wrong host is a no-op; on the right host it removes.
+        book.remove(id: a.id, host: "b:22")
+        XCTAssertEqual(book.terminals(host: "a:22").count, 1, "a delete keyed to the wrong host must not touch host A")
+        book.remove(id: a.id, host: "a:22")
+        XCTAssertTrue(book.terminals(host: "a:22").isEmpty)
+        XCTAssertEqual(book.terminals(host: "b:22").count, 1, "host B is untouched throughout")
+    }
+
+    func testLegacyMigrationFoldsIntoTheFirstHostOnce() {
+        var legacy = SavedTerminals()
+        legacy.add(paneID: "wOld:p1", createdUnixMs: 1)
+        legacy.add(paneID: "wOld:p2", createdUnixMs: 2)
+
+        var book = HostScopedTerminals()
+        XCTAssertTrue(book.migrateLegacy(legacy, into: "a:22"), "first host inherits the legacy list")
+        XCTAssertEqual(book.terminals(host: "a:22").count, 2)
+
+        // A second host does NOT get the legacy list again (the host already inherited it, and the
+        // caller retires the blob). And a host that already has a bucket is never overwritten.
+        XCTAssertFalse(book.migrateLegacy(legacy, into: "a:22"), "same host with a bucket is not re-migrated")
+        XCTAssertTrue(book.terminals(host: "b:22").isEmpty, "host B starts clean")
+    }
+
+    func testMigrationOfAnEmptyLegacyIsANoOp() {
+        var book = HostScopedTerminals()
+        XCTAssertFalse(book.migrateLegacy(SavedTerminals(), into: "a:22"))
+        XCTAssertTrue(book.terminals(host: "a:22").isEmpty)
+    }
+
+    func testHostKeyCanonicalizesSpellings() {
+        XCTAssertEqual(HostKey.canonical(host: "Example.COM.", port: 22), "example.com:22")
+        XCTAssertEqual(HostKey.canonical(host: "[2001:DB8::1]", port: 2222), "2001:db8::1:2222")
+        XCTAssertEqual(HostKey.canonical(host: " 10.0.0.1 ", port: 22), "10.0.0.1:22")
+        XCTAssertNotEqual(HostKey.canonical(host: "a", port: 22), HostKey.canonical(host: "a", port: 2200),
+                          "different ports are different hosts")
+    }
+
+    func testBookRoundTripsThroughCodable() throws {
+        var book = HostScopedTerminals()
+        book.add(paneID: "wA:p1", createdUnixMs: 1, host: "a:22")
+        let data = try JSONEncoder().encode(book)
+        let decoded = try JSONDecoder().decode(HostScopedTerminals.self, from: data)
+        XCTAssertEqual(decoded, book)
+    }
+}


### PR DESCRIPTION
**Bug:** the Terminals list was a single global UserDefaults list shared across every connection, so a terminal opened on host A appeared on host B (where its pane doesn't exist) — a phantom. A terminal is a pane on **one** daemon, so the list must be scoped per host.

- **HerdrKit `HostScopedTerminals`** buckets the existing `SavedTerminals` list by an opaque host key; `HostKey.canonical(host:port:)` builds the key (lowercased host + port, brackets/trailing-dots stripped). Pure + Linux-tested.
- **`SavedTerminalsStore`** now backs onto `[hostKey: SavedTerminals]` under `dev.herdr.savedTerminals.v2`, with host-scoped `add/delete/rename/terminals`. **One-time migration** folds the old global `.v1` list into the first host connected after the upgrade (keeps the owner's named terminals — e.g. `myterminal` — on their main box), and every host is isolated thereafter.
- **`RootView`** derives the key from `credentials` (host:port) and threads it into `TerminalHomeView`; the Terminals section's reads + writes are all host-scoped.

Tests (HerdrKit, green on Linux): two hosts stay separate; delete/rename are host-scoped; legacy migration folds once; host-key canonicalization. Phase 1 of the new-agent/terminals batch — app-only, ships independently.
