### PR TITLE
fix(accounts): confirm sign-in from the account probe, not terminal text

### DIFF
--- a/App/AccountLoginSheet.swift
+++ b/App/AccountLoginSheet.swift
@@ -36,16 +36,35 @@ struct AccountLoginSheet: View {
     @State private var submitBaseline: String = ""
     /// Briefly shown after the link is copied, so the tap has a visible result.
     @State private var copied = false
+    /// The account's email as the daemon reported it BEFORE this attempt started.
+    /// Sign-in is confirmed by this going from absent to present — see `pollSignedIn`.
+    @State private var baselineEmail: String??
+    /// The identity actually signed in, shown on success. Worth surfacing: an OAuth
+    /// page approves whoever the BROWSER is signed in as, so a "new" account can end
+    /// up holding the same person as an existing one. Naming it makes that obvious
+    /// immediately instead of days later in the accounts list.
+    @State private var signedInEmail: String?
 
     var body: some View {
         NavigationStack {
             ScrollView {
                 VStack(alignment: .leading, spacing: 16) {
                     if signedIn {
-                        Label("Signed in to \(account.label)", systemImage: "checkmark.circle.fill")
-                            .font(Typography.app(17, .semibold))
-                            .foregroundStyle(.green)
-                            .padding(.top, 24)
+                        VStack(alignment: .leading, spacing: 6) {
+                            Label("Signed in to \(account.label)", systemImage: "checkmark.circle.fill")
+                                .font(Typography.app(17, .semibold))
+                                .foregroundStyle(.green)
+                            if let signedInEmail {
+                                // Name the identity. The OAuth page approves whoever the
+                                // BROWSER is signed in as, so a "new" account can quietly
+                                // end up holding an existing one's person.
+                                Text(signedInEmail)
+                                    .font(Typography.machine(12))
+                                    .foregroundStyle(Palette.textDim)
+                                    .textSelection(.enabled)
+                            }
+                        }
+                        .padding(.top, 24)
                     } else if let url = signInURL {
                         stepCard(number: "1", title: "Open the sign-in page") {
                             Button { openURL(url) } label: {
@@ -165,6 +184,8 @@ struct AccountLoginSheet: View {
         submitting = false
         submitBaseline = ""
         copied = false
+        baselineEmail = nil
+        signedInEmail = nil
         code = ""
         status = "Starting sign-in…"
         do {
@@ -194,27 +215,66 @@ struct AccountLoginSheet: View {
                         status = "Open the link, approve, then paste the code below."
                     }
                 }
-                switch claudeLoginOutcome(from: text) {
-                case .signedIn:
-                    signedIn = true
+                // FAILURE is still read from the pane, and only from output produced
+                // after the submission (see `submitBaseline`) — the harness does print
+                // its rejections.
+                if submitting, claudeLoginOutcome(from: outputSinceSubmit(text)) == .failed {
                     submitting = false
-                    status = "Signed in."
-                    // Show the confirmation long enough to read as an outcome, then close
-                    // and hand the user back to Accounts (refreshed by `finish`).
-                    try? await Task.sleep(nanoseconds: 1_200_000_000)
-                    if !Task.isCancelled { finish() }
+                    status = "That code didn't work — check it and try again."
+                }
+                // If the harness DOES print a success line (the setup-token path can),
+                // use it only to poll immediately rather than to declare success. The
+                // probe below stays the sole authority on whether an identity landed;
+                // this just saves a tick.
+                if claudeLoginOutcome(from: text) == .signedIn, await pollSignedIn() {
                     return
-                case .failed, .pending:
-                    // Success is judged on the whole buffer; FAILURE only on what arrived
-                    // after the submission (see `submitBaseline`).
-                    if submitting, claudeLoginOutcome(from: outputSinceSubmit(text)) == .failed {
-                        submitting = false
-                        status = "That code didn't work — check it and try again."
-                    }
                 }
             }
+            // SUCCESS is NOT read from the pane.
+            //
+            // It used to be, by matching phrases like "login successful" in the
+            // terminal text — and it silently never fired, because
+            // `claude auth login --claudeai` is an INTERACTIVE TUI that renders a
+            // screen instead of printing those lines. Real sign-ins completed and
+            // wrote credentials while this sheet sat there and then claimed "no
+            // response", which is the worst possible way to be wrong: it reports
+            // failure over something that worked.
+            //
+            // The daemon already reads each account's identity out of its config-home,
+            // so ask IT. Verified against the live box: a logged-out config-home
+            // reports no email (whether or not it has a `.claude.json`), and one gets
+            // set the moment a login lands. That makes absent -> present an
+            // authoritative signal with no phrase matching and no extra pane.
+            if await pollSignedIn() { return }
             try? await Task.sleep(nanoseconds: 4_000_000_000)
         }
+    }
+
+    /// Asks the daemon whether this account's identity has appeared yet. Returns true
+    /// when sign-in is confirmed (and closes the sheet).
+    ///
+    /// Only an absent -> present transition counts. Re-signing in to an account that
+    /// ALREADY has an identity cannot be confirmed this way — the email is rewritten
+    /// with the same value — so that case falls through to the timeout rather than
+    /// claiming a success it did not observe.
+    private func pollSignedIn() async -> Bool {
+        guard let accounts = try? await client.accountsList(),
+              let mine = accounts.first(where: { $0.id == account.id })
+        else { return false }
+        if baselineEmail == nil { baselineEmail = .some(mine.email) }
+        let before = baselineEmail ?? nil
+        guard signInConfirmed(baseline: before, current: mine.email), let now = mine.email
+        else { return false }
+
+        signedIn = true
+        signedInEmail = now
+        submitting = false
+        status = "Signed in as \(now)."
+        // Long enough to read as an outcome — and long enough to notice WHICH identity
+        // it was — then hand the user back to a refreshed Accounts list.
+        try? await Task.sleep(nanoseconds: 1_600_000_000)
+        if !Task.isCancelled { finish() }
+        return true
     }
 
     private func sendCode() async {
@@ -260,7 +320,7 @@ struct AccountLoginSheet: View {
             guard !Task.isCancelled, submitting, !signedIn else { return }
             submitting = false
             if code.isEmpty { code = submitted }
-            status = "No response yet — check the code and try again."
+            status = "Couldn't confirm the sign-in. Check Accounts — it may have worked."
         }
     }
 

--- a/Sources/HerdrKit/AccountLogin.swift
+++ b/Sources/HerdrKit/AccountLogin.swift
@@ -99,3 +99,21 @@ public func claudeLoginOutcome(from text: String) -> ClaudeLoginOutcome {
     if failure.contains(where: haystack.contains) { return .failed }
     return .pending
 }
+
+/// Whether an account's identity going from `baseline` to `current` confirms a sign-in.
+///
+/// The sheet cannot read success off the terminal: `claude auth login --claudeai` is an
+/// interactive TUI, so the phrases it used to match never appear and real sign-ins were
+/// reported as failures. The daemon reads each account's identity out of its config-home
+/// instead, and a logged-out config-home reports none — so ABSENT -> PRESENT is the
+/// signal.
+///
+/// A re-sign-in to an account that already has an identity is deliberately NOT
+/// confirmable this way: the same email is simply rewritten, so there is nothing to
+/// observe. Returning false there means the sheet says it could not confirm — which is
+/// honest — rather than claiming a success it never saw.
+public func signInConfirmed(baseline: String?, current: String?) -> Bool {
+    guard let current, !current.isEmpty else { return false }
+    guard let baseline, !baseline.isEmpty else { return true }
+    return baseline != current
+}

--- a/Tests/HerdrKitTests/LoginOutcomeAndArchiveAttributionTests.swift
+++ b/Tests/HerdrKitTests/LoginOutcomeAndArchiveAttributionTests.swift
@@ -67,6 +67,41 @@ final class LoginOutcomeAndArchiveAttributionTests: XCTestCase {
                        "a retry judged on fresh output only must not inherit the old failure")
     }
 
+    // MARK: - sign-in confirmation (the probe, not the terminal text)
+
+    /// A fresh account has no identity until a login lands, so absent -> present is a
+    /// confirmed sign-in. This is the case that was broken: real sign-ins wrote
+    /// credentials while the sheet reported "no response", because success was being
+    /// matched against terminal phrases that an interactive TUI never prints.
+    func testAbsentToPresentIdentityConfirmsSignIn() {
+        XCTAssertTrue(signInConfirmed(baseline: nil, current: "jerry@example.com"))
+        XCTAssertTrue(signInConfirmed(baseline: "", current: "jerry@example.com"),
+                      "an empty baseline is as absent as nil")
+    }
+
+    /// Nothing yet is not success. Asserting this direction matters more than the other:
+    /// a false positive would close the sheet and tell the user they are signed in when
+    /// they are not.
+    func testNoIdentityIsNotASignIn() {
+        XCTAssertFalse(signInConfirmed(baseline: nil, current: nil))
+        XCTAssertFalse(signInConfirmed(baseline: nil, current: ""))
+        XCTAssertFalse(signInConfirmed(baseline: "jerry@example.com", current: nil),
+                       "losing an identity is not a sign-in")
+    }
+
+    /// Switching an account to a DIFFERENT identity is a real sign-in and must confirm.
+    func testChangingIdentityConfirmsSignIn() {
+        XCTAssertTrue(signInConfirmed(baseline: "old@example.com", current: "new@example.com"))
+    }
+
+    /// Re-signing in as the SAME identity is deliberately not confirmable — the email is
+    /// rewritten with the same value, so there is nothing to observe. The sheet then says
+    /// it could not confirm, which is honest; claiming success here would be inventing an
+    /// observation.
+    func testSameIdentityIsNotTreatedAsAFreshSignIn() {
+        XCTAssertFalse(signInConfirmed(baseline: "jerry@example.com", current: "jerry@example.com"))
+    }
+
     // MARK: - archive attribution
 
     private final class CapturingTransport: HerdrTransport, @unchecked Sendable {


### PR DESCRIPTION
Owner reported sign-in saying **"no response"** — and then found the new account showing an existing account's email. Two findings; only one is a bug.

## The account binding is NOT a bug
`/root/.claude-7` has its **own** credentials file and its own identity. It read `jerry.fanelli@gmail.com` because that is who the **browser** was signed in as when the OAuth page was approved. Proof the wiring is sound: three new accounts landed in three separate config-homes with **two different identities** (`.claude-8` → `faceboourl@`, `.claude-9` → `crazyjerry543@`). I also checked the daemon's `read_claude_config_json` fallback, which is correctly gated to the DEFAULT config-home only, so a new account cannot inherit the primary's email.

## The bug: success was detected from terminal text
All three sign-ins **succeeded** (credentials written 16:24, 16:27, 16:28) while the sheet timed out and reported failure.

Success was matched against phrases like `"login successful"` in the pane. But the command is `claude auth login --claudeai`, an **interactive TUI** that renders a screen instead of printing those lines — the matcher could never fire. Reporting failure over something that worked is the worst direction to be wrong in: it sent the owner hunting a bug that did not exist.

**Fix: ask the daemon.** It already reads each account's identity from its config-home. Verified on the live box — a logged-out config-home reports **no email** (with or without a `.claude.json`; checked both shapes), and one appears the moment a login lands. So absent → present is authoritative, with no phrase matching and no extra pane.

A re-sign-in as the **same** identity is deliberately *not* confirmable — the same email is rewritten, so there is nothing to observe. The sheet then says it could not confirm, rather than claiming a success it never saw. The timeout wording no longer implies failure.

## The success banner now names the identity
An OAuth page approves whoever the browser is signed in as, so a "new" account can quietly end up holding an existing one's person — exactly what happened here, discovered only later in the accounts list. Showing **"Signed in as \<email\>"** surfaces it at the moment it happens.

## Tests
The rule is extracted to `signInConfirmed(baseline:current:)` so it is testable away from the view: absent → present confirms; **no identity is not success** (the false-positive direction matters more — it would close the sheet claiming a sign-in that did not happen); a changed identity confirms; the same identity does not.

The phrase classifier is kept but demoted to an accelerator — if a success line does appear it triggers an immediate probe instead of declaring success itself, so its existing tests stay meaningful rather than guarding dead code.