### PR TITLE
feat: lowercase the herdrup app name everywhere it's user-facing

### DIFF
--- a/App/GesturesHelpView.swift
+++ b/App/GesturesHelpView.swift
@@ -68,7 +68,7 @@ struct GesturesHelpView: View {
                 Text("Gestures")
                     .font(Typography.app(20, .semibold))
                     .foregroundStyle(Palette.text)
-                Text("How to move around Herdr")
+                Text("How to move around herdrup")
                     .font(Typography.app(12))
                     .foregroundStyle(Palette.textFaint)
             }

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -2245,8 +2245,8 @@ struct TerminalHomeView: View {
                 .font(Typography.app(20, .bold)).foregroundStyle(Palette.text)
                 .multilineTextAlignment(.center)
             Text(herdrIncompatibleBuild
-                 ? "Herdrup runs the herdr daemon on your machine over SSH. The herdr on this host can't run the app bridge. It's too old, or isn't the jerryfane/herdr fork. Update or install the fork, then reconnect."
-                 : "Herdrup runs the herdr daemon on your machine over SSH. It isn't installed yet. Install the jerryfane/herdr fork, then reconnect.")
+                 ? "herdrup runs the herdr daemon on your machine over SSH. The herdr on this host can't run the app bridge. It's too old, or isn't the jerryfane/herdr fork. Update or install the fork, then reconnect."
+                 : "herdrup runs the herdr daemon on your machine over SSH. It isn't installed yet. Install the jerryfane/herdr fork, then reconnect.")
                 .font(Typography.app(14)).foregroundStyle(Palette.textDim)
                 .multilineTextAlignment(.center)
                 .fixedSize(horizontal: false, vertical: true)
@@ -4517,7 +4517,7 @@ struct SettingsView: View {
     private var notifyAuthBody: String {
         switch notifyRowState {
         case .denied:
-            return "Herdrup can't send these alerts until you allow notifications in iOS Settings."
+            return "herdrup can't send these alerts until you allow notifications in iOS Settings."
         case .needAllow:
             return "Allow notifications so these alerts can reach you when an agent needs you or a gram arrives."
         case .ok:

--- a/App/VoiceInput.swift
+++ b/App/VoiceInput.swift
@@ -88,7 +88,7 @@ final class SpeechDictator: ObservableObject {
             guard self.state == .requesting else { return }
             guard granted else {
                 self.state = .denied
-                self.note = "To dictate, enable Microphone and Speech Recognition for Herdrup in Settings."
+                self.note = "To dictate, enable Microphone and Speech Recognition for herdrup in Settings."
                 return
             }
             do {

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Herdrup
+# herdrup
 
 **Answer your AI coding agents from your phone.**
 
-Herdrup is an iOS client for [herdr](https://github.com/jerryfane/herdr) — a calm status
+herdrup is an iOS client for [herdr](https://github.com/jerryfane/herdr) — a calm status
 board for the coding agents running on your machine, with a real terminal one tap behind each.
 When an agent needs you, you see it at a glance and can reply from anywhere.
 
@@ -23,7 +23,7 @@ herdr's JSON API exposes both, so panes and agents become real UI objects instea
 
 ## Requirements
 
-Herdrup is a client — it talks to a **herdr** daemon running on your own machine over SSH (nothing is
+herdrup is a client — it talks to a **herdr** daemon running on your own machine over SSH (nothing is
 public; it rides your own network). You need the fork that adds the gram / push / live-terminal APIs:
 [**jerryfane/herdr**](https://github.com/jerryfane/herdr). The app tells you if it's talking to a
 daemon that doesn't have them.

--- a/project.yml
+++ b/project.yml
@@ -123,10 +123,12 @@ targets:
     info:
       path: App/Info.plist
       properties:
-        # Marketed name is Herdrup (App Store / TestFlight); the home-screen label
-        # matches it. The in-app title (ConnectView) reads "herdrup" in the design's
-        # lowercase treatment.
-        CFBundleDisplayName: Herdrup
+        # The name is "herdrup" — all lowercase, everywhere: home-screen label, App
+        # Store / TestFlight, and the in-app title (ConnectView) + version footer.
+        # CFBundleName is set explicitly too (it otherwise resolves to the target
+        # name "Herdr" — the daemon's name, not the app's).
+        CFBundleDisplayName: herdrup
+        CFBundleName: herdrup
         # Names the asset-catalog icon set for the runtime. actool also injects
         # this via ASSETCATALOG_COMPILER_APPICON_NAME, but this Info.plist is
         # generated (GENERATE_INFOPLIST_FILE: NO), so we set it explicitly too.
@@ -137,8 +139,8 @@ targets:
         # Voice input (#89): the mic button by the Gram composer and terminal reply bar
         # dictates on-device. Both strings are required or the app crashes the first time
         # it requests the permission.
-        NSMicrophoneUsageDescription: Herdrup uses the microphone only while you hold a dictation session, to turn your speech into text in the message field. Audio is transcribed on-device and never leaves your phone.
-        NSSpeechRecognitionUsageDescription: Herdrup transcribes your dictation into text on-device, so you can talk instead of type. Your speech is not sent anywhere.
+        NSMicrophoneUsageDescription: herdrup uses the microphone only while you hold a dictation session, to turn your speech into text in the message field. Audio is transcribed on-device and never leaves your phone.
+        NSSpeechRecognitionUsageDescription: herdrup transcribes your dictation into text on-device, so you can talk instead of type. Your speech is not sent anywhere.
         # Export compliance: herdr uses ONLY standard, published encryption (AES/SSH
         # via a standard library — no proprietary or custom cryptography), which
         # QUALIFIES FOR THE STANDARD MASS-MARKET EXEMPTION (EAR Category 5 Part 2). So
@@ -271,7 +273,7 @@ targets:
     info:
       path: HerdrWidgets/Info.plist
       properties:
-        CFBundleDisplayName: Herdrup
+        CFBundleDisplayName: herdrup
         NSExtension:
           NSExtensionPointIdentifier: com.apple.widgetkit-extension
     settings:


### PR DESCRIPTION
Normalizes the app name to lowercase **herdrup** everywhere it's user-facing — it was inconsistent (home-screen `CFBundleDisplayName` = `Herdrup`, bundle name silently resolving to `Herdr` = the daemon's name, but the in-app title + version footer already `herdrup`).

- **`project.yml`**: `CFBundleDisplayName` → `herdrup` (app + widget); **set `CFBundleName: herdrup`** explicitly (was unset → resolved to the target name `Herdr`); mic/speech permission strings → `herdrup` (they mirror the OS-shown label).
- **In-app copy**: fork-notice, notifications-permission, voice-dictation, and gestures-help strings → `herdrup`.
- **README** → `herdrup`.

**Left untouched (correctly):** every `herdr` **daemon/fork** reference (a separate product), bundle ids `com.jerryfane.herdr*`, UserDefaults keys `dev.herdr.*`, and Apple provisioning-profile / icon-kit identifiers (`Herdrup App Store` etc.) that must match the developer portal. The internal Xcode target stays `Herdr` (not user-facing).

On TestFlight the home-screen icon label + Settings-list name read `herdrup`, consistent with the ConnectView title and version footer. (Separate, owner-gated: the App Store Connect listing name Herdrup → herdrup, submitted with the next build.)
