### PR TITLE
feat(accounts): rebuild the sign-in flow to the design system

### DIFF
--- a/App/AccountLoginSheet.swift
+++ b/App/AccountLoginSheet.swift
@@ -8,6 +8,12 @@ import HerdrKit
 /// the user approves in the browser and pastes the code back. The command always clears
 /// the global CLAUDE_CODE_OAUTH_TOKEN and pins CLAUDE_CONFIG_DIR (see `claudeLoginCommand`),
 /// so credentials land in THIS account only.
+///
+/// The SURFACE is built to the "herdrup · account sign-in · v1" Claude Design canvas. The
+/// FLOW is unchanged from the version that shipped: `start`, `scrapeLoop`, `sendCode`,
+/// `pollSignedIn` and the timeout are the same code, because they encode findings that
+/// were expensive to get (success is never read from the pane; failure is judged only on
+/// output produced after the submission). Only the view layer was replaced.
 struct AccountLoginSheet: View {
     let client: HerdrClient
     let account: CredentialAccount
@@ -16,11 +22,26 @@ struct AccountLoginSheet: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(\.openURL) private var openURL
 
+    /// Which board is on screen. Previously every one of these was a sentence in `status`
+    /// and the layout could not tell them apart, so all of them rendered as one faint line
+    /// — three genuinely different situations wearing the same shape. `status` still holds
+    /// the sentence; this decides the composition.
+    private enum Phase: Equatable {
+        case starting       // A  — nothing to do yet, a background command is running
+        case linkReady      // B  — the URL is up; paste a code back
+        case submitting     // B2 — a code is in flight
+        case rejected       // C1 — recoverable, retry in place
+        case unconfirmed    // C2 — neither success nor failure; resolve it
+        case unsupported    // C3 — dead end, hand over the command instead
+        case signedIn       // D  — which identity landed
+    }
+
     @State private var method: ClaudeLoginMethod = .oauth
     @State private var paneID: String?
     @State private var signInURL: URL?
     @State private var code: String = ""
     @State private var status: String = "Starting sign-in…"
+    @State private var phase: Phase = .starting
     @State private var signedIn = false
     @State private var scrapeTask: Task<Void, Never>?
     /// A code has been submitted and we are waiting on the harness. While true the input is
@@ -36,6 +57,13 @@ struct AccountLoginSheet: View {
     @State private var submitBaseline: String = ""
     /// Briefly shown after the link is copied, so the tap has a visible result.
     @State private var copied = false
+    /// Once the link has been opened or copied, step 1's control demotes to an outline —
+    /// the ink fill belongs to whatever you should do NEXT, which by then is step 2.
+    @State private var linkUsed = false
+    /// Wall-clock since the current wait began, for the mono metadata line. The design asks
+    /// the waiting states to say what is running and for how long, rather than only that
+    /// something is.
+    @State private var waitedSeconds: Int = 0
     /// The account's email as the daemon reported it BEFORE this attempt started.
     /// Sign-in is confirmed by this going from absent to present — see `pollSignedIn`.
     @State private var baselineEmail: String??
@@ -45,136 +73,514 @@ struct AccountLoginSheet: View {
     /// immediately instead of days later in the accounts list.
     @State private var signedInEmail: String?
 
-    var body: some View {
-        NavigationStack {
-            ScrollView {
-                VStack(alignment: .leading, spacing: 16) {
-                    if signedIn {
-                        VStack(alignment: .leading, spacing: 6) {
-                            Label("Signed in to \(account.label)", systemImage: "checkmark.circle.fill")
-                                .font(Typography.app(17, .semibold))
-                                .foregroundStyle(.green)
-                            if let signedInEmail {
-                                // Name the identity. The OAuth page approves whoever the
-                                // BROWSER is signed in as, so a "new" account can quietly
-                                // end up holding an existing one's person.
-                                Text(signedInEmail)
-                                    .font(Typography.machine(12))
-                                    .foregroundStyle(Palette.textDim)
-                                    .textSelection(.enabled)
-                            }
-                        }
-                        .padding(.top, 24)
-                    } else if let url = signInURL {
-                        stepCard(number: "1", title: "Open the sign-in page") {
-                            Button { openURL(url) } label: {
-                                Label("Open sign-in page", systemImage: "safari")
-                                    .frame(maxWidth: .infinity)
-                            }
-                            .buttonStyle(.borderedProminent)
-                            // Tap the URL itself to copy it — for signing in on another
-                            // device, or when the in-app browser hand-off is not wanted.
-                            // Clipboard WRITE only (same as CopyForAgentButton); a
-                            // programmatic READ is what drew the App Store 2.1a rejection.
-                            Button {
-                                UIPasteboard.general.string = url.absoluteString
-                                copied = true
-                                Task {
-                                    try? await Task.sleep(nanoseconds: 2_000_000_000)
-                                    copied = false
-                                }
-                            } label: {
-                                HStack(spacing: 6) {
-                                    Image(systemName: copied ? "checkmark" : "doc.on.doc")
-                                        .font(.system(size: 10))
-                                    Text(copied ? "Copied" : url.absoluteString)
-                                        .font(Typography.machine(11))
-                                        .lineLimit(2)
-                                        .multilineTextAlignment(.leading)
-                                }
-                                .foregroundStyle(copied ? Palette.done : Palette.textFaint)
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                            }
-                            .buttonStyle(.plain)
-                            .accessibilityLabel(Text(copied ? "Sign-in link copied" : "Copy sign-in link"))
-                        }
-                        stepCard(number: "2", title: "Paste the code you get back") {
-                            if submitting {
-                                HStack(spacing: 10) {
-                                    ProgressView()
-                                    Text("Signing you in…")
-                                        .font(Typography.app(14)).foregroundStyle(Palette.textDim)
-                                }
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                                .padding(.vertical, 6)
-                            } else {
-                                TextField("Code or URL from the browser", text: $code, axis: .vertical)
-                                    .textFieldStyle(.roundedBorder)
-                                    .lineLimit(1...3)
-                                    .autocorrectionDisabled()
-                                    .textInputAutocapitalization(.never)
-                                Button("Sign in") { Task { await sendCode() } }
-                                    .buttonStyle(.borderedProminent)
-                                    .frame(maxWidth: .infinity)
-                                    .disabled(code.trimmingCharacters(in: .whitespaces).isEmpty)
-                            }
-                        }
-                    } else {
-                        HStack(spacing: 10) {
-                            ProgressView()
-                            Text(status).font(Typography.app(15)).foregroundStyle(Palette.textDim)
-                        }
-                        .padding(.top, 36)
-                    }
+    private let tick = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
 
-                    if !signedIn {
-                        Text(status).font(Typography.app(12)).foregroundStyle(Palette.textFaint)
-                        Button(method == .oauth ? "Use a setup token instead" : "Use browser sign-in instead") {
-                            method = method == .oauth ? .setupToken : .oauth
-                            Task { await start() }
-                        }
-                        .font(Typography.app(13)).foregroundStyle(Palette.brand)
-                    }
-                }
-                .padding(16)
+    var body: some View {
+        ZStack {
+            Palette.ground.ignoresSafeArea()
+            VStack(spacing: 0) {
+                header
+                Divider().overlay(Palette.hairlineQuiet)
+                board
             }
-            .navigationTitle("Sign in · \(account.label)")
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    Button(signedIn ? "Done" : "Cancel") { finish() }
-                }
-            }
-            .task { await start() }
         }
+        .task { await start() }
+        .onReceive(tick) { _ in
+            // Only the two waiting boards show an elapsed count.
+            if phase == .starting || phase == .submitting { waitedSeconds += 1 }
+        }
+    }
+
+    // MARK: - chrome
+
+    /// The `AccountsSetupView` header, not a system nav bar: title, a mono subtitle naming
+    /// the account, and a round ✕. The identity chip joins it so the sheet names its
+    /// account the way an Accounts row does.
+    private var header: some View {
+        HStack(spacing: 12) {
+            identityChip(size: 34, corner: 9, glyph: 15)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(phase == .signedIn ? "Signed in" : "Sign in")
+                    .font(Typography.app(20, .semibold))
+                    .foregroundStyle(Palette.text)
+                // Mono because `kind · label` is machine data — the one place this
+                // deviates from the brief's "12pt textFaint", and deliberately.
+                Text("\(account.kind) · \(account.label)")
+                    .font(Typography.machine(12))
+                    .foregroundStyle(Palette.textFaint)
+                    .lineLimit(1)
+            }
+            Spacer(minLength: 8)
+            Button { finish() } label: {
+                Image(systemName: "xmark")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(Palette.textDim)
+                    .frame(width: 36, height: 36)
+                    .background(Circle().fill(Palette.surface))
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Close")
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
     }
 
     @ViewBuilder
-    private func stepCard<Content: View>(
-        number: String, title: String, @ViewBuilder content: () -> Content
-    ) -> some View {
-        VStack(alignment: .leading, spacing: 10) {
-            HStack(spacing: 8) {
-                Text(number)
-                    .font(Typography.app(13, .bold)).foregroundStyle(.white)
-                    .frame(width: 22, height: 22)
-                    .background(Circle().fill(Palette.brand))
-                Text(title).font(Typography.app(15, .semibold)).foregroundStyle(Palette.text)
-            }
-            content()
+    private var board: some View {
+        switch phase {
+        case .starting: centred { startingBoard }
+        case .linkReady, .submitting, .rejected: stepsBoard
+        case .unconfirmed: centred { unconfirmedBoard }
+        case .unsupported: centred { unsupportedBoard }
+        case .signedIn: centred { signedInBoard }
         }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(14)
-        .background(Palette.card)
-        .clipShape(RoundedRectangle(cornerRadius: 12))
-        .overlay(RoundedRectangle(cornerRadius: 12).stroke(Palette.hairline, lineWidth: 1))
     }
+
+    /// The states with nothing to DO are centred; only the two working boards are
+    /// top-aligned, because those are a task. Previously every state was stacked at the
+    /// top of a scroll view, so waiting and success were two lines above an empty screen.
+    private func centred<Content: View>(@ViewBuilder _ content: () -> Content) -> some View {
+        VStack {
+            Spacer(minLength: 0)
+            content()
+            Spacer(minLength: 0)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.horizontal, 22)
+    }
+
+    // MARK: - A · starting
+
+    private var startingBoard: some View {
+        VStack(spacing: 14) {
+            TurningRing(color: Palette.working, diameter: 30, lineWidth: 2)
+            VStack(spacing: 6) {
+                Text(status)
+                    .font(Typography.app(16, .semibold))
+                    .foregroundStyle(Palette.text)
+                    .multilineTextAlignment(.center)
+                Text(runningMetadata)
+                    .font(Typography.machine(11))
+                    .foregroundStyle(Palette.textFaint)
+                    .monospacedDigit()
+                    .multilineTextAlignment(.center)
+            }
+            pendingSteps
+            methodFooter
+        }
+    }
+
+    /// What is actually running, and for how long — the mono half of the one status line.
+    private var runningMetadata: String {
+        let verb = method == .oauth ? "claude auth login" : "claude setup-token"
+        return "\(verb) · background · \(waitedSeconds)s"
+    }
+
+    /// The two steps, shown greyed before there is anything to do with them, so the shape
+    /// of what is coming is visible while waiting.
+    private var pendingSteps: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            pendingStepRow("01", "Open the sign-in page")
+            Rectangle().fill(Palette.hairlineQuiet).frame(height: 1)
+            pendingStepRow("02", "Paste the code you get back")
+        }
+        .padding(14)
+        .background(RoundedRectangle(cornerRadius: 12).fill(Palette.surface.opacity(0.5)))
+        .overlay(RoundedRectangle(cornerRadius: 12).stroke(Palette.hairlineQuiet, lineWidth: 1))
+        .padding(.top, 6)
+    }
+
+    private func pendingStepRow(_ number: String, _ title: String) -> some View {
+        HStack(spacing: 10) {
+            numeralTile(number)
+            Text(title).font(Typography.app(14)).foregroundStyle(Palette.textFaint)
+            Spacer(minLength: 0)
+        }
+    }
+
+    // MARK: - B / B2 / C1 · the steps
+
+    private var stepsBoard: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 14) {
+                // ONE grouped stack with a divider, not two floating cards that happen to
+                // be numbered — so the sequence reads as a sequence.
+                VStack(alignment: .leading, spacing: 0) {
+                    stepOne
+                    Rectangle().fill(Palette.hairlineQuiet).frame(height: 1)
+                    stepTwo
+                }
+                .background(RoundedRectangle(cornerRadius: 12).fill(Palette.surface))
+                .overlay(RoundedRectangle(cornerRadius: 12).stroke(Palette.hairline, lineWidth: 1))
+                methodFooter
+            }
+            .padding(.horizontal, 16)
+            .padding(.top, 14)
+            .padding(.bottom, 24)
+        }
+    }
+
+    private var stepOne: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            stepHeading("01", "Open the sign-in page")
+            if let url = signInURL {
+                if linkUsed {
+                    outlineControl(linkUsed ? "Open sign-in page again" : "Open sign-in page") {
+                        openURL(url)
+                    }
+                } else {
+                    inkControl("Open sign-in page", icon: "safari") {
+                        openURL(url)
+                        linkUsed = true
+                    }
+                }
+                Button {
+                    UIPasteboard.general.string = url.absoluteString
+                    copied = true
+                    linkUsed = true
+                    Task {
+                        try? await Task.sleep(nanoseconds: 2_000_000_000)
+                        copied = false
+                    }
+                } label: {
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text(url.absoluteString)
+                            .font(Typography.machine(11))
+                            .foregroundStyle(Palette.text)
+                            .lineLimit(2)
+                            .truncationMode(.middle)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(8)
+                            .background(RoundedRectangle(cornerRadius: 8).fill(Palette.surfaceRaised))
+                        if copied {
+                            copiedChip
+                        } else {
+                            Text("tap to copy · sign in on another device")
+                                .font(Typography.machine(10))
+                                .foregroundStyle(Palette.textFaint)
+                        }
+                    }
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(copied ? "Sign-in link copied" : "Copy sign-in link")
+            }
+        }
+        .padding(14)
+    }
+
+    /// Shape AND colour, never colour alone — a tick beside the word, not a green flash.
+    private var copiedChip: some View {
+        HStack(spacing: 5) {
+            Image(systemName: "checkmark").font(.system(size: 9, weight: .bold))
+            Text("link copied").font(Typography.machine(10, .semibold))
+        }
+        .foregroundStyle(Palette.done)
+        .padding(.horizontal, 8).padding(.vertical, 3)
+        .background(Capsule().fill(Palette.surfaceRaised))
+    }
+
+    private var stepTwo: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            stepHeading("02", "Paste the code you get back")
+            if submitting {
+                // The input is REPLACED, not disabled, and the wait names who it is
+                // waiting on and for how long.
+                HStack(spacing: 9) {
+                    TurningRing(color: Palette.working)
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Signing you in…")
+                            .font(Typography.app(14))
+                            .foregroundStyle(Palette.text)
+                        Text("code sent · waiting on \(account.kind) · \(waitedSeconds)s")
+                            .font(Typography.machine(10))
+                            .foregroundStyle(Palette.textFaint)
+                            .monospacedDigit()
+                    }
+                    Spacer(minLength: 0)
+                }
+                Text("the field comes back either way — it never ends on a spinner")
+                    .font(Typography.machine(10))
+                    .foregroundStyle(Palette.textFaint)
+            } else {
+                if phase == .rejected {
+                    // Recoverable, so the recovery lives where it happens: a pill and a
+                    // sentence inside step 2, with the typed code kept.
+                    statusPill("needs another go", tone: Palette.waiting)
+                    Text(status)
+                        .font(Typography.app(13))
+                        .foregroundStyle(Palette.textDim)
+                }
+                TextField("code or URL from the browser", text: $code, axis: .vertical)
+                    .font(Typography.machine(12))
+                    .foregroundStyle(Palette.text)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+                    .lineLimit(1...3)
+                    .padding(10)
+                    .background(RoundedRectangle(cornerRadius: 8).fill(Palette.surfaceRaised))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 8)
+                            .stroke(phase == .rejected ? Palette.waiting.opacity(0.4) : Color.clear,
+                                    lineWidth: 1)
+                    )
+                let ready = !code.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                if ready {
+                    inkControl("Sign in") { Task { await sendCode() } }
+                } else {
+                    disabledControl("Sign in")
+                }
+                Text(phase == .rejected
+                     ? "your code is kept · codes expire, so fetch a fresh one if this repeats"
+                     : "the code is a one-time grant · it expires in a few minutes")
+                    .font(Typography.machine(10))
+                    .foregroundStyle(Palette.textFaint)
+            }
+        }
+        .padding(14)
+    }
+
+    // MARK: - C2 · couldn't confirm
+
+    private var unconfirmedBoard: some View {
+        VStack(spacing: 14) {
+            // A new mark: the unconfirmed outcome had no shape in the kit. Amber follows
+            // AgentGroup.unrecognised, which is already amber on the same reasoning —
+            // "cannot be read" is nearer to needs-you than to nothing-to-do.
+            statusMark("questionmark", tone: Palette.waiting)
+            Text("Couldn't confirm the sign-in")
+                .font(Typography.app(17, .semibold))
+                .foregroundStyle(Palette.text)
+                .multilineTextAlignment(.center)
+            Text("It may have worked. Accounts reads each identity off your box — if \(account.label) now has an email, you are in.")
+                .font(Typography.app(13))
+                .lineSpacing(3)
+                .foregroundStyle(Palette.textDim)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 290)
+            Text("no identity after 45s · pane closed")
+                .font(Typography.machine(11))
+                .foregroundStyle(Palette.textFaint)
+            VStack(spacing: 8) {
+                inkControl("Check Accounts") { finish() }
+                outlineControl("Try again") { Task { await start() } }
+            }
+            .padding(.top, 2)
+        }
+    }
+
+    // MARK: - C3 · not supported
+
+    private var unsupportedBoard: some View {
+        VStack(spacing: 14) {
+            // Deliberately colourless: nothing is waiting, running or dead here, so no
+            // status hue may appear. The only colour is the identity chip.
+            Text("—")
+                .font(Typography.machine(15))
+                .foregroundStyle(Palette.textDim)
+                .frame(width: 30, height: 30)
+                .background(Circle().fill(Palette.surface))
+                .overlay(Circle().stroke(Palette.hairline, lineWidth: 1))
+            Text("Sign-in isn't supported for \(account.kind) accounts yet")
+                .font(Typography.app(17, .semibold))
+                .foregroundStyle(Palette.text)
+                .multilineTextAlignment(.center)
+            Text("Nothing to retry from here. Log in on the box pointed at this account's folder and it turns up in Accounts by itself.")
+                .font(Typography.app(13))
+                .lineSpacing(3)
+                .foregroundStyle(Palette.textDim)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 290)
+            monoCard(caption: "On your box", body: unsupportedCommand)
+            Button { finish() } label: {
+                Text("Got it")
+                    .font(Typography.app(15, .semibold))
+                    .foregroundStyle(Palette.textDim)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 13)
+            }
+            .buttonStyle(.plain)
+        }
+    }
+
+    /// Lifted from `AccountsSetupView`'s own instructions rather than written here, so the
+    /// two screens cannot drift into telling the user different things.
+    private var unsupportedCommand: String {
+        let dir = account.configDir ?? "~/.\(account.kind)"
+        let envVar = account.kind == "codex" ? "CODEX_HOME" : "\(account.kind.uppercased())_HOME"
+        return "\(envVar)=\(dir) \(account.kind)"
+    }
+
+    // MARK: - D · signed in
+
+    private var signedInBoard: some View {
+        VStack(spacing: 14) {
+            statusMark("checkmark", tone: Palette.done)
+            Text("Signed in to \(account.label)")
+                .font(Typography.app(17, .semibold))
+                .foregroundStyle(Palette.text)
+                .multilineTextAlignment(.center)
+            // The outcome is WHICH IDENTITY LANDED, so it is drawn as the Accounts row you
+            // are about to be returned to.
+            HStack(spacing: 12) {
+                identityChip(size: 40, corner: 10, glyph: 18)
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(account.label)
+                        .font(Typography.app(15, .semibold))
+                        .foregroundStyle(Palette.text)
+                    Text(signedInEmail ?? "resolving identity…")
+                        .font(Typography.machine(12))
+                        .foregroundStyle(Palette.textDim)
+                        .textSelection(.enabled)
+                }
+                Spacer(minLength: 8)
+            }
+            .padding(12)
+            .background(RoundedRectangle(cornerRadius: 14).fill(Palette.surface))
+            .overlay(RoundedRectangle(cornerRadius: 14).stroke(Palette.hairline, lineWidth: 1))
+            Text("read back from your box · returning to accounts")
+                .font(Typography.machine(11))
+                .foregroundStyle(Palette.textFaint)
+        }
+    }
+
+    // MARK: - shared pieces
+
+    private func stepHeading(_ number: String, _ title: String) -> some View {
+        HStack(spacing: 10) {
+            numeralTile(number)
+            Text(title).font(Typography.app(15, .semibold)).foregroundStyle(Palette.text)
+            Spacer(minLength: 0)
+        }
+    }
+
+    /// The step numeral: mono on a raised tile. It used to be white on a violet circle —
+    /// the violet is retired, and a number is machine data anyway.
+    private func numeralTile(_ number: String) -> some View {
+        Text(number)
+            .font(Typography.machine(10, .semibold))
+            .foregroundStyle(Palette.textDim)
+            .frame(width: 22, height: 22)
+            .background(RoundedRectangle(cornerRadius: 6).fill(Palette.surfaceRaised))
+    }
+
+    /// Acting controls are filled with INK, not a system accent — the same fill as Approve
+    /// and ⏎ elsewhere in the app.
+    private func inkControl(_ title: String, icon: String? = nil, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            HStack(spacing: 7) {
+                if let icon { Image(systemName: icon).font(.system(size: 13, weight: .semibold)) }
+                Text(title).font(Typography.app(15, .semibold))
+            }
+            .foregroundStyle(Palette.ground)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 12)
+            .background(RoundedRectangle(cornerRadius: 11).fill(Palette.text))
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func outlineControl(_ title: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Text(title)
+                .font(Typography.app(15, .semibold))
+                .foregroundStyle(Palette.text)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 12)
+                .overlay(RoundedRectangle(cornerRadius: 11).stroke(Palette.hairline, lineWidth: 1))
+        }
+        .buttonStyle(.plain)
+    }
+
+    /// Disabled is transparent + hairline + faint ink — never a tinted grey capsule, which
+    /// reads as a colour with a meaning it does not have.
+    private func disabledControl(_ title: String) -> some View {
+        Text(title)
+            .font(Typography.app(15, .semibold))
+            .foregroundStyle(Palette.textFaint)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 12)
+            .overlay(RoundedRectangle(cornerRadius: 11).stroke(Palette.hairline, lineWidth: 1))
+    }
+
+    /// The capsule idiom, same geometry as the "exhausted" and "no account" pills.
+    private func statusPill(_ text: String, tone: Color) -> some View {
+        Text(text)
+            .font(Typography.machine(11, .semibold))
+            .foregroundStyle(tone)
+            .padding(.horizontal, 8).padding(.vertical, 3)
+            .background(Capsule().fill(tone.opacity(0.12)))
+            .overlay(Capsule().stroke(tone.opacity(0.5), lineWidth: 1))
+    }
+
+    private func statusMark(_ symbol: String, tone: Color) -> some View {
+        Image(systemName: symbol)
+            .font(.system(size: 13, weight: .bold))
+            .foregroundStyle(tone)
+            .frame(width: 30, height: 30)
+            .background(Circle().fill(tone.opacity(0.12)))
+            .overlay(Circle().stroke(tone.opacity(0.5), lineWidth: 1.5))
+    }
+
+    /// `AccountsSetupView`'s captioned mono chip.
+    private func monoCard(caption: String, body: String) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(caption)
+                .font(Typography.app(12, .semibold))
+                .foregroundStyle(Palette.textFaint)
+            Text(body)
+                .font(Typography.machine(12))
+                .foregroundStyle(Palette.text)
+                .textSelection(.enabled)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(10)
+                .background(RoundedRectangle(cornerRadius: 8).fill(Palette.surfaceRaised))
+        }
+    }
+
+    private func identityChip(size: CGFloat, corner: CGFloat, glyph: CGFloat) -> some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: corner)
+                .fill(AgentIdentity.gradient(for: account.kind))
+                .frame(width: size, height: size)
+            Text(AgentIdentity.glyph(for: account.kind))
+                .font(Typography.app(glyph, .bold))
+                .foregroundStyle(.white)
+        }
+    }
+
+    /// The method switch, as a bordered footer row rather than a floating violet link.
+    @ViewBuilder
+    private var methodFooter: some View {
+        // C2 deliberately has none: the flow already ran, and that screen resolves it.
+        if phase != .signedIn && phase != .unsupported && phase != .unconfirmed {
+            Button {
+                method = (method == .oauth) ? .setupToken : .oauth
+                Task { await start() }
+            } label: {
+                VStack(spacing: 3) {
+                    Text(method == .oauth ? "Use a setup token instead" : "Use browser sign-in instead")
+                        .font(Typography.app(13.5, .medium))
+                        .foregroundStyle(Palette.textDim)
+                    Text(method == .oauth ? "swaps to setup-token · starts over" : "swaps to browser sign-in · starts over")
+                        .font(Typography.machine(10))
+                        .foregroundStyle(Palette.textFaint)
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 11)
+                .overlay(RoundedRectangle(cornerRadius: 11).stroke(Palette.hairline, lineWidth: 1))
+            }
+            .buttonStyle(.plain)
+        }
+    }
+
+    // MARK: - flow (unchanged)
 
     private func start() async {
         guard let configDir = account.configDir,
               let cmd = claudeLoginCommand(kind: account.kind, configDir: configDir, method: method)
         else {
             status = "Sign-in isn't supported for \(account.kind) accounts yet."
+            phase = .unsupported
             return
         }
         scrapeTask?.cancel()
@@ -184,10 +590,13 @@ struct AccountLoginSheet: View {
         submitting = false
         submitBaseline = ""
         copied = false
+        linkUsed = false
+        waitedSeconds = 0
         baselineEmail = nil
         signedInEmail = nil
         code = ""
         status = "Starting sign-in…"
+        phase = .starting
         do {
             let pane = try await client.splitPane(cwd: nil)
             paneID = pane
@@ -196,7 +605,8 @@ struct AccountLoginSheet: View {
             status = "Getting your sign-in link…"
             scrapeTask = Task { await scrapeLoop(pane: pane) }
         } catch {
-            status = "Couldn't start sign-in: \(error)"
+            status = "Couldn't start sign-in — check the connection to your box and try again."
+            phase = .unconfirmed
         }
     }
 
@@ -213,6 +623,7 @@ struct AccountLoginSheet: View {
                         .first(where: { $0.scheme == "https" }) {
                         signInURL = url
                         status = "Open the link, approve, then paste the code below."
+                        phase = .linkReady
                     }
                 }
                 // FAILURE is still read from the pane, and only from output produced
@@ -221,6 +632,7 @@ struct AccountLoginSheet: View {
                 if submitting, claudeLoginOutcome(from: outputSinceSubmit(text)) == .failed {
                     submitting = false
                     status = "That code didn't work — check it and try again."
+                    phase = .rejected
                 }
                 // If the harness DOES print a success line (the setup-token path can),
                 // use it only to poll immediately rather than to declare success. The
@@ -270,6 +682,7 @@ struct AccountLoginSheet: View {
         signedInEmail = now
         submitting = false
         status = "Signed in as \(now)."
+        phase = .signedIn
         // Long enough to read as an outcome — and long enough to notice WHICH identity
         // it was — then hand the user back to a refreshed Accounts list.
         try? await Task.sleep(nanoseconds: 1_600_000_000)
@@ -285,7 +698,9 @@ struct AccountLoginSheet: View {
         // fail this one before it is even answered.
         submitBaseline = (try? await client.read(pane: pane, source: .recentUnwrapped, format: .text))?.text ?? ""
         submitting = true
+        waitedSeconds = 0
         status = "Signing you in…"
+        phase = .submitting
         do {
             try await client.sendText(pane: pane, text: value)
             try await client.sendPaneKeys(pane: pane, keys: ["Enter"])
@@ -293,8 +708,18 @@ struct AccountLoginSheet: View {
         } catch {
             // Never leave the spinner up on a send that did not happen.
             submitting = false
-            status = "Couldn't send the code: \(error)"
+            status = "Couldn't send the code — check the connection to your box and try again."
+            phase = .rejected
         }
+    }
+
+    /// The pane output produced since the last submission. Falls back to the whole buffer
+    /// when the baseline is no longer a prefix — the rolling window scrolled past it —
+    /// which at worst costs one extra retry prompt rather than a stuck spinner.
+    private func outputSinceSubmit(_ text: String) -> String {
+        guard !submitBaseline.isEmpty else { return text }
+        guard text.hasPrefix(submitBaseline) else { return text }
+        return String(text.dropFirst(submitBaseline.count))
     }
 
     /// Bounds the wait that the spinner hides the input behind.
@@ -305,15 +730,6 @@ struct AccountLoginSheet: View {
     /// the spinner would simply be the last thing that ever happened. On expiry the typed
     /// code is restored rather than discarded, so a long token does not have to be pasted
     /// again.
-    /// The pane output produced since the last submission. Falls back to the whole buffer
-    /// when the baseline is no longer a prefix — the rolling window scrolled past it —
-    /// which at worst costs one extra retry prompt rather than a stuck spinner.
-    private func outputSinceSubmit(_ text: String) -> String {
-        guard !submitBaseline.isEmpty else { return text }
-        guard text.hasPrefix(submitBaseline) else { return text }
-        return String(text.dropFirst(submitBaseline.count))
-    }
-
     private func armSubmitTimeout(for submitted: String) {
         Task {
             try? await Task.sleep(nanoseconds: 45_000_000_000)
@@ -321,6 +737,7 @@ struct AccountLoginSheet: View {
             submitting = false
             if code.isEmpty { code = submitted }
             status = "Couldn't confirm the sign-in. Check Accounts — it may have worked."
+            phase = .unconfirmed
         }
     }
 

--- a/App/AddAccountSheet.swift
+++ b/App/AddAccountSheet.swift
@@ -5,6 +5,12 @@ import HerdrKit
 /// `accounts.create` (the daemon derives a fresh config-home + id, writes config.toml,
 /// reloads), then hands back the refreshed list + the new account so the caller can
 /// chain into sign-in. No credential is written here — that's the login step.
+///
+/// Built to the "herdrup · account sign-in · v1" Claude Design canvas. It was a plain
+/// system `Form` with no design tokens at all — the biggest style break in the feature.
+/// There are only two questions here, which is not enough to justify a Form: the kind
+/// becomes three identity tiles you can SEE rather than a picker you have to open, and
+/// the label becomes one mono field, because a label is config data.
 struct AddAccountSheet: View {
     let client: HerdrClient
     /// (refreshed accounts, the newly created account if found).
@@ -19,34 +25,178 @@ struct AddAccountSheet: View {
     private let kinds = ["claude", "codex", "kimi"]
 
     var body: some View {
-        NavigationStack {
-            Form {
-                Section("Account") {
-                    Picker("Kind", selection: $kind) {
-                        ForEach(kinds, id: \.self) { Text($0.capitalized).tag($0) }
+        ZStack {
+            Palette.ground.ignoresSafeArea()
+            VStack(spacing: 0) {
+                header
+                Divider().overlay(Palette.hairlineQuiet)
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 18) {
+                        kindSection
+                        labelSection
+                        if let errorText {
+                            Text(errorText)
+                                .font(Typography.machine(12))
+                                .foregroundStyle(Palette.died)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .padding(.horizontal, 16)
+                        }
+                        createSection
                     }
-                    TextField("Label (e.g. Claude · work)", text: $label)
-                        .autocorrectionDisabled()
-                        .textInputAutocapitalization(.never)
-                }
-                Section {
-                    Text("A new config-home is created for this account; you'll sign in next.")
-                        .font(.footnote).foregroundStyle(.secondary)
-                }
-                if let errorText {
-                    Section { Text(errorText).font(.footnote).foregroundStyle(.red) }
-                }
-            }
-            .navigationTitle("Add account")
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) { Button("Cancel") { dismiss() } }
-                ToolbarItem(placement: .confirmationAction) {
-                    Button("Create") { Task { await create() } }
-                        .disabled(busy || label.trimmingCharacters(in: .whitespaces).isEmpty)
+                    .padding(.top, 16)
+                    .padding(.bottom, 24)
                 }
             }
         }
+    }
+
+    private var header: some View {
+        HStack(spacing: 12) {
+            VStack(alignment: .leading, spacing: 1) {
+                Text("Add account")
+                    .font(Typography.app(20, .semibold))
+                    .foregroundStyle(Palette.text)
+                Text("Another subscription on your box")
+                    .font(Typography.app(12))
+                    .foregroundStyle(Palette.textFaint)
+            }
+            Spacer(minLength: 8)
+            Button { dismiss() } label: {
+                Image(systemName: "xmark")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(Palette.textDim)
+                    .frame(width: 36, height: 36)
+                    .background(Circle().fill(Palette.surface))
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Close")
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+    }
+
+    private var kindSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            sectionLabel("KIND")
+            HStack(spacing: 10) {
+                ForEach(kinds, id: \.self) { value in
+                    kindTile(value)
+                }
+            }
+            .padding(.horizontal, 16)
+            Text("kind decides which harness signs in")
+                .font(Typography.machine(10))
+                .foregroundStyle(Palette.textFaint)
+                .padding(.horizontal, 16)
+        }
+    }
+
+    /// An identity tile, not a picker row: the same gradient + glyph the agent cards and
+    /// account rows use, so the choice looks like the thing it will become. `kimi` has no
+    /// case in `AgentIdentity`, so it takes the default violet and its first letter —
+    /// which is identity, not the retired brand accent.
+    private func kindTile(_ value: String) -> some View {
+        let picked = value == kind
+        return Button {
+            kind = value
+        } label: {
+            VStack(spacing: 8) {
+                ZStack {
+                    RoundedRectangle(cornerRadius: 10)
+                        .fill(AgentIdentity.gradient(for: value))
+                        .frame(width: 40, height: 40)
+                    Text(AgentIdentity.glyph(for: value))
+                        .font(Typography.app(18, .bold))
+                        .foregroundStyle(.white)
+                }
+                HStack(spacing: 4) {
+                    if picked {
+                        Image(systemName: "checkmark")
+                            .font(.system(size: 9, weight: .bold))
+                            .foregroundStyle(Palette.text)
+                    }
+                    Text(value)
+                        .font(Typography.machine(11))
+                        .foregroundStyle(picked ? Palette.text : Palette.textFaint)
+                }
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 12)
+            .background(
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(picked ? Palette.surfaceRaised : Palette.surface.opacity(0.5))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 12)
+                    .stroke(picked ? Palette.hairline : Palette.hairlineQuiet, lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(value)
+        .accessibilityAddTraits(picked ? [.isSelected] : [])
+    }
+
+    private var labelSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            sectionLabel("LABEL")
+            TextField("Claude · work", text: $label)
+                .font(Typography.machine(13))
+                .foregroundStyle(Palette.text)
+                .autocorrectionDisabled()
+                .textInputAutocapitalization(.never)
+                .padding(12)
+                .background(RoundedRectangle(cornerRadius: 11).fill(Palette.surface))
+                .overlay(RoundedRectangle(cornerRadius: 11).stroke(Palette.hairline, lineWidth: 1))
+                .padding(.horizontal, 16)
+            Text("how it reads in accounts, and in an agent's menu")
+                .font(Typography.machine(10))
+                .foregroundStyle(Palette.textFaint)
+                .padding(.horizontal, 16)
+        }
+    }
+
+    private var createSection: some View {
+        VStack(spacing: 8) {
+            let ready = !label.trimmingCharacters(in: .whitespaces).isEmpty && !busy
+            if ready {
+                Button { Task { await create() } } label: {
+                    Text("Add account")
+                        .font(Typography.app(15, .semibold))
+                        .foregroundStyle(Palette.ground)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 12)
+                        .background(RoundedRectangle(cornerRadius: 11).fill(Palette.text))
+                }
+                .buttonStyle(.plain)
+            } else {
+                HStack(spacing: 8) {
+                    if busy { TurningRing(color: Palette.working) }
+                    Text(busy ? "Adding…" : "Add account")
+                        .font(Typography.app(15, .semibold))
+                        .foregroundStyle(Palette.textFaint)
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 12)
+                .overlay(RoundedRectangle(cornerRadius: 11).stroke(Palette.hairline, lineWidth: 1))
+            }
+            Text("sign in to it next, or later, from accounts")
+                .font(Typography.machine(10))
+                .foregroundStyle(Palette.textFaint)
+        }
+        .padding(.horizontal, 16)
+        .padding(.top, 4)
+    }
+
+    /// The app's section micro-label: uppercase mono with a rule running off to the right.
+    private func sectionLabel(_ text: String) -> some View {
+        HStack(spacing: 8) {
+            Text(text)
+                .font(Typography.microLabel)
+                .tracking(1.2)
+                .foregroundStyle(Palette.textFaint)
+            Rectangle().fill(Palette.hairline).frame(height: 1)
+        }
+        .padding(.horizontal, 16)
     }
 
     private func create() async {
@@ -59,7 +209,7 @@ struct AddAccountSheet: View {
             onCreated(refreshed, created)
             dismiss()
         } catch {
-            errorText = "Couldn't add the account: \(error)"
+            errorText = "Couldn't add the account — check the connection to your box and try again."
         }
         busy = false
     }

--- a/App/DesignSystem.swift
+++ b/App/DesignSystem.swift
@@ -166,11 +166,17 @@ extension Color {
 /// meaning (the working blue); the motion says "live" without claiming a duration.
 struct TurningRing: View {
     var color: Color
+    /// Sized like `PulsingDot.diameter`: the defaults are the inline badge size, so the
+    /// agent-list call site is unchanged. The sign-in flow's "starting" composition asks
+    /// for a larger ring (30/2) because it is the only thing on the screen, and the same
+    /// ring inline (13/1.6) while a code is in flight.
+    var diameter: CGFloat = 13
+    var lineWidth: CGFloat = 1.6
     @State private var spin = false
     var body: some View {
         Circle().trim(from: 0, to: 0.72)
-            .stroke(color, style: StrokeStyle(lineWidth: 1.6, lineCap: .round))
-            .frame(width: 13, height: 13)
+            .stroke(color, style: StrokeStyle(lineWidth: lineWidth, lineCap: .round))
+            .frame(width: diameter, height: diameter)
             .rotationEffect(.degrees(spin ? 360 : 0))
             .onAppear {
                 withAnimation(.linear(duration: 0.9).repeatForever(autoreverses: false)) { spin = true }

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -3892,6 +3892,10 @@ struct SettingsView: View {
                     AccountLoginSheet(client: client, account: account) {
                         Task { accounts = (try? await client.accountsList()) ?? [] }
                     }
+                    // The chrome every other sheet in the app gets and this one did not:
+                    // full height with a grabber, so swipe-down closes it.
+                    .presentationDetents([.large])
+                    .presentationDragIndicator(.visible)
                 }
                 .sheet(isPresented: $showAddAccount) {
                     AddAccountSheet(client: client) { refreshed, created in
@@ -3905,6 +3909,8 @@ struct SettingsView: View {
                             }
                         }
                     }
+                    .presentationDetents([.large])
+                    .presentationDragIndicator(.visible)
                 }
                 .confirmationDialog(
                     logoutAccount.map { "Log out \($0.label)?" } ?? "",


### PR DESCRIPTION
Implements the **"herdrup · account sign-in · v1"** Claude Design canvas. Authorization: gitmoot note 90918.

## What was wrong

The flow was stock iOS with one branded card in the middle of it, one tap from screens that are fully custom: a system sheet background, a system nav bar, two `.borderedProminent` capsules, a `.roundedBorder` field, two system spinners, raw `.green` for success, and violet numerals using a token the design system had **already retired**. `AddAccountSheet` was an entire system `Form` with zero design tokens.

## The surface is replaced, the flow is not

`start`, `scrapeLoop`, `sendCode`, `pollSignedIn`, `outputSinceSubmit`, `armSubmitTimeout` and `finish` are the same code — **six of seven byte-identical**, `start()` gains one state reset. They encode findings that were expensive to get (success is never read from the pane, because the login is an interactive TUI that prints nothing; failure is judged only on output produced *after* the submission), so none of it was worth re-deriving for a restyle. **No terminal is designed back in.**

## What the states cost before

Every situation was a sentence in one `status` string, so the layout could not tell them apart. Three genuinely different outcomes — a rejected code, an unconfirmed sign-in, an unsupported harness — all rendered as the same faint 12pt line. And the same string was drawn **twice on screen at two sizes**, which is visible in the owner's screenshot.

A `Phase` enum now decides the composition; `status` only carries the sentence:

| phase | composition |
|---|---|
| `starting` | centred, 30px turning ring, a mono line saying what is running and for how long |
| `linkReady` | **one grouped stack** with a divider, not two floating numbered cards |
| `submitting` | input **replaced** rather than disabled, naming who it waits on; copy confirmation is a tick **and** a word |
| `rejected` | recovery where it happens — a pill inside step 2, typed code kept, field outlined in the status colour |
| `unconfirmed` | a resolution screen with both honest exits |
| `unsupported` | terminal and deliberately colourless, hands over the command |
| `signedIn` | drawn as the Accounts row you return to — the outcome is *which identity landed* |

Acting controls take the **ink fill** the system specifies (`text` on `ground`); disabled is transparent + hairline + faint ink, never a tinted grey capsule implying a colour meaning it does not have. The states with nothing to do are **centred**, not stacked at the top of a scroll view.

## Four arguable calls, implemented as drawn

The designer flagged these and invited argument; the owner approved the design as it stands.

1. **A rejected code is amber, not red.** `died` means a pane exited — nothing died here, you are being asked to look at something.
2. **A new amber `?` mark** for the unconfirmed outcome, following `AgentGroup.unrecognised`, already amber on the same reasoning.
3. **The header subtitle is mono** — `kind · label` is machine data.
4. **The unsupported state gained a path forward** rather than being a bare sentence.

## Incidental

- `TurningRing` gains `diameter`/`lineWidth`, defaulted to today's values so the agent-list call site is untouched — the same shape `PulsingDot` already has.
- Both sheets gain the `.presentationDetents` / `.presentationDragIndicator` chrome every other sheet has and these two were missing.

## Not compiled

**No Swift toolchain on the machine this was written on — macOS CI is the first real check.** Treat a failure there as expected-and-mine. Verified locally: no raw SwiftUI control styles remain (checked 10 patterns, all zero), no literal hex in the view code, brace balance unchanged against `HEAD`, and the HerdrKit command builders untouched.

## Out of scope, filed separately

Two behavioural bugs found while reading the file, deliberately **not** fixed here so a design PR does not quietly become a behaviour PR: the background login pane spawns with `focus: true` and steals focus, and swipe-down dismissal skips `finish()`, leaking a live `claude auth login` pane.