### PR TITLE
feat(accounts): in-app Add account (create + sign in)

### DIFF
--- a/App/AddAccountSheet.swift
+++ b/App/AddAccountSheet.swift
@@ -1,0 +1,66 @@
+import SwiftUI
+import HerdrKit
+
+/// Add a brand-new credential account from the app. Picks a kind + label, calls
+/// `accounts.create` (the daemon derives a fresh config-home + id, writes config.toml,
+/// reloads), then hands back the refreshed list + the new account so the caller can
+/// chain into sign-in. No credential is written here — that's the login step.
+struct AddAccountSheet: View {
+    let client: HerdrClient
+    /// (refreshed accounts, the newly created account if found).
+    var onCreated: ([CredentialAccount], CredentialAccount?) -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var kind = "claude"
+    @State private var label = ""
+    @State private var busy = false
+    @State private var errorText: String?
+
+    private let kinds = ["claude", "codex", "kimi"]
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Account") {
+                    Picker("Kind", selection: $kind) {
+                        ForEach(kinds, id: \.self) { Text($0.capitalized).tag($0) }
+                    }
+                    TextField("Label (e.g. Claude · work)", text: $label)
+                        .autocorrectionDisabled()
+                        .textInputAutocapitalization(.never)
+                }
+                Section {
+                    Text("A new config-home is created for this account; you'll sign in next.")
+                        .font(.footnote).foregroundStyle(.secondary)
+                }
+                if let errorText {
+                    Section { Text(errorText).font(.footnote).foregroundStyle(.red) }
+                }
+            }
+            .navigationTitle("Add account")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) { Button("Cancel") { dismiss() } }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Create") { Task { await create() } }
+                        .disabled(busy || label.trimmingCharacters(in: .whitespaces).isEmpty)
+                }
+            }
+        }
+    }
+
+    private func create() async {
+        busy = true
+        errorText = nil
+        let trimmed = label.trimmingCharacters(in: .whitespacesAndNewlines)
+        do {
+            let refreshed = try await client.accountsCreate(kind: kind, label: trimmed)
+            let created = refreshed.last(where: { $0.kind == kind && $0.label == trimmed })
+            onCreated(refreshed, created)
+            dismiss()
+        } catch {
+            errorText = "Couldn't add the account: \(error)"
+        }
+        busy = false
+    }
+}

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -3574,6 +3574,8 @@ struct SettingsView: View {
     @State private var bulkSwapTarget: CredentialAccount?
     /// The account whose in-app sign-in sheet is open (nil = closed).
     @State private var loginAccount: CredentialAccount?
+    /// Whether the "Add account" sheet is open.
+    @State private var showAddAccount = false
     /// The account staged for a log-out confirmation (nil = none).
     @State private var logoutAccount: CredentialAccount?
     /// The result summary of the last bulk swap ("Moved 3 of 4 …"), shown in an
@@ -3834,6 +3836,19 @@ struct SettingsView: View {
                 .sheet(item: $loginAccount) { account in
                     AccountLoginSheet(client: client, account: account) {
                         Task { accounts = (try? await client.accountsList()) ?? [] }
+                    }
+                }
+                .sheet(isPresented: $showAddAccount) {
+                    AddAccountSheet(client: client) { refreshed, created in
+                        accounts = refreshed
+                        // Chain into sign-in for the new account once the add sheet
+                        // has dismissed (sequential sheets on the same anchor).
+                        if let created {
+                            Task {
+                                try? await Task.sleep(nanoseconds: 400_000_000)
+                                loginAccount = created
+                            }
+                        }
                     }
                 }
                 .confirmationDialog(
@@ -4444,8 +4459,12 @@ struct SettingsView: View {
                 .overlay(RoundedRectangle(cornerRadius: 12).stroke(Palette.hairline, lineWidth: 1))
                 .padding(.horizontal, 16).padding(.top, 10)
             }
-            richActionRow("How to set up accounts", systemImage: "plus.circle",
-                          subtitle: "Add another subscription on your box") {
+            richActionRow("Add account", systemImage: "plus.circle",
+                          subtitle: "Register a new subscription, then sign in") {
+                showAddAccount = true
+            }
+            richActionRow("How to set up accounts", systemImage: "questionmark.circle",
+                          subtitle: "Manual setup on your box") {
                 showAccountsSetup = true
             }
         }

--- a/Sources/HerdrKit/HerdrClient.swift
+++ b/Sources/HerdrKit/HerdrClient.swift
@@ -68,6 +68,34 @@ public actor HerdrClient {
         try await call("accounts.list", EmptyParams(), as: AccountsListResult.self).accounts
     }
 
+    struct AccountsCreateParams: Encodable {
+        let kind: String
+        let label: String
+        let configDir: String?
+        enum CodingKeys: String, CodingKey {
+            case kind, label
+            case configDir = "config_dir"
+        }
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(kind, forKey: .kind)
+            try container.encode(label, forKey: .label)
+            try container.encodeIfPresent(configDir, forKey: .configDir)
+        }
+    }
+
+    /// Register a NEW credential account (`accounts.create`): the daemon derives a
+    /// fresh config-home + id, creates the dir, appends it to config.toml, reloads, and
+    /// returns the refreshed list. Only non-secret metadata is written — the caller then
+    /// drives login into the new account's config-home. Returns the refreshed accounts.
+    @discardableResult
+    public func accountsCreate(kind: String, label: String, configDir: String? = nil) async throws -> [CredentialAccount] {
+        try await call("accounts.create",
+                       AccountsCreateParams(kind: kind, label: label, configDir: configDir),
+                       as: AccountsListResult.self)
+            .accounts
+    }
+
     /// The running daemon's version/protocol plus any staged update the fleet build step pre-staged
     /// (`server.staged_update`). Parameterless read; THROWS the server's `APIError` on a daemon too
     /// old to know the method, so callers that want a quiet degrade use `try?` (mirrors


### PR DESCRIPTION
The final slice of in-app account management: **Add a brand-new account** from the app, then sign in — no more hand-editing config on the box.

## What
- **"Add account"** action in the Accounts section → a small sheet: pick **kind** (claude/codex/kimi) + **label** → calls the daemon's **`accounts.create`** (herdr#118: derives a fresh config-home + id, writes config.toml, reloads) → refreshes the list → **chains into the sign-in sheet** for the new account.
- Adds the `accountsCreate` RPC to HerdrClient.
- The manual "How to set up accounts" guide stays (as a secondary help row).

Completes the account story in the app: **list · swap · log in/out · add**.

## Notes
Needs herdr#118 (`accounts.create`) merged + deployed to function; the button no-ops gracefully (surfaces the daemon error) without it. macOS `build-and-uitest` CI validates the build.

/cc JARVIS for review + merge.