### PR TITLE
feat(accounts): attribute app archives, and finish the sign-in flow

### DIFF
--- a/App/AccountLoginSheet.swift
+++ b/App/AccountLoginSheet.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit    // UIPasteboard (tap the sign-in link to copy it)
 import HerdrKit
 
 /// In-app claude account sign-in (issue #173 follow-up), clean stepped flow — NO raw
@@ -22,6 +23,19 @@ struct AccountLoginSheet: View {
     @State private var status: String = "Starting sign-in…"
     @State private var signedIn = false
     @State private var scrapeTask: Task<Void, Never>?
+    /// A code has been submitted and we are waiting on the harness. While true the input is
+    /// replaced by a spinner — so it MUST be cleared on failure too, or a mistyped code
+    /// leaves the user on a spinner with no way to retry.
+    @State private var submitting = false
+    /// The pane text as it stood when the last code was submitted.
+    ///
+    /// Failure is judged ONLY on output produced after this point. The pane buffer is
+    /// cumulative, so a rejected first attempt leaves "invalid code" sitting in it forever
+    /// — and a retry would then be failed instantly by the previous attempt's message, no
+    /// matter how good the new code is.
+    @State private var submitBaseline: String = ""
+    /// Briefly shown after the link is copied, so the tap has a visible result.
+    @State private var copied = false
 
     var body: some View {
         NavigationStack {
@@ -39,20 +53,52 @@ struct AccountLoginSheet: View {
                                     .frame(maxWidth: .infinity)
                             }
                             .buttonStyle(.borderedProminent)
-                            Text(url.absoluteString)
-                                .font(Typography.machine(11)).foregroundStyle(Palette.textFaint)
-                                .lineLimit(2).textSelection(.enabled)
+                            // Tap the URL itself to copy it — for signing in on another
+                            // device, or when the in-app browser hand-off is not wanted.
+                            // Clipboard WRITE only (same as CopyForAgentButton); a
+                            // programmatic READ is what drew the App Store 2.1a rejection.
+                            Button {
+                                UIPasteboard.general.string = url.absoluteString
+                                copied = true
+                                Task {
+                                    try? await Task.sleep(nanoseconds: 2_000_000_000)
+                                    copied = false
+                                }
+                            } label: {
+                                HStack(spacing: 6) {
+                                    Image(systemName: copied ? "checkmark" : "doc.on.doc")
+                                        .font(.system(size: 10))
+                                    Text(copied ? "Copied" : url.absoluteString)
+                                        .font(Typography.machine(11))
+                                        .lineLimit(2)
+                                        .multilineTextAlignment(.leading)
+                                }
+                                .foregroundStyle(copied ? Palette.done : Palette.textFaint)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                            }
+                            .buttonStyle(.plain)
+                            .accessibilityLabel(Text(copied ? "Sign-in link copied" : "Copy sign-in link"))
                         }
                         stepCard(number: "2", title: "Paste the code you get back") {
-                            TextField("Code or URL from the browser", text: $code, axis: .vertical)
-                                .textFieldStyle(.roundedBorder)
-                                .lineLimit(1...3)
-                                .autocorrectionDisabled()
-                                .textInputAutocapitalization(.never)
-                            Button("Sign in") { Task { await sendCode() } }
-                                .buttonStyle(.borderedProminent)
-                                .frame(maxWidth: .infinity)
-                                .disabled(code.trimmingCharacters(in: .whitespaces).isEmpty)
+                            if submitting {
+                                HStack(spacing: 10) {
+                                    ProgressView()
+                                    Text("Signing you in…")
+                                        .font(Typography.app(14)).foregroundStyle(Palette.textDim)
+                                }
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .padding(.vertical, 6)
+                            } else {
+                                TextField("Code or URL from the browser", text: $code, axis: .vertical)
+                                    .textFieldStyle(.roundedBorder)
+                                    .lineLimit(1...3)
+                                    .autocorrectionDisabled()
+                                    .textInputAutocapitalization(.never)
+                                Button("Sign in") { Task { await sendCode() } }
+                                    .buttonStyle(.borderedProminent)
+                                    .frame(maxWidth: .infinity)
+                                    .disabled(code.trimmingCharacters(in: .whitespaces).isEmpty)
+                            }
                         }
                     } else {
                         HStack(spacing: 10) {
@@ -116,6 +162,9 @@ struct AccountLoginSheet: View {
         if let old = paneID { try? await client.closePane(paneID: old); paneID = nil }
         signInURL = nil
         signedIn = false
+        submitting = false
+        submitBaseline = ""
+        copied = false
         code = ""
         status = "Starting sign-in…"
         do {
@@ -145,11 +194,23 @@ struct AccountLoginSheet: View {
                         status = "Open the link, approve, then paste the code below."
                     }
                 }
-                if text.range(of: "logged in", options: .caseInsensitive) != nil
-                    || text.range(of: "login successful", options: .caseInsensitive) != nil {
+                switch claudeLoginOutcome(from: text) {
+                case .signedIn:
                     signedIn = true
+                    submitting = false
                     status = "Signed in."
+                    // Show the confirmation long enough to read as an outcome, then close
+                    // and hand the user back to Accounts (refreshed by `finish`).
+                    try? await Task.sleep(nanoseconds: 1_200_000_000)
+                    if !Task.isCancelled { finish() }
                     return
+                case .failed, .pending:
+                    // Success is judged on the whole buffer; FAILURE only on what arrived
+                    // after the submission (see `submitBaseline`).
+                    if submitting, claudeLoginOutcome(from: outputSinceSubmit(text)) == .failed {
+                        submitting = false
+                        status = "That code didn't work — check it and try again."
+                    }
                 }
             }
             try? await Task.sleep(nanoseconds: 4_000_000_000)
@@ -160,13 +221,46 @@ struct AccountLoginSheet: View {
         guard let pane = paneID else { return }
         let value = code.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !value.isEmpty else { return }
+        // Freeze what the pane already said, so the previous attempt's rejection cannot
+        // fail this one before it is even answered.
+        submitBaseline = (try? await client.read(pane: pane, source: .recentUnwrapped, format: .text))?.text ?? ""
+        submitting = true
+        status = "Signing you in…"
         do {
             try await client.sendText(pane: pane, text: value)
             try await client.sendPaneKeys(pane: pane, keys: ["Enter"])
-            code = ""
-            status = "Submitting… hang on."
+            armSubmitTimeout(for: value)
         } catch {
+            // Never leave the spinner up on a send that did not happen.
+            submitting = false
             status = "Couldn't send the code: \(error)"
+        }
+    }
+
+    /// Bounds the wait that the spinner hides the input behind.
+    ///
+    /// Success and explicit failure both arrive via the scrape loop, but neither is
+    /// guaranteed: the harness can print something we do not recognise, or nothing at all.
+    /// Without this the input would never come back and the sign-in could not be retried —
+    /// the spinner would simply be the last thing that ever happened. On expiry the typed
+    /// code is restored rather than discarded, so a long token does not have to be pasted
+    /// again.
+    /// The pane output produced since the last submission. Falls back to the whole buffer
+    /// when the baseline is no longer a prefix — the rolling window scrolled past it —
+    /// which at worst costs one extra retry prompt rather than a stuck spinner.
+    private func outputSinceSubmit(_ text: String) -> String {
+        guard !submitBaseline.isEmpty else { return text }
+        guard text.hasPrefix(submitBaseline) else { return text }
+        return String(text.dropFirst(submitBaseline.count))
+    }
+
+    private func armSubmitTimeout(for submitted: String) {
+        Task {
+            try? await Task.sleep(nanoseconds: 45_000_000_000)
+            guard !Task.isCancelled, submitting, !signedIn else { return }
+            submitting = false
+            if code.isEmpty { code = submitted }
+            status = "No response yet — check the code and try again."
         }
     }
 

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -2180,7 +2180,15 @@ struct TerminalHomeView: View {
                         Button {
                             Task {
                                 do {
-                                    try await client.archiveAgent(target: row.info.paneID)
+                                    // Attributed on purpose. Without `by`/`reason` the
+                                    // daemon records `by: "api"` and no reason — the same
+                                    // shape it writes for a pane that merely died, so a
+                                    // deliberate archive would be indistinguishable from
+                                    // bookkeeping to anything reading the record later.
+                                    try await client.archiveAgent(
+                                        target: row.info.paneID,
+                                        reason: HerdrKit.appArchiveReason,
+                                        by: HerdrKit.appArchiveActor)
                                     await load()
                                 } catch let e {
                                     error = "couldn't archive \(row.title): \(e)"

--- a/Sources/HerdrKit/AccountLogin.swift
+++ b/Sources/HerdrKit/AccountLogin.swift
@@ -52,3 +52,50 @@ public func claudeAuthStatusCommand(kind: String, configDir: String) -> String? 
     guard kind == "claude" else { return nil }
     return "env -u CLAUDE_CODE_OAUTH_TOKEN CLAUDE_CONFIG_DIR=\(shellQuoteSingle(configDir)) claude auth status"
 }
+
+/// What the sign-in pane's output says about the attempt so far.
+public enum ClaudeLoginOutcome: Equatable, Sendable {
+    /// The harness reported a completed sign-in.
+    case signedIn
+    /// The harness rejected what was submitted — retry, do not keep waiting.
+    case failed
+    /// Nothing conclusive yet.
+    case pending
+}
+
+/// Classifies the sign-in pane's recent output.
+///
+/// This exists because the UI hides the input box while it waits. Waiting on a success
+/// signal alone would strand the user on a spinner the moment a code is mistyped, so a
+/// FAILURE signal is a first-class outcome that hands the input back.
+///
+/// Matching is deliberately narrow. The pane carries the whole terminal tail, including a
+/// shell prompt and whatever the user typed, so loose matching on a bare word like "error"
+/// would end the flow on unrelated noise — which is worse than waiting, because it discards
+/// a sign-in that was actually working. Success is checked FIRST: output that reports a
+/// completed login while also containing an earlier failed attempt is a success.
+public func claudeLoginOutcome(from text: String) -> ClaudeLoginOutcome {
+    let haystack = text.lowercased()
+    let success = [
+        "logged in",
+        "login successful",
+        "successfully logged in",
+        "authentication successful",
+    ]
+    if success.contains(where: haystack.contains) { return .signedIn }
+    let failure = [
+        "invalid code",
+        "invalid token",
+        "authentication failed",
+        "login failed",
+        // Qualified on purpose: a bare "expired" also matches benign copy like
+        // "your token expires in 30 days", which would hand the input back mid-flight
+        // on a sign-in that was working.
+        "code expired",
+        "token expired",
+        "session expired",
+        "try again",
+    ]
+    if failure.contains(where: haystack.contains) { return .failed }
+    return .pending
+}

--- a/Sources/HerdrKit/HerdrClient.swift
+++ b/Sources/HerdrKit/HerdrClient.swift
@@ -719,21 +719,23 @@ public actor HerdrClient {
             .agent
     }
 
-    /// `agent.archive` params. `reason`/`force` are OMITTED when nil/false so a plain
+    /// `agent.archive` params. `reason`/`by`/`force` are OMITTED when nil/false so a plain
     /// archive sends `{ target }` and matches the server's optional/skip-if-none.
     struct AgentArchiveParams: Encodable {
         let target: String
         let reason: String?
+        let by: String?
         let force: Bool
 
         enum CodingKeys: String, CodingKey {
-            case target, reason, force
+            case target, reason, by, force
         }
 
         func encode(to encoder: Encoder) throws {
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(target, forKey: .target)
             try container.encodeIfPresent(reason, forKey: .reason)
+            try container.encodeIfPresent(by, forKey: .by)
             if force { try container.encode(true, forKey: .force) }
         }
     }
@@ -743,9 +745,20 @@ public actor HerdrClient {
     /// is the pane id (or agent name). The server REJECTS archiving an agent that is
     /// mid-turn unless `force` — that surfaces as an `APIError` the caller shows.
     /// Returns the archived agent (its `archived` block now set).
+    ///
+    /// PASS `by` AND `reason`. They are optional on the wire, and omitting them is not
+    /// neutral: the daemon then records `by: "api"` with no reason, which is exactly what
+    /// it records for bookkeeping on a pane that merely died. An archive that does not say
+    /// who did it or why is indistinguishable from one nobody decided — a real ambiguity
+    /// downstream, where tooling reads the `archived` block as evidence a seat is gone.
+    /// Both are `encodeIfPresent`, so a caller that passes neither still sends the exact
+    /// bytes it did before.
     @discardableResult
-    public func archiveAgent(target: String, reason: String? = nil, force: Bool = false) async throws -> AgentInfo {
-        try await call("agent.archive", AgentArchiveParams(target: target, reason: reason, force: force),
+    public func archiveAgent(
+        target: String, reason: String? = nil, by: String? = nil, force: Bool = false
+    ) async throws -> AgentInfo {
+        try await call("agent.archive",
+                       AgentArchiveParams(target: target, reason: reason, by: by, force: force),
                        as: AgentInfoResult.self)
             .agent
     }
@@ -992,6 +1005,20 @@ public actor HerdrClient {
         return try await call("pane.set_pty_size", params, as: PanePtySize.self)
     }
 }
+
+/// Who the app reports as the actor when it archives an agent, and why.
+///
+/// Constants, not free text, for two readers. A person sees
+/// "archived by herdrup · user action" on the archived row. Fleet tooling that treats the
+/// `archived` block as evidence a seat is gone can match these EXACTLY to tell a deliberate
+/// archive from bookkeeping on a dead pane — a distinction that was previously impossible,
+/// because the app sent neither field and the daemon's `by: "api"` default is what a
+/// reasonless archive looks like too.
+///
+/// `by` names the actor; `reason` says it was deliberate. Neither repeats the other, since
+/// the row renders them joined.
+public let appArchiveActor = "herdrup"
+public let appArchiveReason = "user action"
 
 /// Decodes any JSON value, for calls whose result body the client ignores.
 struct JSONNull: Decodable {

--- a/Tests/HerdrKitTests/LoginOutcomeAndArchiveAttributionTests.swift
+++ b/Tests/HerdrKitTests/LoginOutcomeAndArchiveAttributionTests.swift
@@ -1,0 +1,112 @@
+import XCTest
+@testable import HerdrKit
+
+/// Two guards for the sign-in sheet and the archive action.
+///
+/// The sign-in sheet HIDES the input box while it waits, so the classifier is what decides
+/// whether the user ever gets it back. Both directions matter: missing a failure strands
+/// them on a spinner, and inventing one throws away a sign-in that was still working.
+final class LoginOutcomeAndArchiveAttributionTests: XCTestCase {
+
+    // MARK: - sign-in outcome classification
+
+    func testRecognisesACompletedSignIn() {
+        XCTAssertEqual(claudeLoginOutcome(from: "You are now logged in."), .signedIn)
+        XCTAssertEqual(claudeLoginOutcome(from: "Login successful!"), .signedIn)
+        XCTAssertEqual(claudeLoginOutcome(from: "AUTHENTICATION SUCCESSFUL"), .signedIn,
+                       "matching must be case-insensitive; terminals shout")
+    }
+
+    func testRecognisesARejectedCode() {
+        XCTAssertEqual(claudeLoginOutcome(from: "Invalid code, please try again"), .failed)
+        XCTAssertEqual(claudeLoginOutcome(from: "Authentication failed"), .failed)
+        XCTAssertEqual(claudeLoginOutcome(from: "That code expired"), .failed)
+    }
+
+    /// Ordinary terminal output must stay pending. The pane carries the shell prompt, the
+    /// command line the user typed, and the harness's own banner — none of that is an
+    /// outcome, and treating it as one would end the flow before it started.
+    func testOrdinaryOutputStaysPending() {
+        let noise = """
+        root@box ~ # env -u CLAUDE_CODE_OAUTH_TOKEN CLAUDE_CONFIG_DIR='/root/.claude' claude auth login
+        Visit https://claude.ai/oauth/authorize?code=xyz to continue.
+        Paste the code here:
+        """
+        XCTAssertEqual(claudeLoginOutcome(from: noise), .pending)
+        XCTAssertEqual(claudeLoginOutcome(from: ""), .pending)
+    }
+
+    /// A bare "expired" appears in benign copy. Matching it would hand the input back
+    /// during a sign-in that is still fine.
+    func testBenignExpiryCopyIsNotAFailure() {
+        XCTAssertEqual(claudeLoginOutcome(from: "Your token expires in 30 days."), .pending)
+    }
+
+    /// Success wins over an earlier failed attempt in the same scrollback — the pane text
+    /// is cumulative, so a retry that eventually succeeds must read as success.
+    func testSuccessAfterAnEarlierFailureReadsAsSuccess() {
+        let both = "Invalid code, please try again\nPaste the code here:\nYou are now logged in."
+        XCTAssertEqual(claudeLoginOutcome(from: both), .signedIn)
+    }
+
+    /// THE RETRY CASE. The pane buffer is cumulative, so a rejected first attempt leaves
+    /// its rejection in the text permanently. The sheet therefore judges failure only on
+    /// output produced AFTER the submission — this pins the classifier half of that: given
+    /// only the fresh output, a good retry must NOT read as failed even though the full
+    /// buffer still contains the earlier rejection.
+    func testFreshOutputOfAGoodRetryIsNotAFailure() {
+        let wholeBuffer = """
+        Invalid code, please try again
+        Paste the code here:
+        """
+        // What the sheet passes in is the slice after the baseline, not the whole buffer.
+        let freshOutput = "\nPaste the code here:\n"
+        XCTAssertEqual(claudeLoginOutcome(from: wholeBuffer), .failed,
+                       "the cumulative buffer does still contain the old rejection")
+        XCTAssertEqual(claudeLoginOutcome(from: freshOutput), .pending,
+                       "a retry judged on fresh output only must not inherit the old failure")
+    }
+
+    // MARK: - archive attribution
+
+    private final class CapturingTransport: HerdrTransport, @unchecked Sendable {
+        var lastRequest = ""
+        func roundTrip(_ requestLine: String) async throws -> String {
+            lastRequest = requestLine
+            return #"{"id":"x","result":{"type":"agent_info","agent":{"pane_id":"w1:p1"}}}"#
+        }
+        func stream(_ requestLine: String) -> AsyncThrowingStream<String, Error> {
+            AsyncThrowingStream { $0.finish() }
+        }
+    }
+
+    /// An archive from the app must say who did it and why. Without both, the daemon
+    /// records `by:"api"` and no reason — the same shape it writes for a pane that merely
+    /// died, which is what made a deliberate archive indistinguishable from bookkeeping.
+    func testArchiveSendsActorAndReason() async throws {
+        let t = CapturingTransport()
+        _ = try await HerdrClient(transport: t).archiveAgent(
+            target: "w1:p1", reason: appArchiveReason, by: appArchiveActor)
+
+        XCTAssertTrue(t.lastRequest.contains(#""by":"herdrup""#), t.lastRequest)
+        XCTAssertTrue(t.lastRequest.contains(#""reason":"user action""#), t.lastRequest)
+    }
+
+    /// Omitting them must send NO such keys — an older daemon and every existing caller
+    /// keep the exact bytes they had before.
+    func testArchiveOmitsAttributionWhenNotGiven() async throws {
+        let t = CapturingTransport()
+        _ = try await HerdrClient(transport: t).archiveAgent(target: "w1:p1")
+
+        XCTAssertFalse(t.lastRequest.contains("\"by\""), "nil by must be omitted, not null")
+        XCTAssertFalse(t.lastRequest.contains("\"reason\""), "nil reason must be omitted, not null")
+        XCTAssertFalse(t.lastRequest.contains("\"force\""), "false force stays omitted")
+    }
+
+    /// The constants are the fleet's matching key, so pin them: tooling that reads the
+    /// archived block distinguishes a decision from bookkeeping by these exact strings.
+    func testAttributionConstantsAreStable() {
+        XCTAssertEqual(appArchiveActor, "herdrup")
+        XCTAssertEqual(appArchiveReason, "user action")
+    }
+}


### PR DESCRIPTION
Two owner requests after build 103.

## 1. App archives now say who and why

`by = "herdrup"`, `reason = "user action"` → the row reads **`archived by herdrup · user action`**.

Sending neither was **not neutral**: the daemon then records `by:"api"` with no reason — the *same shape it writes for bookkeeping on a pane that merely died*. So a deliberate archive was indistinguishable from one nobody decided. apps-coc measured exactly that asymmetry, and gm-archive's gitmoot#1643 ingest treats the `archived` block as evidence a seat is gone, so this closes a real fleet-wide ambiguity (reported as note 88067).

Both fields stay `encodeIfPresent`, so any caller passing nothing sends the same bytes as before. **No daemon change** — `agent.archive` already accepted `by` and `reason`; only the app failed to send them. The two strings are constants in HerdrKit so tooling can match them exactly.

## 2. Sign-in flow

- **Tap the URL to copy it** — clipboard *write* only, the same pattern as `CopyForAgentButton`; never a programmatic read, which is what drew the 2.1a rejection.
- **Submitting replaces the input with a spinner.**
- **On success the sheet closes itself** back to Accounts after a brief confirmation.

### The part that needed care
Hiding the input is the risky half of this request: waiting on a signal that may never arrive would strand the user on a spinner with **no way to retry a mistyped code**. So the wait is bounded — an explicit rejection returns the input immediately, and a 45s timeout returns it with the typed code preserved (so a long token needn't be pasted again).

**Failure is judged only on output produced after the submission.** The pane buffer is cumulative, so a rejected first attempt leaves "invalid code" in the text permanently — without scoping, a retry would be failed instantly by the *previous* attempt no matter how good the new code is. Success is still judged on the whole buffer, so a retry that eventually works reads as success.

Match terms are deliberately narrow: a bare `"expired"` is qualified to `code/token/session expired`, because "your token expires in 30 days" would otherwise hand the input back mid-flight on a sign-in that was fine.

## Tests
- Outcome classification both ways — success and rejection detected, ordinary terminal noise (shell prompt, the login command, the URL banner) stays `pending`, benign expiry copy is not a failure, and success wins over an earlier failure in the same scrollback.
- The retry case pinned explicitly: the cumulative buffer still reads `failed`, while the fresh slice reads `pending`.
- Archive sends `by`+`reason` when given and **omits both keys entirely** when not; the constants are pinned as the fleet's matching key.