### PR TITLE
fix(accounts): stop the background sign-in pane stealing focus and leaking

### DIFF
--- a/App/AccountLoginSheet.swift
+++ b/App/AccountLoginSheet.swift
@@ -85,6 +85,11 @@ struct AccountLoginSheet: View {
             }
         }
         .task { await start() }
+        // THE ONLY PATH EVERY DISMISSAL TAKES. `finish()` covers the ✕ and a confirmed
+        // success, but a SWIPE-DOWN calls neither — and that left a live
+        // `claude auth login` pane running on the box, which the user could later
+        // stumble onto in the terminal tab with no idea where it came from.
+        .onDisappear { cleanupPane() }
         .onReceive(tick) { _ in
             // Only the two waiting boards show an elapsed count.
             if phase == .starting || phase == .submitting { waitedSeconds += 1 }
@@ -598,7 +603,8 @@ struct AccountLoginSheet: View {
         status = "Starting sign-in…"
         phase = .starting
         do {
-            let pane = try await client.splitPane(cwd: nil)
+            // Background: the user never sees this pane, so it must not take focus.
+            let pane = try await client.splitPane(cwd: nil, focus: false)
             paneID = pane
             try await client.sendText(pane: pane, text: cmd)
             try await client.sendPaneKeys(pane: pane, keys: ["Enter"])
@@ -742,10 +748,18 @@ struct AccountLoginSheet: View {
     }
 
     private func finish() {
-        scrapeTask?.cancel()
-        let pane = paneID
+        // Pane teardown belongs to `cleanupPane` via `.onDisappear`, so there is ONE
+        // owner rather than two paths that must each remember. `dismiss()` triggers it.
         onFinished()
         dismiss()
-        Task { if let pane { try? await client.closePane(paneID: pane) } }
+    }
+
+    /// Cancel the scrape and close the background pane. Idempotent: it clears `paneID`
+    /// first, so being called twice (finish → dismiss → onDisappear) closes once.
+    private func cleanupPane() {
+        scrapeTask?.cancel()
+        guard let pane = paneID else { return }
+        paneID = nil
+        Task { try? await client.closePane(paneID: pane) }
     }
 }

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -3964,7 +3964,8 @@ struct SettingsView: View {
               let cmd = claudeLogoutCommand(kind: account.kind, configDir: configDir)
         else { return }
         do {
-            let pane = try await client.splitPane(cwd: nil)
+            // Same as sign-in: a short-lived background pane the user never sees.
+            let pane = try await client.splitPane(cwd: nil, focus: false)
             try await client.sendText(pane: pane, text: cmd)
             try await client.sendPaneKeys(pane: pane, keys: ["Enter"])
             try? await Task.sleep(nanoseconds: 2_500_000_000)

--- a/Sources/HerdrKit/HerdrClient.swift
+++ b/Sources/HerdrKit/HerdrClient.swift
@@ -614,8 +614,14 @@ public actor HerdrClient {
     /// the working directory the new pane (and the agent started in it) runs in —
     /// the "folder" of the new-agent form; nil follows the split pane's cwd.
     /// No target pane is sent, so the server splits whatever is focused.
-    public func splitPane(cwd: String?, direction: SplitDirection = .down) async throws -> String {
-        let params = PaneSplitParams(direction: direction.rawValue, cwd: cwd, focus: true)
+    ///
+    /// `focus` defaults to true, which is right for a pane the user ASKED for and is
+    /// about to look at. Pass false for a BACKGROUND pane the app drives on the user's
+    /// behalf — sign-in and log-out run a command in a pane the user never sees, and
+    /// focusing it yanks the box's focus away from whatever they were actually doing.
+    public func splitPane(cwd: String?, direction: SplitDirection = .down,
+                          focus: Bool = true) async throws -> String {
+        let params = PaneSplitParams(direction: direction.rawValue, cwd: cwd, focus: focus)
         return try await call("pane.split", params, as: PaneInfoResult.self).pane.paneID
     }
 


### PR DESCRIPTION
Two defects in the account sign-in and log-out flows, found while rebuilding that screen in #187 and deliberately held back so a restyle would not quietly become a behaviour change. Authorization: gitmoot note 90977.

## 1. The background pane stole focus

Sign-in and log-out each run a command in a pane **the user never sees** — but both created it through `splitPane`, which sends `focus: true` unconditionally. Starting a sign-in from the phone therefore yanked the focus on the box away from whatever was actually being worked on, in favour of a pane with nothing to look at.

`splitPane` gains a `focus` parameter **defaulting to `true`**, so every user-facing split (new agent, new terminal) is byte-identical. Only the two background call sites opt out.

## 2. Swiping the sheet away leaked a live login pane

`finish()` closed the pane — and `finish()` is called by the ✕ and by a confirmed success. **A swipe-down dismissal calls neither.** The sheet vanished and left a live `claude auth login` process running on the box, which the user could later stumble onto in the terminal tab with no idea what it was.

Cancelling a sign-in by swiping is the ordinary way to abandon one, so this was not an edge case.

Teardown now has **one owner**: `cleanupPane()`, hooked to `.onDisappear` — the only path every dismissal takes. It is idempotent (clears `paneID` before closing), so the `finish → dismiss → onDisappear` sequence closes exactly once. `finish()` no longer closes anything itself, which removes the second path that had to remember.

## Verification

**Not compiled — no Swift toolchain here; macOS CI is the check.** Locally verified: brace balance unchanged against `HEAD`, and the two user-facing `splitPane` call sites still take the default.

Worth checking by hand on the build: start a sign-in and confirm the box's focus does **not** move, then swipe the sheet away and confirm no `claude auth login` pane is left behind.