### PR TITLE
ci: run the HerdrKit tests, and fix the guard that was failing on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,31 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # THE 369 HerdrKit TESTS, WHICH UNTIL NOW RAN NOWHERE (herdrup#189).
+  #
+  # ci.yml built the app and ran the XCUITest and never invoked `swift test`, so every
+  # test under Tests/HerdrKitTests was written, maintained and executed by nothing —
+  # including the wire-protocol tests, which are the ones where silence is expensive: a
+  # wrong CodingKey decodes as nil rather than throwing, so the app quietly loses a field
+  # instead of failing. A failing test also sat unnoticed on main because of this.
+  #
+  # It needs no macOS runner. HerdrKit is pure Swift with no UI framework, so it builds
+  # and tests on Linux in about 40 seconds — the cheapest job in the repo, on the runner
+  # class that is free for public repositories.
+  herdrkit:
+    name: HerdrKit (Linux)
+    runs-on: ubuntu-latest
+    container: swift:6.1
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build
+        run: swift build
+
+      - name: Test
+        run: swift test
+
   build-and-uitest:
     runs-on: macos-latest
     timeout-minutes: 45

--- a/Tests/HerdrKitTests/ReadmeLayoutTests.swift
+++ b/Tests/HerdrKitTests/ReadmeLayoutTests.swift
@@ -66,9 +66,18 @@ final class ReadmeLayoutTests: XCTestCase {
         // dispatch before shipping it.
         //
         // The block is a bare code fence, so decoration is not expected and
-        // rejecting it is correct. Two shapes are legal and nothing else is:
+        // rejecting it is correct. Three shapes are legal and nothing else is:
         //     <name>.swift        a file under Sources/HerdrKit
         //     Sources/<name>/     a source directory
+        //     Tests/<name>/       a test directory
+        //
+        // `Tests/` was added because the README legitimately names
+        // `Tests/HerdrKitTests/` and the grammar had no way to express it, so the
+        // guard failed closed on a row that was CORRECT. That is the right failure
+        // mode — it is why this was noticed at all — but the fix belongs in the
+        // grammar, not in the README: the row points at something real, which is
+        // the exact property this test exists to protect. The prefix list is
+        // explicit rather than "any directory" so an unknown shape still fails.
         var named: [String] = []
         var unparsed: [String] = []
         for line in block.split(separator: "\n") {
@@ -78,9 +87,13 @@ final class ReadmeLayoutTests: XCTestCase {
             let isFile = token.hasSuffix(".swift")
                 && token.dropLast(6).allSatisfy { $0.isLetter || $0.isNumber || $0 == "_" }
                 && !token.dropLast(6).isEmpty
-            let isDir = token.hasPrefix("Sources/") && token.hasSuffix("/")
-                && token.dropFirst(8).dropLast().allSatisfy { $0.isLetter || $0.isNumber || $0 == "_" }
-                && !token.dropFirst(8).dropLast().isEmpty
+            let dirPrefix = ["Sources/", "Tests/"].first { token.hasPrefix($0) }
+            let isDir: Bool = {
+                guard let dirPrefix, token.hasSuffix("/") else { return false }
+                let name = token.dropFirst(dirPrefix.count).dropLast()
+                return !name.isEmpty
+                    && name.allSatisfy { $0.isLetter || $0.isNumber || $0 == "_" }
+            }()
             if isFile { named.append("Sources/HerdrKit/" + token) }
             else if isDir { named.append(String(token.dropLast())) }
             else { unparsed.append(text) }


### PR DESCRIPTION
Closes the gap filed in #189. Two halves of one problem.

## The 369 tests that ran nowhere

`ci.yml` built the app and ran the XCUITest and **never invoked `swift test`**. Every test under `Tests/HerdrKitTests/` was written, maintained, and executed by nothing.

That includes the wire-protocol tests, which are exactly where silence is expensive: a wrong `CodingKey` decodes as `nil` rather than throwing, so the app quietly loses a field instead of failing loudly. Several tests exist specifically to catch that, and nothing ran them.

The new job **needs no macOS runner** — HerdrKit is pure Swift with no UI framework, so it builds and tests on Linux in ~40 seconds. Cheapest job in the repo, on the runner class that is free for public repos.

## The test that was failing on main

`ReadmeLayoutTests` parses the README layout block and checks every path it names exists. Its grammar allowed `<name>.swift` and `Sources/<name>/` — and nothing else. But the README legitimately names `Tests/HerdrKitTests/`, so **the guard failed closed on a row that was correct.**

Failing closed there was the right behaviour, and is the only reason this was findable at all. So the fix goes in the grammar, not the README: the row points at something real, which is the exact property this test exists to protect.

`Tests/` joins `Sources/` as an **explicit prefix**, not "any directory" — an unknown shape must still fail.

## Mutation-checked, not just green

Going green proves nothing on its own here — a guard can pass by no longer checking anything. So both directions were tested:

| mutation | result |
|---|---|
| a row with an unrecognised shape (`Vendor/Nonsense*/`) | still **REJECTED** — fail-closed intact |
| a `Tests/` directory that does not exist | still **CAUGHT** — existence still verified |

README restored byte-identical after each.

## Verified locally

`swift test` — **369 tests, 0 failures, exit 0**, using the toolchain at `/opt/swift/usr/bin` (Swift 6.1.2).

*(Disclosure, since it is the reason #189 existed: I spent a day asserting this machine had no Swift toolchain, having concluded that from `which swift` returning nothing because it is not on `PATH`. It was there the whole time.)*