### PR TITLE
fix(agents): distinct archived rows, one timing anchor, no endless reconnect

### DIFF
--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -2851,10 +2851,24 @@ struct TerminalPaneContent: View {
         .background(Palette.surface)
     }
 
-    /// When the agent entered its current status — approximated by the last completed
-    /// turn (for idle, when it finished; for working, ≈ the current turn's start). Nil
-    /// when there is no completed turn yet, which hides the timer.
-    private var statusSinceMs: Int64? { agent?.lastCompletedTurn?.completedUnixMs }
+    /// When the agent entered its current status — the SAME anchor the list card's
+    /// time-in-state badge uses (`status_since_unix_ms`, daemon #173), so the two
+    /// screens cannot disagree about one fact.
+    ///
+    /// This used to read `lastCompletedTurn.completedUnixMs` and call it an
+    /// approximation of the current turn's start. For an IDLE agent that happens to be
+    /// exact — it went idle precisely when its last turn completed — which is why idle
+    /// always matched and the bug hid. For a WORKING agent it is the moment the
+    /// PREVIOUS turn finished, so the header over-counted by the entire idle gap before
+    /// the current turn began. The real field existed all along; the header was never
+    /// repointed at it when the list badge was.
+    ///
+    /// The completed-turn value stays as the fallback for a daemon too old to report
+    /// `status_since` — a slightly-off timer beats no timer.
+    private var statusSinceMs: Int64? {
+        statusAnchorUnixMs(statusSinceUnixMs: agent?.statusSinceUnixMs,
+                           lastCompletedUnixMs: agent?.lastCompletedTurn?.completedUnixMs)
+    }
 
     /// Compact elapsed-time label: "45s", "1m 20s", "12m", "1h 5m". Seconds show only
     /// for the first ten minutes, where they read as motion; past that the minute (then

--- a/App/LiveTerminalView.swift
+++ b/App/LiveTerminalView.swift
@@ -213,6 +213,13 @@ struct LiveTerminalView: UIViewRepresentable {
         /// Set once the server sends an `exited` frame, so a normal stream end is
         /// distinguished from an unexpected EOF (which must surface, not freeze).
         private var sawExited = false
+        /// Set when the SERVER permanently refused this pane (e.g. `pane_not_found`),
+        /// as opposed to the stream dropping. A dropped stream deserves the reconnect
+        /// loop; a refusal does not — the pane will never come back, so retrying just
+        /// spins "connection lost; reconnecting…" forever with nothing behind it. Any
+        /// path that could restart the stream (the backoff task, the heartbeat
+        /// watchdog) honours this exactly like `sawExited`.
+        private var paneGone = false
         /// Set in `stop()` so a LATE async `sizeChanged` callback (SwiftTerm
         /// dispatches them asynchronously) cannot start a NEW `lock:true` resize
         /// AFTER we've released geometry ownership — which would re-pin the pane and
@@ -644,6 +651,13 @@ struct LiveTerminalView: UIViewRepresentable {
         private func start() {
             streamTask?.cancel()
             sawExited = false
+            // Cleared with `sawExited`, and for the same reason: a refusal is permanent for
+            // the pane it was about, not for this coordinator. `start()` is only ever reached
+            // deliberately once `paneGone` is set — the reconnect task is gated on it — so
+            // arriving here means a manual refresh or a different pane, and both deserve a
+            // real attempt. Leaving it latched would turn one dead pane into a view that can
+            // never show any pane again.
+            paneGone = false
             lastStreamActivity = Date()
             streamRunID &+= 1
             let myRun = streamRunID
@@ -674,7 +688,7 @@ struct LiveTerminalView: UIViewRepresentable {
             watchdogTask = Task { @MainActor [weak self] in
                 while !Task.isCancelled {
                     try? await Task.sleep(nanoseconds: 5_000_000_000)   // poll every 5s
-                    guard let self, !self.stopped, !self.sawExited else { return }
+                    guard let self, !self.stopped, !self.sawExited, !self.paneGone else { return }
                     if Date().timeIntervalSince(self.lastStreamActivity) > Self.streamStuckTimeout {
                         self.scheduleReconnect("no response for \(Int(Self.streamStuckTimeout))s")
                         return   // scheduleReconnect → start() re-arms a fresh watchdog
@@ -713,7 +727,7 @@ struct LiveTerminalView: UIViewRepresentable {
         /// or a real process `exited`; at most one restart in flight.
         @MainActor
         private func scheduleReconnect(_ reason: String) {
-            guard !stopped, !sawExited, reconnectTask == nil else { return }
+            guard !stopped, !sawExited, !paneGone, reconnectTask == nil else { return }
             reconnectAttempts += 1
             let capped = min(20.0, 0.5 * pow(2.0, Double(max(0, reconnectAttempts - 1))))  // 0.5,1,2,4,8,16,20
             let delay = capped * Double.random(in: 0.6...1.0)                               // full-ish jitter
@@ -791,6 +805,17 @@ struct LiveTerminalView: UIViewRepresentable {
             }
         }
 
+        /// The user-facing notice for an error the server will keep giving, or nil when the
+        /// failure is transient and the reconnect loop should run.
+        ///
+        /// Delegates the decision to `HerdrKit.permanentStreamRefusal` so the rule is unit
+        /// tested away from the view. Kept as a thin seam here because `streamEnded` is
+        /// `@MainActor` and view-bound.
+        static func permanentRefusalNotice(_ error: Error?) -> String? {
+            guard let apiError = error as? APIError else { return nil }
+            return permanentStreamRefusal(code: apiError.code)
+        }
+
         @MainActor
         private func streamEnded(_ error: Error?, run: Int) {
             // Only the CURRENT stream's end may reconnect. A superseded task (cancelled by a
@@ -802,6 +827,17 @@ struct LiveTerminalView: UIViewRepresentable {
             // torn-down view must not reconnect either.
             if sawExited { return }
             guard !stopped, view != nil else { return }
+            // A PERMANENT server refusal is not a dropped connection. Reconnecting cannot
+            // change the answer, so retrying only spins "reconnecting…" forever over a pane
+            // that will never be served. Say so once and stop.
+            if let notice = Self.permanentRefusalNotice(error) {
+                paneGone = true
+                if let view {
+                    let line = "\r\n\u{1b}[2m\(notice)\u{1b}[0m\r\n"
+                    view.feed(byteArray: [UInt8](line.utf8)[...])
+                }
+                return
+            }
             // Otherwise the feed died while the process may still be live — auto-restart with backoff
             // rather than stranding a dead terminal behind a manual refresh.
             scheduleReconnect(error == nil ? "connection closed" : "connection lost")

--- a/Sources/HerdrKit/AgentList.swift
+++ b/Sources/HerdrKit/AgentList.swift
@@ -103,7 +103,7 @@ public struct AgentRow: Equatable, Sendable, Identifiable {
     public let status: AgentStatus
     public let group: AgentGroup
 
-    public var id: String { info.paneID }
+    public var id: String { info.id }
     public var title: String { info.displayName }
 
     /// Whether the pane still exists. A row for a pane herdr no longer lists is
@@ -230,6 +230,25 @@ public struct AgentList: Equatable, Sendable {
 /// + one letter ("5m" / "2h" / "3d"). `nil` when the daemon reported no
 /// `status_since` (older server, or not yet transitioned) or the timestamp is in the
 /// future (clock skew) — the card then shows no badge rather than a wrong one.
+/// The single instant "how long has it been in this state" is measured from, for BOTH
+/// the list card's badge and the terminal header's live timer.
+///
+/// There is one right answer — `status_since_unix_ms`, the moment the agent entered its
+/// current state — and two screens that must not disagree about it. They did: the header
+/// measured from `last_completed_turn.completed_unix_ms` instead. For an IDLE agent those
+/// are the same instant (it went idle exactly when its turn completed), which is why idle
+/// always matched and the mismatch stayed hidden. For a WORKING agent the completed-turn
+/// stamp is the moment the PREVIOUS turn ended, so the header over-counted by the whole
+/// idle gap before the current turn began.
+///
+/// The completed-turn value survives only as the fallback for a daemon too old to report
+/// `status_since` — an approximate timer beats none, and on those servers both screens
+/// still agree because both land here.
+public func statusAnchorUnixMs(statusSinceUnixMs: UInt64?, lastCompletedUnixMs: Int64?) -> Int64? {
+    if let since = statusSinceUnixMs { return Int64(since) }
+    return lastCompletedUnixMs
+}
+
 public func compactTimeInState(sinceUnixMs: UInt64?, nowUnixMs: UInt64) -> String? {
     guard let since = sinceUnixMs, nowUnixMs >= since else { return nil }
     let seconds = (nowUnixMs - since) / 1000

--- a/Sources/HerdrKit/Wire.swift
+++ b/Sources/HerdrKit/Wire.swift
@@ -25,6 +25,35 @@ struct ErrorEnvelope: Decodable {
     let error: APIError
 }
 
+/// Whether a failed pane stream was PERMANENTLY refused by the server — and if so, what
+/// to tell the user. Returns nil for anything transient, which the caller must keep
+/// retrying.
+///
+/// A dropped socket and a refusal both arrive at the client as "the stream ended with an
+/// error", but they need opposite handling. The reconnect loop is right for a drop and
+/// actively harmful for a refusal: the server's answer will not change, so the terminal
+/// sits on "connection lost; reconnecting…" forever with nothing behind it. That is the
+/// shape a real daemon bug took — it advertised a pane in `agent.list`/`pane.list` that
+/// `pane.stream` then refused, and the app spun instead of saying so.
+///
+/// Only codes that CANNOT become true by waiting belong here. `pane_not_found` is
+/// permanent for a given pane id: pane ids are not reused, so a pane that is gone stays
+/// gone, and a fresh id means a fresh stream. `invalid_request` means this server does
+/// not speak the method — retrying the same call against the same daemon cannot help.
+/// Everything else (transport failures, timeouts, a server restarting) stays transient
+/// by default, because misclassifying a transient error as permanent strands a terminal
+/// that would have recovered on its own.
+public func permanentStreamRefusal(code: String) -> String? {
+    switch code {
+    case "pane_not_found":
+        return "this pane no longer exists on the server; not reconnecting"
+    case "invalid_request":
+        return "this server does not support live terminals; not reconnecting"
+    default:
+        return nil
+    }
+}
+
 struct ResultEnvelope<R: Decodable>: Decodable {
     let id: String?
     let result: R
@@ -129,7 +158,23 @@ public struct AgentInfo: Decodable, Equatable, Sendable, Identifiable {
     /// so an older/non-archiving server is unaffected.
     public let archived: AgentArchivedInfo?
 
-    public var id: String { paneID }
+    /// Stable list identity. A LIVE agent is keyed on its pane id, which is unique
+    /// and stable while it runs. An ARCHIVED agent has NO pane — the server empties
+    /// `pane_id` because the pane is genuinely released (herdr src/app/agents.rs
+    /// `archived_agent_info`) — so keying on it collapsed EVERY archived row onto the
+    /// same `""` identity, and SwiftUI rendered them all as whichever one sorted
+    /// first. That is the duplicate-name bug: the archived section sorts
+    /// most-recently-archived first, so every row wore the last-archived name, and
+    /// walked to the next name as each was unarchived.
+    ///
+    /// `terminal_id` is the durable handle: always non-empty, unique, and preserved
+    /// across archive/unarchive (the server rehydrates the same terminal id on
+    /// resume). It is also what `agent.unarchive` accepts as a target. `name` is the
+    /// last resort — it can be nil for an unnamed agent, so it cannot lead.
+    public var id: String {
+        if !paneID.isEmpty { return paneID }
+        return terminalID ?? name ?? paneID
+    }
 
     /// This agent has been archived (its pane released, session preserved).
     public var isArchived: Bool { archived != nil }

--- a/Tests/HerdrKitTests/AgentListTests.swift
+++ b/Tests/HerdrKitTests/AgentListTests.swift
@@ -10,17 +10,32 @@ final class AgentListTests: XCTestCase {
     /// the JSON key was wrong.
     private func agent(
         pane: String, status: String?, name: String? = nil, completedUnixMs: Int64? = nil,
-        archivedBy: String? = nil, archivedAt: String? = nil
+        archivedBy: String? = nil, archivedAt: String? = nil, terminalID: String? = nil
     ) throws -> AgentInfo {
         var obj: [String: Any] = ["pane_id": pane]
         if let status { obj["agent_status"] = status }
         if let name { obj["name"] = name }
+        if let terminalID { obj["terminal_id"] = terminalID }
         if let completedUnixMs { obj["last_completed_turn"] = ["completed_unix_ms": completedUnixMs] }
         if let archivedBy {
             obj["archived"] = ["at": archivedAt ?? "2026-08-26T18:00:00Z", "by": archivedBy]
         }
         let data = try JSONSerialization.data(withJSONObject: obj)
         return try JSONDecoder().decode(AgentInfo.self, from: data)
+    }
+
+    /// An ARCHIVED agent exactly as the server emits one: `pane_id` EMPTY, because the
+    /// pane is genuinely released, with `terminal_id` carrying the durable identity.
+    ///
+    /// This shape is the whole point. The original archived fixtures gave each archived
+    /// agent its own non-empty pane id — a state the server never produces — so every
+    /// row had a distinct id and the identity collision these tests now guard was
+    /// unreachable. The fixture, not the assertion, was the bug.
+    private func archivedAgent(
+        terminalID: String, name: String?, at: String, by: String = "jerry"
+    ) throws -> AgentInfo {
+        try agent(pane: "", status: "idle", name: name,
+                  archivedBy: by, archivedAt: at, terminalID: terminalID)
     }
 
     // MARK: - archived agents (issue #173)
@@ -43,15 +58,58 @@ final class AgentListTests: XCTestCase {
     func testArchivedAgentsPartitionOutOfLiveSections() throws {
         let list = AgentList(agents: [
             try agent(pane: "p1", status: "blocked"),                                  // live, needsYou
-            try agent(pane: "p2", status: "idle", name: "old", archivedBy: "a", archivedAt: "2026-08-26T10:00:00Z"),
-            try agent(pane: "p3", status: "idle", name: "new", archivedBy: "b", archivedAt: "2026-08-26T20:00:00Z"),
+            try archivedAgent(terminalID: "term-old", name: "old", at: "2026-08-26T10:00:00Z"),
+            try archivedAgent(terminalID: "term-new", name: "new", at: "2026-08-26T20:00:00Z"),
         ])
         // Live sections/rows exclude the two archived agents.
         XCTAssertEqual(list.rows.map(\.info.paneID), ["p1"])
         XCTAssertFalse(list.rows.contains { $0.info.isArchived })
         XCTAssertEqual(list.needsYouCount, 1)
         // Archived collected separately, most-recently-archived first.
-        XCTAssertEqual(list.archived.map(\.info.paneID), ["p3", "p2"])
+        XCTAssertEqual(list.archived.map(\.title), ["new", "old"])
+    }
+
+    /// EVERY archived row must carry a DISTINCT, non-empty list identity.
+    ///
+    /// The server empties `pane_id` on archive (the pane is released), so keying rows on
+    /// it collapsed every archived row onto `""`. SwiftUI then rendered them all as
+    /// whichever sorted first — and because the section sorts most-recently-archived
+    /// first, every row wore the LAST-archived name, then walked to the next name as
+    /// each was unarchived. Three archived agents with three names is the minimum that
+    /// can tell "distinct" from "all the same".
+    func testArchivedRowsKeepDistinctIdentitiesDespiteEmptyPaneIDs() throws {
+        let list = AgentList(agents: [
+            try archivedAgent(terminalID: "term-a", name: "among-friends", at: "2026-08-27T08:40:38Z"),
+            try archivedAgent(terminalID: "term-b", name: "trend-scout",   at: "2026-08-27T08:40:34Z"),
+            try archivedAgent(terminalID: "term-c", name: "aste-screener", at: "2026-08-27T08:40:30Z"),
+        ])
+        XCTAssertEqual(list.archived.count, 3)
+        // The premise: the server really did give us no pane ids.
+        XCTAssertTrue(list.archived.allSatisfy { $0.info.paneID.isEmpty },
+                      "fixture must model the server: an archived agent has NO pane id")
+        // The guard: ids are unique and none is empty.
+        let ids = list.archived.map(\.id)
+        XCTAssertFalse(ids.contains(""), "an archived row must not fall back to an empty id")
+        XCTAssertEqual(Set(ids).count, 3, "archived rows collapsed onto \(Set(ids).count) identities: \(ids)")
+        // The symptom: each row renders its OWN name, not the first row's.
+        XCTAssertEqual(list.archived.map(\.title), ["among-friends", "trend-scout", "aste-screener"])
+    }
+
+    /// A LIVE row's identity is unchanged — still its pane id. The archived fix must not
+    /// re-key live rows, or every live row's SwiftUI identity churns on upgrade.
+    func testLiveRowIdentityIsStillThePaneID() throws {
+        let live = try agent(pane: "w1:p7", status: "working", name: "vetrina", terminalID: "term-live")
+        XCTAssertEqual(AgentRow(info: live).id, "w1:p7")
+    }
+
+    /// An archived agent with NO name still gets a distinct identity from its terminal
+    /// id — name cannot lead the fallback, because it is optional.
+    func testUnnamedArchivedRowsStillGetDistinctIdentities() throws {
+        let list = AgentList(agents: [
+            try archivedAgent(terminalID: "term-a", name: nil, at: "2026-08-27T08:00:00Z"),
+            try archivedAgent(terminalID: "term-b", name: nil, at: "2026-08-27T07:00:00Z"),
+        ])
+        XCTAssertEqual(Set(list.archived.map(\.id)).count, 2)
     }
 
     // MARK: - time-in-state badge (issue #173)
@@ -389,5 +447,83 @@ final class AgentListTests: XCTestCase {
         XCTAssertTrue(list.isQuiet)
         XCTAssertEqual(list.needsYouCount, 0)
         XCTAssertTrue(list.sections.isEmpty)
+    }
+
+    // MARK: - one timing anchor for the list badge and the terminal header
+
+    /// A WORKING agent's timer must measure from when it STARTED WORKING, not from when
+    /// its previous turn finished. Those differ by the idle gap between turns, which is
+    /// exactly the amount the terminal header used to over-count while the list card was
+    /// right.
+    ///
+    /// The two stamps are deliberately far apart (a 10-minute idle gap): if the anchor
+    /// ever reverts to the completed-turn stamp, this reads 10 minutes too old and fails
+    /// loudly rather than drifting by a plausible-looking second.
+    func testWorkingAgentMeasuresFromStatusSinceNotTheLastCompletedTurn() {
+        let lastTurnEnded: Int64 = 1_000_000_000_000          // previous turn finished
+        let startedWorking: UInt64 = 1_000_000_600_000        // 10 minutes later
+        let anchor = statusAnchorUnixMs(statusSinceUnixMs: startedWorking,
+                                        lastCompletedUnixMs: lastTurnEnded)
+        XCTAssertEqual(anchor, Int64(startedWorking))
+        XCTAssertNotEqual(anchor, lastTurnEnded,
+                          "the header measured from the PREVIOUS turn's end — the 10m idle gap is counted as work")
+    }
+
+    /// The list badge and the terminal header must derive from the SAME instant. This is
+    /// the property the bug violated; asserting each screen separately would not catch
+    /// two screens that are individually defensible and mutually inconsistent.
+    func testListBadgeAndTerminalHeaderShareOneAnchor() {
+        let info = (statusSince: UInt64(1_000_000_600_000), lastCompleted: Int64(1_000_000_000_000))
+        let headerAnchor = statusAnchorUnixMs(statusSinceUnixMs: info.statusSince,
+                                              lastCompletedUnixMs: info.lastCompleted)
+        // The badge reads status_since directly; the header must land on the same value.
+        XCTAssertEqual(headerAnchor.map(UInt64.init), info.statusSince)
+        // And therefore both render the same elapsed label at the same "now".
+        let now: UInt64 = 1_000_000_900_000        // 5 minutes after work started
+        XCTAssertEqual(compactTimeInState(sinceUnixMs: info.statusSince, nowUnixMs: now), "5m")
+        XCTAssertEqual(compactTimeInState(sinceUnixMs: headerAnchor.map(UInt64.init), nowUnixMs: now), "5m")
+    }
+
+    /// An IDLE agent is the case that always matched — both stamps are the same instant.
+    /// Keeping it asserted proves the fix did not achieve agreement by breaking the case
+    /// that already worked.
+    func testIdleAgentAnchorIsUnchanged() {
+        let wentIdle: Int64 = 1_000_000_000_000
+        XCTAssertEqual(statusAnchorUnixMs(statusSinceUnixMs: UInt64(wentIdle),
+                                          lastCompletedUnixMs: wentIdle),
+                       wentIdle)
+    }
+
+    /// An older daemon reports no `status_since`; the completed-turn stamp remains the
+    /// fallback so the timer degrades instead of vanishing.
+    func testFallsBackToLastCompletedTurnOnAnOlderDaemon() {
+        XCTAssertEqual(statusAnchorUnixMs(statusSinceUnixMs: nil, lastCompletedUnixMs: 42), 42)
+        XCTAssertNil(statusAnchorUnixMs(statusSinceUnixMs: nil, lastCompletedUnixMs: nil))
+    }
+
+    // MARK: - permanent stream refusal (never spin on an answer that cannot change)
+
+    /// A refusal the server will repeat must END the stream, and a transient failure must
+    /// NOT — otherwise the terminal either spins forever on a dead pane or gives up on one
+    /// that would have recovered. Both directions are asserted: a rule that only ever said
+    /// "permanent" would pass a one-sided test while stranding every recoverable terminal.
+    func testPermanentRefusalsStopTheRetryLoopAndTransientOnesDoNot() {
+        // Permanent: the pane is gone, and pane ids are not reused.
+        XCTAssertNotNil(permanentStreamRefusal(code: "pane_not_found"))
+        // Permanent: this daemon does not speak the method.
+        XCTAssertNotNil(permanentStreamRefusal(code: "invalid_request"))
+        // Transient — every one of these can succeed on a retry, so none may be
+        // classified permanent.
+        for code in ["internal_error", "busy", "timeout", "unavailable", "agent_working", ""] {
+            XCTAssertNil(permanentStreamRefusal(code: code),
+                         "'\(code)' was treated as permanent; a recoverable stream would be stranded")
+        }
+    }
+
+    /// The notice is what the user reads instead of an endless "reconnecting…", so it must
+    /// actually say the retrying stopped.
+    func testPermanentRefusalNoticeSaysItIsNotReconnecting() {
+        let notice = permanentStreamRefusal(code: "pane_not_found")
+        XCTAssertEqual(notice?.contains("not reconnecting"), true)
     }
 }


### PR DESCRIPTION
Three defects the owner hit after archiving agents from the app.

## 1. Every archived row showed the same name
**Symptom:** archived agents all displayed the most-recently-archived name; unarchiving one re-labelled the whole list to the next name (`among-friends` → all `trend-scout` → all `aste-screener`).

**Cause:** `AgentRow.id`/`AgentInfo.id` keyed on `pane_id`. The server **empties `pane_id` on archive** (verified live — the pane is genuinely released; herdr `archived_agent_info` sets `pane_id: String::new()`). So every archived row collided on `id: ""` and SwiftUI rendered them as one identity. The section sorts most-recently-archived first, which is exactly why the winning name was the last one archived.

**Fix:** identity falls back to `terminal_id` — always non-empty, unique, and preserved across archive/unarchive (it is also what `agent.unarchive` accepts as a target) — then `name`. **Live rows keep their pane id unchanged**, so no live identity churns.

**Why no test caught it:** the archived fixtures gave each agent its own non-empty pane id (`p2`, `p3`) — a state the server never produces. The fixture contradicted the daemon, making the collision unreachable. Fixtures now model the real shape (`pane_id: ""`).

## 2. Working-agent timer disagreed between list and terminal header
**Symptom:** the time on the agent card and in the terminal header didn't match for working agents. Idle matched.

**Cause:** the header measured from `last_completed_turn.completed_unix_ms` (when the **previous** turn ended) while the list badge used `status_since_unix_ms`. For idle those are the same instant — which is why idle matched and this stayed hidden. For working, the header over-counted by the entire idle gap before the current turn began. The list was right; the header was never repointed when the real field was added.

**Fix:** both screens derive from one `statusAnchorUnixMs` helper. The completed-turn stamp survives only as the fallback for a daemon too old to report `status_since`.

## 3. A permanently refused stream retried forever
**Symptom:** opening certain agents showed "connection lost, reconnecting…" endlessly.

**Cause:** `streamEnded` reconnects with backoff on **any** error, so a permanent semantic refusal (`pane_not_found`) is indistinguishable from a dropped socket. The app spun over a pane the server would never serve.

**Fix:** permanent refusals paint a clear notice and stop; everything else keeps today's backoff. The flag clears on a deliberate `start()`, so a refusal is permanent for the *pane*, not for the view.

This surfaced a **real daemon bug** (filed separately): after `agent.unarchive`, the daemon advertises a pane in `agent.list`/`pane.list` that `pane.read`/`pane.stream` then refuse — it inserts the terminal state but never spawns a PTY runtime, because the spawn is deferred to a geometry-gated render loop a headless daemon never satisfies. This PR stops the app from spinning on it; the daemon fix follows.

## Tests
- Archived rows keep **distinct, non-empty** ids given empty pane ids (three agents — the minimum that distinguishes "distinct" from "all the same"); unnamed archived agents too; a live row's id is still its pane id.
- Working anchor uses `status_since`, with the two stamps 10 minutes apart so a revert fails loudly rather than drifting; both screens render the same label; idle unchanged; older-daemon fallback.
- Permanent refusals stop the loop **and** transient ones don't (both directions — a one-sided test would pass while stranding every recoverable terminal).