### PR TITLE
ci: build per pull request instead of per push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,28 @@
 name: CI
 
 on:
-  push:
-    branches-ignore: [main]
+  # PULL REQUESTS, NOT EVERY PUSH.
+  #
+  # This job is a full Xcode build plus an XCUITest — ~17 minutes on a macOS runner,
+  # which GitHub bills at roughly ten times the Linux rate. On `push` it fired for every
+  # commit on every non-main branch, including work-in-progress pushes to branches that
+  # never became a PR: 120 runs across 85 distinct branches, 35 of them repeat builds of a
+  # branch that had already been built. That was ~71% of the account's entire monthly
+  # GitHub bill, and it hit the spending limit, which took CI down for every private repo.
+  #
+  # The `concurrency` block below already cancels a superseded run, and it works — but it
+  # can only help while the previous build is still running. Pushes minutes apart on a
+  # 17-minute build never overlap, so each one cost a full build. Building per PR instead
+  # of per push is what removes those.
+  #
+  # `main` is not branch-protected, so no required status check depends on the old push
+  # trigger. `workflow_dispatch` stays for deliberate one-off runs.
+  pull_request:
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+      - ".github/ISSUE_TEMPLATE/**"
+      - "LICENSE"
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Phase 1 of the CI cost plan. Authorized by gitmoot `herdr/fork-sync` row **89053** (owner approved all three phases); directive **89032**.

## Why
This repo is **~71% of the account's entire monthly GitHub bill** — $71.31 of $100, 3,581 macOS minutes — and it pushed the account into its spending limit, which took CI down for **every** private repo.

The cost is this job: a full Xcode build plus XCUITest, **~17 minutes**, on a runner billed at roughly 10× the Linux rate. On `push` it fired for every commit on every non-main branch — **120 runs across 85 distinct branches**, of which **35 were repeat builds of a branch that had already built** (~595 macOS minutes).

## Why the existing concurrency block doesn't already fix this
It does work — 15 of 120 sampled runs are `cancelled` — but it can only cancel a run that is *still going*. Pushes minutes apart on a 17-minute build never overlap, so each one paid for a full build. I expected to find no concurrency group and recommend adding one; it was already there and already correct, so this PR leaves it untouched.

## What changes
`on: push (branches-ignore: [main])` → `on: pull_request` (+ the existing `workflow_dispatch`), plus `paths-ignore` for docs-only changes.

A branch now builds when it is proposed for merge and on each update to that PR, instead of on every WIP push to a branch that may never become one.

## Safety
- `main` is **not** branch-protected (`/branches/main/protection` → 404), so no required status check depended on the push trigger — this cannot block merges.
- The concurrency group still keys on `github.ref`, which is unique per PR, so per-PR cancellation still works.
- `workflow_dispatch` is retained for deliberate one-off runs.
- `testflight.yml` is untouched — it was already gated to `workflow_dispatch` + `v*` tags, not every push.

## Evidence it works
Pushing this branch produced **no CI run**. Under the old trigger that push alone would have started a 17-minute macOS build.

## Not in this PR
Phase 2 (registering a second self-hosted runner on the MacBook Air, scoped to this repo) and Phase 3 (moving *only* CI to that runner) follow separately. Phase 3 carries an accepted tradeoff: a self-hosted-only selector does not fail fast when the Air is asleep — the job queues until the 45-minute timeout. TestFlight deliberately stays on `macos-latest` so shipping is never blocked by a sleeping laptop.