### PR TITLE
feat(agents): in-app Archive/Unarchive + collapsed Archived section

### DIFF
--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -1163,6 +1163,9 @@ struct TerminalHomeView: View {
     /// The Terminals section starts collapsed like the idle agents — a compact header row
     /// (TERMINALS · N) the reader expands on demand, so it never competes with the herd.
     @State private var terminalsCollapsed = true
+    /// The Archived section (issue #173) starts collapsed too — archived agents are
+    /// the least-active thing on screen, so they stay tucked behind an ARCHIVED · N row.
+    @State private var archivedCollapsed = true
 
     /// The whole list derived from the current agents + census. The grouping,
     /// fail-closed placement, stable order, count and quiet flag all live in
@@ -1908,6 +1911,11 @@ struct TerminalHomeView: View {
                             sectionView(section.group, section.rows)
                         }
                     }
+                    // Archived agents sit below the live herd (above terminals) and only
+                    // when there are some. Hidden during a search (that filters live agents).
+                    if search.isEmpty && !fullList.archived.isEmpty {
+                        archivedSection
+                    }
                     // Terminals sit BELOW the herd and only when you have some — agents
                     // are the priority. Open one from the header's terminal button.
                     // Hidden during an agent search (that filters agents, not shells).
@@ -1970,6 +1978,94 @@ struct TerminalHomeView: View {
                 }
             }
         }
+    }
+
+    // MARK: archived
+
+    /// The Archived section (issue #173): agents whose pane was released but whose
+    /// session the daemon preserved, so they can be resumed. Collapsed by default and
+    /// pinned at the bottom (below agents, above terminals) — an archived agent needs
+    /// nothing from you. Structurally mirrors `terminalsSection`. Long-press a row to
+    /// Unarchive (resume it into a fresh pane). Archived rows are NOT tappable to a
+    /// terminal — there is no live pane to open.
+    private var archivedSection: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Button {
+                archivedCollapsed.toggle()
+            } label: {
+                HStack(spacing: 8) {
+                    Text(archivedCollapsed
+                        ? "ARCHIVED · \(fullList.archived.count)" : "ARCHIVED")
+                        .font(Typography.microLabel).tracking(1.2).foregroundStyle(Palette.textFaint)
+                    Image(systemName: archivedCollapsed ? "chevron.right" : "chevron.down")
+                        .font(.system(size: 9, weight: .semibold)).foregroundStyle(Palette.textFaint)
+                    Rectangle().fill(Palette.hairline).frame(height: 1)
+                }
+            }
+            .buttonStyle(.plain)
+            .padding(.horizontal, 16).padding(.top, 10)
+
+            if !archivedCollapsed {
+                ForEach(fullList.archived) { row in
+                    archivedCard(row)
+                        .contextMenu {
+                            // Unarchive = resume the preserved session into a fresh pane,
+                            // restoring the agent's identity. Target by name (or terminal id)
+                            // since the pane id no longer resolves once archived.
+                            Button {
+                                Task {
+                                    do {
+                                        try await client.unarchiveAgent(target: unarchiveTarget(row.info))
+                                        await load()
+                                    } catch let e {
+                                        error = "couldn't unarchive \(row.title): \(e)"
+                                    }
+                                }
+                            } label: { Label("Unarchive", systemImage: "arrow.uturn.up") }
+                        }
+                }
+            }
+        }
+    }
+
+    /// The unarchive target: an archived agent's pane id is released, so resolve it by
+    /// name, falling back to the terminal id, then pane id.
+    private func unarchiveTarget(_ info: AgentInfo) -> String {
+        info.name ?? info.terminalID ?? info.paneID
+    }
+
+    /// A dimmed agent card for the Archived section: same shape as `card`, an archive
+    /// glyph instead of the live status badge, and provenance ("archived by X · reason")
+    /// as the subtitle.
+    private func archivedCard(_ row: AgentRow) -> some View {
+        HStack(spacing: 12) {
+            ZStack {
+                RoundedRectangle(cornerRadius: 10).fill(AgentIdentity.gradient(for: row.info.agent))
+                    .frame(width: 40, height: 40).opacity(0.5)
+                Image(systemName: "archivebox.fill")
+                    .font(.system(size: 15, weight: .semibold)).foregroundStyle(.white)
+            }
+            VStack(alignment: .leading, spacing: 3) {
+                Text(row.title).font(Typography.app(16, .semibold)).foregroundStyle(Palette.textDim)
+                Text(archivedSubtitle(row.info))
+                    .font(Typography.machine(12)).foregroundStyle(Palette.textFaint).lineLimit(1)
+            }
+            Spacer(minLength: 8)
+        }
+        .padding(12)
+        .background(Palette.card)
+        .clipShape(RoundedRectangle(cornerRadius: 14))
+        .overlay(RoundedRectangle(cornerRadius: 14).stroke(Palette.hairline, lineWidth: 1))
+        .padding(.horizontal, 16).padding(.vertical, 4)
+        .contentShape(Rectangle())
+    }
+
+    /// "archived by X · reason" from the `archived` provenance block; degrades to
+    /// "archived" when the daemon didn't record a `by`.
+    private func archivedSubtitle(_ info: AgentInfo) -> String {
+        let by = (info.archived?.by).map { "archived by \($0)" } ?? "archived"
+        if let reason = info.archived?.reason, !reason.isEmpty { return "\(by) · \(reason)" }
+        return by
     }
 
     private func terminalCard(_ terminal: SavedTerminal) -> some View {
@@ -2076,6 +2172,21 @@ struct TerminalHomeView: View {
                                 }
                             } label: { Label("Swap subscription", systemImage: "arrow.left.arrow.right") }
                         }
+                        // Archive = release the pane but PRESERVE the session so it can be
+                        // resumed later (`agent.archive`, issue #173). Reversible via the
+                        // Archived section's Unarchive, so it fires directly (no confirm).
+                        // The daemon REJECTS archiving a mid-turn agent unless forced, so a
+                        // working agent surfaces that error rather than being torn off a turn.
+                        Button {
+                            Task {
+                                do {
+                                    try await client.archiveAgent(target: row.info.paneID)
+                                    await load()
+                                } catch let e {
+                                    error = "couldn't archive \(row.title): \(e)"
+                                }
+                            }
+                        } label: { Label("Archive", systemImage: "archivebox") }
                     }
                 }
             }
@@ -5207,7 +5318,8 @@ struct MockTransport: HerdrTransport {
       {"pane_id":"w3:p1","name":"clientloop","agent":"claude","agent_status":"idle","cwd":"/root/clientloop","terminal_title_stripped":"amigo-poc scaffold"},
       {"pane_id":"w3:p2","name":"aste-screener","agent":"codex","agent_status":"idle","cwd":"/root/aste-screener","terminal_title_stripped":"apify-harvest"},
       {"pane_id":"w4:p1","name":"discovery","agent":"gemini","agent_status":"idle","cwd":"/root/discovery-calls","terminal_title_stripped":"redaction-pass v3"},
-      {"pane_id":"w4:p2","name":"bank-qa","agent":"claude","agent_status":"done","cwd":"/root/bank-qa","terminal_title_stripped":"deal-assistant rag"}
+      {"pane_id":"w4:p2","name":"bank-qa","agent":"claude","agent_status":"done","cwd":"/root/bank-qa","terminal_title_stripped":"deal-assistant rag"},
+      {"pane_id":"w5:p1","name":"huurjacht","agent":"claude","agent_status":"idle","cwd":"/root/huurjacht","terminal_title_stripped":"pararius scrape","archived":{"at":"2026-08-26T18:00:00Z","by":"jerry","reason":"parked for the weekend"}}
     ]}}
     """#
 

--- a/Sources/HerdrKit/AgentList.swift
+++ b/Sources/HerdrKit/AgentList.swift
@@ -157,6 +157,12 @@ public struct AgentList: Equatable, Sendable {
     /// omitted; the screen renders no heading for a section with nothing in it.
     public let sections: [(group: AgentGroup, rows: [AgentRow])]
 
+    /// Archived agents (issue #173), kept OUT of the live status sections and out
+    /// of `rows`/`needsYouCount`/`isQuiet` entirely — an archived agent needs
+    /// nothing from you. Rendered in the screen's own collapsed "Archived" section,
+    /// most-recently-archived first.
+    public let archived: [AgentRow]
+
     /// What the top of the screen says. Counts only positively-blocked agents —
     /// an unrecognised status is surfaced by its own section, and inflating this
     /// number with maybes would make the one number on the screen untrustworthy.
@@ -174,7 +180,9 @@ public struct AgentList: Equatable, Sendable {
         !rows.contains { $0.group == .needsYou || $0.group == .unrecognised }
     }
 
-    public static func == (a: AgentList, b: AgentList) -> Bool { a.rows == b.rows }
+    public static func == (a: AgentList, b: AgentList) -> Bool {
+        a.rows == b.rows && a.archived == b.archived
+    }
 
     /// Builds the list from an `agent.list` response.
     ///
@@ -184,7 +192,15 @@ public struct AgentList: Equatable, Sendable {
     /// reading, since inferring death from missing evidence would mark every
     /// agent stopped the moment a census failed to arrive.
     public init(agents: [AgentInfo], livePaneIDs: Set<String>? = nil) {
-        let rows = agents.map { info in
+        // Archived agents are pulled out first: they never appear in a live status
+        // section and never count toward "needs you" / quiet. A released pane is not
+        // "live", so they carry isLive = false; their own section renders them.
+        let archivedInfos = agents.filter { $0.isArchived }
+        let liveInfos = agents.filter { !$0.isArchived }
+        self.archived = archivedInfos
+            .map { AgentRow(info: $0, isLive: false) }
+            .sorted { ($0.info.archived?.at ?? "") > ($1.info.archived?.at ?? "") }
+        let rows = liveInfos.map { info in
             AgentRow(info: info, isLive: livePaneIDs.map { $0.contains(info.paneID) } ?? true)
         }
         // Group order first (the screen's primary signal — "does anything need me").

--- a/Sources/HerdrKit/HerdrClient.swift
+++ b/Sources/HerdrKit/HerdrClient.swift
@@ -648,6 +648,64 @@ public actor HerdrClient {
             .agent
     }
 
+    /// `agent.archive` params. `reason`/`force` are OMITTED when nil/false so a plain
+    /// archive sends `{ target }` and matches the server's optional/skip-if-none.
+    struct AgentArchiveParams: Encodable {
+        let target: String
+        let reason: String?
+        let force: Bool
+
+        enum CodingKeys: String, CodingKey {
+            case target, reason, force
+        }
+
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(target, forKey: .target)
+            try container.encodeIfPresent(reason, forKey: .reason)
+            if force { try container.encode(true, forKey: .force) }
+        }
+    }
+
+    /// Archives an agent (`agent.archive`, issue #173): the daemon releases its pane
+    /// but preserves the session ref so `agent.unarchive` can resume it later. `target`
+    /// is the pane id (or agent name). The server REJECTS archiving an agent that is
+    /// mid-turn unless `force` — that surfaces as an `APIError` the caller shows.
+    /// Returns the archived agent (its `archived` block now set).
+    @discardableResult
+    public func archiveAgent(target: String, reason: String? = nil, force: Bool = false) async throws -> AgentInfo {
+        try await call("agent.archive", AgentArchiveParams(target: target, reason: reason, force: force),
+                       as: AgentInfoResult.self)
+            .agent
+    }
+
+    /// `agent.unarchive` params. `fresh` (start a clean agent instead of resuming the
+    /// preserved session) is OMITTED when false.
+    struct AgentUnarchiveParams: Encodable {
+        let target: String
+        let fresh: Bool
+
+        enum CodingKeys: String, CodingKey {
+            case target, fresh
+        }
+
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(target, forKey: .target)
+            if fresh { try container.encode(true, forKey: .fresh) }
+        }
+    }
+
+    /// Unarchives an agent (`agent.unarchive`, issue #173): resumes the preserved
+    /// session into a fresh pane, restoring the agent's terminal identity. `target` is
+    /// the archived agent's name or terminal id. Returns the resumed agent.
+    @discardableResult
+    public func unarchiveAgent(target: String, fresh: Bool = false) async throws -> AgentInfo {
+        try await call("agent.unarchive", AgentUnarchiveParams(target: target, fresh: fresh),
+                       as: AgentInfoResult.self)
+            .agent
+    }
+
     struct PaneRenameParams: Encodable {
         let paneID: String
         let label: String

--- a/Sources/HerdrKit/Wire.swift
+++ b/Sources/HerdrKit/Wire.swift
@@ -73,6 +73,16 @@ public struct CompletedTurn: Decodable, Equatable, Sendable {
     }
 }
 
+/// The `archived { at, by, reason }` provenance the daemon surfaces on an archived
+/// agent in `agent.list` (issue #173). Its PRESENCE on an `AgentInfo` is the
+/// load-bearing "this agent is archived" signal; absent means active. Decoded
+/// leniently (at/by optional) so a partial record never fails the whole list.
+public struct AgentArchivedInfo: Decodable, Equatable, Sendable {
+    public let at: String?
+    public let by: String?
+    public let reason: String?
+}
+
 public struct AgentInfo: Decodable, Equatable, Sendable, Identifiable {
     public let agent: String?
     public let agentStatus: String?
@@ -110,8 +120,15 @@ public struct AgentInfo: Decodable, Equatable, Sendable, Identifiable {
     public let machineID: String?
     public let reachability: String?
     public let lastKnownStatus: String?
+    /// Present only for an archived agent (issue #173). Its presence is the
+    /// load-bearing "is archived" signal; absent means active. Decoded leniently,
+    /// so an older/non-archiving server is unaffected.
+    public let archived: AgentArchivedInfo?
 
     public var id: String { paneID }
+
+    /// This agent has been archived (its pane released, session preserved).
+    public var isArchived: Bool { archived != nil }
 
     /// Human label for a pane, preferring the agent's assigned name.
     public var displayName: String {
@@ -132,7 +149,7 @@ public struct AgentInfo: Decodable, Equatable, Sendable, Identifiable {
     public var isUnreachable: Bool { reachability == "unreachable" }
 
     enum CodingKeys: String, CodingKey {
-        case agent, name, composer, revision, turn, cwd, focused, reachability
+        case agent, name, composer, revision, turn, cwd, focused, reachability, archived
         case agentStatus = "agent_status"
         case inputPending = "input_pending"
         case inputPromptKind = "input_prompt_kind"

--- a/Tests/HerdrKitTests/AgentListTests.swift
+++ b/Tests/HerdrKitTests/AgentListTests.swift
@@ -9,14 +9,49 @@ final class AgentListTests: XCTestCase {
     /// path the wire does. Constructing it in memory would let a test pass while
     /// the JSON key was wrong.
     private func agent(
-        pane: String, status: String?, name: String? = nil, completedUnixMs: Int64? = nil
+        pane: String, status: String?, name: String? = nil, completedUnixMs: Int64? = nil,
+        archivedBy: String? = nil, archivedAt: String? = nil
     ) throws -> AgentInfo {
         var obj: [String: Any] = ["pane_id": pane]
         if let status { obj["agent_status"] = status }
         if let name { obj["name"] = name }
         if let completedUnixMs { obj["last_completed_turn"] = ["completed_unix_ms": completedUnixMs] }
+        if let archivedBy {
+            obj["archived"] = ["at": archivedAt ?? "2026-08-26T18:00:00Z", "by": archivedBy]
+        }
         let data = try JSONSerialization.data(withJSONObject: obj)
         return try JSONDecoder().decode(AgentInfo.self, from: data)
+    }
+
+    // MARK: - archived agents (issue #173)
+
+    /// The `archived` block decodes through the wire path and drives `isArchived`.
+    /// An agent with no block is active. Building the JSON keeps the keys honest.
+    func testArchivedBlockDecodesAndDrivesIsArchived() throws {
+        let archived = try agent(pane: "p1", status: "idle", name: "huurjacht",
+                                 archivedBy: "jerry", archivedAt: "2026-08-26T18:00:00Z")
+        XCTAssertTrue(archived.isArchived)
+        XCTAssertEqual(archived.archived?.by, "jerry")
+        XCTAssertEqual(archived.archived?.at, "2026-08-26T18:00:00Z")
+        let active = try agent(pane: "p2", status: "idle")
+        XCTAssertFalse(active.isArchived)
+        XCTAssertNil(active.archived)
+    }
+
+    /// Archived agents are pulled OUT of the live status sections and collected in
+    /// `archived` (most-recently-archived first), and never counted toward needsYou.
+    func testArchivedAgentsPartitionOutOfLiveSections() throws {
+        let list = AgentList(agents: [
+            try agent(pane: "p1", status: "blocked"),                                  // live, needsYou
+            try agent(pane: "p2", status: "idle", name: "old", archivedBy: "a", archivedAt: "2026-08-26T10:00:00Z"),
+            try agent(pane: "p3", status: "idle", name: "new", archivedBy: "b", archivedAt: "2026-08-26T20:00:00Z"),
+        ])
+        // Live sections/rows exclude the two archived agents.
+        XCTAssertEqual(list.rows.map(\.info.paneID), ["p1"])
+        XCTAssertFalse(list.rows.contains { $0.info.isArchived })
+        XCTAssertEqual(list.needsYouCount, 1)
+        // Archived collected separately, most-recently-archived first.
+        XCTAssertEqual(list.archived.map(\.info.paneID), ["p3", "p2"])
     }
 
     /// Within a group, order is most-recently-active first (largest

--- a/Tests/HerdrKitTests/MockWireFixtureTests.swift
+++ b/Tests/HerdrKitTests/MockWireFixtureTests.swift
@@ -39,7 +39,8 @@ final class MockWireFixtureTests: XCTestCase {
     func testMockAgentListDecodesRealisticStatuses() async throws {
         let client = HerdrClient(transport: FixtureTransport())
         let agents = try await client.agentList()
-        XCTAssertEqual(agents.count, 8, "mock agent.list did not decode to 8 agents")
+        XCTAssertEqual(agents.count, 9, "mock agent.list did not decode to 9 agents (8 live + 1 archived)")
+        XCTAssertEqual(agents.filter { $0.isArchived }.count, 1, "one fixture agent carries an archived block")
         XCTAssertEqual(agents.first?.paneID, "w1:p1")
         XCTAssertEqual(agents.first?.displayName, "jarvis",
                        "the card headlines the assigned name; fixtures must carry distinct names")
@@ -77,6 +78,11 @@ final class MockWireFixtureTests: XCTestCase {
         XCTAssertEqual(counts[.working], 1)
         XCTAssertEqual(counts[.idle], 4, "the done agent should fold into idle, making IDLE · 4")
         XCTAssertEqual(list.needsYouCount, 2, "header would show the wrong 'N need you'")
+        // The archived fixture agent is partitioned OUT of the live sections (which still
+        // sum to 8) and into its own collapsed section.
+        XCTAssertEqual(list.rows.count, 8, "archived agents must not inflate the live rows")
+        XCTAssertEqual(list.archived.count, 1, "the archived fixture agent lands in the Archived section")
+        XCTAssertEqual(list.archived.first?.info.name, "huurjacht")
 
         // STOPPED must come from liveness: w2:p1 is the excluded pane, and its
         // status string is a quiet 'idle' — so if it shows as stopped, that is
@@ -411,7 +417,8 @@ enum MockWireFixtures {
       {"pane_id":"w3:p1","name":"clientloop","agent":"claude","agent_status":"idle","cwd":"/root/clientloop","terminal_title_stripped":"amigo-poc scaffold"},
       {"pane_id":"w3:p2","name":"aste-screener","agent":"codex","agent_status":"idle","cwd":"/root/aste-screener","terminal_title_stripped":"apify-harvest"},
       {"pane_id":"w4:p1","name":"discovery","agent":"gemini","agent_status":"idle","cwd":"/root/discovery-calls","terminal_title_stripped":"redaction-pass v3"},
-      {"pane_id":"w4:p2","name":"bank-qa","agent":"claude","agent_status":"done","cwd":"/root/bank-qa","terminal_title_stripped":"deal-assistant rag"}
+      {"pane_id":"w4:p2","name":"bank-qa","agent":"claude","agent_status":"done","cwd":"/root/bank-qa","terminal_title_stripped":"deal-assistant rag"},
+      {"pane_id":"w5:p1","name":"huurjacht","agent":"claude","agent_status":"idle","cwd":"/root/huurjacht","terminal_title_stripped":"pararius scrape","archived":{"at":"2026-08-26T18:00:00Z","by":"jerry","reason":"parked for the weekend"}}
     ]}}
     """#
 


### PR DESCRIPTION
The #173 **app side**: surfaces the daemon's agent archiving (herdr #112/#113, live on the box) in herdrup. Owner-requested; deferred earlier by the account-swap incident.

## What
- **Decode** the daemon's `archived { at, by, reason }` block on `AgentInfo` (Wire.swift). Its **presence** is the load-bearing "is archived" signal (matches the daemon's own contract); absent = active, so older servers are unaffected.
- **RPCs** `archiveAgent(target:reason:force:)` / `unarchiveAgent(target:)` (HerdrClient) → `agent.archive` / `agent.unarchive`, following the `restartAgent`/`renameAgent` pattern (custom-encode omits nil/false).
- **Partition** archived agents out of the live status sections — and out of `needsYou`/`isQuiet` — into a separate `archived` list (AgentList), most-recently-archived first.
- **UI** (HerdrApp.swift): a collapsed **"ARCHIVED · N"** section pinned at the list bottom (below agents, above terminals), mirroring the existing `terminalsSection` idiom. Dimmed provenance cards ("archived by X · reason"), **not tappable** (no live pane). **Archive** context action on live rows; **Unarchive** on archived rows. Both land on **iPhone and iPad/Mac** since they share one `agentList`.
- Archive fires directly (reversible); a mid-turn agent surfaces the daemon's reject (force is a follow-up).

## Tests
New `AgentListTests`: the `archived` block decodes + drives `isArchived`; archived agents partition out of the live sections into `archived`. The machine-checked `MockWireFixtures.agentList` twin gains one archived agent (kept byte-identical to the App's MockTransport), with the count + partition assertions updated. Couldn't compile on the Linux box (no Swift toolchain) — relying on macOS CI for build + tests.

## Not in this PR
The compact time-in-state badge (the other parked #173 piece) — it needs a daemon `status_since` field first.

/cc JARVIS for review + merge.