### PR TITLE
feat(setup): copy the account/machine guides as an agent-ready prompt

### DIFF
--- a/App/AccountsSetupView.swift
+++ b/App/AccountsSetupView.swift
@@ -51,6 +51,23 @@ struct AccountsSetupView: View {
     config_dir = "/root/.codex-work"
     """
 
+    /// The whole guide as a paste-ready instruction for an agent — built from the SAME command snippets
+    /// shown above so the on-screen steps and the copied text can never drift. Handed to
+    /// `CopyForAgentButton`; the owner pastes it to an agent to have the setup done for them.
+    static let agentPrompt = """
+    Set up another subscription (account) on my herdr home box so it shows up in the herdr app, and walk me through each step as you do it.
+
+    1. Make a config-home folder for the account (one folder per account keeps their logins separate), e.g. ~/.codex-work or ~/.claude-2.
+    2. Log in pointed at that folder — this writes the login into the folder, not the default one:
+    \(Self.loginSnippet)
+    3. Register it in ~/.config/herdr/config.toml with an [[accounts]] block:
+    \(Self.configSnippet)
+    4. Apply it with no restart:
+    herdr server reload-config
+
+    First ask me which harness (codex / claude / kimi) and what label I want, then carry it out and tell me the exact steps and commands you ran.
+    """
+
     var body: some View {
         VStack(spacing: 0) {
             header
@@ -139,12 +156,15 @@ struct AccountsSetupView: View {
     }
 
     private var footer: some View {
-        Button(action: onClose) {
-            Text("Got it")
-                .font(Typography.app(15, .semibold))
-                .foregroundStyle(Palette.textDim)
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 10)
+        VStack(spacing: 8) {
+            CopyForAgentButton(prompt: Self.agentPrompt)
+            Button(action: onClose) {
+                Text("Got it")
+                    .font(Typography.app(15, .semibold))
+                    .foregroundStyle(Palette.textDim)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 10)
+            }
         }
         .padding(.horizontal, 16)
         .padding(.top, 8)

--- a/App/CopyForAgentButton.swift
+++ b/App/CopyForAgentButton.swift
@@ -1,0 +1,46 @@
+import SwiftUI
+import UIKit
+
+/// Footer action for the setup guides (`AccountsSetupView` / `FederationSetupView`): copies that guide as
+/// a paste-ready instruction so the owner can hand it to any agent and have it PERFORM the setup and
+/// report the steps back, instead of following the guide by hand.
+///
+/// Clipboard WRITE only (`UIPasteboard.general.string`, the same pattern as the "Copy diagnostics" /
+/// install-command surfaces) — it never READS the pasteboard, so it does not trigger the App Store 2.1a
+/// paste-permission prompt that a `UIPasteboard` read would.
+struct CopyForAgentButton: View {
+    let prompt: String
+    @State private var copied = false
+
+    var body: some View {
+        VStack(spacing: 6) {
+            Button(action: copy) {
+                HStack(spacing: 8) {
+                    Image(systemName: copied ? "checkmark" : "sparkles")
+                        .font(.system(size: 14, weight: .semibold))
+                    Text(copied ? "Copied — paste it to an agent" : "Copy these steps for an agent")
+                        .font(Typography.app(16, .semibold))
+                }
+                .foregroundStyle(Palette.text)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 14)
+                .background(RoundedRectangle(cornerRadius: 14).fill(Palette.brand))
+            }
+            .buttonStyle(.plain)
+            Text("Paste into any agent — it'll do it for you and tell you each step.")
+                .font(Typography.app(12))
+                .foregroundStyle(Palette.textFaint)
+                .multilineTextAlignment(.center)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private func copy() {
+        UIPasteboard.general.string = prompt
+        withAnimation(.easeOut(duration: 0.15)) { copied = true }
+        Task {
+            try? await Task.sleep(nanoseconds: 1_900_000_000)
+            withAnimation(.easeOut(duration: 0.2)) { copied = false }
+        }
+    }
+}

--- a/App/FederationSetupView.swift
+++ b/App/FederationSetupView.swift
@@ -40,6 +40,22 @@ struct FederationSetupView: View {
     endpoint = "ssh://user@mac-studio"
     """
 
+    /// The whole guide as a paste-ready instruction for an agent — built from the SAME config snippet
+    /// shown above so the on-screen steps and the copied text can never drift. Handed to
+    /// `CopyForAgentButton`; the owner pastes it to an agent to have the machine added for them.
+    static let agentPrompt = """
+    Add another machine to my herd so its agents show up in the herdr app, and walk me through each step as you do it.
+
+    1. Install the jerryfane/herdr fork on the machine — it has the api-bridge my home box connects through (official herdr does not).
+    2. Put it on my network: join it to my Tailscale tailnet (or any address my home box can reach) and authorize my home box's SSH key on it.
+    3. Add it as a peer in ~/.config/herdr/config.toml:
+    \(Self.configSnippet)
+    4. Apply it with no restart:
+    herdr server reload-config
+
+    First ask me the machine's alias and its ssh user@host (Tailscale IP or name), then carry it out and tell me the exact steps and commands you ran.
+    """
+
     var body: some View {
         VStack(spacing: 0) {
             header
@@ -149,8 +165,9 @@ struct FederationSetupView: View {
 
     private var footer: some View {
         VStack(spacing: 8) {
-            // Primary action: send them to the fork's install instructions (step 1),
-            // reusing the one shared install link the fork notice uses.
+            CopyForAgentButton(prompt: Self.agentPrompt)
+            // Send them to the fork's install instructions (step 1), reusing the one
+            // shared install link the fork notice uses.
             InstallInstructionsLink()
             Button(action: onClose) {
                 Text("Got it")


### PR DESCRIPTION
Small feature the owner asked for: a one-tap way to hand either setup guide to an agent instead of following it by hand.

## What
Both in-app guides — **Set up an account** (`AccountsSetupView`) and **Add a machine** (`FederationSetupView`) — get a **"Copy these steps for an agent"** button in the footer, with the caption *"Paste into any agent — it'll do it for you and tell you each step."* Tapping copies the whole guide to the clipboard as a paste-ready instruction and flips the label to **"Copied ✓"** for ~2s.

## How
- New shared `App/CopyForAgentButton.swift` — clipboard **write** only (`UIPasteboard.general.string`, the same pattern as Copy-diagnostics / the install command). It never *reads* the pasteboard, so it does **not** trigger the App Store 2.1a Allow-Paste prompt.
- The copied prompt is a `static let agentPrompt` on each guide, **built from the same command snippets already shown on screen** (`loginSnippet`/`configSnippet`), so the visible steps and the copied text can never drift.
- Wired into each footer above "Got it"; Federation keeps its existing install link.

## Verify
- macOS `build-and-uitest` CI green (App target).
- On device: Settings → Accounts → "How to set up accounts" and Federation → "How to add a machine" → tap the button → "Copied ✓" → paste into Notes/an agent, confirm the full prompt with real commands landed. No system paste prompt appears (write-only).