### PR TITLE
feat(accounts): remove an account from the list

### DIFF
--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -3578,6 +3578,8 @@ struct SettingsView: View {
     @State private var showAddAccount = false
     /// The account staged for a log-out confirmation (nil = none).
     @State private var logoutAccount: CredentialAccount?
+    /// The account staged for a remove-from-list confirmation (nil = none).
+    @State private var removeAccount: CredentialAccount?
     /// The result summary of the last bulk swap ("Moved 3 of 4 …"), shown in an
     /// alert. nil = no alert.
     @State private var bulkResult: String?
@@ -3867,6 +3869,32 @@ struct SettingsView: View {
                     Text("This clears \(account.label)'s saved credentials on your box. "
                         + "You can sign back in from here anytime.")
                 }
+                .confirmationDialog(
+                    removeAccount.map { "Remove \($0.label)?" } ?? "",
+                    isPresented: Binding(
+                        get: { removeAccount != nil },
+                        set: { if !$0 { removeAccount = nil } }
+                    ),
+                    titleVisibility: .visible,
+                    presenting: removeAccount
+                ) { account in
+                    Button("Remove", role: .destructive) {
+                        Task { await performRemove(account) }
+                    }
+                } message: { account in
+                    Text("This removes \(account.label) from the accounts list. "
+                        + "Its saved credentials stay on your box, so you can add it back later.")
+                }
+        }
+    }
+
+    /// Remove an account from the list (`accounts.remove`): the daemon drops it from
+    /// config.toml and returns the refreshed list. Credentials are left in place.
+    private func performRemove(_ account: CredentialAccount) async {
+        do {
+            accounts = try await client.accountsRemove(id: account.id)
+        } catch {
+            bulkResult = "Couldn't remove \(account.label): \(error)"
         }
     }
 
@@ -4451,6 +4479,13 @@ struct SettingsView: View {
                                         logoutAccount = account
                                     } label: { Label("Log out", systemImage: "rectangle.portrait.and.arrow.right") }
                                 }
+                                // Remove the account from the list entirely (any kind) —
+                                // drops it from config.toml; the config-home + creds stay,
+                                // so it can be re-added. For clearing out junk/duplicate
+                                // entries.
+                                Button(role: .destructive) {
+                                    removeAccount = account
+                                } label: { Label("Remove account", systemImage: "trash") }
                             }
                         if index < accounts.count - 1 { rowDivider }
                     }

--- a/Sources/HerdrKit/HerdrClient.swift
+++ b/Sources/HerdrKit/HerdrClient.swift
@@ -96,6 +96,22 @@ public actor HerdrClient {
             .accounts
     }
 
+    struct AccountsRemoveParams: Encodable {
+        let id: String
+    }
+
+    /// Unregister an account (`accounts.remove`): the daemon drops its `[[accounts]]`
+    /// block from config.toml and reloads, returning the refreshed list. Does NOT delete
+    /// the account's config-home or credentials — the entry can be re-added later. THROWS
+    /// the server's `APIError` on an older daemon that lacks the method.
+    @discardableResult
+    public func accountsRemove(id: String) async throws -> [CredentialAccount] {
+        try await call("accounts.remove",
+                       AccountsRemoveParams(id: id),
+                       as: AccountsListResult.self)
+            .accounts
+    }
+
     /// The running daemon's version/protocol plus any staged update the fleet build step pre-staged
     /// (`server.staged_update`). Parameterless read; THROWS the server's `APIError` on a daemon too
     /// old to know the method, so callers that want a quiet degrade use `try?` (mirrors


### PR DESCRIPTION
Owner asked: they created logged-out accounts (claudej, claude-2) with no way to remove them. This adds an in-app **Remove account** action.

## What it does
- `HerdrClient.accountsRemove(id:)` — calls the daemon's `accounts.remove`, returns the refreshed list (throws on an older daemon).
- A **Remove account** destructive context action on every account row (any kind) → a confirmation dialog → `accountsRemove` → refresh. Errors surface in the existing `bulkResult` banner.
- The dialog states credentials are kept, so the account can be re-added later.

Pairs with daemon PR jerryfane/herdr#119 (`accounts.remove`). Needs that deployed to function; degrades quietly on an older daemon.

Separate from the login-redesign PR #178.