### PR TITLE
fix(terminal): stop kitty/graphics escape strings from crashing the terminal (#170)

### DIFF
--- a/App/LiveTerminalView.swift
+++ b/App/LiveTerminalView.swift
@@ -226,6 +226,16 @@ struct LiveTerminalView: UIViewRepresentable {
         /// Guards the one-time scrollback-cap raise + history prepend to the FIRST reset only.
         private var didSeedOnce = false
 
+        /// Strips terminal graphics escape strings (kitty APC, high-volume DCS) from the raw PTY
+        /// bytes before they reach SwiftTerm, which crash-loops on them (#170). Stateful — a graphics
+        /// string spans stream chunks — so it is carried across `.data`/`.reset` feeds and reset at
+        /// each keyframe. Only stream bytes go through it; app-generated notices are already safe.
+        private var graphicsFilter = TerminalGraphicsFilter()
+        private func feedFiltered(_ data: Data, into view: TerminalView) {
+            let clean = graphicsFilter.filter([UInt8](data)[...])
+            if !clean.isEmpty { view.feed(byteArray: clean[...]) }
+        }
+
         /// Auto-reconnect. `reconnectAttempts` drives capped exponential backoff (reset once a
         /// fresh stream delivers a real `.reset`, i.e. it genuinely re-established). `lastStreamActivity`
         /// feeds the heartbeat watchdog: the server pings every 20s (`PING_INTERVAL`), so a long
@@ -731,6 +741,7 @@ struct LiveTerminalView: UIViewRepresentable {
                 switch frame {
                 case .reset(_, _, let cols, let rows, let data, _):
                     reconnectAttempts = 0   // a full keyframe = the stream genuinely (re)established
+                    graphicsFilter.reset()  // fresh screen: abandon any graphics string split before this keyframe
                     let firstReset = !didSeedOnce
                     if firstReset {
                         didSeedOnce = true
@@ -756,7 +767,8 @@ struct LiveTerminalView: UIViewRepresentable {
                         // erase can't tint the rows the seed does not repaint.
                         let history = await backfillTask?.value ?? nil
                         if let history, !history.isEmpty, !stopped {
-                            view.feed(byteArray: history[...])
+                            let cleanHistory = graphicsFilter.filter(history[...])   // backfill can carry graphics too
+                            if !cleanHistory.isEmpty { view.feed(byteArray: cleanHistory[...]) }
                             view.feed(byteArray: [UInt8]("\u{1b}[0m".utf8)[...])
                         }
                     }
@@ -764,9 +776,9 @@ struct LiveTerminalView: UIViewRepresentable {
                     // then paint the full-screen seed. `lagged` resets seed identically (the server
                     // already collapsed the backlog into this keyframe).
                     view.feed(byteArray: Self.clearSequence[...])
-                    if !data.isEmpty { view.feed(byteArray: [UInt8](data)[...]) }
+                    if !data.isEmpty { feedFiltered(data, into: view) }
                 case .data(_, _, let data):
-                    if !data.isEmpty { view.feed(byteArray: [UInt8](data)[...]) }
+                    if !data.isEmpty { feedFiltered(data, into: view) }
                 case .resize(_, _, let cols, let rows):
                     resizeEmulator(cols: cols, rows: rows, in: view)
                 case .ping:

--- a/Sources/HerdrKit/TerminalGraphicsFilter.swift
+++ b/Sources/HerdrKit/TerminalGraphicsFilter.swift
@@ -1,0 +1,137 @@
+import Foundation
+
+/// Strips terminal *graphics* escape strings from a raw PTY byte stream before it
+/// reaches the on-device terminal emulator (SwiftTerm), which crashes on them.
+///
+/// ## Why this exists
+/// A herdr pane running `terminal-browser` draws a real Chromium view into the
+/// terminal using the **kitty graphics protocol** — high-volume base64 image data
+/// carried in APC escape strings (`ESC _ G … ESC \`). The daemon's own VT handles
+/// these (it has first-class kitty support); the iOS client feeds the same raw
+/// firehose straight into SwiftTerm 1.15.0, which chokes on the payload and takes
+/// the whole app down. Because the pane re-feeds on every open, it is a crash loop
+/// (jerryfane/herdrup#170, directive 83120).
+///
+/// The app is a *read-only display*: it never needs to act on a graphics string,
+/// so the safe fix is to drop them client-side before `feed`. That is correct
+/// regardless of whether SwiftTerm dies parsing the payload or on its size — it
+/// simply never sees it. The daemon / TUI / ghostty path is untouched; this is a
+/// client-renderer defect and the fix belongs in the client.
+///
+/// ## What is dropped, what is kept
+/// - **APC** (`ESC _ … ST/BEL`) — dropped entirely. This is kitty graphics and any
+///   other APC protocol; a display terminal has no use for APC. Covers the reported
+///   crash and any APC-based image protocol at once, not just a kitty-specific
+///   `_G` match (jarvis: prefer the general form when it costs the same).
+/// - **DCS** (`ESC P … ST/BEL`) — *size-gated*: a DCS whose bytes exceed
+///   ``dcsPassThroughLimit`` is dropped (sixel / high-volume graphics); a small one
+///   passes through verbatim, so legitimate control strings (e.g. DECRQSS status
+///   replies) are preserved.
+/// - **Everything else passes through byte-identical** — plain text, CSI/SGR
+///   (`ESC [ …`), and OSC (`ESC ] …`, used by SwiftTerm for title/colours). OSC-1337
+///   inline images (iTerm2) are a size-gate follow-up, noted on #170.
+///
+/// ## Statefulness
+/// The daemon streams PTY output in chunks, so a single graphics string routinely
+/// spans several `feed` calls. This filter is therefore a **stateful** byte machine:
+/// one instance per live stream, carried across chunks. Only the 7-bit `ESC`-
+/// introduced forms are recognised — the 8-bit C1 introducers (0x90/0x9f) are left
+/// alone because in a UTF-8 stream those bytes are valid multi-byte continuation
+/// bytes, and treating them as controls would corrupt text.
+public struct TerminalGraphicsFilter {
+
+    /// A DCS string at or under this many bytes passes through unchanged; a larger
+    /// one is dropped as graphics. Legitimate DCS control replies are tens of bytes;
+    /// sixel/graphics DCS run to many kilobytes, so this cleanly separates them.
+    public static let dcsPassThroughLimit = 4096
+
+    private enum Mode {
+        case ground   // normal passthrough
+        case esc      // saw ESC (0x1b); next byte classifies the sequence
+        case apc      // inside an APC string — dropping
+        case dcs      // inside a DCS string — buffering to decide pass/drop by size
+    }
+
+    private var mode: Mode = .ground
+    /// Inside `.apc`/`.dcs`: the previous byte was ESC (0x1b), so the current byte
+    /// may complete an ST terminator (`ESC \`).
+    private var escPending = false
+    /// Buffered DCS bytes (from the `ESC P` intro), held so a small DCS can be
+    /// re-emitted verbatim. Emptied and abandoned once `dcsOverflow` trips.
+    private var dcsBuffer: [UInt8] = []
+    /// The current DCS exceeded ``dcsPassThroughLimit`` — stop buffering (bounded
+    /// memory) and drop it on termination.
+    private var dcsOverflow = false
+
+    public init() {}
+
+    /// Abandon any in-progress sequence. Call at a full keyframe (`reset`), where a
+    /// fresh screen means any partial string from the previous stream is void.
+    public mutating func reset() {
+        mode = .ground
+        escPending = false
+        dcsBuffer = []
+        dcsOverflow = false
+    }
+
+    /// Filter one chunk, returning the bytes safe to feed to the emulator. State
+    /// carries to the next call, so a sequence split across chunks is handled.
+    public mutating func filter(_ input: ArraySlice<UInt8>) -> [UInt8] {
+        var out: [UInt8] = []
+        out.reserveCapacity(input.count)
+        for b in input {
+            switch mode {
+            case .ground:
+                if b == 0x1b { mode = .esc }   // hold the ESC; classify on the next byte
+                else { out.append(b) }
+
+            case .esc:
+                switch b {
+                case 0x5f:                     // ESC _  → APC: drop until terminator
+                    mode = .apc; escPending = false
+                case 0x50:                     // ESC P  → DCS: buffer until terminator
+                    mode = .dcs; escPending = false; dcsBuffer = [0x1b, 0x50]; dcsOverflow = false
+                case 0x1b:                     // ESC ESC → emit the first, keep holding the second
+                    out.append(0x1b)
+                default:                       // any other 2-byte / CSI / OSC intro: not a graphics string
+                    out.append(0x1b)
+                    out.append(b)
+                    mode = .ground
+                }
+
+            case .apc:                         // drop everything to the ST/BEL terminator
+                if escPending {
+                    if b == 0x5c { mode = .ground; escPending = false }   // ESC \ = ST → end
+                    else if b != 0x1b { escPending = false }              // ESC + other: still inside
+                    // ESC ESC: keep escPending true
+                } else if b == 0x07 { mode = .ground }                    // BEL → end
+                else if b == 0x1b { escPending = true }
+                // otherwise: drop the byte
+
+            case .dcs:                         // buffer (bounded) to decide pass vs drop by size
+                appendDCS(b)
+                if escPending {
+                    if b == 0x5c { flushDCS(&out); mode = .ground; escPending = false }  // ST → end
+                    else if b != 0x1b { escPending = false }
+                } else if b == 0x07 { flushDCS(&out); mode = .ground }    // BEL → end
+                else if b == 0x1b { escPending = true }
+            }
+        }
+        return out
+    }
+
+    private mutating func appendDCS(_ b: UInt8) {
+        if dcsOverflow { return }
+        dcsBuffer.append(b)
+        if dcsBuffer.count > Self.dcsPassThroughLimit {
+            dcsOverflow = true    // give up buffering; this DCS is graphics and will be dropped
+            dcsBuffer = []
+        }
+    }
+
+    private mutating func flushDCS(_ out: inout [UInt8]) {
+        if !dcsOverflow { out.append(contentsOf: dcsBuffer) }   // small DCS → verbatim; large → dropped
+        dcsBuffer = []
+        dcsOverflow = false
+    }
+}

--- a/Tests/HerdrKitTests/TerminalGraphicsFilterTests.swift
+++ b/Tests/HerdrKitTests/TerminalGraphicsFilterTests.swift
@@ -1,0 +1,165 @@
+import XCTest
+@testable import HerdrKit
+
+final class TerminalGraphicsFilterTests: XCTestCase {
+
+    // MARK: byte helpers
+
+    private let ESC: UInt8 = 0x1b
+    private let BEL: UInt8 = 0x07
+    private func bytes(_ s: String) -> [UInt8] { Array(s.utf8) }
+    private var ST: [UInt8] { [ESC, 0x5c] }                       // ESC \
+    private func apcOpen() -> [UInt8] { [ESC, 0x5f] }             // ESC _
+    private func dcsOpen() -> [UInt8] { [ESC, 0x50] }             // ESC P
+
+    /// A realistic kitty graphics APC: `ESC _ G <control> ; <base64 payload> ESC \`.
+    private func kitty(payload: Int) -> [UInt8] {
+        var seq = apcOpen()
+        seq += bytes("Gf=100,a=T,s=64,v=64;")
+        seq += Array(repeating: UInt8(ascii: "Q"), count: payload)  // stand-in base64 body
+        seq += ST
+        return seq
+    }
+
+    /// Feed a whole byte array through a fresh filter in one chunk.
+    private func filterWhole(_ input: [UInt8]) -> [UInt8] {
+        var f = TerminalGraphicsFilter()
+        return f.filter(input[...])
+    }
+
+    /// Feed `input` split at every boundary in `cuts`, concatenating the outputs —
+    /// proves state carries across chunks.
+    private func filterChunked(_ input: [UInt8], cuts: [Int]) -> [UInt8] {
+        var f = TerminalGraphicsFilter()
+        var out: [UInt8] = []
+        var start = 0
+        for cut in (cuts + [input.count]) {
+            out += f.filter(input[start..<cut])
+            start = cut
+        }
+        return out
+    }
+
+    // MARK: passthrough — nothing that is not a graphics string may change
+
+    func testPlainTextUnchanged() {
+        let input = bytes("hello world\r\n$ ls -la\r\n")
+        XCTAssertEqual(filterWhole(input), input)
+    }
+
+    func testCsiSgrUnchanged() {
+        let input = bytes("\u{1b}[31mred\u{1b}[0m and \u{1b}[1;32mbold green\u{1b}[0m\r\n")
+        XCTAssertEqual(filterWhole(input), input)
+    }
+
+    func testOscTitleUnchanged_ST() {
+        // OSC is used by SwiftTerm for the window title/colours — must pass through.
+        let input: [UInt8] = [ESC, 0x5d] + bytes("0;my title") + ST + bytes("body")
+        XCTAssertEqual(filterWhole(input), input)
+    }
+
+    func testOscTitleUnchanged_BEL() {
+        let input: [UInt8] = [ESC, 0x5d] + bytes("0;my title") + [BEL] + bytes("body")
+        XCTAssertEqual(filterWhole(input), input)
+    }
+
+    func testEscEscPreserved() {
+        let input: [UInt8] = [ESC, ESC] + bytes("[0m") + bytes("x")
+        XCTAssertEqual(filterWhole(input), input)
+    }
+
+    func testLosslessForNonGraphicsByteByByte() {
+        // Text + CSI + OSC fed one byte at a time must reassemble byte-identical
+        // (ESC emission is deferred one chunk, but concatenation is unchanged).
+        var input: [UInt8] = bytes("\u{1b}[2J\u{1b}[H")
+        input += [ESC, 0x5d] + bytes("0;title") + [BEL]
+        input += bytes("\u{1b}[38;5;213mcolour\u{1b}[0m\r\nplain\r\n")
+        XCTAssertEqual(filterChunked(input, cuts: Array(1..<input.count)), input)
+    }
+
+    // MARK: APC / kitty — dropped
+
+    func testKittyApcDropped_ST() {
+        let input = bytes("before ") + kitty(payload: 500) + bytes(" after")
+        XCTAssertEqual(filterWhole(input), bytes("before  after"))
+    }
+
+    func testApcDropped_BEL() {
+        let input: [UInt8] = bytes("a") + apcOpen() + bytes("Gf=1;PAYLOAD") + [BEL] + bytes("b")
+        XCTAssertEqual(filterWhole(input), bytes("ab"))
+    }
+
+    func testApcWithEmbeddedNonTerminatorEscDropped() {
+        // An ESC inside the APC that is NOT a valid ST must not end the drop early.
+        var apc: [UInt8] = apcOpen()
+        apc += bytes("G;AA")
+        apc += [ESC, 0x58]        // ESC X — not a valid ST
+        apc += bytes("BB")
+        apc += ST
+        let input: [UInt8] = bytes("x") + apc + bytes("y")
+        XCTAssertEqual(filterWhole(input), bytes("xy"))
+    }
+
+    func testKittyApcSplitAcrossChunks() {
+        let input = bytes("L") + kitty(payload: 800) + bytes("R")
+        // Cut mid-payload and again right between the ESC and the '\' of the ST.
+        let mid = 1 + 6 + 300
+        let escOfST = input.count - 1 - 1   // index of the ESC in the trailing ST
+        XCTAssertEqual(filterChunked(input, cuts: [1, mid, escOfST, escOfST + 1]), bytes("LR"))
+    }
+
+    func testEscAtChunkBoundaryBeginsApc() {
+        // Chunk 1 ends on a lone ESC that opens an APC in chunk 2.
+        let input = bytes("A") + kitty(payload: 200) + bytes("B")
+        XCTAssertEqual(filterChunked(input, cuts: [2]), bytes("AB"))  // cut right after the ESC of ESC_
+    }
+
+    func testMultipleKittyFramesWithText() {
+        let input = bytes("row1\r\n") + kitty(payload: 300) + bytes("row2\r\n") + kitty(payload: 300) + bytes("row3")
+        XCTAssertEqual(filterWhole(input), bytes("row1\r\nrow2\r\nrow3"))
+    }
+
+    // MARK: DCS — size-gated
+
+    func testSmallDcsPassesVerbatim() {
+        // DECRQSS-shaped small DCS: ESC P $ q m ESC \  — legit, must survive.
+        let dcs = dcsOpen() + bytes("$qm") + ST
+        let input = bytes("p") + dcs + bytes("q")
+        XCTAssertEqual(filterWhole(input), input)
+    }
+
+    func testLargeDcsDropped() {
+        var dcs = dcsOpen() + bytes("q")   // sixel-ish intro
+        dcs += Array(repeating: UInt8(ascii: "#"), count: TerminalGraphicsFilter.dcsPassThroughLimit + 100)
+        dcs += ST
+        let input = bytes("[") + dcs + bytes("]")
+        XCTAssertEqual(filterWhole(input), bytes("[]"))
+    }
+
+    func testLargeDcsSplitAcrossChunksDropped() {
+        var dcs = dcsOpen() + bytes("q")
+        dcs += Array(repeating: UInt8(ascii: "#"), count: TerminalGraphicsFilter.dcsPassThroughLimit * 2)
+        dcs += ST
+        let input = bytes("(") + dcs + bytes(")")
+        let cuts = [1, 1 + 2000, 1 + 5000, input.count - 3]
+        XCTAssertEqual(filterChunked(input, cuts: cuts), bytes("()"))
+    }
+
+    func testSmallDcsBoundaryAtLimitPasses() {
+        // Exactly at the limit still passes (limit is inclusive).
+        let bodyLen = TerminalGraphicsFilter.dcsPassThroughLimit - 2 /*ESC P*/ - 2 /*ESC \*/
+        let dcs = dcsOpen() + Array(repeating: UInt8(ascii: "z"), count: bodyLen) + ST
+        XCTAssertEqual(dcs.count, TerminalGraphicsFilter.dcsPassThroughLimit)
+        XCTAssertEqual(filterWhole(dcs), dcs)
+    }
+
+    // MARK: reset
+
+    func testResetAbandonsPartialSequence() {
+        var f = TerminalGraphicsFilter()
+        // Feed the opening of a kitty APC, then a keyframe reset, then plain text.
+        _ = f.filter((apcOpen() + bytes("Gf=1;PARTIAL"))[...])
+        f.reset()
+        XCTAssertEqual(f.filter(bytes("clean")[...]), bytes("clean"))
+    }
+}


### PR DESCRIPTION
Fixes #170. Directive 83120.

## Problem
A herdr pane running `terminal-browser` draws a real Chromium view via the **kitty graphics protocol** — high-volume base64 image data carried in **APC** escape strings (`ESC _ G … ESC \`). herdrup fed the raw PTY firehose straight into **SwiftTerm 1.15.0**, which crash-loops on the payload (the pane re-feeds on every open). The daemon's VT handles kitty fine — this is purely a client-renderer defect, so the fix is client-side.

## Fix
New stateful `HerdrKit/TerminalGraphicsFilter` filters the PTY byte stream before the three `feed(byteArray:)` sites in `App/LiveTerminalView.swift` (history seed, reset keyframe, live data):
- **APC** (`ESC _ … ST/BEL`) → dropped entirely (kitty + any APC — general, not a kitty-only `_G` match).
- **DCS** (`ESC P … ST/BEL`) → size-gated: dropped over `dcsPassThroughLimit` (4 KiB, sixel/high-volume), small ones pass verbatim so legit control replies (DECRQSS) survive.
- **Everything else byte-identical** — text, CSI/SGR, and **OSC** (title/colours SwiftTerm needs).

Stateful because a graphics string spans stream chunks; the filter carries across `.data`/`.reset` feeds and resets at each keyframe. Read-only display, so dropping graphics client-side is safe; the **daemon / TUI / ghostty path is untouched** (not a daemon-side strip, per jarvis).

Chose the general APC+DCS form over kitty-specific because it's the same state machine at the same cost and also covers sixel/high-volume DCS. OSC-1337 (iTerm2) inline images are a size-gate follow-up (noted on #170).

## Tests
`Tests/HerdrKitTests/TerminalGraphicsFilterTests.swift` — pure bytes→bytes, run on Linux (17 cases): kitty drop (ST + BEL), cross-chunk splits, ESC-at-chunk-boundary, embedded-non-terminator ESC, DCS size-gate (drop large / pass small / boundary), reset-abandons-partial, and lossless passthrough of text/CSI/OSC (whole + byte-by-byte). Mutation-checked (disabling the APC drop turns the kitty test red).

## Acceptance (done condition — per jarvis, not "compiles and looks right")
After this reaches **TestFlight**: the owner runs `tb <url>` in a herdr pane and opens that pane in herdrup, and **the app does not crash** — the browser region degrades to blank/placeholder while the rest of the pane renders normally. jarvis can drive `tb` on the box to help verify.