### PR TITLE
fix(hosts): a Mac user could not enter a private key at all

### DIFF
--- a/App/HostEditor.swift
+++ b/App/HostEditor.swift
@@ -41,10 +41,9 @@ struct HostEditor: View {
     /// "Choose key file…" — the path that works everywhere, including the Mac build where
     /// `PasteButton` is inert.
     @State private var showingKeyImporter = false
-    /// Last-resort manual entry. Off by default because it is the one route that puts the
-    /// key on screen; a person who opens it has chosen that, which an ambient screenshot
-    /// has not.
-    @State private var showingManualEntry = false
+    /// Manual paste, shown ALONGSIDE the file picker rather than behind a disclosure.
+    /// Starts empty and is cleared the instant a key is accepted, so the only thing ever
+    /// on screen is what the person just put there.
     @State private var manualKey = ""
 
     private let editing: SavedHost?
@@ -234,87 +233,107 @@ struct HostEditor: View {
         NavigationStack {
             ZStack {
                 Palette.ground.ignoresSafeArea()
-                VStack(alignment: .leading, spacing: 14) {
-                    Text("Copy your ed25519 private key (PEM) to the clipboard, then paste it here. It is stored in the Keychain (device-only) and sent over the SSH connection; it is never displayed, so it can't appear in a screenshot.")
-                        .font(Typography.app(13)).foregroundStyle(Palette.textDim)
+                // Scrolled, matching the main form above. With two routes on screen —
+                // file button, caption, PasteButton, rule, a 110pt editor, accept button,
+                // the "Key set" row and an error line — this overflows a small iPhone,
+                // and raising the keyboard for the paste field guarantees it.
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 14) {
+                        // The old copy said the key comes from the clipboard and is "never
+                        // displayed". Both stopped being true here: there are two routes now,
+                        // and the paste field shows the key while it is being pasted. A
+                        // security claim left standing after the property it described is gone
+                        // is worse than no claim, so it says what is actually true instead.
+                        Text("Pick your ed25519 private key file, or paste the key below. It is stored in the Keychain on this device only, and sent over the SSH connection.")
+                            .font(Typography.app(13)).foregroundStyle(Palette.textDim)
 
-                    // FILE FIRST, and deliberately so. herdrup runs on macOS as a
-                    // "Designed for iPad" app (SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD),
-                    // where the PasteButton below is inert — the Mac pasteboard does not
-                    // surface a matching payload type to the iOS compatibility layer, so
-                    // the control stays disabled and there is NOTHING ELSE on this sheet.
-                    // A Mac user was therefore hard-blocked from adding a host at all.
-                    //
-                    // The file path also happens to be the natural one on a Mac: the key
-                    // is already at ~/.ssh/id_ed25519, and reading it renders nothing.
-                    Button { showingKeyImporter = true } label: {
-                        Label("Choose key file…", systemImage: "folder")
-                            .font(Typography.app(16, .semibold))
-                            .frame(maxWidth: .infinity).padding(.vertical, 15)
-                            .background(Palette.text).foregroundStyle(Palette.ground)
-                            .clipShape(RoundedRectangle(cornerRadius: 12))
-                    }
-                    .buttonStyle(.plain)
+                        // FILE FIRST, and deliberately so. herdrup runs on macOS as a
+                        // "Designed for iPad" app (SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD),
+                        // where the PasteButton below is inert — the Mac pasteboard does not
+                        // surface a matching payload type to the iOS compatibility layer, so
+                        // the control stays disabled and there is NOTHING ELSE on this sheet.
+                        // A Mac user was therefore hard-blocked from adding a host at all.
+                        //
+                        // The file path also happens to be the natural one on a Mac: the key
+                        // is already at ~/.ssh/id_ed25519, and reading it renders nothing.
+                        Button { showingKeyImporter = true } label: {
+                            Label("Choose key file…", systemImage: "folder")
+                                .font(Typography.app(16, .semibold))
+                                .frame(maxWidth: .infinity).padding(.vertical, 15)
+                                .background(Palette.text).foregroundStyle(Palette.ground)
+                                .clipShape(RoundedRectangle(cornerRadius: 12))
+                        }
+                        .buttonStyle(.plain)
 
-                    caption("Your key is usually at ~/.ssh/id_ed25519. That folder is "
-                            + "hidden — in the file picker press ⇧⌘. to show hidden files, "
-                            + "or ⇧⌘G and type the path.", color: Palette.textFaint)
+                        caption("Your key is usually at ~/.ssh/id_ed25519. That folder is "
+                                + "hidden — in the file picker press ⇧⌘. to show hidden files, "
+                                + "or ⇧⌘G and type the path.", color: Palette.textFaint)
 
-                    // System PasteButton, NOT a programmatic UIPasteboard read: the tap
-                    // itself is the paste consent, so it never shows the "Allow Paste"
-                    // permission prompt (which was the iPad App Review failure) and still
-                    // hands us the key WITHOUT rendering it. Auto-disables when the
-                    // clipboard holds no text — which on the Mac build is always.
-                    PasteButton(payloadType: String.self) { items in
-                        // The action can run off the main actor; hop before touching @State.
-                        Task { @MainActor in ingestKey(items.first) }
-                    }
-                    .labelStyle(.titleAndIcon)
-                    .tint(Palette.text)
-                    .buttonBorderShape(.roundedRectangle(radius: 12))
-                    .controlSize(.large)
-                    .frame(maxWidth: .infinity)
+                        // System PasteButton, NOT a programmatic UIPasteboard read: the tap
+                        // itself is the paste consent, so it never shows the "Allow Paste"
+                        // permission prompt (which was the iPad App Review failure) and still
+                        // hands us the key WITHOUT rendering it. Auto-disables when the
+                        // clipboard holds no text — which on the Mac build is always.
+                        PasteButton(payloadType: String.self) { items in
+                            // The action can run off the main actor; hop before touching @State.
+                            Task { @MainActor in ingestKey(items.first) }
+                        }
+                        .labelStyle(.titleAndIcon)
+                        .tint(Palette.text)
+                        .buttonBorderShape(.roundedRectangle(radius: 12))
+                        .controlSize(.large)
+                        .frame(maxWidth: .infinity)
 
-                    // Last resort, and the only route that shows the key. Pasting into a
-                    // field the user focused is their own action, so it triggers no
-                    // "Allow Paste" prompt — the thing that got this app rejected was a
-                    // PROGRAMMATIC pasteboard read, not a user pressing Cmd-V.
-                    if showingManualEntry {
+                        // The second route, a PEER of the file picker rather than something
+                        // hidden behind a disclosure. Pasting into a field the user focused is
+                        // their own action, so it triggers no "Allow Paste" prompt — what got
+                        // this app rejected under 2.1a was a PROGRAMMATIC pasteboard read, not
+                        // a person pressing Cmd-V.
+                        HStack(spacing: 10) {
+                            Rectangle().fill(Palette.surface).frame(height: 1)
+                            Text("or paste it").font(Typography.app(12))
+                                .foregroundStyle(Palette.textFaint)
+                            Rectangle().fill(Palette.surface).frame(height: 1)
+                        }
+                        .padding(.vertical, 2)
+
                         TextEditor(text: $manualKey)
                             .font(Typography.machine(12))
-                            .frame(height: 120)
+                            .frame(height: 110)
                             .scrollContentBackground(.hidden)
                             .background(Palette.surface)
                             .clipShape(RoundedRectangle(cornerRadius: 12))
                             .autocorrectionDisabled()
                             .textInputAutocapitalization(.never)
-                        Button("Use this key") {
-                            ingestKey(manualKey)
-                            // Drop the visible copy the moment it is accepted.
-                            if keyError == nil { manualKey = ""; showingManualEntry = false }
-                        }
-                        .font(Typography.app(15)).foregroundStyle(Palette.text)
-                        .disabled(manualKey.isEmpty)
-                    } else {
-                        Button("Paste it manually instead") { showingManualEntry = true }
-                            .font(Typography.app(14)).foregroundStyle(Palette.textDim)
-                    }
 
-                    if !keyPEM.isEmpty {
-                        HStack(spacing: 8) {
-                            Image(systemName: "checkmark.seal.fill").foregroundStyle(Palette.done)
-                            Text("Key set").font(Typography.app(15)).foregroundStyle(Palette.text)
-                            Spacer(minLength: 8)
-                            Button("Clear") { keyPEM = ""; keyError = nil }
-                                .font(Typography.app(14)).foregroundStyle(Palette.died)
+                        Button("Use pasted key") {
+                            ingestKey(manualKey)
+                            // Drop the visible copy as soon as it is accepted.
+                            if keyError == nil { manualKey = "" }
                         }
-                        .padding(.horizontal, 14).padding(.vertical, 12)
-                        .background(Palette.surface).clipShape(RoundedRectangle(cornerRadius: 12))
+                        .font(Typography.app(15, .semibold))
+                        .foregroundStyle(manualKey.isEmpty ? Palette.textFaint : Palette.text)
+                        .frame(maxWidth: .infinity).padding(.vertical, 12)
+                        .background(Palette.surface)
+                        .clipShape(RoundedRectangle(cornerRadius: 12))
+                        .disabled(manualKey.isEmpty)
+
+                        if !keyPEM.isEmpty {
+                            HStack(spacing: 8) {
+                                Image(systemName: "checkmark.seal.fill").foregroundStyle(Palette.done)
+                                Text("Key set").font(Typography.app(15)).foregroundStyle(Palette.text)
+                                Spacer(minLength: 8)
+                                Button("Clear") { keyPEM = ""; keyError = nil }
+                                    .font(Typography.app(14)).foregroundStyle(Palette.died)
+                            }
+                            .padding(.horizontal, 14).padding(.vertical, 12)
+                            .background(Palette.surface).clipShape(RoundedRectangle(cornerRadius: 12))
+                        }
+                        if let keyError { caption(keyError, color: Palette.died) }
+                        Spacer(minLength: 0)
                     }
-                    if let keyError { caption(keyError, color: Palette.died) }
-                    Spacer()
+                    .padding(20)
                 }
-                .padding(20)
             }
             .navigationTitle("Private key")
             .fileImporter(
@@ -364,15 +383,16 @@ struct HostEditor: View {
         }
     }
 
-    /// Ingest a PEM key handed over by the system `PasteButton`, WITHOUT rendering it.
-    /// Loosely sanity-checks it looks like a PEM private key so a stray clipboard string
-    /// isn't stored as a key. Never reads `UIPasteboard` directly — a programmatic read
-    /// triggers the system paste-permission prompt (the iPad App Review failure); the
-    /// PasteButton delivers the string instead.
+    /// Accept a PEM key from ANY of the three routes: the file picker, the system
+    /// `PasteButton`, or the manual paste field.
+    ///
+    /// Loosely sanity-checks that it looks like a PEM private key, so a stray string
+    /// isn't stored as a key. Note what is NOT here: a programmatic `UIPasteboard` read.
+    /// That triggers the system paste-permission prompt, which is what failed iPad App
+    /// Review under 2.1a — every route above hands the string in instead.
     private func ingestKey(_ raw: String?) {
-        // Source-agnostic wording: this is reached from the file picker, the PasteButton
-        // and the manual field, so a message naming the clipboard would be wrong on two
-        // of the three.
+        // Source-agnostic wording: a message naming the clipboard would be wrong for two
+        // of the three callers.
         guard let s = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !s.isEmpty else {
             keyError = "That was empty. Choose your private key file, or paste the key."
             return

--- a/App/HostEditor.swift
+++ b/App/HostEditor.swift
@@ -38,6 +38,14 @@ struct HostEditor: View {
     @State private var password = ""
     @State private var error: String?
     @State private var keyError: String?
+    /// "Choose key file…" — the path that works everywhere, including the Mac build where
+    /// `PasteButton` is inert.
+    @State private var showingKeyImporter = false
+    /// Last-resort manual entry. Off by default because it is the one route that puts the
+    /// key on screen; a person who opens it has chosen that, which an ambient screenshot
+    /// has not.
+    @State private var showingManualEntry = false
+    @State private var manualKey = ""
 
     private let editing: SavedHost?
 
@@ -230,11 +238,33 @@ struct HostEditor: View {
                     Text("Copy your ed25519 private key (PEM) to the clipboard, then paste it here. It is stored in the Keychain (device-only) and sent over the SSH connection; it is never displayed, so it can't appear in a screenshot.")
                         .font(Typography.app(13)).foregroundStyle(Palette.textDim)
 
+                    // FILE FIRST, and deliberately so. herdrup runs on macOS as a
+                    // "Designed for iPad" app (SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD),
+                    // where the PasteButton below is inert — the Mac pasteboard does not
+                    // surface a matching payload type to the iOS compatibility layer, so
+                    // the control stays disabled and there is NOTHING ELSE on this sheet.
+                    // A Mac user was therefore hard-blocked from adding a host at all.
+                    //
+                    // The file path also happens to be the natural one on a Mac: the key
+                    // is already at ~/.ssh/id_ed25519, and reading it renders nothing.
+                    Button { showingKeyImporter = true } label: {
+                        Label("Choose key file…", systemImage: "folder")
+                            .font(Typography.app(16, .semibold))
+                            .frame(maxWidth: .infinity).padding(.vertical, 15)
+                            .background(Palette.text).foregroundStyle(Palette.ground)
+                            .clipShape(RoundedRectangle(cornerRadius: 12))
+                    }
+                    .buttonStyle(.plain)
+
+                    caption("Your key is usually at ~/.ssh/id_ed25519. That folder is "
+                            + "hidden — in the file picker press ⇧⌘. to show hidden files, "
+                            + "or ⇧⌘G and type the path.", color: Palette.textFaint)
+
                     // System PasteButton, NOT a programmatic UIPasteboard read: the tap
                     // itself is the paste consent, so it never shows the "Allow Paste"
                     // permission prompt (which was the iPad App Review failure) and still
                     // hands us the key WITHOUT rendering it. Auto-disables when the
-                    // clipboard holds no text.
+                    // clipboard holds no text — which on the Mac build is always.
                     PasteButton(payloadType: String.self) { items in
                         // The action can run off the main actor; hop before touching @State.
                         Task { @MainActor in ingestKey(items.first) }
@@ -244,6 +274,31 @@ struct HostEditor: View {
                     .buttonBorderShape(.roundedRectangle(radius: 12))
                     .controlSize(.large)
                     .frame(maxWidth: .infinity)
+
+                    // Last resort, and the only route that shows the key. Pasting into a
+                    // field the user focused is their own action, so it triggers no
+                    // "Allow Paste" prompt — the thing that got this app rejected was a
+                    // PROGRAMMATIC pasteboard read, not a user pressing Cmd-V.
+                    if showingManualEntry {
+                        TextEditor(text: $manualKey)
+                            .font(Typography.machine(12))
+                            .frame(height: 120)
+                            .scrollContentBackground(.hidden)
+                            .background(Palette.surface)
+                            .clipShape(RoundedRectangle(cornerRadius: 12))
+                            .autocorrectionDisabled()
+                            .textInputAutocapitalization(.never)
+                        Button("Use this key") {
+                            ingestKey(manualKey)
+                            // Drop the visible copy the moment it is accepted.
+                            if keyError == nil { manualKey = ""; showingManualEntry = false }
+                        }
+                        .font(Typography.app(15)).foregroundStyle(Palette.text)
+                        .disabled(manualKey.isEmpty)
+                    } else {
+                        Button("Paste it manually instead") { showingManualEntry = true }
+                            .font(Typography.app(14)).foregroundStyle(Palette.textDim)
+                    }
 
                     if !keyPEM.isEmpty {
                         HStack(spacing: 8) {
@@ -262,10 +317,49 @@ struct HostEditor: View {
                 .padding(20)
             }
             .navigationTitle("Private key")
+            .fileImporter(
+                isPresented: $showingKeyImporter,
+                allowedContentTypes: [.item],  // an SSH key has no UTType and no extension
+                allowsMultipleSelection: false
+            ) { result in
+                importKeyFile(result)
+            }
             .toolbar {
                 ToolbarItem(placement: .topBarTrailing) {
                     Button("Done") { showingKeySheet = false }.foregroundStyle(Palette.textDim)
                 }
+            }
+        }
+    }
+
+    /// Read a private key the user picked in the file browser.
+    ///
+    /// This is the path that unblocks macOS, where `PasteButton` never enables. The file
+    /// is read and discarded — nothing is copied into the app's container, and the key is
+    /// not rendered.
+    private func importKeyFile(_ result: Result<[URL], Swift.Error>) {
+        switch result {
+        case .failure(let err):
+            keyError = "Couldn't open that file: \(err.localizedDescription)"
+        case .success(let urls):
+            guard let url = urls.first else { return }
+            // A file picked outside the sandbox is security-scoped; without this the read
+            // fails with a permission error that reads like a missing file.
+            let scoped = url.startAccessingSecurityScopedResource()
+            defer { if scoped { url.stopAccessingSecurityScopedResource() } }
+            do {
+                let text = try String(contentsOf: url, encoding: .utf8)
+                // A public key is the easy mistake to make here (id_ed25519.pub sits right
+                // next to the private one and sorts adjacent in the picker), and the
+                // generic "expected a PEM block" message would not explain it.
+                if text.hasPrefix("ssh-") || url.pathExtension == "pub" {
+                    keyError = "That's the PUBLIC key. Pick the file WITHOUT the .pub "
+                        + "ending — usually id_ed25519."
+                    return
+                }
+                ingestKey(text)
+            } catch {
+                keyError = "Couldn't read that file: \(error.localizedDescription)"
             }
         }
     }
@@ -276,12 +370,16 @@ struct HostEditor: View {
     /// triggers the system paste-permission prompt (the iPad App Review failure); the
     /// PasteButton delivers the string instead.
     private func ingestKey(_ raw: String?) {
+        // Source-agnostic wording: this is reached from the file picker, the PasteButton
+        // and the manual field, so a message naming the clipboard would be wrong on two
+        // of the three.
         guard let s = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !s.isEmpty else {
-            keyError = "Nothing to paste. Copy your private key to the clipboard first."
+            keyError = "That was empty. Choose your private key file, or paste the key."
             return
         }
         guard s.contains("PRIVATE KEY") else {
-            keyError = "That doesn't look like a private key (expected a PEM block)."
+            keyError = "That doesn't look like a private key. It should start with "
+                + "-----BEGIN OPENSSH PRIVATE KEY-----."
             return
         }
         keyPEM = s


### PR DESCRIPTION
## The bug

herdrup runs on macOS as a **"Designed for iPad"** app (`SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD`, `project.yml:203`). The private-key sheet contained exactly one control — a SwiftUI `PasteButton` — and in that compatibility environment the Mac pasteboard never surfaces a matching payload type, so the button never enables.

With nothing else on the sheet, **adding a key-authenticated host on a Mac was impossible**, not merely awkward. Reported by the owner, who hit it directly.

## The fix

Two routes, neither depending on the pasteboard, both first-class:

- **Choose key file…** — a `.fileImporter`, the same mechanism `GramView` already uses. On a Mac the key is already at `~/.ssh/id_ed25519`, so this is the natural path and it renders nothing: the file is read and discarded, never copied into the app container. The security-scoped resource is opened explicitly — without that the read fails with a permission error that reads like a missing file. The caption says how to reach a hidden folder in the picker (`⇧⌘.`), because `~/.ssh` is hidden and the picker gives no hint.
- **Paste field** — a person pressing ⌘V in a field they focused triggers no "Allow Paste" prompt. What failed iPad App Review under 2.1a was a *programmatic* `UIPasteboard` read, not a user paste. The field starts empty, nothing pre-fills it, and it clears the instant the key is accepted.

The `PasteButton` stays for iOS, where it works and is the App-Review-safe path.

Picking `id_ed25519.pub` by mistake gets its own message — it sits next to the private key and sorts adjacent in the picker, so it is the easy error, and the generic "expected a PEM block" would not have explained it.

## Two things found while making the change

**The sheet's intro text became false in two ways.** It said the key comes from the clipboard (no longer the only route) and that it "is never displayed, so it can't appear in a screenshot" — which stops being true once a paste field is on screen. A security claim left standing after the property it described is gone is worse than no claim, because a reader keeps trusting it. Rewritten to state what is actually true: Keychain, this device only, sent over SSH.

**The sheet never scrolled.** Its `VStack` was not inside a `ScrollView` — the one at `HostEditor.swift:98` wraps the main form, not this sheet. With both routes present it overflows a small iPhone, and raising the keyboard for the paste field guarantees it. Now wrapped, same shape as the form above.

## Verification — stated honestly

This is App-target SwiftUI and **does not build on the Linux box this was written on**.

What was checked locally: `swiftc -parse App/HostEditor.swift` passes, and that check was confirmed able to *fail* by breaking a function signature and watching it go red — so the pass means something. Every symbol used (`caption`, `Typography.machine/app`, all seven `Palette` members, `TextEditor` + `scrollContentBackground`, which `HerdrApp.swift:808` already uses) was confirmed to exist.

**Type checking is unverified until `build-and-uitest` on macos-latest runs here.** And whether the picker actually enumerates `~/.ssh`, and whether paste lands, can only be shown on a real Mac — a green CI build does not demonstrate either.

No HerdrKit code is touched, so the 390 `herdrkit` tests should be unaffected.

## Scope

Separate from #126 (QR pairing), deliberately. That work removes this screen from a new user's path entirely, but it does not help anyone on the current build — which is why this ships on its own.
