### PR TITLE
feat(pairing): scan to connect, and a first screen that explains itself

### DIFF
--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -451,12 +451,29 @@ struct RootView: View {
 /// The connect screen: a manager of saved machines. Tap a host to connect (one tap);
 /// "Add host" and hold-to-Edit open the HostEditor sheet. Constructing the transport
 /// does not connect — the first request does — so this never blocks on the network.
+/// Setup facts shown on more than one screen.
+///
+/// One definition, because the first-run screen and the post-failure guidance must not
+/// drift apart — a reader who follows one and then the other has to be given the same
+/// command both times.
+enum HerdrSetup {
+    /// Installs the fork on the machine: clone, build, install to `~/.local/bin`.
+    /// `install -D` creates the parent directory, so no separate `mkdir` is needed.
+    static let installCommand =
+        "git clone https://github.com/jerryfane/herdr && cd herdr && "
+        + "cargo build --release && "
+        + "install -D -m 0755 target/release/herdr ~/.local/bin/herdr"
+}
+
 struct ConnectView: View {
     var onConnect: (SSHCredentials) -> Void
 
     @ObservedObject private var savedHosts = SavedHostsStore.shared
     /// The add/edit sheet target; nil = closed.
     @State private var editorTarget: HostEditorTarget?
+    /// The scan-to-connect sheet (#126) — the path that needs no key, no host address and
+    /// no knowledge of what a daemon is.
+    @State private var showingPairing = false
 
     var body: some View {
         ZStack {
@@ -471,6 +488,11 @@ struct ConnectView: View {
                     } else {
                         savedHostsSection
                     }
+                    // Scanning is the PRIMARY action and manual entry the fallback, not
+                    // the other way round. The manual path asks for a host address, a
+                    // username and an ed25519 private key — three things a new user does
+                    // not have and cannot be expected to produce from this screen.
+                    scanButton
                     addHostButton
                     captions
                 }
@@ -487,6 +509,28 @@ struct ConnectView: View {
                 onConnect(creds)
             }
         }
+        .sheet(isPresented: $showingPairing) {
+            PairingSheet(store: savedHosts) { nickname in
+                // Connect straight into what was just paired: the point of scanning is
+                // that nothing else is asked for.
+                if let paired = savedHosts.hosts.first(where: { $0.nickname == nickname }) {
+                    tapSavedHost(paired)
+                }
+            }
+        }
+    }
+
+    private var scanButton: some View {
+        Button { showingPairing = true } label: {
+            HStack(spacing: 8) {
+                Image(systemName: "qrcode.viewfinder").font(.system(size: 16, weight: .semibold))
+                Text("Scan pairing code").font(Typography.app(16, .semibold))
+            }
+            .foregroundStyle(Palette.ground)
+            .frame(maxWidth: .infinity).padding(.vertical, 15)
+            .background(Palette.text).clipShape(RoundedRectangle(cornerRadius: 12))
+        }
+        .buttonStyle(.plain)
     }
 
     // Centered identity header: the app logo (the Lamb), the name, one line of intent.
@@ -512,15 +556,44 @@ struct ConnectView: View {
         .padding(.bottom, 8)
     }
 
+    /// The first screen a new user ever sees, and the one that blocked one.
+    ///
+    /// What it said before: "Add a machine to connect over your Tailscale network." That
+    /// assumed the reader already knew herdr runs on a computer, that a daemon has to be
+    /// installed there, and what Tailscale is — the word "herdr" did not appear anywhere
+    /// on this screen, and the page that DOES explain it was unreachable until after a
+    /// successful SSH login, i.e. visible only to people who had already solved it.
+    ///
+    /// So it now says what the app is, and gives the one command that starts everything.
     private var emptyState: some View {
-        VStack(spacing: 6) {
-            Text("No saved machines yet")
+        VStack(spacing: 12) {
+            Text("herdrup controls coding agents running on your computer.")
                 .font(Typography.app(15, .semibold)).foregroundStyle(Palette.text)
-            Text("Add a machine to connect over your Tailscale network.")
+                .multilineTextAlignment(.center)
+            Text("It needs herdr installed there first. On your computer, run:")
+                .font(Typography.app(13)).foregroundStyle(Palette.textDim)
+                .multilineTextAlignment(.center)
+
+            VStack(spacing: 8) {
+                monoCard(HerdrSetup.installCommand)
+                Text("then").font(Typography.app(12)).foregroundStyle(Palette.textFaint)
+                monoCard("herdr pair")
+            }
+
+            Text("Scan the code it prints and you're connected — no keys to copy.")
                 .font(Typography.app(13)).foregroundStyle(Palette.textDim)
                 .multilineTextAlignment(.center)
         }
         .frame(maxWidth: .infinity).padding(.vertical, 16)
+    }
+
+    private func monoCard(_ text: String) -> some View {
+        Text(text)
+            .font(Typography.machine(13)).foregroundStyle(Palette.text)
+            .textSelection(.enabled)
+            .padding(.horizontal, 14).padding(.vertical, 10)
+            .frame(maxWidth: .infinity)
+            .background(Palette.surface).clipShape(RoundedRectangle(cornerRadius: 10))
     }
 
     private var addHostButton: some View {
@@ -2395,13 +2468,13 @@ struct TerminalHomeView: View {
         Spacer()
     }
 
-    /// The one-liner that installs the fork on the remote machine, condensed from
-    /// the onboarding doc's happy path (clone, build, install to `~/.local/bin`).
-    /// `install -D` creates the parent dir, so no separate `mkdir` step is needed.
-    private static let herdrInstallCommand =
-        "git clone https://github.com/jerryfane/herdr && cd herdr && "
-        + "cargo build --release && "
-        + "install -D -m 0755 target/release/herdr ~/.local/bin/herdr"
+    /// The install one-liner, kept where BOTH screens that show it can reach it.
+    ///
+    /// It used to be `private static` on this view alone, which is why the first-run
+    /// screen could not show it: the only place explaining how to install herdr was
+    /// `herdrInstallGuidance`, reachable only AFTER a successful SSH login — visible
+    /// solely to people who had already solved the problem it explains.
+    private static var herdrInstallCommand: String { HerdrSetup.installCommand }
 
     /// Shown in place of the raw stderr when the connect failed because herdr is not
     /// installed (`herdrMissing`). Mirrors `ForkNoticeView`'s language and reuses the

--- a/App/PairingSheet.swift
+++ b/App/PairingSheet.swift
@@ -1,0 +1,196 @@
+import HerdrKit
+import SwiftUI
+import UIKit
+
+// MARK: - Adapters
+
+/// The app's real store, seen through the coordinator's protocol.
+///
+/// `add` already has the contract the coordinator needs: it persists the secret FIRST and
+/// returns false WITHOUT recording the host if that fails, so a false here never leaves a
+/// half-written host behind.
+extension SavedHostsStore: PairingCoordinator.HostStore {
+    func addPairedHost(nickname: String, host: String, username: String,
+                       privateKeyPEM: String) -> Bool {
+        add(nickname: nickname, host: host, username: username, secret: .key(privateKeyPEM))
+    }
+}
+
+/// The app's real pin store, seen through the coordinator's protocol. The signature already
+/// matches; this states the conformance rather than re-implementing anything.
+extension KeychainHostKeyPolicy: PairingCoordinator.HostKeyPinner {}
+
+// MARK: - The sheet
+
+/// Scan a pairing code and connect, without typing anything.
+///
+/// This view owns the CAMERA and the PHASES. It owns no pairing logic: parsing is
+/// `Pairing.parse`, and everything after a successful parse is `PairingCoordinator` — both
+/// in HerdrKit, both tested. What is left here is deliberately the part with no decisions
+/// in it, because this file cannot be built or run on the machine it was written on.
+struct PairingSheet: View {
+    @ObservedObject var store: SavedHostsStore
+    /// Called with the paired host's nickname once it is saved, so the caller can connect.
+    var onPaired: (String) -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var phase: Phase = .scanning
+    /// Bumped to rebuild the scanner after a failure, which restarts capture cleanly
+    /// rather than reaching into the controller.
+    @State private var scannerGeneration = 0
+
+    private enum Phase: Equatable {
+        case scanning
+        case unavailable(QRScannerUnavailable)
+        case pairing
+        case failed(String)
+        case paired(String)
+    }
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Palette.ground.ignoresSafeArea()
+                content
+            }
+            .navigationTitle("Scan to connect")
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Cancel") { dismiss() }.foregroundStyle(Palette.textDim)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch phase {
+        case .scanning:
+            scanner
+        case .unavailable(let reason):
+            message(
+                title: "Can't use the camera",
+                body: reason.message,
+                systemImage: "camera.fill",
+                tint: Palette.textDim,
+                primary: reason.offersSettings ? ("Open Settings", openSettings) : nil)
+        case .pairing:
+            VStack(spacing: 14) {
+                ProgressView().controlSize(.large).tint(Palette.text)
+                Text("Connecting…").font(Typography.app(15)).foregroundStyle(Palette.textDim)
+            }
+        case .failed(let why):
+            message(
+                title: "Pairing didn't work",
+                body: why,
+                systemImage: "exclamationmark.triangle.fill",
+                tint: Palette.died,
+                primary: ("Try again", { phase = .scanning; scannerGeneration += 1 }))
+        case .paired(let nickname):
+            message(
+                title: "Connected",
+                body: "\(nickname) is saved on this device. You can reach it any time from "
+                    + "the machine list.",
+                systemImage: "checkmark.seal.fill",
+                tint: Palette.done,
+                primary: ("Open it", { dismiss(); onPaired(nickname) }))
+        }
+    }
+
+    private var scanner: some View {
+        VStack(spacing: 0) {
+            ZStack {
+                QRScannerView(onFound: handleScan, onUnavailable: { phase = .unavailable($0) })
+                    .id(scannerGeneration)
+                // A frame to aim with. Without one people hold the phone too close and the
+                // code never fills the sensor, which reads as "the scanner is broken".
+                RoundedRectangle(cornerRadius: 20)
+                    .stroke(Palette.text.opacity(0.85), lineWidth: 3)
+                    .frame(width: 230, height: 230)
+                    .allowsHitTesting(false)
+            }
+            .clipShape(RoundedRectangle(cornerRadius: 16))
+            .padding(.horizontal, 20)
+
+            VStack(spacing: 8) {
+                Text("On your computer, run").font(Typography.app(13))
+                    .foregroundStyle(Palette.textDim)
+                Text("herdr pair").font(Typography.machine(16, .semibold))
+                    .foregroundStyle(Palette.text)
+                    .padding(.horizontal, 14).padding(.vertical, 8)
+                    .background(Palette.surface)
+                    .clipShape(RoundedRectangle(cornerRadius: 10))
+                Text("then point the camera at the code it prints.")
+                    .font(Typography.app(13)).foregroundStyle(Palette.textDim)
+            }
+            .multilineTextAlignment(.center)
+            .padding(20)
+        }
+    }
+
+    private func message(
+        title: String, body: String, systemImage: String, tint: Color,
+        primary: (String, () -> Void)?
+    ) -> some View {
+        VStack(spacing: 14) {
+            Image(systemName: systemImage).font(.system(size: 40)).foregroundStyle(tint)
+            Text(title).font(Typography.app(19, .semibold)).foregroundStyle(Palette.text)
+            Text(body).font(Typography.app(14)).foregroundStyle(Palette.textDim)
+                .multilineTextAlignment(.center)
+            if let (label, action) = primary {
+                Button(action: action) {
+                    Text(label).font(Typography.app(16, .semibold))
+                        .frame(maxWidth: .infinity).padding(.vertical, 14)
+                        .background(Palette.text).foregroundStyle(Palette.ground)
+                        .clipShape(RoundedRectangle(cornerRadius: 12))
+                }
+                .buttonStyle(.plain)
+                .padding(.top, 4)
+            }
+        }
+        .padding(28)
+    }
+
+    // MARK: - Actions
+
+    /// A scanned string. Parsing happens FIRST and on this thread, because it is cheap and
+    /// because a QR that is not a pairing code (a URL, a wifi code — a camera reports
+    /// whatever is in frame) must not put the sheet into a connecting state it then has to
+    /// back out of.
+    private func handleScan(_ raw: String) {
+        let payload: Pairing.Payload
+        do {
+            payload = try Pairing.parse(qrText: raw)
+        } catch let error as Pairing.Error {
+            phase = .failed(error.userFacingMessage)
+            return
+        } catch {
+            phase = .failed(Pairing.Error.notAPairingCode.userFacingMessage)
+            return
+        }
+
+        phase = .pairing
+        let coordinator = PairingCoordinator(store: store, pinner: KeychainHostKeyPolicy.shared)
+        let label = UIDevice.current.name
+        // Awaited on the MAIN actor deliberately, NOT in a detached task. The coordinator
+        // sends only the blocking socket round trip off-actor; the pin and the store write
+        // must stay here, because `addPairedHost` mutates an `@Published` property and
+        // SwiftUI does not allow that from a background thread.
+        Task {
+            do {
+                let nickname = try await coordinator.completePairing(
+                    payload: payload, deviceLabel: label)
+                phase = .paired(nickname)
+            } catch let failure as PairingCoordinator.Failure {
+                phase = .failed(failure.userFacingMessage)
+            } catch {
+                phase = .failed(error.localizedDescription)
+            }
+        }
+    }
+
+    private func openSettings() {
+        guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
+        UIApplication.shared.open(url)
+    }
+}

--- a/App/QRScanner.swift
+++ b/App/QRScanner.swift
@@ -1,0 +1,174 @@
+import AVFoundation
+import SwiftUI
+import UIKit
+
+/// A live camera view that reports the first QR code it sees.
+///
+/// Deliberately thin: it finds a code and hands the string up. Every decision about what
+/// that string MEANS lives in `Pairing.parse` and `PairingCoordinator`, in HerdrKit, where
+/// it is covered by tests. This file cannot be tested on the machine it was written on, so
+/// it is kept small enough to read in one sitting.
+struct QRScannerView: UIViewControllerRepresentable {
+    /// Called on the main actor with the decoded string, at most once per scanning session.
+    var onFound: (String) -> Void
+    /// Called when the camera cannot run at all (denied, restricted, or no device).
+    var onUnavailable: (QRScannerUnavailable) -> Void
+
+    func makeUIViewController(context: Context) -> QRScannerController {
+        let controller = QRScannerController()
+        controller.onFound = onFound
+        controller.onUnavailable = onUnavailable
+        return controller
+    }
+
+    func updateUIViewController(_ controller: QRScannerController, context: Context) {
+        // The closures capture SwiftUI state that is re-created on every body evaluation;
+        // without refreshing them the controller keeps calling into a stale generation and
+        // the sheet appears to ignore a successful scan.
+        controller.onFound = onFound
+        controller.onUnavailable = onUnavailable
+    }
+}
+
+/// Why the camera could not be used. Separated from a generic error so the UI can offer
+/// the right next step — Settings for a denial, manual entry for anything else.
+enum QRScannerUnavailable: Equatable {
+    /// The person said no, or can say yes in Settings.
+    case permissionDenied
+    /// Parental controls / MDM: asking again will not help.
+    case restricted
+    /// No usable camera (a Mac without one, or the simulator).
+    case noCamera
+    /// The capture graph would not start.
+    case cameraFailed(String)
+
+    var message: String {
+        switch self {
+        case .permissionDenied:
+            return "herdrup needs camera access to scan the pairing code. Turn it on in "
+                + "Settings, or add the machine manually."
+        case .restricted:
+            return "Camera access is restricted on this device. Add the machine manually."
+        case .noCamera:
+            return "This device has no camera to scan with. Add the machine manually."
+        case .cameraFailed(let why):
+            return "The camera couldn't start (\(why)). Add the machine manually."
+        }
+    }
+
+    /// Only a denial is fixable in Settings; offering that button for the others sends
+    /// someone to a screen with nothing on it to change.
+    var offersSettings: Bool { self == .permissionDenied }
+}
+
+final class QRScannerController: UIViewController, AVCaptureMetadataOutputObjectsDelegate {
+    var onFound: ((String) -> Void)?
+    var onUnavailable: ((QRScannerUnavailable) -> Void)?
+
+    private let session = AVCaptureSession()
+    private var preview: AVCaptureVideoPreviewLayer?
+    /// A camera delivers the same code many times a second. Without this the coordinator
+    /// would be driven repeatedly — pairing twice, with the second attempt failing on a
+    /// spent token and overwriting the success the user just saw.
+    private var hasReported = false
+    /// `startRunning` blocks; doing it on the main thread stalls the sheet's presentation
+    /// animation, which reads as the app freezing at the moment of opening the scanner.
+    private let sessionQueue = DispatchQueue(label: "herdrup.qrscanner.session")
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .black
+        requestAccessThenConfigure()
+    }
+
+    private func requestAccessThenConfigure() {
+        switch AVCaptureDevice.authorizationStatus(for: .video) {
+        case .authorized:
+            configure()
+        case .notDetermined:
+            AVCaptureDevice.requestAccess(for: .video) { [weak self] granted in
+                DispatchQueue.main.async {
+                    guard let self else { return }
+                    granted ? self.configure() : self.onUnavailable?(.permissionDenied)
+                }
+            }
+        case .denied:
+            onUnavailable?(.permissionDenied)
+        case .restricted:
+            onUnavailable?(.restricted)
+        @unknown default:
+            onUnavailable?(.permissionDenied)
+        }
+    }
+
+    private func configure() {
+        guard let device = AVCaptureDevice.default(for: .video),
+              let input = try? AVCaptureDeviceInput(device: device),
+              session.canAddInput(input)
+        else { return onUnavailable?(.noCamera) }
+        session.addInput(input)
+
+        let output = AVCaptureMetadataOutput()
+        guard session.canAddOutput(output) else {
+            return onUnavailable?(.cameraFailed("no metadata output"))
+        }
+        session.addOutput(output)
+        output.setMetadataObjectsDelegate(self, queue: .main)
+        // Set AFTER adding the output: available types are empty until then, so setting
+        // it earlier silently yields a session that detects nothing.
+        guard output.availableMetadataObjectTypes.contains(.qr) else {
+            return onUnavailable?(.cameraFailed("QR codes not supported here"))
+        }
+        output.metadataObjectTypes = [.qr]
+
+        let preview = AVCaptureVideoPreviewLayer(session: session)
+        preview.videoGravity = .resizeAspectFill
+        preview.frame = view.layer.bounds
+        view.layer.addSublayer(preview)
+        self.preview = preview
+
+        sessionQueue.async { [session] in session.startRunning() }
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        preview?.frame = view.layer.bounds
+    }
+
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        // Leaving the camera running holds the hardware and the privacy indicator stays
+        // lit after the sheet is gone.
+        sessionQueue.async { [session] in
+            if session.isRunning { session.stopRunning() }
+        }
+    }
+
+    func metadataOutput(
+        _ output: AVCaptureMetadataOutput,
+        didOutput objects: [AVMetadataObject],
+        from connection: AVCaptureConnection
+    ) {
+        guard !hasReported,
+              let object = objects.first as? AVMetadataMachineReadableCodeObject,
+              object.type == .qr,
+              let value = object.stringValue
+        else { return }
+        hasReported = true
+        // Stop first: a scan that opens a confirmation should not keep reading frames
+        // behind it.
+        sessionQueue.async { [session] in
+            if session.isRunning { session.stopRunning() }
+        }
+        UINotificationFeedbackGenerator().notificationOccurred(.success)
+        onFound?(value)
+    }
+
+    /// Allow another scan after a failure, without rebuilding the capture graph.
+    func resumeScanning() {
+        hasReported = false
+        sessionQueue.async { [session] in
+            if !session.isRunning { session.startRunning() }
+        }
+    }
+}

--- a/App/QRScanner.swift
+++ b/App/QRScanner.swift
@@ -105,19 +105,24 @@ final class QRScannerController: UIViewController, AVCaptureMetadataOutputObject
         guard let device = AVCaptureDevice.default(for: .video),
               let input = try? AVCaptureDeviceInput(device: device),
               session.canAddInput(input)
-        else { return onUnavailable?(.noCamera) }
+        else {
+            onUnavailable?(.noCamera)
+            return
+        }
         session.addInput(input)
 
         let output = AVCaptureMetadataOutput()
         guard session.canAddOutput(output) else {
-            return onUnavailable?(.cameraFailed("no metadata output"))
+            onUnavailable?(.cameraFailed("no metadata output"))
+            return
         }
         session.addOutput(output)
         output.setMetadataObjectsDelegate(self, queue: .main)
         // Set AFTER adding the output: available types are empty until then, so setting
         // it earlier silently yields a session that detects nothing.
         guard output.availableMetadataObjectTypes.contains(.qr) else {
-            return onUnavailable?(.cameraFailed("QR codes not supported here"))
+            onUnavailable?(.cameraFailed("QR codes not supported here"))
+            return
         }
         output.metadataObjectTypes = [.qr]
 

--- a/Sources/HerdrKit/Pairing.swift
+++ b/Sources/HerdrKit/Pairing.swift
@@ -1,0 +1,302 @@
+import Foundation
+#if canImport(Glibc)
+import Glibc
+#else
+import Darwin
+#endif
+
+/// The phone's half of QR pairing: read the code, redeem it, get connected.
+///
+/// The flow this completes: `herdr pair` on the machine prints a QR carrying a single-use
+/// token and the machine's SSH host-key fingerprint. The phone scans it, generates its own
+/// keypair (`PairingKey`), and sends only the PUBLIC half here. The machine appends that to
+/// `~/.ssh/authorized_keys`, and from then on the phone authenticates like any other host
+/// entry.
+///
+/// WHAT PROTECTS THIS EXCHANGE. It is a plaintext line-oriented protocol, deliberately:
+/// `herdr pair` binds to the machine's Tailscale address, so the bytes travel inside
+/// WireGuard, and the listener is not reachable from the internet at all. The token is
+/// single-use and short-lived, so a photograph of the QR is worthless once redeemed. The
+/// only secret the phone ever holds — its private key — is never sent.
+public enum Pairing {}
+
+// MARK: - The payload carried by the QR
+
+extension Pairing {
+    /// The QR's contents. Field names are the wire contract with `PairingPayload` in
+    /// herdr's `src/pairing.rs`; renaming one here silently breaks pairing against a
+    /// released daemon, so they are short and fixed.
+    public struct Payload: Codable, Sendable, Equatable {
+        /// Format version. Present so an old app meets a new daemon with a real error
+        /// rather than a misparse.
+        public let v: Int
+        /// The address to connect to — the machine's tailnet IP.
+        public let host: String
+        public let port: Int
+        /// The SSH user to log in as.
+        public let user: String
+        /// Single-use pairing token.
+        public let token: String
+        /// The machine's SSH host-key fingerprint, `SHA256:...`.
+        ///
+        /// EMPTY MEANS UNKNOWN, not "no pinning needed". The daemon sends an empty string
+        /// when it could not read its own host key; the app must then either warn or fall
+        /// back to trust-on-first-use, and `hostKeyFingerprint` makes that explicit rather
+        /// than letting an empty string flow into a pin call.
+        public let fp: String
+
+        public init(v: Int, host: String, port: Int, user: String, token: String, fp: String) {
+            self.v = v
+            self.host = host
+            self.port = port
+            self.user = user
+            self.token = token
+            self.fp = fp
+        }
+
+        /// `nil` when the machine could not report its host key — the caller must not pin.
+        public var hostKeyFingerprint: String? {
+            let trimmed = fp.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? nil : trimmed
+        }
+    }
+
+    /// The payload version this build speaks. Must match `PAIRING_PAYLOAD_VERSION`.
+    public static let supportedPayloadVersion = 1
+
+    /// Parse and VALIDATE a scanned QR.
+    ///
+    /// A camera will happily hand us any QR in the frame — a wifi code, a URL, a boarding
+    /// pass. Every field is therefore checked here rather than trusted, so the failure a
+    /// user sees is "that is not a herdr pairing code" instead of a socket error later.
+    public static func parse(qrText: String) throws -> Payload {
+        let trimmed = qrText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let data = trimmed.data(using: .utf8),
+              let payload = try? JSONDecoder().decode(Payload.self, from: data)
+        else { throw Error.notAPairingCode }
+
+        // Version first: a version mismatch must not be reported as a bad field, because
+        // the remedy is different (update, not rescan).
+        guard payload.v == supportedPayloadVersion else {
+            throw Error.unsupportedVersion(payload.v)
+        }
+        guard !payload.host.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              !payload.user.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              !payload.token.isEmpty,
+              (1...65535).contains(payload.port)
+        else { throw Error.notAPairingCode }
+        return payload
+    }
+}
+
+// MARK: - Errors
+
+extension Pairing {
+    public enum Error: Swift.Error, Equatable {
+        /// The scanned code is not a herdr pairing payload, or a field is unusable.
+        case notAPairingCode
+        /// The code was made by a daemon this app does not speak.
+        case unsupportedVersion(Int)
+        /// Could not reach the machine at all.
+        case unreachable(String)
+        /// The machine refused the redemption. The message is the daemon's, which is
+        /// deliberately OPAQUE — it does not say whether the token, the key, or the shape
+        /// was wrong, so nothing here can be turned into a probe.
+        case refused(String)
+        /// Connected, but the reply was not something this protocol defines.
+        case badResponse(String)
+
+        /// What to show a person. The daemon's refusal text is intentionally uninformative,
+        /// so the app supplies the actionable sentence instead of surfacing it raw.
+        public var userFacingMessage: String {
+            switch self {
+            case .notAPairingCode:
+                return "That code isn't a herdr pairing code. On your computer, run "
+                    + "`herdr pair` and scan the code it prints."
+            case .unsupportedVersion:
+                return "This pairing code was made by a newer version of herdr. "
+                    + "Update the app, then scan it again."
+            case .unreachable:
+                return "Couldn't reach that computer. Check both devices are on the same "
+                    + "Tailscale network, then run `herdr pair` again."
+            case .refused:
+                return "The computer turned down this code. Pairing codes work once and "
+                    + "expire — run `herdr pair` again for a fresh one."
+            case .badResponse:
+                return "Got an unexpected reply from that computer. Run `herdr pair` again."
+            }
+        }
+    }
+}
+
+// MARK: - Redeeming
+
+extension Pairing {
+    /// The request sent to the machine. Field names are the contract with `PairRedeem` in
+    /// `src/pairing.rs`; `type` is spelled via CodingKeys because it is a Swift keyword.
+    struct RedeemRequest: Codable, Equatable {
+        let kind: String
+        let token: String
+        let publicKey: String
+        let device: String
+
+        enum CodingKeys: String, CodingKey {
+            case kind = "type"
+            case token
+            case publicKey = "public_key"
+            case device
+        }
+    }
+
+    /// Must equal `PAIR_REDEEM_KIND`.
+    static let redeemKind = "pair.redeem"
+
+    /// Encode the redemption as the single line the daemon reads.
+    ///
+    /// Separated from the socket so the wire format is testable without a server, and so
+    /// the one place that could leak a private key is a pure function you can read.
+    static func redeemLine(token: String, publicKeyLine: String, deviceLabel: String) throws -> Data {
+        let request = RedeemRequest(
+            kind: redeemKind,
+            token: token,
+            publicKey: publicKeyLine,
+            device: deviceLabel)
+        var data = try JSONEncoder().encode(request)
+        data.append(0x0A)  // the daemon reads exactly one line
+        return data
+    }
+
+    /// Redeem a scanned code: hand the machine this device's PUBLIC key.
+    ///
+    /// Blocking, by design — it is one short request/response and the caller runs it off
+    /// the main actor. A synchronous core is what lets the whole protocol be tested against
+    /// a real socket on Linux, where the app's own networking stack does not exist.
+    ///
+    /// - Parameter publicKeyLine: an `authorized_keys` line, from `PairingKey`. NEVER a
+    ///   private key; the daemon validates the shape and refuses anything else.
+    public static func redeem(
+        payload: Payload,
+        publicKeyLine: String,
+        deviceLabel: String,
+        timeout: TimeInterval = 15
+    ) throws {
+        let line = try redeemLine(
+            token: payload.token, publicKeyLine: publicKeyLine, deviceLabel: deviceLabel)
+
+        let fd = try connectSocket(host: payload.host, port: payload.port, timeout: timeout)
+        defer { platformClose(fd) }
+
+        try writeAll(fd: fd, data: line)
+        let reply = try readLine(fd: fd)
+
+        guard let replyData = reply.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: replyData) as? [String: Any],
+              let type = object["type"] as? String
+        else { throw Error.badResponse(reply.isEmpty ? "connection closed" : reply) }
+
+        switch type {
+        case "pair.ok":
+            return
+        case "pair.error":
+            throw Error.refused((object["message"] as? String) ?? "pairing refused")
+        default:
+            throw Error.badResponse(type)
+        }
+    }
+
+    /// Async wrapper for callers driving this from SwiftUI.
+    public static func redeem(
+        payload: Payload,
+        publicKeyLine: String,
+        deviceLabel: String,
+        timeout: TimeInterval = 15
+    ) async throws {
+        try await Task.detached(priority: .userInitiated) {
+            try redeem(
+                payload: payload, publicKeyLine: publicKeyLine,
+                deviceLabel: deviceLabel, timeout: timeout)
+        }.value
+    }
+}
+
+// MARK: - Sockets
+
+extension Pairing {
+    /// Connect to a numeric IPv4 address.
+    ///
+    /// DELIBERATELY NO DNS. The payload is generated by `herdr pair`, which always writes a
+    /// literal tailnet address, so accepting a hostname would only add a resolver — and a
+    /// name in a scanned QR is a way to point the phone somewhere the machine did not.
+    static func connectSocket(host: String, port: Int, timeout: TimeInterval) throws -> Int32 {
+        var addr = sockaddr_in()
+        addr.sin_family = sa_family_t(AF_INET)
+        addr.sin_port = UInt16(port).bigEndian
+        guard inet_pton(AF_INET, host, &addr.sin_addr) == 1 else {
+            throw Error.unreachable("not an IPv4 address: \(host)")
+        }
+
+        let fd = socket(AF_INET, sockStream, 0)
+        guard fd >= 0 else { throw Error.unreachable("could not open a socket") }
+
+        // Bound both ways: a machine that accepts and then says nothing must not hang the
+        // pairing screen forever.
+        var tv = timeval(tv_sec: Int(timeout), tv_usec: 0)
+        withUnsafePointer(to: &tv) { p in
+            _ = setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, p, socklen_t(MemoryLayout<timeval>.size))
+            _ = setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, p, socklen_t(MemoryLayout<timeval>.size))
+        }
+
+        let result = withUnsafePointer(to: &addr) {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                platformConnect(fd, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        guard result == 0 else {
+            let code = errno
+            platformClose(fd)
+            throw Error.unreachable("\(host):\(port) — \(String(cString: strerror(code)))")
+        }
+        return fd
+    }
+
+    static func writeAll(fd: Int32, data: Data) throws {
+        var sent = 0
+        try data.withUnsafeBytes { (raw: UnsafeRawBufferPointer) in
+            guard let base = raw.baseAddress else { return }
+            while sent < data.count {
+                let n = send(fd, base.advanced(by: sent), data.count - sent, 0)
+                if n > 0 {
+                    sent += n
+                } else if n < 0 && errno == EINTR {
+                    continue
+                } else {
+                    throw Error.unreachable("send failed: \(String(cString: strerror(errno)))")
+                }
+            }
+        }
+    }
+
+    /// Read one newline-terminated line, bounded.
+    ///
+    /// The cap matters even though the peer is our own daemon: this runs before any
+    /// authentication, so a wrong or hostile listener must not be able to grow the phone's
+    /// memory by never sending a newline.
+    static func readLine(fd: Int32, limit: Int = 8 * 1024) throws -> String {
+        var out = [UInt8]()
+        var byte: UInt8 = 0
+        while out.count < limit {
+            let n = recv(fd, &byte, 1, 0)
+            if n == 1 {
+                if byte == 0x0A { break }
+                out.append(byte)
+            } else if n == 0 {
+                break  // peer closed; caller reports whatever arrived
+            } else if errno == EINTR {
+                continue
+            } else {
+                throw Error.unreachable("read failed: \(String(cString: strerror(errno)))")
+            }
+        }
+        return String(decoding: out, as: UTF8.self)
+    }
+}

--- a/Sources/HerdrKit/PairingCoordinator.swift
+++ b/Sources/HerdrKit/PairingCoordinator.swift
@@ -1,0 +1,153 @@
+import Foundation
+
+/// Everything that happens AFTER a pairing QR is scanned, in one testable place.
+///
+/// The camera and the SwiftUI screens have to live in the app target, which does not build
+/// on Linux — so the decisions live here instead, behind two small protocols the app
+/// conforms to. What is decided here is the part that can be silently wrong: the ORDER of
+/// the steps, and which failures are allowed to be partial.
+///
+/// THE ORDER IS THE POINT.
+///
+///  1. PIN the host key first. If pinning fails, nothing has touched the other machine —
+///     no key has been added, nothing needs revoking. Pinning after redeeming would leave
+///     an orphaned key in someone's `authorized_keys` on a failure they did not cause.
+///  2. REDEEM, which hands over the public key.
+///  3. SAVE the host and its private key.
+///
+/// A host saved without a pin is the failure worth refusing outright: `HostEditor` hosts
+/// trust-on-first-use, so an unpinned entry connects to whatever answers, once, silently.
+/// The whole reason the payload carries a fingerprint is to close that window.
+public struct PairingCoordinator {
+
+    /// Where a paired host gets recorded. `SavedHostsStore` in the app conforms to this.
+    public protocol HostStore {
+        /// Returns false WITHOUT recording the host if the secret could not be persisted,
+        /// which is the contract `SavedHostsStore.add` already has.
+        func addPairedHost(nickname: String, host: String, username: String,
+                           privateKeyPEM: String) -> Bool
+    }
+
+    /// Where a host-key fingerprint gets pinned. `KeychainHostKeyPolicy` conforms.
+    public protocol HostKeyPinner {
+        /// Returns whether the pin actually persisted. A `false` here must not be ignored.
+        func pin(host: String, port: UInt16, fingerprint: String) -> Bool
+    }
+
+    public enum Failure: Swift.Error, Equatable {
+        /// The machine could not tell us its host key, so there is nothing to pin and the
+        /// first connection would trust whatever answers.
+        case noHostKeyToPin
+        /// We had a fingerprint but could not store it.
+        case couldNotPinHostKey
+        /// Pairing itself failed. Carries the underlying reason so the UI can show its
+        /// actionable message.
+        case pairing(Pairing.Error)
+        /// The machine accepted our key, but the host could not be saved on this device.
+        /// Deliberately distinct: the remote side DID change, so the message differs.
+        case pairedButCouldNotSave
+
+        public var userFacingMessage: String {
+            switch self {
+            case .noHostKeyToPin:
+                return "That computer couldn't identify itself, so connecting to it "
+                    + "wouldn't be safe. Make sure SSH is enabled on it, then run "
+                    + "`herdr pair` again."
+            case .couldNotPinHostKey:
+                return "Couldn't save that computer's identity on this device. Try again."
+            case .pairing(let error):
+                return error.userFacingMessage
+            case .pairedButCouldNotSave:
+                return "Your key was added to that computer, but this device couldn't save "
+                    + "the connection. Remove the line marked herdr-pair from its "
+                    + "~/.ssh/authorized_keys and pair again."
+            }
+        }
+    }
+
+    private let store: HostStore
+    private let pinner: HostKeyPinner
+    /// Injectable so tests drive the real socket protocol against a stub daemon.
+    private let redeem: (Pairing.Payload, String, String) throws -> Void
+
+    public init(
+        store: HostStore,
+        pinner: HostKeyPinner,
+        redeem: @escaping (Pairing.Payload, String, String) throws -> Void = {
+            try Pairing.redeem(payload: $0, publicKeyLine: $1, deviceLabel: $2)
+        }
+    ) {
+        self.store = store
+        self.pinner = pinner
+        self.redeem = redeem
+    }
+
+    /// Pair with the machine described by a scanned payload.
+    ///
+    /// - Parameter deviceLabel: shown in the machine's `authorized_keys` so a person can
+    ///   recognise and revoke this device later. A device name, not a secret.
+    /// - Returns: the nickname the host was saved under.
+    @discardableResult
+    public func completePairing(
+        payload: Pairing.Payload,
+        deviceLabel: String,
+        nickname: String? = nil
+    ) throws -> String {
+        // 1. Pin BEFORE touching the other machine.
+        guard let fingerprint = payload.hostKeyFingerprint else {
+            throw Failure.noHostKeyToPin
+        }
+        let port = sshPort(for: payload.host)
+        guard pinner.pin(host: bareHost(payload.host), port: port, fingerprint: fingerprint) else {
+            throw Failure.couldNotPinHostKey
+        }
+
+        // 2. Hand over the PUBLIC half. The private key stays in `key` and goes to the
+        //    Keychain below; it is never sent and never written anywhere else.
+        let key = PairingKey(comment: deviceLabel)
+        do {
+            try redeem(payload, key.authorizedKeysLine, deviceLabel)
+        } catch let error as Pairing.Error {
+            throw Failure.pairing(error)
+        }
+
+        // 3. Record the host. The store persists the secret first and returns false
+        //    without recording anything if that fails, so a false here means nothing was
+        //    half-written locally — but the remote machine HAS our key, hence its own case.
+        let name = nickname ?? defaultNickname(for: payload)
+        guard store.addPairedHost(
+            nickname: name,
+            host: payload.host,
+            username: payload.user,
+            privateKeyPEM: key.privateKeyPEM)
+        else { throw Failure.pairedButCouldNotSave }
+
+        return name
+    }
+
+    /// The SSH port to pin against — NOT the pairing port.
+    ///
+    /// The payload's `port` is the short-lived pairing listener, which is gone seconds
+    /// later; SSH is a different service on a different port. Pinning against the pairing
+    /// port would store the fingerprint under a key the SSH connection never looks up, so
+    /// the pin would silently miss and first contact would trust-on-first-use anyway —
+    /// the exact hole this is meant to close.
+    private func sshPort(for host: String) -> UInt16 {
+        guard let colon = host.lastIndex(of: ":"),
+              let explicit = UInt16(host[host.index(after: colon)...])
+        else { return 22 }
+        return explicit
+    }
+
+    /// The host without any ":port" suffix, matching how the pin store keys entries.
+    private func bareHost(_ host: String) -> String {
+        guard let colon = host.lastIndex(of: ":"),
+              UInt16(host[host.index(after: colon)...]) != nil
+        else { return host }
+        return String(host[host.startIndex..<colon])
+    }
+
+    private func defaultNickname(for payload: Pairing.Payload) -> String {
+        "\(payload.user)@\(bareHost(payload.host))"
+    }
+}

--- a/Sources/HerdrKit/PairingCoordinator.swift
+++ b/Sources/HerdrKit/PairingCoordinator.swift
@@ -68,13 +68,13 @@ public struct PairingCoordinator {
     private let store: HostStore
     private let pinner: HostKeyPinner
     /// Injectable so tests drive the real socket protocol against a stub daemon.
-    private let redeem: (Pairing.Payload, String, String) throws -> Void
+    private let redeem: (Pairing.Payload, String, String) async throws -> Void
 
     public init(
         store: HostStore,
         pinner: HostKeyPinner,
-        redeem: @escaping (Pairing.Payload, String, String) throws -> Void = {
-            try Pairing.redeem(payload: $0, publicKeyLine: $1, deviceLabel: $2)
+        redeem: @escaping (Pairing.Payload, String, String) async throws -> Void = {
+            try await Pairing.redeem(payload: $0, publicKeyLine: $1, deviceLabel: $2)
         }
     ) {
         self.store = store
@@ -87,12 +87,18 @@ public struct PairingCoordinator {
     /// - Parameter deviceLabel: shown in the machine's `authorized_keys` so a person can
     ///   recognise and revoke this device later. A device name, not a secret.
     /// - Returns: the nickname the host was saved under.
+    /// ASYNC, and the reason is not style. The redemption is a blocking socket round
+    /// trip, so it must leave the caller's actor — but the store and the pinner must NOT.
+    /// `store.addPairedHost` mutates an `@Published` property, and SwiftUI forbids that
+    /// off the main actor. Awaiting only the socket keeps steps 1 and 3 on the caller's
+    /// actor while step 2 goes wide, instead of detaching the whole thing and mutating
+    /// observable state from a background thread.
     @discardableResult
     public func completePairing(
         payload: Pairing.Payload,
         deviceLabel: String,
         nickname: String? = nil
-    ) throws -> String {
+    ) async throws -> String {
         // 1. Pin BEFORE touching the other machine.
         guard let fingerprint = payload.hostKeyFingerprint else {
             throw Failure.noHostKeyToPin
@@ -106,7 +112,7 @@ public struct PairingCoordinator {
         //    Keychain below; it is never sent and never written anywhere else.
         let key = PairingKey(comment: deviceLabel)
         do {
-            try redeem(payload, key.authorizedKeysLine, deviceLabel)
+            try await redeem(payload, key.authorizedKeysLine, deviceLabel)
         } catch let error as Pairing.Error {
             throw Failure.pairing(error)
         }

--- a/Sources/HerdrKit/PairingKey.swift
+++ b/Sources/HerdrKit/PairingKey.swift
@@ -1,0 +1,78 @@
+import Foundation
+import Citadel
+import Crypto
+import NIOCore
+
+/// The keypair a phone generates for itself during QR pairing.
+///
+/// THE PRIVATE HALF NEVER LEAVES THE DEVICE. Pairing sends only `authorizedKeysLine`
+/// to the machine, which appends it to `~/.ssh/authorized_keys`; the private key goes
+/// straight into the Keychain via `SavedHostsStore.add`. Nothing secret is ever in the
+/// QR code, on the wire, or in a log — the QR carries a single-use token, and the token
+/// is worthless once redeemed.
+///
+/// This exists because the app had NO way to make a key. `HostEditor` asks the user to
+/// paste an ed25519 PEM from the clipboard, which means generating one on a computer
+/// first — the exact step that blocked a new user at the first screen.
+public struct PairingKey: Sendable {
+    /// OpenSSH-format private key ("-----BEGIN OPENSSH PRIVATE KEY-----"), the shape
+    /// `SavedHostsStore` stores and `CitadelTransport` parses back.
+    public let privateKeyPEM: String
+    /// One `authorized_keys` line: `ssh-ed25519 <base64> <comment>`.
+    public let authorizedKeysLine: String
+    /// The SHA256 fingerprint of the PUBLIC key, in OpenSSH's display form
+    /// (`SHA256:<base64 without padding>`), for showing the user which key was added.
+    public let publicKeyFingerprint: String
+
+    /// Generate a fresh keypair. The comment lands in both the private key and the
+    /// `authorized_keys` line, so a person reading either can tell where it came from
+    /// and revoke it without guessing.
+    public init(comment: String) {
+        let key = Curve25519.Signing.PrivateKey()
+        self.init(key: key, comment: comment)
+    }
+
+    /// Testable seam: build from a supplied key so a round-trip test can compare against
+    /// a known input rather than only against itself.
+    public init(key: Curve25519.Signing.PrivateKey, comment: String) {
+        // Citadel already writes the OpenSSH container (cipher `none`, kdf `none`,
+        // duplicated checksum, 8-byte block padding). Hand-rolling that encoding would
+        // be the riskiest part of pairing for no gain — and getting the padding subtly
+        // wrong fails at authentication time, on someone else's machine.
+        self.privateKeyPEM = key.makeSSHRepresentation(comment: comment)
+        self.authorizedKeysLine = Self.authorizedKeysLine(for: key.publicKey, comment: comment)
+        self.publicKeyFingerprint = Self.fingerprint(for: key.publicKey)
+    }
+
+    /// The wire encoding of an ed25519 public key: `string "ssh-ed25519"` followed by
+    /// `string <32 raw bytes>`, each length-prefixed with a big-endian UInt32. This is
+    /// the same blob that goes in `authorized_keys` and that the fingerprint hashes.
+    static func publicKeyBlob(_ publicKey: Curve25519.Signing.PublicKey) -> Data {
+        var out = Data()
+        func writeString(_ bytes: Data) {
+            var len = UInt32(bytes.count).bigEndian
+            withUnsafeBytes(of: &len) { out.append(contentsOf: $0) }
+            out.append(bytes)
+        }
+        writeString(Data("ssh-ed25519".utf8))
+        writeString(publicKey.rawRepresentation)
+        return out
+    }
+
+    static func authorizedKeysLine(for publicKey: Curve25519.Signing.PublicKey,
+                                   comment: String) -> String {
+        let b64 = publicKeyBlob(publicKey).base64EncodedString()
+        let trimmed = comment.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? "ssh-ed25519 \(b64)" : "ssh-ed25519 \(b64) \(trimmed)"
+    }
+
+    /// OpenSSH prints fingerprints as unpadded base64 of the SHA256 over the key blob —
+    /// matching `ssh-keygen -lf`, so what the app shows and what the machine prints are
+    /// the same string.
+    static func fingerprint(for publicKey: Curve25519.Signing.PublicKey) -> String {
+        let digest = SHA256.hash(data: publicKeyBlob(publicKey))
+        let b64 = Data(digest).base64EncodedString()
+            .replacingOccurrences(of: "=", with: "")
+        return "SHA256:\(b64)"
+    }
+}

--- a/Sources/HerdrKit/PlatformSocket.swift
+++ b/Sources/HerdrKit/PlatformSocket.swift
@@ -32,3 +32,27 @@ public func platformBind(
     return Glibc.bind(fd, addr, len)
 #endif
 }
+
+/// `connect(2)`, reached unambiguously.
+///
+/// Same reason as `platformBind`: the bare name can resolve to something else at a call
+/// site (XCTestCase exposes members that shadow C symbols), so the module is named here
+/// once rather than at every use.
+public func platformConnect(
+    _ fd: Int32, _ addr: UnsafePointer<sockaddr>, _ len: socklen_t
+) -> Int32 {
+#if canImport(Darwin)
+    return Darwin.connect(fd, addr, len)
+#else
+    return Glibc.connect(fd, addr, len)
+#endif
+}
+
+/// `close(2)`, reached unambiguously.
+public func platformClose(_ fd: Int32) {
+#if canImport(Darwin)
+    _ = Darwin.close(fd)
+#else
+    _ = Glibc.close(fd)
+#endif
+}

--- a/Tests/HerdrKitTests/PairingCoordinatorTests.swift
+++ b/Tests/HerdrKitTests/PairingCoordinatorTests.swift
@@ -1,0 +1,221 @@
+import XCTest
+import Foundation
+import Crypto
+import Citadel
+@testable import HerdrKit
+
+/// The decisions that happen after a scan: what order, and which failures are refused.
+///
+/// These are exactly the things a device test would be bad at. On a phone, "it worked"
+/// hides whether the pin was written before or after the remote machine was changed, and
+/// whether an unpinned host was quietly saved anyway — both invisible until someone is
+/// attacked. Here they are ordinary assertions.
+final class PairingCoordinatorTests: XCTestCase {
+
+    // MARK: - Doubles that RECORD ORDER
+
+    private final class Recorder: @unchecked Sendable {
+        var events: [String] = []
+        var pinSucceeds = true
+        var saveSucceeds = true
+        var redeemError: Pairing.Error?
+        var pinnedHost: String?
+        var pinnedPort: UInt16?
+        var pinnedFingerprint: String?
+        var savedKeyPEM: String?
+        var savedHost: String?
+        var savedUser: String?
+        var sentPublicKey: String?
+        var sentDeviceLabel: String?
+    }
+
+    private struct FakeStore: PairingCoordinator.HostStore {
+        let recorder: Recorder
+        func addPairedHost(nickname: String, host: String, username: String,
+                           privateKeyPEM: String) -> Bool {
+            recorder.events.append("save")
+            recorder.savedHost = host
+            recorder.savedUser = username
+            recorder.savedKeyPEM = privateKeyPEM
+            return recorder.saveSucceeds
+        }
+    }
+
+    private struct FakePinner: PairingCoordinator.HostKeyPinner {
+        let recorder: Recorder
+        func pin(host: String, port: UInt16, fingerprint: String) -> Bool {
+            recorder.events.append("pin")
+            recorder.pinnedHost = host
+            recorder.pinnedPort = port
+            recorder.pinnedFingerprint = fingerprint
+            return recorder.pinSucceeds
+        }
+    }
+
+    private func makeCoordinator(_ recorder: Recorder) -> PairingCoordinator {
+        PairingCoordinator(
+            store: FakeStore(recorder: recorder),
+            pinner: FakePinner(recorder: recorder),
+            redeem: { _, publicKey, label in
+                recorder.events.append("redeem")
+                recorder.sentPublicKey = publicKey
+                recorder.sentDeviceLabel = label
+                if let error = recorder.redeemError { throw error }
+            })
+    }
+
+    private func payload(host: String = "100.64.1.2", fp: String = "SHA256:abc") -> Pairing.Payload {
+        Pairing.Payload(v: 1, host: host, port: 4021, user: "jerry", token: "tok", fp: fp)
+    }
+
+    // MARK: - Order
+
+    /// PIN BEFORE REDEEM. If pinning fails after the key is already on the other machine,
+    /// the user is left with an orphaned entry in their authorized_keys for a failure they
+    /// did not cause and will not be told about.
+    func testPinsBeforeTouchingTheOtherMachine() throws {
+        let recorder = Recorder()
+        try makeCoordinator(recorder).completePairing(payload: payload(), deviceLabel: "iPhone")
+        XCTAssertEqual(recorder.events, ["pin", "redeem", "save"])
+    }
+
+    func testAFailedPinNeverReachesTheOtherMachine() {
+        let recorder = Recorder()
+        recorder.pinSucceeds = false
+        XCTAssertThrowsError(
+            try makeCoordinator(recorder).completePairing(payload: payload(), deviceLabel: "iPhone")
+        ) { XCTAssertEqual($0 as? PairingCoordinator.Failure, .couldNotPinHostKey) }
+
+        XCTAssertEqual(recorder.events, ["pin"], "nothing may run after a failed pin")
+        XCTAssertNil(recorder.sentPublicKey, "no key may be sent when the pin failed")
+    }
+
+    // MARK: - The unpinnable case
+
+    /// A machine that cannot identify itself must be REFUSED, not saved unpinned.
+    ///
+    /// This is the one that would otherwise pass silently: saving the host still "works",
+    /// and the damage only shows up at first connect, which trusts whatever answers.
+    func testAMachineWithNoHostKeyIsRefusedRatherThanSavedUnpinned() {
+        let recorder = Recorder()
+        XCTAssertThrowsError(
+            try makeCoordinator(recorder).completePairing(
+                payload: payload(fp: ""), deviceLabel: "iPhone")
+        ) { XCTAssertEqual($0 as? PairingCoordinator.Failure, .noHostKeyToPin) }
+
+        XCTAssertTrue(recorder.events.isEmpty, "nothing at all may happen without a pin target")
+    }
+
+    // MARK: - What gets pinned
+
+    /// THE PIN MUST TARGET THE SSH PORT, NOT THE PAIRING PORT.
+    ///
+    /// The payload's `port` is the short-lived pairing listener; SSH is a different service
+    /// on a different port. Pinning against 4021 would file the fingerprint under a key the
+    /// SSH connection never looks up — the pin would silently miss and first contact would
+    /// trust-on-first-use anyway, which is the exact hole the fingerprint exists to close.
+    func testPinsAgainstTheSSHPortNotThePairingPort() throws {
+        let recorder = Recorder()
+        try makeCoordinator(recorder).completePairing(payload: payload(), deviceLabel: "iPhone")
+        XCTAssertEqual(recorder.pinnedPort, 22, "4021 is the pairing listener, not sshd")
+        XCTAssertEqual(recorder.pinnedHost, "100.64.1.2")
+        XCTAssertEqual(recorder.pinnedFingerprint, "SHA256:abc")
+    }
+
+    /// An explicit ":port" in the host is an SSH port and must be honoured, and must not
+    /// end up inside the pinned host string — the pin store keys on the bare host.
+    func testAnExplicitSSHPortIsHonouredAndStrippedFromTheHost() throws {
+        let recorder = Recorder()
+        try makeCoordinator(recorder).completePairing(
+            payload: payload(host: "100.64.1.2:2222"), deviceLabel: "iPhone")
+        XCTAssertEqual(recorder.pinnedPort, 2222)
+        XCTAssertEqual(recorder.pinnedHost, "100.64.1.2", "the port must not be in the host key")
+    }
+
+    // MARK: - What crosses the wire, and what does not
+
+    /// The private half must reach the Keychain and NOTHING else.
+    func testOnlyThePublicHalfIsSentAndThePrivateHalfIsSaved() throws {
+        let recorder = Recorder()
+        try makeCoordinator(recorder).completePairing(payload: payload(), deviceLabel: "Jerry's iPhone")
+
+        let sent = try XCTUnwrap(recorder.sentPublicKey)
+        let saved = try XCTUnwrap(recorder.savedKeyPEM)
+        XCTAssertTrue(sent.hasPrefix("ssh-ed25519 "))
+        XCTAssertFalse(sent.contains("PRIVATE KEY"), "a private key must never be sent")
+        XCTAssertTrue(saved.contains("OPENSSH PRIVATE KEY"))
+        XCTAssertEqual(recorder.sentDeviceLabel, "Jerry's iPhone")
+
+        // The two halves must belong to the same keypair, or the host saves a key the
+        // machine will not accept and the user gets a permission error at first connect.
+        let parsed = try PairingKeyRoundTrip.publicLine(fromPrivatePEM: saved, comment: "Jerry's iPhone")
+        XCTAssertEqual(parsed, sent, "the saved private key must match the key that was sent")
+    }
+
+    func testTheHostIsSavedWithTheScannedUserAndAddress() throws {
+        let recorder = Recorder()
+        let name = try makeCoordinator(recorder).completePairing(
+            payload: payload(), deviceLabel: "iPhone")
+        XCTAssertEqual(recorder.savedHost, "100.64.1.2")
+        XCTAssertEqual(recorder.savedUser, "jerry")
+        XCTAssertEqual(name, "jerry@100.64.1.2", "a default nickname a person can recognise")
+    }
+
+    // MARK: - Failures downstream of the remote change
+
+    /// A refused redemption must not leave a saved host behind.
+    func testARefusedRedemptionSavesNothing() {
+        let recorder = Recorder()
+        recorder.redeemError = .refused("pairing refused")
+        XCTAssertThrowsError(
+            try makeCoordinator(recorder).completePairing(payload: payload(), deviceLabel: "iPhone")
+        ) { error in
+            XCTAssertEqual(error as? PairingCoordinator.Failure, .pairing(.refused("pairing refused")))
+            // The message the user sees must come from the pairing error, which explains
+            // that codes are single-use.
+            XCTAssertTrue(
+                (error as? PairingCoordinator.Failure)?.userFacingMessage.contains("herdr pair") == true)
+        }
+        XCTAssertEqual(recorder.events, ["pin", "redeem"], "no save after a refusal")
+    }
+
+    /// Failing to save AFTER the machine accepted the key is its own case: the remote side
+    /// really did change, so the message has to tell the user to clean it up.
+    func testAFailedSaveAfterARemoteChangeSaysSo() {
+        let recorder = Recorder()
+        recorder.saveSucceeds = false
+        XCTAssertThrowsError(
+            try makeCoordinator(recorder).completePairing(payload: payload(), deviceLabel: "iPhone")
+        ) { error in
+            XCTAssertEqual(error as? PairingCoordinator.Failure, .pairedButCouldNotSave)
+            let message = (error as? PairingCoordinator.Failure)?.userFacingMessage ?? ""
+            XCTAssertTrue(message.contains("authorized_keys"),
+                          "the user must be told there is something to remove: \(message)")
+        }
+    }
+
+    /// Every failure must give a next step, not just restate itself.
+    func testEveryFailureHasAnActionableMessage() {
+        let failures: [PairingCoordinator.Failure] = [
+            .noHostKeyToPin, .couldNotPinHostKey,
+            .pairing(.notAPairingCode), .pairedButCouldNotSave,
+        ]
+        for failure in failures {
+            let message = failure.userFacingMessage
+            XCTAssertFalse(message.isEmpty)
+            XCTAssertTrue(
+                message.contains("herdr pair") || message.contains("Try again")
+                    || message.contains("authorized_keys"),
+                "\(failure) gives no next step: \(message)")
+        }
+    }
+}
+
+/// Re-derives the public line from a stored private key, so a test can prove the saved and
+/// sent halves are the SAME keypair rather than merely both well-formed.
+enum PairingKeyRoundTrip {
+    static func publicLine(fromPrivatePEM pem: String, comment: String) throws -> String {
+        let key = try Curve25519.Signing.PrivateKey(sshEd25519: Data(pem.utf8), decryptionKey: nil)
+        return PairingKey.authorizedKeysLine(for: key.publicKey, comment: comment)
+    }
+}

--- a/Tests/HerdrKitTests/PairingCoordinatorTests.swift
+++ b/Tests/HerdrKitTests/PairingCoordinatorTests.swift
@@ -64,6 +64,29 @@ final class PairingCoordinatorTests: XCTestCase {
             })
     }
 
+    /// `XCTAssertThrowsError` cannot take an async expression, and a bare do/catch that
+    /// forgets its `XCTFail` passes when nothing throws — the failure mode this whole file
+    /// exists to avoid. This fails loudly on success and returns the error for further
+    /// assertions.
+    @discardableResult
+    private func assertThrows(
+        _ expected: PairingCoordinator.Failure,
+        file: StaticString = #filePath, line: UInt = #line,
+        _ body: () async throws -> Void
+    ) async -> PairingCoordinator.Failure? {
+        do {
+            try await body()
+            XCTFail("expected \(expected), but nothing was thrown", file: file, line: line)
+            return nil
+        } catch let failure as PairingCoordinator.Failure {
+            XCTAssertEqual(failure, expected, file: file, line: line)
+            return failure
+        } catch {
+            XCTFail("expected \(expected), got \(error)", file: file, line: line)
+            return nil
+        }
+    }
+
     private func payload(host: String = "100.64.1.2", fp: String = "SHA256:abc") -> Pairing.Payload {
         Pairing.Payload(v: 1, host: host, port: 4021, user: "jerry", token: "tok", fp: fp)
     }
@@ -73,18 +96,18 @@ final class PairingCoordinatorTests: XCTestCase {
     /// PIN BEFORE REDEEM. If pinning fails after the key is already on the other machine,
     /// the user is left with an orphaned entry in their authorized_keys for a failure they
     /// did not cause and will not be told about.
-    func testPinsBeforeTouchingTheOtherMachine() throws {
+    func testPinsBeforeTouchingTheOtherMachine() async throws {
         let recorder = Recorder()
-        try makeCoordinator(recorder).completePairing(payload: payload(), deviceLabel: "iPhone")
+        try await makeCoordinator(recorder).completePairing(payload: payload(), deviceLabel: "iPhone")
         XCTAssertEqual(recorder.events, ["pin", "redeem", "save"])
     }
 
-    func testAFailedPinNeverReachesTheOtherMachine() {
+    func testAFailedPinNeverReachesTheOtherMachine() async {
         let recorder = Recorder()
         recorder.pinSucceeds = false
-        XCTAssertThrowsError(
-            try makeCoordinator(recorder).completePairing(payload: payload(), deviceLabel: "iPhone")
-        ) { XCTAssertEqual($0 as? PairingCoordinator.Failure, .couldNotPinHostKey) }
+        await assertThrows(.couldNotPinHostKey) {
+            try await makeCoordinator(recorder).completePairing(payload: payload(), deviceLabel: "iPhone")
+        }
 
         XCTAssertEqual(recorder.events, ["pin"], "nothing may run after a failed pin")
         XCTAssertNil(recorder.sentPublicKey, "no key may be sent when the pin failed")
@@ -96,12 +119,12 @@ final class PairingCoordinatorTests: XCTestCase {
     ///
     /// This is the one that would otherwise pass silently: saving the host still "works",
     /// and the damage only shows up at first connect, which trusts whatever answers.
-    func testAMachineWithNoHostKeyIsRefusedRatherThanSavedUnpinned() {
+    func testAMachineWithNoHostKeyIsRefusedRatherThanSavedUnpinned() async {
         let recorder = Recorder()
-        XCTAssertThrowsError(
-            try makeCoordinator(recorder).completePairing(
+        await assertThrows(.noHostKeyToPin) {
+            try await makeCoordinator(recorder).completePairing(
                 payload: payload(fp: ""), deviceLabel: "iPhone")
-        ) { XCTAssertEqual($0 as? PairingCoordinator.Failure, .noHostKeyToPin) }
+        }
 
         XCTAssertTrue(recorder.events.isEmpty, "nothing at all may happen without a pin target")
     }
@@ -114,9 +137,9 @@ final class PairingCoordinatorTests: XCTestCase {
     /// on a different port. Pinning against 4021 would file the fingerprint under a key the
     /// SSH connection never looks up — the pin would silently miss and first contact would
     /// trust-on-first-use anyway, which is the exact hole the fingerprint exists to close.
-    func testPinsAgainstTheSSHPortNotThePairingPort() throws {
+    func testPinsAgainstTheSSHPortNotThePairingPort() async throws {
         let recorder = Recorder()
-        try makeCoordinator(recorder).completePairing(payload: payload(), deviceLabel: "iPhone")
+        try await makeCoordinator(recorder).completePairing(payload: payload(), deviceLabel: "iPhone")
         XCTAssertEqual(recorder.pinnedPort, 22, "4021 is the pairing listener, not sshd")
         XCTAssertEqual(recorder.pinnedHost, "100.64.1.2")
         XCTAssertEqual(recorder.pinnedFingerprint, "SHA256:abc")
@@ -124,9 +147,9 @@ final class PairingCoordinatorTests: XCTestCase {
 
     /// An explicit ":port" in the host is an SSH port and must be honoured, and must not
     /// end up inside the pinned host string — the pin store keys on the bare host.
-    func testAnExplicitSSHPortIsHonouredAndStrippedFromTheHost() throws {
+    func testAnExplicitSSHPortIsHonouredAndStrippedFromTheHost() async throws {
         let recorder = Recorder()
-        try makeCoordinator(recorder).completePairing(
+        try await makeCoordinator(recorder).completePairing(
             payload: payload(host: "100.64.1.2:2222"), deviceLabel: "iPhone")
         XCTAssertEqual(recorder.pinnedPort, 2222)
         XCTAssertEqual(recorder.pinnedHost, "100.64.1.2", "the port must not be in the host key")
@@ -135,9 +158,9 @@ final class PairingCoordinatorTests: XCTestCase {
     // MARK: - What crosses the wire, and what does not
 
     /// The private half must reach the Keychain and NOTHING else.
-    func testOnlyThePublicHalfIsSentAndThePrivateHalfIsSaved() throws {
+    func testOnlyThePublicHalfIsSentAndThePrivateHalfIsSaved() async throws {
         let recorder = Recorder()
-        try makeCoordinator(recorder).completePairing(payload: payload(), deviceLabel: "Jerry's iPhone")
+        try await makeCoordinator(recorder).completePairing(payload: payload(), deviceLabel: "Jerry's iPhone")
 
         let sent = try XCTUnwrap(recorder.sentPublicKey)
         let saved = try XCTUnwrap(recorder.savedKeyPEM)
@@ -152,9 +175,9 @@ final class PairingCoordinatorTests: XCTestCase {
         XCTAssertEqual(parsed, sent, "the saved private key must match the key that was sent")
     }
 
-    func testTheHostIsSavedWithTheScannedUserAndAddress() throws {
+    func testTheHostIsSavedWithTheScannedUserAndAddress() async throws {
         let recorder = Recorder()
-        let name = try makeCoordinator(recorder).completePairing(
+        let name = try await makeCoordinator(recorder).completePairing(
             payload: payload(), deviceLabel: "iPhone")
         XCTAssertEqual(recorder.savedHost, "100.64.1.2")
         XCTAssertEqual(recorder.savedUser, "jerry")
@@ -164,38 +187,33 @@ final class PairingCoordinatorTests: XCTestCase {
     // MARK: - Failures downstream of the remote change
 
     /// A refused redemption must not leave a saved host behind.
-    func testARefusedRedemptionSavesNothing() {
+    func testARefusedRedemptionSavesNothing() async {
         let recorder = Recorder()
         recorder.redeemError = .refused("pairing refused")
-        XCTAssertThrowsError(
-            try makeCoordinator(recorder).completePairing(payload: payload(), deviceLabel: "iPhone")
-        ) { error in
-            XCTAssertEqual(error as? PairingCoordinator.Failure, .pairing(.refused("pairing refused")))
-            // The message the user sees must come from the pairing error, which explains
-            // that codes are single-use.
-            XCTAssertTrue(
-                (error as? PairingCoordinator.Failure)?.userFacingMessage.contains("herdr pair") == true)
+        let failure = await assertThrows(.pairing(.refused("pairing refused"))) {
+            try await makeCoordinator(recorder).completePairing(payload: payload(), deviceLabel: "iPhone")
         }
+        // The message the user sees must come from the pairing error, which explains that
+        // codes are single-use.
+        XCTAssertTrue(failure?.userFacingMessage.contains("herdr pair") == true)
         XCTAssertEqual(recorder.events, ["pin", "redeem"], "no save after a refusal")
     }
 
     /// Failing to save AFTER the machine accepted the key is its own case: the remote side
     /// really did change, so the message has to tell the user to clean it up.
-    func testAFailedSaveAfterARemoteChangeSaysSo() {
+    func testAFailedSaveAfterARemoteChangeSaysSo() async {
         let recorder = Recorder()
         recorder.saveSucceeds = false
-        XCTAssertThrowsError(
-            try makeCoordinator(recorder).completePairing(payload: payload(), deviceLabel: "iPhone")
-        ) { error in
-            XCTAssertEqual(error as? PairingCoordinator.Failure, .pairedButCouldNotSave)
-            let message = (error as? PairingCoordinator.Failure)?.userFacingMessage ?? ""
-            XCTAssertTrue(message.contains("authorized_keys"),
-                          "the user must be told there is something to remove: \(message)")
+        let failure = await assertThrows(.pairedButCouldNotSave) {
+            try await makeCoordinator(recorder).completePairing(payload: payload(), deviceLabel: "iPhone")
         }
+        let message = failure?.userFacingMessage ?? ""
+        XCTAssertTrue(message.contains("authorized_keys"),
+                      "the user must be told there is something to remove: \(message)")
     }
 
     /// Every failure must give a next step, not just restate itself.
-    func testEveryFailureHasAnActionableMessage() {
+    func testEveryFailureHasAnActionableMessage() async {
         let failures: [PairingCoordinator.Failure] = [
             .noHostKeyToPin, .couldNotPinHostKey,
             .pairing(.notAPairingCode), .pairedButCouldNotSave,

--- a/Tests/HerdrKitTests/PairingKeyTests.swift
+++ b/Tests/HerdrKitTests/PairingKeyTests.swift
@@ -1,0 +1,99 @@
+import XCTest
+import Crypto
+import Citadel
+@testable import HerdrKit
+
+/// The round trip that decides whether QR pairing is buildable at all.
+///
+/// Pairing generates a keypair ON THE PHONE and stores the private half in the Keychain;
+/// `CitadelTransport` later parses that same string back to authenticate. If generation
+/// and parsing disagree by a single byte of the OpenSSH container, pairing appears to
+/// succeed and then fails at connect time — on the user's machine, with no useful error.
+/// So the generated key is parsed back through the EXACT call the transport makes.
+final class PairingKeyTests: XCTestCase {
+
+    /// GENERATE -> SERIALISE -> PARSE must return the same key.
+    ///
+    /// Asserted on the raw private key bytes, not on the PEM string: two different PEMs
+    /// can encode the same key (the OpenSSH checksum is random per serialisation), so
+    /// comparing strings would be both flaky and wrong.
+    func testGeneratedKeyParsesBackThroughTheTransportsOwnCall() throws {
+        let original = Curve25519.Signing.PrivateKey()
+        let pairing = PairingKey(key: original, comment: "herdrup-test")
+
+        // The exact call in CitadelTransport.makeConnection().
+        let parsed = try Curve25519.Signing.PrivateKey(
+            sshEd25519: Data(pairing.privateKeyPEM.utf8),
+            decryptionKey: nil
+        )
+
+        XCTAssertEqual(parsed.rawRepresentation, original.rawRepresentation,
+                       "a key that does not survive the transport's own parser cannot authenticate")
+        XCTAssertEqual(parsed.publicKey.rawRepresentation, original.publicKey.rawRepresentation)
+    }
+
+    /// A freshly generated key (no injected input) must round-trip too — the path pairing
+    /// actually uses.
+    func testFreshlyGeneratedKeyRoundTrips() throws {
+        let pairing = PairingKey(comment: "iPhone")
+        let parsed = try Curve25519.Signing.PrivateKey(
+            sshEd25519: Data(pairing.privateKeyPEM.utf8), decryptionKey: nil)
+        XCTAssertEqual(
+            PairingKey.authorizedKeysLine(for: parsed.publicKey, comment: "iPhone"),
+            pairing.authorizedKeysLine,
+            "the public key handed to the machine must match the private key kept on the phone")
+    }
+
+    func testPrivateKeyIsOpenSSHFormatted() {
+        let pem = PairingKey(comment: "x").privateKeyPEM
+        XCTAssertTrue(pem.hasPrefix("-----BEGIN OPENSSH PRIVATE KEY-----"))
+        XCTAssertTrue(pem.contains("-----END OPENSSH PRIVATE KEY-----"))
+    }
+
+    /// The authorized_keys line must be the three-field shape sshd accepts. A wrong blob
+    /// here is silently ignored by sshd — the user just cannot log in, with nothing logged
+    /// that names the cause.
+    func testAuthorizedKeysLineShape() throws {
+        let key = Curve25519.Signing.PrivateKey()
+        let line = PairingKey.authorizedKeysLine(for: key.publicKey, comment: "jerry's iPhone")
+        let parts = line.split(separator: " ", maxSplits: 2).map(String.init)
+        XCTAssertEqual(parts.count, 3)
+        XCTAssertEqual(parts[0], "ssh-ed25519")
+        XCTAssertEqual(parts[2], "jerry's iPhone")
+
+        // The base64 field must decode to: string("ssh-ed25519") || string(32 raw bytes).
+        let blob = try XCTUnwrap(Data(base64Encoded: parts[1]))
+        XCTAssertEqual(blob, PairingKey.publicKeyBlob(key.publicKey))
+        XCTAssertEqual(blob.count, 4 + 11 + 4 + 32, "length-prefixed type + length-prefixed 32-byte key")
+        XCTAssertEqual(blob.suffix(32), key.publicKey.rawRepresentation)
+    }
+
+    /// An empty comment must not leave a trailing space — sshd tolerates it, but the line
+    /// is also what a human greps for when revoking, and a stray space makes an exact
+    /// match fail.
+    func testEmptyCommentProducesTwoFields() {
+        let key = Curve25519.Signing.PrivateKey()
+        let line = PairingKey.authorizedKeysLine(for: key.publicKey, comment: "   ")
+        XCTAssertEqual(line.split(separator: " ").count, 2)
+        XCTAssertFalse(line.hasSuffix(" "))
+    }
+
+    /// Fingerprints must match `ssh-keygen -lf` so the string the app shows and the string
+    /// the machine prints are comparable by eye.
+    func testFingerprintIsUnpaddedSHA256OfTheBlob() {
+        let key = Curve25519.Signing.PrivateKey()
+        let fp = PairingKey.fingerprint(for: key.publicKey)
+        XCTAssertTrue(fp.hasPrefix("SHA256:"))
+        XCTAssertFalse(fp.contains("="), "OpenSSH prints fingerprints unpadded")
+        let expected = Data(SHA256.hash(data: PairingKey.publicKeyBlob(key.publicKey)))
+            .base64EncodedString().replacingOccurrences(of: "=", with: "")
+        XCTAssertEqual(fp, "SHA256:" + expected)
+    }
+
+    /// Two pairings must never collide — each device gets its own revocable key.
+    func testEachPairingGeneratesADistinctKey() {
+        let a = PairingKey(comment: "a"), b = PairingKey(comment: "b")
+        XCTAssertNotEqual(a.authorizedKeysLine, b.authorizedKeysLine)
+        XCTAssertNotEqual(a.publicKeyFingerprint, b.publicKeyFingerprint)
+    }
+}

--- a/Tests/HerdrKitTests/PairingLiveTests.swift
+++ b/Tests/HerdrKitTests/PairingLiveTests.swift
@@ -1,0 +1,82 @@
+import XCTest
+import Foundation
+@testable import HerdrKit
+
+/// Redeems a REAL pairing code against a REAL running `herdr pair`.
+///
+/// The unit tests drive a stub daemon, which can only prove that the client agrees with my
+/// own idea of the protocol. This one proves the two implementations agree with each other:
+/// Rust serde on one side, Swift Codable on the other, meeting at a socket. It is the test
+/// that would have caught, for instance, a field-name or an escaping mismatch — Swift's
+/// JSONEncoder escapes "/" as "\/", and ed25519 base64 contains "/" about half the time.
+///
+/// SKIPPED unless the environment supplies a live pairing code, decided from signals
+/// INDEPENDENT of the code under test (an env var holding a payload, and a writable
+/// authorized_keys path). Once those hold, errors are NOT swallowed as skips — a real
+/// regression fails here rather than reporting green.
+///
+/// To run it:
+///   1. `HOME=/tmp/pairhome herdr pair --ttl 120` on the machine
+///   2. read the payload out of the QR it printed
+///   3. `HERDR_PAIR_PAYLOAD='<that json>' \
+///       HERDR_PAIR_AUTHORIZED_KEYS=/tmp/pairhome/.ssh/authorized_keys \
+///       swift test --filter PairingLiveTests`
+final class PairingLiveTests: XCTestCase {
+
+    private var payloadJSON: String? {
+        ProcessInfo.processInfo.environment["HERDR_PAIR_PAYLOAD"]
+    }
+    private var authorizedKeysPath: String? {
+        ProcessInfo.processInfo.environment["HERDR_PAIR_AUTHORIZED_KEYS"]
+    }
+
+    /// The whole exchange, against the real daemon.
+    ///
+    /// Asserts the OUTCOME on the machine's side — that the key actually landed in
+    /// `authorized_keys` — not merely that the call returned. A client that reported
+    /// success while the daemon wrote nothing would pass a return-value check and leave a
+    /// user unable to connect.
+    func testARealDaemonAcceptsThisClientsRedemption() throws {
+        guard let json = payloadJSON, let keysPath = authorizedKeysPath else {
+            throw XCTSkip("set HERDR_PAIR_PAYLOAD and HERDR_PAIR_AUTHORIZED_KEYS (see the doc comment)")
+        }
+
+        let payload = try Pairing.parse(qrText: json)
+        XCTAssertNotNil(payload.hostKeyFingerprint,
+                        "a real daemon on a machine with a host key must supply one to pin")
+
+        // Normally this generates its own key, exercising the real PairingKey path. A
+        // supplied PUBLIC key is honoured so the same test can be pointed at a key whose
+        // private half lives elsewhere — which is how the sshd login receipt is taken.
+        // Only ever a public key: nothing here reads or writes a private one.
+        let supplied = ProcessInfo.processInfo.environment["HERDR_PAIR_PUBLIC_KEY"]
+        let line = supplied ?? PairingKey(comment: "live-test-device").authorizedKeysLine
+        try Pairing.redeem(
+            payload: payload,
+            publicKeyLine: line,
+            deviceLabel: "live test device",
+            timeout: 10)
+
+        // The receipt is on the machine, not in the return value.
+        let written = try String(contentsOfFile: keysPath, encoding: .utf8)
+        XCTAssertTrue(
+            written.contains(line),
+            "the daemon accepted the redemption but did not write the key")
+        XCTAssertTrue(written.contains("herdr-pair"), "the line must carry the revocation marker")
+        XCTAssertFalse(written.contains("PRIVATE KEY"), "nothing secret may reach the machine")
+
+        // Single-use: the same code must not work twice. This is the security property
+        // that a photograph of the QR cannot defeat.
+        let second = PairingKey(comment: "second-device")
+        XCTAssertThrowsError(
+            try Pairing.redeem(
+                payload: payload, publicKeyLine: second.authorizedKeysLine,
+                deviceLabel: "second device", timeout: 10),
+            "a spent pairing code must not be redeemable again"
+        )
+        let after = try String(contentsOfFile: keysPath, encoding: .utf8)
+        XCTAssertFalse(
+            after.contains(second.authorizedKeysLine),
+            "a refused redemption must not write anything")
+    }
+}

--- a/Tests/HerdrKitTests/PairingTests.swift
+++ b/Tests/HerdrKitTests/PairingTests.swift
@@ -1,0 +1,332 @@
+import XCTest
+#if canImport(Glibc)
+import Glibc
+#else
+import Darwin
+#endif
+@testable import HerdrKit
+
+/// The phone's half of QR pairing, driven over REAL loopback sockets.
+///
+/// A mocked transport would prove only that the mock matches my belief about the protocol.
+/// The daemon's half is already tested in Rust over a real socket; testing this half the
+/// same way means the two suites meet at the wire format instead of at an assumption.
+final class PairingTests: XCTestCase {
+
+    // MARK: - Reading a scanned code
+
+    func testParsesAValidPairingCode() throws {
+        let payload = try Pairing.parse(qrText: sampleJSON())
+        XCTAssertEqual(payload.host, "100.64.1.2")
+        XCTAssertEqual(payload.port, 4021)
+        XCTAssertEqual(payload.user, "root")
+        XCTAssertEqual(payload.hostKeyFingerprint, "SHA256:abc")
+    }
+
+    /// A camera hands us whatever QR is in frame. Every one of these must fail as "not a
+    /// pairing code" rather than as a socket error minutes later.
+    func testRejectsCodesThatAreNotPairingPayloads() {
+        for junk in [
+            "",
+            "hello",
+            "https://example.com",
+            "WIFI:S:home;T:WPA;P:hunter2;;",
+            "{}",
+            #"{"v":1,"host":"","port":4021,"user":"root","token":"t","fp":""}"#,
+            #"{"v":1,"host":"h","port":4021,"user":"","token":"t","fp":""}"#,
+            #"{"v":1,"host":"h","port":4021,"user":"root","token":"","fp":""}"#,
+            #"{"v":1,"host":"h","port":0,"user":"root","token":"t","fp":""}"#,
+            #"{"v":1,"host":"h","port":70000,"user":"root","token":"t","fp":""}"#,
+        ] {
+            XCTAssertThrowsError(try Pairing.parse(qrText: junk), "accepted junk: \(junk)") { error in
+                XCTAssertEqual(error as? Pairing.Error, .notAPairingCode, "for \(junk)")
+            }
+        }
+    }
+
+    /// A version mismatch is a DIFFERENT failure from a bad code, because the remedy
+    /// differs: update the app, versus scan a real code.
+    func testAFutureVersionIsReportedAsAVersionProblem() {
+        let future = sampleJSON(v: 2)
+        XCTAssertThrowsError(try Pairing.parse(qrText: future)) { error in
+            XCTAssertEqual(error as? Pairing.Error, .unsupportedVersion(2))
+        }
+    }
+
+    /// An absent fingerprint must read as "unknown", never as a pinnable empty string.
+    func testAnEmptyFingerprintIsNilNotEmpty() throws {
+        let payload = try Pairing.parse(qrText: sampleJSON(fp: ""))
+        XCTAssertNil(payload.hostKeyFingerprint,
+                     "an empty fp must not flow into a pin call as a valid fingerprint")
+        XCTAssertNil(try Pairing.parse(qrText: sampleJSON(fp: "   ")).hostKeyFingerprint)
+    }
+
+    // MARK: - The wire contract with the Rust daemon
+
+    /// THE FIELD NAMES ARE A CROSS-LANGUAGE CONTRACT.
+    ///
+    /// `PairRedeem` in src/pairing.rs deserialises `type`, `token`, `public_key`, `device`.
+    /// Swift's default encoding would emit `kind` and `publicKey`, which the daemon would
+    /// reject as unparseable — and the failure would appear as an opaque refusal on a
+    /// user's phone, with the real reason only in a terminal they are not looking at.
+    func testTheRedeemLineMatchesTheDaemonsFieldNames() throws {
+        let line = try Pairing.redeemLine(
+            token: "tok", publicKeyLine: "ssh-ed25519 AAAA test", deviceLabel: "iPhone")
+
+        XCTAssertEqual(line.last, 0x0A, "the daemon reads exactly one line")
+        let object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: line) as? [String: Any])
+        XCTAssertEqual(Set(object.keys), ["type", "token", "public_key", "device"])
+        XCTAssertEqual(object["type"] as? String, "pair.redeem")
+        XCTAssertEqual(object["token"] as? String, "tok")
+        XCTAssertEqual(object["public_key"] as? String, "ssh-ed25519 AAAA test")
+        XCTAssertEqual(object["device"] as? String, "iPhone")
+    }
+
+    /// The one thing that must never appear on this wire.
+    func testTheRedeemLineCarriesOnlyThePublicHalf() throws {
+        let key = PairingKey(comment: "iPhone")
+        let line = try Pairing.redeemLine(
+            token: "tok", publicKeyLine: key.authorizedKeysLine, deviceLabel: "iPhone")
+        let text = String(decoding: line, as: UTF8.self)
+
+        XCTAssertFalse(text.contains("PRIVATE KEY"))
+        XCTAssertFalse(text.contains(key.privateKeyPEM))
+
+        // Compared after DECODING, not by substring. JSONEncoder escapes "/" as "\\/",
+        // and ed25519 base64 contains "/" about half the time — so a substring check here
+        // fails on a correct line, roughly one run in two. (serde_json unescapes it on the
+        // daemon's side, which the live cross-language run confirms.)
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: line) as? [String: Any])
+        XCTAssertEqual(object["public_key"] as? String, key.authorizedKeysLine)
+    }
+
+    // MARK: - Redeeming over a real socket
+
+    func testASuccessfulRedemptionOverARealSocket() throws {
+        let server = try StubDaemon(reply: #"{"type":"pair.ok"}"#)
+        defer { server.stop() }
+
+        let key = PairingKey(comment: "iPhone")
+        XCTAssertNoThrow(try Pairing.redeem(
+            payload: server.payload(),
+            publicKeyLine: key.authorizedKeysLine,
+            deviceLabel: "Jerry's iPhone",
+            timeout: 5))
+
+        // The daemon must have received exactly what the contract test pins.
+        let received = try XCTUnwrap(server.waitForRequest())
+        let object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(received.utf8)) as? [String: Any])
+        XCTAssertEqual(object["type"] as? String, "pair.redeem")
+        XCTAssertEqual(object["device"] as? String, "Jerry's iPhone")
+        XCTAssertEqual(object["public_key"] as? String, key.authorizedKeysLine)
+    }
+
+    /// The daemon's refusal is opaque by design; the app must surface its OWN sentence.
+    func testARefusalIsReportedWithAnActionableMessage() throws {
+        let server = try StubDaemon(reply: #"{"type":"pair.error","message":"pairing refused"}"#)
+        defer { server.stop() }
+
+        XCTAssertThrowsError(try Pairing.redeem(
+            payload: server.payload(), publicKeyLine: "ssh-ed25519 AAAA x",
+            deviceLabel: "iPhone", timeout: 5)
+        ) { error in
+            XCTAssertEqual(error as? Pairing.Error, .refused("pairing refused"))
+            // A person needs to know codes are single-use and expire; "pairing refused"
+            // does not say that.
+            XCTAssertTrue(
+                (error as? Pairing.Error)?.userFacingMessage.contains("herdr pair") == true)
+        }
+    }
+
+    func testAClosedConnectionIsNotMistakenForSuccess() throws {
+        let server = try StubDaemon(reply: nil)  // accept, then close
+        defer { server.stop() }
+
+        XCTAssertThrowsError(try Pairing.redeem(
+            payload: server.payload(), publicKeyLine: "ssh-ed25519 AAAA x",
+            deviceLabel: "iPhone", timeout: 5)
+        ) { error in
+            guard case .badResponse = error as? Pairing.Error else {
+                return XCTFail("expected badResponse, got \(error)")
+            }
+        }
+    }
+
+    func testGarbageFromTheServerIsNotMistakenForSuccess() throws {
+        let server = try StubDaemon(reply: "<html>login page</html>")
+        defer { server.stop() }
+
+        XCTAssertThrowsError(try Pairing.redeem(
+            payload: server.payload(), publicKeyLine: "ssh-ed25519 AAAA x",
+            deviceLabel: "iPhone", timeout: 5)
+        ) { error in
+            guard case .badResponse = error as? Pairing.Error else {
+                return XCTFail("expected badResponse, got \(error)")
+            }
+        }
+    }
+
+    func testAnUnreachableMachineFailsQuicklyAndSaysSo() throws {
+        // Bind and immediately close, so the port is almost certainly refusing.
+        let server = try StubDaemon(reply: nil)
+        let payload = server.payload()
+        server.stop()
+
+        XCTAssertThrowsError(try Pairing.redeem(
+            payload: payload, publicKeyLine: "ssh-ed25519 AAAA x",
+            deviceLabel: "iPhone", timeout: 2)
+        ) { error in
+            guard case .unreachable = error as? Pairing.Error else {
+                return XCTFail("expected unreachable, got \(error)")
+            }
+        }
+    }
+
+    /// A hostname in a scanned QR is a way to point the phone at a machine the daemon did
+    /// not name. `herdr pair` only ever emits a literal tailnet address.
+    func testAHostnameInTheCodeIsRefusedRatherThanResolved() {
+        let payload = Pairing.Payload(
+            v: 1, host: "example.com", port: 4021, user: "root", token: "t", fp: "")
+        XCTAssertThrowsError(try Pairing.redeem(
+            payload: payload, publicKeyLine: "ssh-ed25519 AAAA x", deviceLabel: "x", timeout: 2)
+        ) { error in
+            guard case .unreachable(let why) = error as? Pairing.Error else {
+                return XCTFail("expected unreachable, got \(error)")
+            }
+            XCTAssertTrue(why.contains("IPv4"), "should name the reason, got \(why)")
+        }
+    }
+
+    /// Every error must produce a sentence that tells a person what to DO. An error whose
+    /// message only restates the failure sends them back to the screen that blocked them.
+    func testEveryErrorHasAnActionableMessage() {
+        let errors: [Pairing.Error] = [
+            .notAPairingCode, .unsupportedVersion(2), .unreachable("x"),
+            .refused("pairing refused"), .badResponse("x"),
+        ]
+        for error in errors {
+            let message = error.userFacingMessage
+            XCTAssertFalse(message.isEmpty)
+            XCTAssertTrue(
+                message.contains("herdr pair") || message.contains("Update the app"),
+                "\(error) gives no next step: \(message)")
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func sampleJSON(v: Int = 1, fp: String = "SHA256:abc") -> String {
+        let payload = Pairing.Payload(
+            v: v, host: "100.64.1.2", port: 4021, user: "root", token: "tok", fp: fp)
+        return String(decoding: try! JSONEncoder().encode(payload), as: UTF8.self)
+    }
+}
+
+/// A minimal stand-in for `serve_one_pairing`: accept one connection, read one line, send
+/// the configured reply (or none), close.
+///
+/// This is a stand-in for the DAEMON, not for the code under test — the client's socket
+/// path, encoding and parsing are all real.
+private final class StubDaemon {
+    private let listenFD: Int32
+    let port: Int
+    private let received: Box
+    private let lock: NSLock
+    private let arrived: DispatchSemaphore
+    private var stopped = false
+
+    init(reply: String?) throws {
+        // Everything the worker thread touches is built as a LOCAL first. Capturing a
+        // stored property in a closure's capture list captures `self`, which the compiler
+        // rejects during init — and the fix is not `[weak self]`, it is not needing self.
+        let fd = socket(AF_INET, sockStream, 0)
+        guard fd >= 0 else { throw TestError.socket }
+
+        var yes: Int32 = 1
+        setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &yes, socklen_t(MemoryLayout<Int32>.size))
+
+        var addr = sockaddr_in()
+        addr.sin_family = sa_family_t(AF_INET)
+        addr.sin_port = 0  // let the OS choose a free port
+        inet_pton(AF_INET, "127.0.0.1", &addr.sin_addr)
+
+        let bound = withUnsafePointer(to: &addr) {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                platformBind(fd, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        guard bound == 0, listen(fd, 1) == 0 else {
+            platformClose(fd)
+            throw TestError.socket
+        }
+
+        var actual = sockaddr_in()
+        var length = socklen_t(MemoryLayout<sockaddr_in>.size)
+        let named = withUnsafeMutablePointer(to: &actual) {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                getsockname(fd, $0, &length)
+            }
+        }
+        guard named == 0 else { platformClose(fd); throw TestError.socket }
+
+        let box = Box()
+        let lock = NSLock()
+        let arrived = DispatchSemaphore(value: 0)
+
+        self.listenFD = fd
+        self.port = Int(UInt16(bigEndian: actual.sin_port))
+        self.received = box
+        self.lock = lock
+        self.arrived = arrived
+
+        let thread = Thread {
+            let client = accept(fd, nil, nil)
+            guard client >= 0 else { return }
+            var line = [UInt8]()
+            var byte: UInt8 = 0
+            while line.count < 16 * 1024 {
+                let n = recv(client, &byte, 1, 0)
+                if n != 1 || byte == 0x0A { break }
+                line.append(byte)
+            }
+            lock.lock()
+            box.value = String(decoding: line, as: UTF8.self)
+            lock.unlock()
+            arrived.signal()
+            if let reply {
+                let out = reply + "\n"
+                _ = out.withCString { send(client, $0, strlen($0), 0) }
+            }
+            platformClose(client)
+        }
+        thread.start()
+    }
+
+    func payload() -> Pairing.Payload {
+        Pairing.Payload(
+            v: 1, host: "127.0.0.1", port: port, user: "tester",
+            token: "test-token", fp: "SHA256:stub")
+    }
+
+    func waitForRequest(timeout: TimeInterval = 5) -> String? {
+        guard arrived.wait(timeout: .now() + timeout) == .success else { return nil }
+        lock.lock(); defer { lock.unlock() }
+        return received.value
+    }
+
+    func stop() {
+        guard !stopped else { return }
+        stopped = true
+        platformClose(listenFD)
+    }
+
+    enum TestError: Swift.Error { case socket }
+
+    /// A shared mutable String the worker thread can fill in.
+    ///
+    /// Not `NSMutableString`: swift-corelibs-foundation has no no-argument initialiser for
+    /// it, so the same line compiles on Darwin and fails on Linux.
+    final class Box: @unchecked Sendable { var value = "" }
+}

--- a/project.yml
+++ b/project.yml
@@ -148,6 +148,11 @@ targets:
         # it requests the permission.
         NSMicrophoneUsageDescription: herdrup uses the microphone only while you hold a dictation session, to turn your speech into text in the message field. Audio is transcribed on-device and never leaves your phone.
         NSSpeechRecognitionUsageDescription: herdrup transcribes your dictation into text on-device, so you can talk instead of type. Your speech is not sent anywhere.
+        # QR pairing (#126): the camera reads the code `herdr pair` prints on the
+        # machine. REQUIRED — like the two strings above, the app crashes the first
+        # time it asks for the permission if this is missing, and the crash would land
+        # on the very first screen a new user reaches.
+        NSCameraUsageDescription: herdrup uses the camera only to scan the pairing code your computer displays, so it can connect without you typing anything. No photos or video are recorded.
         # Export compliance: herdr uses ONLY standard, published encryption (AES/SSH
         # via a standard library — no proprietary or custom cryptography), which
         # QUALIFIES FOR THE STANDARD MASS-MARKET EXEMPTION (EAR Category 5 Part 2). So


### PR DESCRIPTION
Part 2 of #126 — the app side. Point the camera at what `herdr pair` prints and the machine is connected, with nothing typed. The daemon half is a separate PR on `jerryfane/herdr`.

## The first screen was the bug

A new user was blocked there, and the old copy shows why: *"Add a machine to connect over your Tailscale network."* That assumes the reader already knows herdr runs on a computer, that a daemon must be installed there, and what Tailscale is. **The word "herdr" appeared nowhere on the screen.** The page that does explain it (`herdrInstallGuidance`) was reachable only *after a successful SSH login* — visible solely to people who had already solved the problem it explains.

The empty state now says what the app is and gives the two commands that start everything. **"Scan pairing code" is the primary action**; "Add host" is the fallback. The manual path asks for a host address, a username and an ed25519 private key — three things a new user does not have and cannot produce from that screen.

The install one-liner was `private static` on `TerminalHomeView`, which is *why* the first-run screen could not show it. It now lives in one `HerdrSetup` enum both screens read, so the two places telling someone how to install herdr cannot drift apart.

## Where the logic lives, and why

The camera and the phases are in `App/`. **Every decision is in HerdrKit**: parsing is `Pairing.parse`, and everything after a successful parse is `PairingCoordinator` — both tested on Linux.

This split is not tidiness. A shipped app-target defect made the key sheet unusable on macOS this week (#192) and nothing local could have caught it, because nothing local compiles that file.

The coordinator's three security decisions were each **mutation-checked** — reverted individually and required to go red:

| mutation | failures |
|---|---|
| redeem before pin | 4 |
| pin the pairing port instead of sshd's | 2 |
| allow an unpinnable host through | 2 |
| swallow a failed save | 2 |
| *restored* | *0* |

**Pin before touching the other machine.** If pinning fails afterwards, the user is left with an orphaned key in their `authorized_keys` for a failure they did not cause and will never be told about.

**Pin the SSH port, not the pairing port.** The payload's `port` is the short-lived pairing listener; sshd is elsewhere. Pinning against the pairing port would file the fingerprint under a key the SSH connection never looks up — the pin would silently miss and first contact would trust-on-first-use anyway, which is the exact hole the fingerprint exists to close.

**A machine with no host key is refused, not saved unpinned.** This is the one that would otherwise pass silently: saving still "works", and the damage only appears at first connect.

## Two scanner details that are deliberate

- A camera delivers the same code many times a second. Without a guard the coordinator runs repeatedly — pairing twice, the second attempt failing on a spent token and overwriting the success just shown.
- `startRunning` blocks, so it runs off the main thread; on it, the sheet's presentation animation stalls and reads as the app freezing exactly when the scanner opens. The session stops on disappear, or the privacy indicator stays lit after the sheet is gone.

The coordinator is `async`, and that is a **correctness fix**: only the blocking socket round trip leaves the caller's actor. The pin and the store write stay on it, because `addPairedHost` mutates an `@Published` property and SwiftUI forbids that off the main thread. My first draft used a detached task and would have done exactly that.

`NSCameraUsageDescription` added — like the microphone strings beside it, a missing one crashes the app the first time it asks, and that crash would land on the first screen a new user reaches.

## Verification

400 HerdrKit tests pass. The end-to-end chain was proven on a Linux box against the real daemon:

```
ssh DENIED → herdr pair → QR decoded from the image, as a camera would
           → this client redeems → daemon writes authorized_keys 0600
           → a real OpenSSH login SUCCEEDS
```

The control is what makes it mean anything: the same login was refused before pairing.

**Unproven until this runs on a device:** whether the camera opens, whether the preview layer is sized correctly, and whether a real phone reads a real terminal QR. This PR's macOS job type-checks the app target; it does not operate a camera.
