### PR TITLE
feat(new-agent): folder browser + installed-harness picker

### DIFF
--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -644,8 +644,17 @@ struct NewAgentView: View {
     @State private var task: String
     @State private var starting = false
     @State private var errorMessage: String?
+    /// The harnesses actually installed on the connected machine (`agent.kinds`), fetched on appear.
+    /// Empty until loaded, or on a daemon too old to report them — then the static fallback is used.
+    @State private var installedKinds: [String] = []
+    /// The remote folder browser sheet (`fs.list_dir`).
+    @State private var showFolderBrowser = false
 
+    /// Static fallback kinds for a daemon that can't report installed harnesses.
     private static let kinds = ["claude", "codex", "gemini"]
+
+    /// The kinds the picker offers: the installed harnesses, or the static list on an older daemon.
+    private var menuKinds: [String] { installedKinds.isEmpty ? Self.kinds : installedKinds }
 
     init(client: HerdrClient,
          onStarted: @escaping (_ paneID: String, _ name: String, _ task: String) -> Void = { _, _, _ in },
@@ -713,6 +722,21 @@ struct NewAgentView: View {
         // drains, then fires on an unrelated sheet close). Block interactive dismissal
         // mid-spawn — the same invariant the Cancel button's .disabled(starting) holds.
         .interactiveDismissDisabled(starting)
+        // Fetch the machine's installed harnesses so the picker offers only those. `try?` degrades to
+        // the static list on an older daemon (no agent.kinds). Keep the selection valid.
+        .task {
+            let kinds = (try? await client.agentKinds())?.filter { $0.installed }.map(\.kind) ?? []
+            if !kinds.isEmpty {
+                installedKinds = kinds
+                if !kinds.contains(kind) { kind = kinds.first ?? kind }
+            }
+        }
+        // The remote folder browser (fs.list_dir). On pick, fill the folder field.
+        .sheet(isPresented: $showFolderBrowser) {
+            FolderBrowser(client: client, initialPath: trimmedFolder.isEmpty ? nil : trimmedFolder) { picked in
+                folder = picked
+            }
+        }
     }
 
     private var header: some View {
@@ -740,12 +764,18 @@ struct NewAgentView: View {
 
     private var folderRow: some View {
         VStack(alignment: .leading, spacing: 6) {
-            HStack {
+            HStack(spacing: 8) {
                 Text("Folder").font(Typography.app(15)).foregroundStyle(Palette.textDim)
                 TextField("/root/project", text: $folder)
                     .multilineTextAlignment(.trailing)
                     .textInputAutocapitalization(.never).autocorrectionDisabled()
                     .font(Typography.machine(15)).foregroundStyle(Palette.text)
+                // Browse the machine's folders instead of typing (fs.list_dir). Manual entry stays.
+                Button { showFolderBrowser = true } label: {
+                    Image(systemName: "folder").font(.system(size: 15, weight: .semibold))
+                        .foregroundStyle(Palette.textDim)
+                }
+                .accessibilityLabel("Browse folders")
             }
             .rowShell()
             if !folderValid {
@@ -761,7 +791,7 @@ struct NewAgentView: View {
             Text("Agent").font(Typography.app(15)).foregroundStyle(Palette.textDim)
             Spacer()
             Menu {
-                ForEach(Self.kinds, id: \.self) { k in Button(k) { kind = k } }
+                ForEach(menuKinds, id: \.self) { k in Button(k) { kind = k } }
             } label: {
                 HStack(spacing: 6) {
                     Text(kind).font(Typography.machine(15)).foregroundStyle(Palette.text)
@@ -855,6 +885,132 @@ struct NewAgentView: View {
                 }
             }
         }
+    }
+}
+
+/// A remote folder browser over `fs.list_dir`, for choosing an agent's working directory. Lists the
+/// current directory's SUBFOLDERS (files are hidden — a cwd is a folder), tap to descend, ".." to go
+/// up, "Use this folder" to pick the resolved path. Degrades with a clear message on a daemon that
+/// lacks the method — the caller's manual path field stays available.
+struct FolderBrowser: View {
+    let client: HerdrClient
+    let initialPath: String?
+    let onPick: (String) -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var path = ""
+    @State private var dirs: [String] = []
+    @State private var loading = true
+    @State private var error: String?
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Palette.ground.ignoresSafeArea()
+                VStack(spacing: 0) {
+                    Text(path.isEmpty ? "…" : path)
+                        .font(Typography.machine(13)).foregroundStyle(Palette.textDim)
+                        .lineLimit(1).truncationMode(.head)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.horizontal, 16).padding(.vertical, 10)
+                    Divider().overlay(Palette.hairlineQuiet)
+                    content
+                    Button { onPick(path); dismiss() } label: {
+                        Text("Use this folder").font(Typography.app(16, .semibold)).foregroundStyle(Palette.ground)
+                            .frame(maxWidth: .infinity).padding(.vertical, 14)
+                            .background(RoundedRectangle(cornerRadius: 14).fill(Palette.text))
+                    }
+                    .disabled(loading || error != nil || path.isEmpty)
+                    .opacity((loading || error != nil || path.isEmpty) ? 0.5 : 1)
+                    .padding(16)
+                }
+            }
+            .navigationTitle("Choose folder")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }.foregroundStyle(Palette.textDim)
+                }
+            }
+            .task { await load(initialPath) }
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if loading {
+            VStack { ProgressView().tint(Palette.textDim) }
+                .frame(maxWidth: .infinity, maxHeight: .infinity).padding(.top, 40)
+        } else if let error {
+            VStack(spacing: 8) {
+                Text(error).font(Typography.app(13)).foregroundStyle(Palette.died).multilineTextAlignment(.center)
+                Text("Type a path in the folder field instead.")
+                    .font(Typography.app(12)).foregroundStyle(Palette.textFaint)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity).padding(24)
+        } else {
+            ScrollView {
+                VStack(spacing: 0) {
+                    if path != "/" {
+                        folderRow(icon: "arrow.up", label: "..") { Task { await load(parent(of: path)) } }
+                        divider
+                    }
+                    ForEach(dirs, id: \.self) { name in
+                        folderRow(icon: "folder", label: name) { Task { await load(join(path, name)) } }
+                        if name != dirs.last { divider }
+                    }
+                    if dirs.isEmpty {
+                        Text("No subfolders here").font(Typography.app(13)).foregroundStyle(Palette.textFaint)
+                            .frame(maxWidth: .infinity).padding(.vertical, 24)
+                    }
+                }
+            }
+        }
+    }
+
+    private func folderRow(icon: String, label: String, _ action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            HStack(spacing: 12) {
+                Image(systemName: icon).font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(Palette.textDim).frame(width: 22)
+                Text(label).font(Typography.machine(15)).foregroundStyle(Palette.text).lineLimit(1)
+                Spacer()
+                Image(systemName: "chevron.right").font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(Palette.textFaint)
+            }
+            .padding(.horizontal, 16).padding(.vertical, 13).contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var divider: some View {
+        Rectangle().fill(Palette.hairlineQuiet).frame(height: 1).padding(.leading, 16)
+    }
+
+    private func load(_ target: String?) async {
+        loading = true
+        error = nil
+        do {
+            let listing = try await client.listDir(path: target)
+            path = listing.path
+            dirs = listing.entries.filter(\.isDir).map(\.name)
+        } catch let apiError as APIError {
+            error = "Couldn't open that folder (\(apiError.code))."
+        } catch {
+            error = "Folder browsing needs the herdr fork updated on this machine."
+        }
+        loading = false
+    }
+
+    /// The parent path, staying absolute (root's parent is root).
+    private func parent(of p: String) -> String {
+        let trimmed = (p != "/" && p.hasSuffix("/")) ? String(p.dropLast()) : p
+        let up = (trimmed as NSString).deletingLastPathComponent
+        return up.isEmpty ? "/" : up
+    }
+
+    private func join(_ base: String, _ name: String) -> String {
+        base == "/" ? "/" + name : base + "/" + name
     }
 }
 

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -995,9 +995,10 @@ struct FolderBrowser: View {
             path = listing.path
             dirs = listing.entries.filter(\.isDir).map(\.name)
         } catch let apiError as APIError {
-            error = "Couldn't open that folder (\(apiError.code))."
+            // `self.error` — a bare `catch` binds an implicit `error`, so unqualified would shadow.
+            self.error = "Couldn't open that folder (\(apiError.code))."
         } catch {
-            error = "Folder browsing needs the herdr fork updated on this machine."
+            self.error = "Folder browsing needs the herdr fork updated on this machine."
         }
         loading = false
     }

--- a/Sources/HerdrKit/HerdrClient.swift
+++ b/Sources/HerdrKit/HerdrClient.swift
@@ -87,6 +87,36 @@ public actor HerdrClient {
         _ = try await call("server.apply_staged_update", EmptyParams(), as: OkAck.self)
     }
 
+    struct FsListDirParams: Encodable {
+        let path: String?
+        enum CodingKeys: String, CodingKey { case path }
+        // Omit `path` when nil so the daemon defaults to $HOME (rather than sending null).
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encodeIfPresent(path, forKey: .path)
+        }
+    }
+
+    /// List one directory on the connected machine (`fs.list_dir`), for the new-agent folder browser.
+    /// `path` nil → the daemon's `$HOME`; a leading `~` expands there. Returns the resolved absolute
+    /// path + entries (dirs first). THROWS `APIError` (`not_a_directory`) for a non-directory, and on
+    /// a daemon too old to know the method — callers browsing folders use `try?` to degrade to manual
+    /// path entry.
+    public func listDir(path: String?) async throws -> DirListing {
+        try await call("fs.list_dir", FsListDirParams(path: path), as: DirListing.self)
+    }
+
+    struct AgentKindsResult: Decodable {
+        let kinds: [AgentKind]
+    }
+
+    /// The known agent kinds and whether each harness is installed on the connected machine
+    /// (`agent.kinds`). The new-agent picker offers only the installed ones. THROWS on an older daemon
+    /// lacking the method, so callers `try?`-degrade to a static kind list.
+    public func agentKinds() async throws -> [AgentKind] {
+        try await call("agent.kinds", EmptyParams(), as: AgentKindsResult.self).kinds
+    }
+
     /// The complete pane set, as a value that carries its own provenance.
     ///
     /// `SessionRecovery.observe` takes this rather than `[AgentInfo]` because an

--- a/Sources/HerdrKit/Wire.swift
+++ b/Sources/HerdrKit/Wire.swift
@@ -647,3 +647,31 @@ public struct StagedUpdate: Decodable, Sendable, Equatable {
 /// one-shot command socket may instead DROP mid-apply — callers treat both a returned ack and a
 /// transport drop as "restart initiated" and then re-poll `stagedUpdate()`.
 struct OkAck: Decodable, Sendable {}
+
+// MARK: - Folder browsing + agent kinds (fs.list_dir / agent.kinds)
+
+/// Result of `fs.list_dir` (`type: "dir_list"`): the resolved absolute `path` and its entries. The
+/// daemon returns directories first then case-insensitive by name; the app uses `path` to compute a
+/// parent for "up". Mirrors `ResponseResult::DirList`.
+public struct DirListing: Decodable, Sendable, Equatable {
+    public let path: String
+    public let entries: [Entry]
+
+    public struct Entry: Decodable, Sendable, Equatable, Identifiable {
+        public let name: String
+        public let isDir: Bool
+        public var id: String { name }
+        enum CodingKeys: String, CodingKey {
+            case name
+            case isDir = "is_dir"
+        }
+    }
+}
+
+/// One known agent kind and whether its harness binary is installed on the connected machine
+/// (`agent.kinds`). The new-agent picker offers only `installed` kinds.
+public struct AgentKind: Decodable, Sendable, Equatable, Identifiable {
+    public let kind: String
+    public let installed: Bool
+    public var id: String { kind }
+}

--- a/Tests/HerdrKitTests/FolderAndKindsTests.swift
+++ b/Tests/HerdrKitTests/FolderAndKindsTests.swift
@@ -1,0 +1,78 @@
+import XCTest
+@testable import HerdrKit
+
+/// The two client calls the new-agent folder browser + harness picker add: listDir (fs.list_dir →
+/// ResponseResult::DirList) and agentKinds (agent.kinds → ResponseResult::AgentKinds). Request
+/// encoding and response decoding are pinned to herdr's actual wire shapes.
+final class FolderAndKindsTests: XCTestCase {
+
+    private final class CapturingTransport: HerdrTransport, @unchecked Sendable {
+        var lastRequest = ""
+        func roundTrip(_ requestLine: String) async throws -> String {
+            lastRequest = requestLine
+            if requestLine.contains("fs.list_dir") {
+                return #"""
+                {"id":"x","result":{"type":"dir_list","path":"/root/project",\#
+                "entries":[{"name":"src","is_dir":true},{"name":"README.md","is_dir":false}]}}
+                """#
+            }
+            if requestLine.contains("agent.kinds") {
+                return #"""
+                {"id":"x","result":{"type":"agent_kinds","kinds":[\#
+                {"kind":"claude","installed":true},{"kind":"codex","installed":false}]}}
+                """#
+            }
+            return #"{"id":"x","result":{}}"#
+        }
+        func stream(_ requestLine: String) -> AsyncThrowingStream<String, Error> {
+            AsyncThrowingStream { $0.finish() }
+        }
+    }
+
+    func testListDirSendsPathAndDecodesEntries() async throws {
+        let t = CapturingTransport()
+        let listing = try await HerdrClient(transport: t).listDir(path: "/root/project")
+
+        XCTAssertTrue(t.lastRequest.contains(#""method":"fs.list_dir""#), "wrong method")
+        XCTAssertTrue(t.lastRequest.contains("project"), "path was not sent")
+        XCTAssertEqual(listing.path, "/root/project")
+        XCTAssertEqual(listing.entries.map(\.name), ["src", "README.md"])
+        XCTAssertEqual(listing.entries.first?.isDir, true, "is_dir must map to isDir")
+        XCTAssertEqual(listing.entries.last?.isDir, false)
+    }
+
+    func testListDirOmitsPathWhenNil() async throws {
+        let t = CapturingTransport()
+        _ = try await HerdrClient(transport: t).listDir(path: nil)
+        // A nil path must be omitted (not sent as null) so the daemon defaults to $HOME.
+        XCTAssertFalse(t.lastRequest.contains("\"path\""), "nil path should be omitted")
+    }
+
+    func testAgentKindsDecodesInstalledFlags() async throws {
+        let t = CapturingTransport()
+        let kinds = try await HerdrClient(transport: t).agentKinds()
+
+        XCTAssertTrue(t.lastRequest.contains(#""method":"agent.kinds""#), "wrong method")
+        XCTAssertEqual(kinds.map(\.kind), ["claude", "codex"])
+        XCTAssertEqual(kinds.first?.installed, true)
+        XCTAssertEqual(kinds.last?.installed, false)
+        XCTAssertEqual(kinds.filter(\.installed).map(\.kind), ["claude"], "the picker filters to installed")
+    }
+
+    /// AXIS: a non-directory surfaces as a thrown APIError (`not_a_directory`) so the browser can
+    /// show the reason instead of failing silently.
+    func testListDirNonDirectorySurfacesAsAPIError() async throws {
+        struct ErrorTransport: HerdrTransport {
+            func roundTrip(_ r: String) async throws -> String {
+                #"{"id":"x","error":{"code":"not_a_directory","message":"/etc/hosts is not a directory"}}"#
+            }
+            func stream(_ r: String) -> AsyncThrowingStream<String, Error> { AsyncThrowingStream { $0.finish() } }
+        }
+        do {
+            _ = try await HerdrClient(transport: ErrorTransport()).listDir(path: "/etc/hosts")
+            XCTFail("a non-directory must throw")
+        } catch let e as APIError {
+            XCTAssertEqual(e.code, "not_a_directory")
+        }
+    }
+}


### PR DESCRIPTION
Phase 3 of the new-agent/terminals batch — uses the daemon's new `fs.list_dir` + `agent.kinds` (herdr **#107**). Both degrade gracefully on an older daemon.

- **HerdrKit**: `listDir(path:) -> DirListing` and `agentKinds() -> [AgentKind]`, plus the wire types (`DirListing.Entry {name,isDir}`, `AgentKind {kind,installed}`). Wire-pinned tests.
- **Harness menu** (`NewAgentView`): offers only the **installed** kinds (from `agent.kinds`); `try?`-degrades to the static claude/codex/gemini list on an older daemon, and corrects the selection to a valid kind on load.
- **Folder browser**: a folder button on the folder row opens a `FolderBrowser` sheet that browses the machine's directories (`fs.list_dir`) — drill in, `..` to go up, "Use this folder" to pick the resolved path. Manual path entry stays as the fallback (and for older daemons).

Tests (HerdrKit, green on Linux): `listDir` sends/omits `path` + decodes entries; `agent.kinds` installed flags; a non-directory surfaces as `APIError`. App UI compiles under CI.

Activates fully once #107 is deployed (it's merged + already staged, so an in-app Update & restart lights it up).
