### PR TITLE
fix(onboarding): make the install command copyable, and one line

### DIFF
--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -457,12 +457,19 @@ struct RootView: View {
 /// drift apart — a reader who follows one and then the other has to be given the same
 /// command both times.
 enum HerdrSetup {
-    /// Installs the fork on the machine: clone, build, install to `~/.local/bin`.
-    /// `install -D` creates the parent directory, so no separate `mkdir` is needed.
+    /// Installs the fork on the machine.
+    ///
+    /// ONE LINE ON PURPOSE. This was four chained commands that wrapped onto four
+    /// lines in the first-run card — a wall of text as the very first thing a new
+    /// user is asked to do. The script does the same work (clone, build, install to
+    /// `~/.local/bin`) and additionally checks the toolchain BEFORE cloning, so an
+    /// old distro cargo fails with "cargo is too old" instead of an unexplained
+    /// lockfile parse error.
+    ///
+    /// It points at the FORK, not `herdr.dev/install.sh`: upstream's installer
+    /// produces a herdr with no `api-bridge`, which this app cannot drive.
     static let installCommand =
-        "git clone https://github.com/jerryfane/herdr && cd herdr && "
-        + "cargo build --release && "
-        + "install -D -m 0755 target/release/herdr ~/.local/bin/herdr"
+        "curl -fsSL https://herdrup.themartian.app/install.sh | sh"
 }
 
 struct ConnectView: View {
@@ -474,6 +481,8 @@ struct ConnectView: View {
     /// The scan-to-connect sheet (#126) — the path that needs no key, no host address and
     /// no knowledge of what a daemon is.
     @State private var showingPairing = false
+    /// Which command was just copied, so the card can confirm it. Nil = none.
+    @State private var copiedCommand: String?
 
     var body: some View {
         ZStack {
@@ -580,20 +589,51 @@ struct ConnectView: View {
                 monoCard("herdr pair")
             }
 
-            Text("Scan the code it prints and you're connected — no keys to copy.")
+            Text("Scan the code it prints and you're connected. No keys to copy.")
                 .font(Typography.app(13)).foregroundStyle(Palette.textDim)
                 .multilineTextAlignment(.center)
         }
         .frame(maxWidth: .infinity).padding(.vertical, 16)
     }
 
+    /// A command the reader is meant to run on their computer — and can now COPY.
+    ///
+    /// It looked tappable and did nothing, which is worse than looking inert: the
+    /// obvious gesture on a command you are being told to run somewhere else is to
+    /// copy it, and this screen is a phone showing a command for a laptop, so
+    /// copy-then-paste is the whole point.
+    ///
+    /// Clipboard WRITE only (`UIPasteboard.general.string`), the same pattern as
+    /// `CopyForAgentButton` — a programmatic READ is what triggers the system paste
+    /// prompt that failed App Review under 2.1a.
     private func monoCard(_ text: String) -> some View {
-        Text(text)
-            .font(Typography.machine(13)).foregroundStyle(Palette.text)
-            .textSelection(.enabled)
+        Button {
+            UIPasteboard.general.string = text
+            UINotificationFeedbackGenerator().notificationOccurred(.success)
+            copiedCommand = text
+            // Revert the label rather than leaving a permanent "Copied", which would
+            // stop telling the truth the moment the clipboard changed.
+            Task {
+                try? await Task.sleep(nanoseconds: 1_600_000_000)
+                if copiedCommand == text { copiedCommand = nil }
+            }
+        } label: {
+            HStack(alignment: .top, spacing: 10) {
+                Text(text)
+                    .font(Typography.machine(13)).foregroundStyle(Palette.text)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .multilineTextAlignment(.leading)
+                Image(systemName: copiedCommand == text ? "checkmark" : "doc.on.doc")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(copiedCommand == text ? Palette.done : Palette.textFaint)
+                    .padding(.top, 2)
+            }
             .padding(.horizontal, 14).padding(.vertical, 10)
             .frame(maxWidth: .infinity)
             .background(Palette.surface).clipShape(RoundedRectangle(cornerRadius: 10))
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(Text(copiedCommand == text ? "Copied" : "Copy command: \(text)"))
     }
 
     private var addHostButton: some View {


### PR DESCRIPTION
Three fixes from the owner's screenshot of the shipped first-run screen.

THE COMMAND CARDS LOOKED TAPPABLE AND DID NOTHING. That is worse than looking
inert: this screen is a PHONE showing a command meant for a LAPTOP, so the obvious
gesture is to copy it, and the obvious gesture was the one that failed. They now
copy, with a haptic and a checkmark that reverts after ~1.6s rather than sitting
there claiming "Copied" long after the clipboard moved on. Clipboard WRITE only,
the same pattern as CopyForAgentButton -- a programmatic READ is what triggers the
system paste prompt that failed App Review under 2.1a.

THE INSTALL COMMAND WAS FOUR CHAINED COMMANDS that wrapped onto four lines in the
card -- a wall of text as the literal first thing a new user is asked to do. It is
now one line: `curl -fsSL https://herdrup.themartian.app/install.sh | sh`.

That URL is LIVE as of tonight, verified 200 and byte-identical to install.sh in
herdr#133, so the site and the repo cannot drift. Finding where to publish it took
three wrong answers worth recording: themartian-web serves themartian.app and only
LINKS to herdrup; the app repo's docs/ is design notes with no Pages site; and the
domain is not Cloudflare PAGES at all but a WORKER named `herdrup` -- an
`AAAA -> 100::` record was the only thing that said so. herdrup-web/DEPLOY.md still
documents a `wrangler pages deploy` that could never have worked; correcting that
is a separate change.

The script also does more than the four commands did: it checks the toolchain
BEFORE cloning, so an old distro cargo fails with "cargo is too old" instead of an
unexplained lockfile parse error.

EM DASH REMOVED from "you're connected — no keys to copy", per the owner.

Verified: 400 HerdrKit tests pass and the file parses. NOT verified here and worth
stating -- this is App/ target SwiftUI, which does not build on Linux, so the
rendering, the copy gesture and the haptic are unproven until macOS CI type-checks
it and a real device runs it. Two app-target defects shipped tonight for exactly
this reason.