### PR TITLE
feat(accounts): in-app log in / log out of claude accounts

### DIFF
--- a/App/AccountLoginSheet.swift
+++ b/App/AccountLoginSheet.swift
@@ -1,0 +1,154 @@
+import SwiftUI
+import HerdrKit
+
+/// In-app claude account sign-in (issue #173 follow-up). Opens a pane pointed at the
+/// account's config-home running `claude auth login` (or `setup-token`), shows its
+/// live terminal, scrapes the OAuth URL for a one-tap "Open sign-in page", and lets
+/// the user paste the code back. The command ALWAYS clears the global
+/// CLAUDE_CODE_OAUTH_TOKEN and pins CLAUDE_CONFIG_DIR (see `claudeLoginCommand`), so
+/// credentials land in THIS account only — never a global token.
+struct AccountLoginSheet: View {
+    let client: HerdrClient
+    let account: CredentialAccount
+    var onFinished: () -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.openURL) private var openURL
+
+    @State private var method: ClaudeLoginMethod = .oauth
+    @State private var paneID: String?
+    @State private var signInURL: URL?
+    @State private var code: String = ""
+    @State private var phase: String = "Pick a method, then Start."
+    @State private var running = false
+    @State private var scrapeTask: Task<Void, Never>?
+
+    var body: some View {
+        NavigationStack {
+            VStack(alignment: .leading, spacing: 12) {
+                Picker("Method", selection: $method) {
+                    ForEach(ClaudeLoginMethod.allCases, id: \.self) { Text($0.title).tag($0) }
+                }
+                .pickerStyle(.segmented)
+                .disabled(running)
+
+                Group {
+                    if let pane = paneID {
+                        LiveTerminalView(client: client, paneID: pane)
+                    } else {
+                        RoundedRectangle(cornerRadius: 10).fill(Palette.surfaceRaised)
+                            .overlay(Text("The sign-in terminal appears here.")
+                                .font(Typography.app(13)).foregroundStyle(Palette.textFaint))
+                    }
+                }
+                .frame(minHeight: 200)
+                .clipShape(RoundedRectangle(cornerRadius: 10))
+                .overlay(RoundedRectangle(cornerRadius: 10).stroke(Palette.hairline, lineWidth: 1))
+
+                if let url = signInURL {
+                    Button { openURL(url) } label: {
+                        Label("Open sign-in page", systemImage: "safari").frame(maxWidth: .infinity)
+                    }
+                    .buttonStyle(.borderedProminent)
+                }
+
+                HStack(spacing: 8) {
+                    TextField("Paste the code / URL from the browser", text: $code, axis: .vertical)
+                        .textFieldStyle(.roundedBorder)
+                        .lineLimit(1...3)
+                        .autocorrectionDisabled()
+                        .textInputAutocapitalization(.never)
+                    Button("Send") { Task { await sendCode() } }
+                        .buttonStyle(.bordered)
+                        .disabled(code.isEmpty || paneID == nil)
+                }
+
+                Text(phase).font(Typography.app(13)).foregroundStyle(Palette.textDim)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                Spacer(minLength: 0)
+            }
+            .padding(16)
+            .navigationTitle("Sign in · \(account.label)")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) { Button("Close") { finish() } }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(running ? "Restart" : "Start") { Task { await start() } }
+                }
+            }
+        }
+    }
+
+    private func start() async {
+        guard let configDir = account.configDir,
+              let cmd = claudeLoginCommand(kind: account.kind, configDir: configDir, method: method)
+        else {
+            phase = "Sign-in isn't supported for \(account.kind) accounts yet."
+            return
+        }
+        scrapeTask?.cancel()
+        if let old = paneID { try? await client.closePane(paneID: old) }
+        signInURL = nil
+        running = true
+        phase = "Starting sign-in…"
+        do {
+            let pane = try await client.splitPane(cwd: nil)
+            paneID = pane
+            try await client.sendText(pane: pane, text: cmd)
+            try await client.sendKeys(pane: pane, keys: ["Enter"])
+            phase = "Waiting for the sign-in link…"
+            scrapeTask = Task { await scrapeLoop(pane: pane) }
+        } catch {
+            phase = "Couldn't start sign-in: \(error)"
+            running = false
+        }
+    }
+
+    private func scrapeLoop(pane: String) async {
+        let detector = try? NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue)
+        for _ in 0..<120 {  // ~10 min at 5s
+            if Task.isCancelled { return }
+            if let read = try? await client.read(pane: pane, source: .recentUnwrapped, format: .text) {
+                let text = read.text
+                if signInURL == nil, let detector {
+                    let range = NSRange(text.startIndex..., in: text)
+                    if let url = detector.matches(in: text, range: range)
+                        .compactMap({ $0.url })
+                        .first(where: { $0.scheme == "https" }) {
+                        signInURL = url
+                        phase = "Open the link, approve, then paste the code below."
+                    }
+                }
+                if text.range(of: "logged in", options: .caseInsensitive) != nil
+                    || text.range(of: "login successful", options: .caseInsensitive) != nil {
+                    phase = "Signed in — you can close this."
+                    running = false
+                    return
+                }
+            }
+            try? await Task.sleep(nanoseconds: 5_000_000_000)
+        }
+    }
+
+    private func sendCode() async {
+        guard let pane = paneID else { return }
+        let value = code.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !value.isEmpty else { return }
+        do {
+            try await client.sendText(pane: pane, text: value)
+            try await client.sendKeys(pane: pane, keys: ["Enter"])
+            code = ""
+            phase = "Submitted — watch the terminal above."
+        } catch {
+            phase = "Couldn't send the code: \(error)"
+        }
+    }
+
+    private func finish() {
+        scrapeTask?.cancel()
+        let pane = paneID
+        onFinished()
+        dismiss()
+        Task { if let pane { try? await client.closePane(paneID: pane) } }
+    }
+}

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -3572,6 +3572,10 @@ struct SettingsView: View {
     /// no dialog). Set from an account row's long-press menu; the confirm fans the
     /// per-agent swap out over every same-kind agent.
     @State private var bulkSwapTarget: CredentialAccount?
+    /// The account whose in-app sign-in sheet is open (nil = closed).
+    @State private var loginAccount: CredentialAccount?
+    /// The account staged for a log-out confirmation (nil = none).
+    @State private var logoutAccount: CredentialAccount?
     /// The result summary of the last bulk swap ("Moved 3 of 4 …"), shown in an
     /// alert. nil = no alert.
     @State private var bulkResult: String?
@@ -3827,6 +3831,45 @@ struct SettingsView: View {
         detailScaffold(title: "Accounts", subtitle: accountsHeaderSubtitle,
                        subtitleTint: accountsHeaderTint, showBack: showBack) {
             accountsSection
+                .sheet(item: $loginAccount) { account in
+                    AccountLoginSheet(client: client, account: account) {
+                        Task { accounts = (try? await client.accountsList()) ?? [] }
+                    }
+                }
+                .confirmationDialog(
+                    logoutAccount.map { "Log out \($0.label)?" } ?? "",
+                    isPresented: Binding(
+                        get: { logoutAccount != nil },
+                        set: { if !$0 { logoutAccount = nil } }
+                    ),
+                    titleVisibility: .visible,
+                    presenting: logoutAccount
+                ) { account in
+                    Button("Log out", role: .destructive) {
+                        Task { await performLogout(account) }
+                    }
+                } message: { account in
+                    Text("This clears \(account.label)'s saved credentials on your box. "
+                        + "You can sign back in from here anytime.")
+                }
+        }
+    }
+
+    /// Log an account out by running claude's own `auth logout` in a short-lived pane
+    /// pinned to the account's config-home (token cleared), then refresh the list.
+    private func performLogout(_ account: CredentialAccount) async {
+        guard let configDir = account.configDir,
+              let cmd = claudeLogoutCommand(kind: account.kind, configDir: configDir)
+        else { return }
+        do {
+            let pane = try await client.splitPane(cwd: nil)
+            try await client.sendText(pane: pane, text: cmd)
+            try await client.sendKeys(pane: pane, keys: ["Enter"])
+            try? await Task.sleep(nanoseconds: 2_500_000_000)
+            accounts = (try? await client.accountsList()) ?? accounts
+            try? await client.closePane(paneID: pane)
+        } catch let err {
+            bulkResult = "Couldn't log out \(account.label): \(err)"
         }
     }
 
@@ -4381,6 +4424,17 @@ struct SettingsView: View {
                                         Label("Use for all \(account.kind.capitalized) agents",
                                               systemImage: "arrow.left.arrow.right")
                                     }
+                                }
+                                // Sign in / out of the account from the app — runs
+                                // claude's own auth flow pinned to this account's
+                                // config-home (claude only for now; needs config_dir).
+                                if account.kind == "claude", account.configDir != nil {
+                                    Button {
+                                        loginAccount = account
+                                    } label: { Label("Log in", systemImage: "person.crop.circle.badge.plus") }
+                                    Button(role: .destructive) {
+                                        logoutAccount = account
+                                    } label: { Label("Log out", systemImage: "rectangle.portrait.and.arrow.right") }
                                 }
                             }
                         if index < accounts.count - 1 { rowDivider }

--- a/Sources/HerdrKit/AccountLogin.swift
+++ b/Sources/HerdrKit/AccountLogin.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+/// How to authenticate a claude account from the app.
+public enum ClaudeLoginMethod: String, CaseIterable, Sendable {
+    /// `claude auth login` — the browser OAuth flow; saves per-account credentials
+    /// in the account's config-home. The safe, default path.
+    case oauth
+    /// `claude setup-token` — mints a LONG-LIVED token. Kept per-account by the
+    /// config-home; must never be exported globally (a global CLAUDE_CODE_OAUTH_TOKEN
+    /// is exactly what overrode account routing and broke the fleet — see the
+    /// account-routing incident). Offered, but OAuth is preferred.
+    case setupToken
+
+    public var title: String {
+        switch self {
+        case .oauth: return "Sign in (browser)"
+        case .setupToken: return "Setup token"
+        }
+    }
+}
+
+/// Single-quote a path for a POSIX shell so a config-home with spaces/quotes can't
+/// break the command or inject.
+func shellQuoteSingle(_ value: String) -> String {
+    "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"
+}
+
+/// The command to LOG IN a claude account, typed into a pane. It ALWAYS clears the
+/// global `CLAUDE_CODE_OAUTH_TOKEN` and points `CLAUDE_CONFIG_DIR` at the account's
+/// own config-home, so credentials land in THAT account and a stray global token can
+/// never decide the identity (the routing bug this whole safety story exists for).
+/// `nil` for a non-claude kind (codex/kimi login is a follow-up) so the UI can hide it.
+public func claudeLoginCommand(kind: String, configDir: String, method: ClaudeLoginMethod) -> String? {
+    guard kind == "claude" else { return nil }
+    let base = "env -u CLAUDE_CODE_OAUTH_TOKEN CLAUDE_CONFIG_DIR=\(shellQuoteSingle(configDir)) claude"
+    switch method {
+    case .oauth: return "\(base) auth login --claudeai"
+    case .setupToken: return "\(base) setup-token"
+    }
+}
+
+/// The command to LOG OUT a claude account (deletes its `.credentials.json`), typed
+/// into a pane pointed at the account's config-home. `nil` for a non-claude kind.
+public func claudeLogoutCommand(kind: String, configDir: String) -> String? {
+    guard kind == "claude" else { return nil }
+    return "env -u CLAUDE_CODE_OAUTH_TOKEN CLAUDE_CONFIG_DIR=\(shellQuoteSingle(configDir)) claude auth logout"
+}
+
+/// The sanitized status check for a claude account — the authoritative "is it logged
+/// in?" probe (token cleared, config-home pinned). Used to detect login completion.
+public func claudeAuthStatusCommand(kind: String, configDir: String) -> String? {
+    guard kind == "claude" else { return nil }
+    return "env -u CLAUDE_CODE_OAUTH_TOKEN CLAUDE_CONFIG_DIR=\(shellQuoteSingle(configDir)) claude auth status"
+}

--- a/Sources/HerdrKit/Wire.swift
+++ b/Sources/HerdrKit/Wire.swift
@@ -193,7 +193,17 @@ public struct CredentialAccount: Decodable, Equatable, Sendable, Identifiable {
     /// The account's login email, when the daemon can derive it. Optional → an
     /// older daemon that omits it decodes to nil. Identity only, never a secret.
     public let email: String?
+    /// The account's config-home directory (daemon exposes it on accounts.list),
+    /// e.g. `/root/.claude-2`. A non-secret path, never a credential. Optional → an
+    /// older daemon that omits it decodes to nil. The in-app login/logout points
+    /// `CLAUDE_CONFIG_DIR` at it so the flow targets the right account.
+    public let configDir: String?
     public let usage: AccountUsage?
+
+    enum CodingKeys: String, CodingKey {
+        case id, kind, label, active, email, usage
+        case configDir = "config_dir"
+    }
 }
 
 /// One rate-limit window for an account (a 5-hour or weekly bucket, etc.).

--- a/Tests/HerdrKitTests/AccountLoginTests.swift
+++ b/Tests/HerdrKitTests/AccountLoginTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+@testable import HerdrKit
+
+final class AccountLoginTests: XCTestCase {
+    // Every claude login/logout command MUST clear the global token and pin the
+    // account's config-home — that is the whole point of the safety story.
+    func testLoginCommandsClearTheGlobalTokenAndPinTheConfigHome() {
+        let oauth = claudeLoginCommand(kind: "claude", configDir: "/root/.claude-2", method: .oauth)
+        XCTAssertEqual(
+            oauth,
+            "env -u CLAUDE_CODE_OAUTH_TOKEN CLAUDE_CONFIG_DIR='/root/.claude-2' claude auth login --claudeai"
+        )
+        let token = claudeLoginCommand(kind: "claude", configDir: "/root/.claude-2", method: .setupToken)
+        XCTAssertEqual(
+            token,
+            "env -u CLAUDE_CODE_OAUTH_TOKEN CLAUDE_CONFIG_DIR='/root/.claude-2' claude setup-token"
+        )
+        for cmd in [oauth, token].compactMap({ $0 }) {
+            XCTAssertTrue(cmd.contains("-u CLAUDE_CODE_OAUTH_TOKEN"), "must clear the global token: \(cmd)")
+            XCTAssertTrue(cmd.contains("CLAUDE_CONFIG_DIR="), "must pin the config-home: \(cmd)")
+        }
+    }
+
+    func testLogoutAndStatusCommandsAreScopedToTheConfigHome() {
+        XCTAssertEqual(
+            claudeLogoutCommand(kind: "claude", configDir: "/root/.claude"),
+            "env -u CLAUDE_CODE_OAUTH_TOKEN CLAUDE_CONFIG_DIR='/root/.claude' claude auth logout"
+        )
+        XCTAssertEqual(
+            claudeAuthStatusCommand(kind: "claude", configDir: "/root/.claude"),
+            "env -u CLAUDE_CODE_OAUTH_TOKEN CLAUDE_CONFIG_DIR='/root/.claude' claude auth status"
+        )
+    }
+
+    func testNonClaudeKindsHaveNoCommandYet() {
+        XCTAssertNil(claudeLoginCommand(kind: "codex", configDir: "/root/.codex", method: .oauth))
+        XCTAssertNil(claudeLogoutCommand(kind: "kimi", configDir: "/root/.kimi-code"))
+    }
+
+    func testConfigHomeIsShellQuotedAgainstInjection() {
+        let cmd = claudeLoginCommand(kind: "claude", configDir: "/root/it's here", method: .oauth)
+        XCTAssertEqual(cmd?.contains("'/root/it'\\''s here'"), true, "single quotes must be escaped: \(cmd ?? "nil")")
+    }
+}


### PR DESCRIPTION
Feature B (in-app account management), first slice: **log in / log out of existing claude accounts** from the Accounts section — including re-logging-in claude-2, which is logged out on the box right now.

## What
- Per-account **Log in** / **Log out** in the Accounts context menu (claude accounts with a `config_dir`).
- **Login** opens a pane pinned to the account's config-home running `claude auth login` (or `setup-token` — a picker), shows its **live terminal**, **scrapes the OAuth URL** for a one-tap "Open sign-in page", and takes the **pasted code** back (`AccountLoginSheet`).
- **Logout** runs `claude auth logout` in a short-lived config-home pane, then refreshes.
- Decodes the daemon's new account **`config_dir`** (herdr#117).

## Safety
Every command is built by pure, **tested** HerdrKit functions (`claudeLoginCommand`/`claudeLogoutCommand`) that ALWAYS `env -u CLAUDE_CODE_OAUTH_TOKEN` and pin `CLAUDE_CONFIG_DIR` — so credentials land in the selected account only and a stray global token can never decide identity (the exact bug that broke account routing this session). Tests assert the token clear, the config-home pin, shell-quoting against injection, and that non-claude kinds yield no command.

## Scope
claude only (buttons hidden otherwise); **add brand-new accounts** + codex/kimi login are the next slices. Needs herdr#117 (`config_dir`) deployed to light up; degrades to hidden buttons without it.

/cc JARVIS for review + merge.