### PR TITLE
feat(agents): time-in-state badge on agent cards

### DIFF
--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -2207,6 +2207,19 @@ struct TerminalHomeView: View {
                     .font(Typography.machine(12)).foregroundStyle(Palette.textDim).lineLimit(1)
             }
             Spacer(minLength: 8)
+            // How long the agent has been in its current state ("5m/2h/3d"), derived
+            // from the daemon's status_since (#173). Absent on an older server / before
+            // the first transition — then no badge, never a wrong one. Recomputed each
+            // 5s agent-list refresh, which re-renders this card.
+            if let age = compactTimeInState(
+                sinceUnixMs: row.info.statusSinceUnixMs,
+                nowUnixMs: UInt64(Date().timeIntervalSince1970 * 1000)
+            ) {
+                Text(age)
+                    .font(Typography.machine(11))
+                    .foregroundStyle(Palette.textFaint)
+                    .monospacedDigit()
+            }
             // A remote agent whose machine is unreachable has a stale status, so
             // it reads as offline rather than showing a misleading live badge.
             if row.info.isUnreachable {

--- a/Sources/HerdrKit/AgentList.swift
+++ b/Sources/HerdrKit/AgentList.swift
@@ -224,3 +224,16 @@ public struct AgentList: Equatable, Sendable {
         }
     }
 }
+
+/// Compact "time in current state" label for the agent card badge (#173): minutes
+/// under an hour, hours under a day, else days — never seconds, always a few digits
+/// + one letter ("5m" / "2h" / "3d"). `nil` when the daemon reported no
+/// `status_since` (older server, or not yet transitioned) or the timestamp is in the
+/// future (clock skew) — the card then shows no badge rather than a wrong one.
+public func compactTimeInState(sinceUnixMs: UInt64?, nowUnixMs: UInt64) -> String? {
+    guard let since = sinceUnixMs, nowUnixMs >= since else { return nil }
+    let seconds = (nowUnixMs - since) / 1000
+    if seconds < 3600 { return "\(seconds / 60)m" }      // 0m … 59m (never seconds)
+    if seconds < 86_400 { return "\(seconds / 3600)h" }  // 1h … 23h
+    return "\(seconds / 86_400)d"                         // 1d …
+}

--- a/Sources/HerdrKit/Wire.swift
+++ b/Sources/HerdrKit/Wire.swift
@@ -108,6 +108,10 @@ public struct AgentInfo: Decodable, Equatable, Sendable, Identifiable {
     /// refresh possible: poll the cheap list, fetch a screen only when one moves.
     public let revision: Int?
     public let stateChangeSeq: UInt64?
+    /// Wall-clock ms when the agent entered its CURRENT status (daemon #173). `nil`
+    /// until the first transition / on an older server. The card derives a compact
+    /// "5m/2h/3d" time-in-state badge from `now - this`.
+    public let statusSinceUnixMs: UInt64?
     public let turn: Int?
     public let turnEpoch: UInt64?
     public let lastCompletedTurn: CompletedTurn?
@@ -160,6 +164,7 @@ public struct AgentInfo: Decodable, Equatable, Sendable, Identifiable {
         case terminalTitleStripped = "terminal_title_stripped"
         case interactiveReady = "interactive_ready"
         case stateChangeSeq = "state_change_seq"
+        case statusSinceUnixMs = "status_since_unix_ms"
         case turnEpoch = "turn_epoch"
         case lastCompletedTurn = "last_completed_turn"
         case machineID = "machine_id"

--- a/Tests/HerdrKitTests/AgentListTests.swift
+++ b/Tests/HerdrKitTests/AgentListTests.swift
@@ -54,6 +54,36 @@ final class AgentListTests: XCTestCase {
         XCTAssertEqual(list.archived.map(\.info.paneID), ["p3", "p2"])
     }
 
+    // MARK: - time-in-state badge (issue #173)
+
+    func testCompactTimeInStateFormatsMinutesHoursDaysNeverSeconds() {
+        let now: UInt64 = 1_000_000_000_000
+        // No stamp / future stamp (clock skew) → no badge, never a wrong one.
+        XCTAssertNil(compactTimeInState(sinceUnixMs: nil, nowUnixMs: now))
+        XCTAssertNil(compactTimeInState(sinceUnixMs: now + 5_000, nowUnixMs: now))
+        // Minutes under an hour (seconds floor into minutes, never shown).
+        XCTAssertEqual(compactTimeInState(sinceUnixMs: now, nowUnixMs: now), "0m")
+        XCTAssertEqual(compactTimeInState(sinceUnixMs: now - 45_000, nowUnixMs: now), "0m")
+        XCTAssertEqual(compactTimeInState(sinceUnixMs: now - 60_000, nowUnixMs: now), "1m")
+        XCTAssertEqual(compactTimeInState(sinceUnixMs: now - 59 * 60_000, nowUnixMs: now), "59m")
+        // Hours under a day.
+        XCTAssertEqual(compactTimeInState(sinceUnixMs: now - 3_600_000, nowUnixMs: now), "1h")
+        XCTAssertEqual(compactTimeInState(sinceUnixMs: now - 23 * 3_600_000, nowUnixMs: now), "23h")
+        // Days.
+        XCTAssertEqual(compactTimeInState(sinceUnixMs: now - 86_400_000, nowUnixMs: now), "1d")
+        XCTAssertEqual(compactTimeInState(sinceUnixMs: now - 3 * 86_400_000, nowUnixMs: now), "3d")
+    }
+
+    func testStatusSinceUnixMsDecodesFromWire() throws {
+        let absent = try agent(pane: "p1", status: "working")
+        XCTAssertNil(absent.statusSinceUnixMs)
+        let data = try JSONSerialization.data(withJSONObject: [
+            "pane_id": "p2", "agent_status": "working", "status_since_unix_ms": 123_456_789,
+        ])
+        let present = try JSONDecoder().decode(AgentInfo.self, from: data)
+        XCTAssertEqual(present.statusSinceUnixMs, 123_456_789)
+    }
+
     /// Within a group, order is most-recently-active first (largest
     /// completed_unix_ms), then agents with no completed turn, with paneID as the
     /// stable final tiebreak. paneIDs are chosen so recency — not paneID — decides.


### PR DESCRIPTION
The last parked #173 piece: a compact **"5m / 2h / 3d"** badge on each agent card showing how long it's been in its current state. Pairs with the daemon PR (herdr `status_since_unix_ms`).

## What
- Decode `statusSinceUnixMs` on `AgentInfo` (Wire.swift) — the daemon's `status_since_unix_ms`.
- `compactTimeInState(sinceUnixMs:nowUnixMs:)` in HerdrKit: minutes under an hour, hours under a day, else days — **never seconds**, a few digits + one letter. Returns **nil** when the daemon reported nothing or the stamp is in the future (older server / clock skew) → the card shows **no badge, never a wrong one**.
- Render it on the live `card(_:)` next to the status badge, `Palette.textFaint`, monospaced digits. Recomputed each 5s agent-list refresh. **Archived cards excluded** (they're not live).

## Tests
Formatter boundary tests (nil/future/0m/1m/59m/1h/23h/1d/3d) + the wire decode. HerdrKit unit tests; macOS `build-and-uitest` CI validates the build.

Needs the daemon PR (herdr#116, `status_since_unix_ms`) deployed to light up on real agents; degrades to no-badge without it.

/cc JARVIS for review + merge.