### PR TITLE
fix(accounts): sign in on a shell pane, and show real usage reset times

### DIFF
--- a/App/AccountLoginSheet.swift
+++ b/App/AccountLoginSheet.swift
@@ -122,7 +122,7 @@ struct AccountLoginSheet: View {
             let pane = try await client.splitPane(cwd: nil)
             paneID = pane
             try await client.sendText(pane: pane, text: cmd)
-            try await client.sendKeys(pane: pane, keys: ["Enter"])
+            try await client.sendPaneKeys(pane: pane, keys: ["Enter"])
             status = "Getting your sign-in link…"
             scrapeTask = Task { await scrapeLoop(pane: pane) }
         } catch {
@@ -162,7 +162,7 @@ struct AccountLoginSheet: View {
         guard !value.isEmpty else { return }
         do {
             try await client.sendText(pane: pane, text: value)
-            try await client.sendKeys(pane: pane, keys: ["Enter"])
+            try await client.sendPaneKeys(pane: pane, keys: ["Enter"])
             code = ""
             status = "Submitting… hang on."
         } catch {

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -3921,7 +3921,7 @@ struct SettingsView: View {
         do {
             let pane = try await client.splitPane(cwd: nil)
             try await client.sendText(pane: pane, text: cmd)
-            try await client.sendKeys(pane: pane, keys: ["Enter"])
+            try await client.sendPaneKeys(pane: pane, keys: ["Enter"])
             try? await Task.sleep(nanoseconds: 2_500_000_000)
             accounts = (try? await client.accountsList()) ?? accounts
             try? await client.closePane(paneID: pane)
@@ -4626,29 +4626,24 @@ struct SettingsView: View {
         }
     }
 
-    /// "NN% · <label>" plus a compact reset token when present, e.g. "42% · 5h · 18:00".
+    /// "NN% · <label>" plus a compact reset token when present, e.g. "42% · 5h · 2h left"
+    /// or "68% · weekly · Aug 31".
     private func usageMeterLabel(_ window: UsageWindow, percent: Double) -> String {
         var text = "\(Int(percent.rounded()))% · \(window.label)"
         if let hint = resetHint(window.resetsAt) { text += " · \(hint)" }
         return text
     }
 
-    /// A compact reset hint from an ISO-8601 instant (`UsageWindow.resetsAt`): the time
-    /// when it falls today, else the weekday. Nil when absent or unparseable — the meter
-    /// then simply shows no reset token.
-    private func resetHint(_ iso: String?) -> String? {
-        guard let iso, let date = Self.isoResetParser.date(from: iso) else { return nil }
-        let formatter = DateFormatter()
-        formatter.dateFormat = Calendar.current.isDateInToday(date) ? "HH:mm" : "EEE"
-        return formatter.string(from: date)
+    /// The reset token for a usage window: "2h left" when the reset is near, "Aug 31"
+    /// when it is further out. Nil when absent or unparseable, so the meter shows no
+    /// token rather than a wrong one.
+    ///
+    /// Both the parsing and the wording live in `HerdrKit.usageResetLabel` so they can be
+    /// tested without a view. This previously parsed ISO-8601 inline and produced nothing
+    /// at all against a live server, which sends epoch seconds.
+    private func resetHint(_ raw: String?) -> String? {
+        usageResetLabel(resetsAt: raw)
     }
-
-    /// Shared parser for `resetsAt` (e.g. "2026-08-20T18:00:00Z").
-    private static let isoResetParser: ISO8601DateFormatter = {
-        let f = ISO8601DateFormatter()
-        f.formatOptions = [.withInternetDateTime]
-        return f
-    }()
 
     /// Usage colour by headroom: comfortable green, amber as it tightens, red at the
     /// cap. The same meaning-carrying palette as the agent status badges.
@@ -5471,7 +5466,7 @@ struct MockTransport: HerdrTransport {
     /// tests, where it is machine-checked to decode. If you change one, change both.
     static let accountsList = #"""
     {"id":"mock","result":{"type":"accounts_list","accounts":[
-      {"id":"acc-claude-1","kind":"claude","label":"Claude Max (work)","active":true,"email":"work@example.com","usage":{"source":"live","windows":[{"label":"5h","used_percent":42,"resets_at":"2026-08-20T18:00:00Z","status":"ok"},{"label":"weekly","used_percent":68,"status":"ok"}],"primary_used_percent":42,"secondary_used_percent":68,"resets_at":"2026-08-20T18:00:00Z","plan":"Max"}},
+      {"id":"acc-claude-1","kind":"claude","label":"Claude Max (work)","active":true,"email":"work@example.com","usage":{"source":"live","windows":[{"label":"5h","used_percent":42,"resets_at":"2000000000","status":"ok"},{"label":"weekly","used_percent":68,"resets_at":"2030-01-15T18:00:00Z","status":"ok"}],"primary_used_percent":42,"secondary_used_percent":68,"resets_at":"2026-08-20T18:00:00Z","plan":"Max"}},
       {"id":"acc-claude-2","kind":"claude","label":"Claude Pro (personal)","active":false,"email":"personal@example.com","usage":{"primary_used_percent":100,"secondary_used_percent":100,"plan":"Pro"}},
       {"id":"acc-codex-1","kind":"codex","label":"Codex (team)","active":true,"email":"team@example.com","usage":{"tier":"Plus"}},
       {"id":"acc-kimi-1","kind":"kimi","label":"Kimi","active":true}

--- a/Sources/HerdrKit/AgentList.swift
+++ b/Sources/HerdrKit/AgentList.swift
@@ -230,6 +230,52 @@ public struct AgentList: Equatable, Sendable {
 /// + one letter ("5m" / "2h" / "3d"). `nil` when the daemon reported no
 /// `status_since` (older server, or not yet transitioned) or the timestamp is in the
 /// future (clock skew) — the card then shows no badge rather than a wrong one.
+/// Parses `UsageWindow.resetsAt` into an instant. Handles BOTH shapes the server sends.
+///
+/// The field is documented server-side as an "opaque string; may be an epoch or
+/// timestamp", and the daemon really does send epoch seconds as a string
+/// (`"1787831400"`). The app parsed ISO-8601 only, so every real account's reset failed
+/// to parse and the usage meter silently dropped the reset token — the feature looked
+/// unimplemented rather than broken. The mock fixture used ISO, so previews and tests
+/// agreed with each other and not with the server.
+///
+/// All-digits is read as epoch seconds; anything else is tried as ISO-8601. Returns nil
+/// when absent or unparseable, so the caller shows NO token rather than a wrong one.
+public func parseResetInstant(_ raw: String?) -> Date? {
+    guard let raw else { return nil }
+    let trimmed = raw.trimmingCharacters(in: .whitespaces)
+    if trimmed.isEmpty { return nil }
+    if trimmed.allSatisfy(\.isNumber), let epoch = TimeInterval(trimmed) {
+        return Date(timeIntervalSince1970: epoch)
+    }
+    return isoResetParser.date(from: trimmed)
+}
+
+private let isoResetParser: ISO8601DateFormatter = {
+    let f = ISO8601DateFormatter()
+    f.formatOptions = [.withInternetDateTime]
+    return f
+}()
+
+/// The reset token shown beside a usage bar: how much is left when the reset is near,
+/// the calendar date when it is not.
+///
+/// Chosen by the HORIZON, not by the window's name: the daemon labels windows `5h`,
+/// `weekly`, `7d` and could add more, so keying off the text would leave new labels
+/// unformatted. Under an hour reports minutes, because a window resetting in 45 minutes
+/// must not read "0h left".
+public func usageResetLabel(resetsAt: String?, now: Date = Date()) -> String? {
+    guard let reset = parseResetInstant(resetsAt) else { return nil }
+    let seconds = reset.timeIntervalSince(now)
+    // Already past (or clock skew): the window has reset, so promise nothing.
+    guard seconds > 0 else { return nil }
+    if seconds < 3600 { return "\(Int(seconds / 60))m left" }
+    if seconds < 86_400 { return "\(Int(seconds / 3600))h left" }
+    let formatter = DateFormatter()
+    formatter.dateFormat = "MMM d"
+    return formatter.string(from: reset)
+}
+
 /// The single instant "how long has it been in this state" is measured from, for BOTH
 /// the list card's badge and the terminal header's live timer.
 ///

--- a/Sources/HerdrKit/HerdrClient.swift
+++ b/Sources/HerdrKit/HerdrClient.swift
@@ -554,9 +554,36 @@ public actor HerdrClient {
         let keys: [String]
     }
 
-    /// Sends named keys (e.g. "Enter", "Escape", "Up") for dialog navigation.
+    /// Sends named keys (e.g. "Enter", "Escape", "Up") to an AGENT pane, for dialog
+    /// navigation and turn control.
+    ///
+    /// Goes through `agent.send_keys`, which does agent-specific work `pane.send_keys`
+    /// does not: it refuses a pane whose running process is not the expected agent, and
+    /// records a turn abort for keys that interrupt one. Use it only where the pane
+    /// really hosts an agent — the server rejects anything else with `agent_not_found`.
+    /// For a plain shell pane use `sendPaneKeys`.
     public func sendKeys(pane: String, keys: [String]) async throws {
         _ = try await call("agent.send_keys", SendKeysParams(target: pane, keys: keys), as: JSONNull.self)
+    }
+
+    struct PaneSendKeysParams: Encodable {
+        let paneID: String
+        let keys: [String]
+        enum CodingKeys: String, CodingKey {
+            case keys
+            case paneID = "pane_id"
+        }
+    }
+
+    /// Sends named keys to ANY pane, agent or not.
+    ///
+    /// The counterpart to `sendKeys` for panes that host a plain shell — the sign-in and
+    /// sign-out flows split a fresh shell and need to press Enter in it. Those flows used
+    /// `sendKeys`, and every one of them failed: `agent.send_keys` resolves a pane id only
+    /// when that pane is an agent terminal, so a bare shell came back as
+    /// `agent target <pane> not found`.
+    public func sendPaneKeys(pane: String, keys: [String]) async throws {
+        _ = try await call("pane.send_keys", PaneSendKeysParams(paneID: pane, keys: keys), as: JSONNull.self)
     }
 
     // MARK: - Spawning agents

--- a/Tests/HerdrKitTests/AgentListTests.swift
+++ b/Tests/HerdrKitTests/AgentListTests.swift
@@ -501,6 +501,56 @@ final class AgentListTests: XCTestCase {
         XCTAssertNil(statusAnchorUnixMs(statusSinceUnixMs: nil, lastCompletedUnixMs: nil))
     }
 
+    // MARK: - usage reset token (epoch AND iso; near vs far)
+
+    /// The server sends epoch seconds AS A STRING. The app parsed ISO-8601 only, so every
+    /// real account's reset failed to parse and the meter silently showed no token — the
+    /// feature looked unbuilt rather than broken. These are the exact values a live daemon
+    /// returned, so the test fails if the epoch path is ever dropped again.
+    func testResetInstantParsesEpochSecondsAsWellAsISO() {
+        // Real values read off the running daemon.
+        XCTAssertEqual(parseResetInstant("1787831400"),
+                       Date(timeIntervalSince1970: 1_787_831_400))
+        XCTAssertEqual(parseResetInstant("1788217200"),
+                       Date(timeIntervalSince1970: 1_788_217_200))
+        // The documented alternative shape still works.
+        XCTAssertNotNil(parseResetInstant("2026-08-20T18:00:00Z"))
+        // Absent or junk yields nil, so the meter shows nothing rather than a wrong time.
+        XCTAssertNil(parseResetInstant(nil))
+        XCTAssertNil(parseResetInstant(""))
+        XCTAssertNil(parseResetInstant("   "))
+        XCTAssertNil(parseResetInstant("not-a-date"))
+    }
+
+    /// A near reset reads as remaining time, a far one as a date. Driven by the HORIZON,
+    /// not the window's label, so a daemon that invents a new label still formats.
+    func testUsageResetLabelUsesTimeLeftWhenNearAndADateWhenFar() {
+        let now = Date(timeIntervalSince1970: 1_787_824_200)   // 2h before the 5h reset
+        // 5h window, 2h out.
+        XCTAssertEqual(usageResetLabel(resetsAt: "1787831400", now: now), "2h left")
+        // Weekly window, days out — a date, not "109h left".
+        let weekly = usageResetLabel(resetsAt: "1788217200", now: now)
+        XCTAssertNotNil(weekly)
+        XCTAssertFalse(weekly?.contains("left") ?? true,
+                       "a reset days away must read as a date, not remaining hours: \(weekly ?? "nil")")
+    }
+
+    /// Under an hour must report MINUTES. Reporting hours would render "0h left" for a
+    /// window resetting in 45 minutes — the one moment the number matters most.
+    func testUsageResetLabelReportsMinutesUnderAnHour() {
+        let reset: TimeInterval = 1_787_831_400
+        let now = Date(timeIntervalSince1970: reset - 45 * 60)
+        XCTAssertEqual(usageResetLabel(resetsAt: String(Int(reset)), now: now), "45m left")
+    }
+
+    /// A window whose reset has already passed promises nothing, rather than counting
+    /// down into negative time or claiming "0m left" forever.
+    func testUsageResetLabelIsNilOncePassed() {
+        let reset: TimeInterval = 1_787_831_400
+        XCTAssertNil(usageResetLabel(resetsAt: String(Int(reset)),
+                                     now: Date(timeIntervalSince1970: reset + 60)))
+    }
+
     // MARK: - permanent stream refusal (never spin on an answer that cannot change)
 
     /// A refusal the server will repeat must END the stream, and a transient failure must

--- a/Tests/HerdrKitTests/MockWireFixtureTests.swift
+++ b/Tests/HerdrKitTests/MockWireFixtureTests.swift
@@ -438,7 +438,7 @@ enum MockWireFixtures {
     /// in sync with the App's MockTransport.accountsList.
     static let accountsList = #"""
     {"id":"mock","result":{"type":"accounts_list","accounts":[
-      {"id":"acc-claude-1","kind":"claude","label":"Claude Max (work)","active":true,"email":"work@example.com","usage":{"source":"live","windows":[{"label":"5h","used_percent":42,"resets_at":"2026-08-20T18:00:00Z","status":"ok"},{"label":"weekly","used_percent":68,"status":"ok"}],"primary_used_percent":42,"secondary_used_percent":68,"resets_at":"2026-08-20T18:00:00Z","plan":"Max"}},
+      {"id":"acc-claude-1","kind":"claude","label":"Claude Max (work)","active":true,"email":"work@example.com","usage":{"source":"live","windows":[{"label":"5h","used_percent":42,"resets_at":"2000000000","status":"ok"},{"label":"weekly","used_percent":68,"resets_at":"2030-01-15T18:00:00Z","status":"ok"}],"primary_used_percent":42,"secondary_used_percent":68,"resets_at":"2026-08-20T18:00:00Z","plan":"Max"}},
       {"id":"acc-claude-2","kind":"claude","label":"Claude Pro (personal)","active":false,"email":"personal@example.com","usage":{"primary_used_percent":100,"secondary_used_percent":100,"plan":"Pro"}},
       {"id":"acc-codex-1","kind":"codex","label":"Codex (team)","active":true,"email":"team@example.com","usage":{"tier":"Plus"}},
       {"id":"acc-kimi-1","kind":"kimi","label":"Kimi","active":true}

--- a/Tests/HerdrKitTests/SendKeysTargetingTests.swift
+++ b/Tests/HerdrKitTests/SendKeysTargetingTests.swift
@@ -1,0 +1,61 @@
+import XCTest
+@testable import HerdrKit
+
+/// The client has TWO key senders on purpose, and which one a caller picks decides
+/// whether the call works at all.
+///
+/// `agent.send_keys` resolves a pane id only when that pane is an AGENT terminal. The
+/// sign-in and sign-out flows split a fresh shell and press Enter in it, so routing them
+/// through the agent method failed every time with
+/// `agent target <pane> not found` — sign-in visibly, sign-out quietly into a banner.
+///
+/// The two are not interchangeable in the other direction either: `agent.send_keys` also
+/// refuses a pane whose running process is not the expected agent, and records a turn
+/// abort for interrupting keys. So this pins BOTH methods and BOTH param shapes — a
+/// future "these look duplicated, merge them" fails here instead of in the field.
+final class SendKeysTargetingTests: XCTestCase {
+
+    private final class CapturingTransport: HerdrTransport, @unchecked Sendable {
+        var lastRequest = ""
+        func roundTrip(_ requestLine: String) async throws -> String {
+            lastRequest = requestLine
+            return #"{"id":"x","result":{}}"#
+        }
+        func stream(_ requestLine: String) -> AsyncThrowingStream<String, Error> {
+            AsyncThrowingStream { $0.finish() }
+        }
+    }
+
+    /// A plain shell pane must go to the PANE method, keyed by `pane_id`.
+    func testSendPaneKeysUsesThePaneMethod() async throws {
+        let t = CapturingTransport()
+        try await HerdrClient(transport: t).sendPaneKeys(pane: "wV:pM", keys: ["Enter"])
+
+        XCTAssertTrue(t.lastRequest.contains(#""method":"pane.send_keys""#),
+                      "a shell pane must not be sent to the agent method: \(t.lastRequest)")
+        XCTAssertTrue(t.lastRequest.contains(#""pane_id":"wV:pM""#),
+                      "pane.send_keys is keyed by pane_id, not target: \(t.lastRequest)")
+        XCTAssertTrue(t.lastRequest.contains("Enter"))
+    }
+
+    /// An agent pane must still go to the AGENT method, keyed by `target`, so the
+    /// agent-hosting check and turn-abort bookkeeping are not lost.
+    func testSendKeysStillUsesTheAgentMethod() async throws {
+        let t = CapturingTransport()
+        try await HerdrClient(transport: t).sendKeys(pane: "w1:p3", keys: ["Escape"])
+
+        XCTAssertTrue(t.lastRequest.contains(#""method":"agent.send_keys""#),
+                      "the agent path must keep its agent-specific handling: \(t.lastRequest)")
+        XCTAssertTrue(t.lastRequest.contains(#""target":"w1:p3""#),
+                      "agent.send_keys is keyed by target, not pane_id: \(t.lastRequest)")
+    }
+
+    /// The two must not converge on one wire method — that is precisely the bug.
+    func testTheTwoSendersDoNotShareAWireMethod() async throws {
+        let a = CapturingTransport(), b = CapturingTransport()
+        try await HerdrClient(transport: a).sendPaneKeys(pane: "p", keys: ["Enter"])
+        try await HerdrClient(transport: b).sendKeys(pane: "p", keys: ["Enter"])
+        XCTAssertNotEqual(a.lastRequest, b.lastRequest,
+                          "pane and agent key sends collapsed onto one request shape")
+    }
+}


### PR DESCRIPTION
Owner reported sign-in failing with `couldn't start sign in - agent not found: agent target wV:pM not found`, and asked for the usage meter to say when each limit resets. Investigating the second turned up a third defect: the reset time is **not displayed at all today**.

## 1. Sign-in (and sign-out) fail on a shell pane

`HerdrClient.sendKeys` calls **`agent.send_keys`** with a pane id. The daemon's `resolve_agent_target` accepts a pane id only when that pane is an *agent terminal* — and the sign-in flow splits a **fresh shell** and presses Enter in it. Hence the exact reported error. `sendText` was unaffected; it already used `pane.send_text`.

**Sign-out was broken identically** and failed quietly into the `bulkResult` banner (`performLogout` uses the same split-shell → Enter sequence), so it may have looked like it worked.

**Fix:** new `sendPaneKeys` → `pane.send_keys`, used by the two sign-in sends and the sign-out send.

**The agent path deliberately keeps `agent.send_keys`.** That method is not a synonym: it additionally requires `effective_known_agent()`, verifies via `runtime_hosts_agent` that the pane really hosts the expected agent, and calls `terminal.mark_turn_aborted()` for abort keys. Rerouting it would silently drop turn-abort tracking, so the tests pin both methods and both param shapes against a future "these look duplicated" merge.

## 2. The usage reset time never rendered

`resetHint` parsed `resetsAt` with `ISO8601DateFormatter`. The live daemon sends **epoch seconds as a string**:

| account | window | `resets_at` |
|---|---|---|
| claude-primary | `5h` | `"1787831400"` |
| claude-primary | `weekly` | `"1788217200"` |
| codex-default | `weekly` | `"1788272166"` |

Every parse returned nil, so the meter dropped the token on **every real account** — the feature looked unimplemented rather than broken. The daemon's schema documents the field as *"opaque string; may be an epoch or timestamp"*; only the timestamp half was implemented.

**Why it shipped:** the mock fixture used `"2026-08-20T18:00:00Z"`, and the only test asserted that ISO string round-trips. The fixture contradicted the server, so previews and tests agreed with each other and not with production — the same failure mode as the archived-rows fixture in #180. The fixture now carries one epoch and one ISO.

## 3. Reset wording (owner-chosen)

`2h left` when the reset is under a day away, `Aug 31` beyond it — giving `42% · 5h · 2h left` and `68% · weekly · Aug 31`.

Chosen by the **horizon, not the window's label**, so a daemon that sends `7d` or a new bucket still formats. Under an hour reports minutes, because a window resetting in 45 minutes must not read `0h left`. A reset already past yields no token rather than counting into negative time.

## Tests
- Both key senders: correct wire method **and** param key each, plus an explicit assertion that they do not converge on one request shape.
- Reset parsing: the real epoch values above, ISO still works, and nil/empty/junk yield nil (no token) rather than a wrong time.
- Reset wording: 2h out reads `2h left`; days out reads as a date, asserted *not* to contain "left"; 45 minutes reads `45m left` not `0h left`; already-passed yields nil.

No daemon change needed — it already reports every field required.