### PR TITLE
feat(agents): let a running agent switch between Claude Code and Codex

### DIFF
--- a/App/AgentSessionTransferSheet.swift
+++ b/App/AgentSessionTransferSheet.swift
@@ -1,0 +1,642 @@
+import HerdrKit
+import SwiftUI
+
+/// Two-phase Claude Code <-> Codex transfer. Preparing is non-destructive: Herdr
+/// builds and rereads the destination transcript while this agent stays live. The
+/// user sees the exact visible-message and omission counts before confirmation.
+struct AgentSessionTransferSheet: View {
+    let client: HerdrClient
+    let agent: AgentInfo
+    let title: String
+    let accounts: [CredentialAccount]
+    let onRefresh: () -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var target: AgentSessionTransferHarness
+    @State private var selectedAccountID: String
+    @State private var transfer: AgentSessionTransferInfo?
+    @State private var sourceStatus: String?
+    @State private var busy = false
+    @State private var errorText: String?
+
+    init(
+        client: HerdrClient,
+        agent: AgentInfo,
+        title: String,
+        target: AgentSessionTransferHarness,
+        accounts: [CredentialAccount],
+        onRefresh: @escaping () -> Void
+    ) {
+        self.client = client
+        self.agent = agent
+        self.title = title
+        self.accounts = accounts
+        self.onRefresh = onRefresh
+
+        let existing = agent.sessionTransfer.flatMap { info -> AgentSessionTransferInfo? in
+            guard info.target == target else { return nil }
+            return info
+        }
+        _target = State(initialValue: target)
+        _transfer = State(initialValue: existing)
+        _selectedAccountID = State(initialValue: existing?.targetAccount ?? "")
+        _sourceStatus = State(initialValue: agent.agentStatus)
+    }
+
+    private var source: AgentSessionTransferHarness {
+        target == .codex ? .claude : .codex
+    }
+
+    private var targetAccounts: [CredentialAccount] {
+        accounts.filter { $0.kind == target.rawValue }
+    }
+
+    private var selectedAccount: String? {
+        selectedAccountID.isEmpty ? nil : selectedAccountID
+    }
+
+    private var selectedAccountLabel: String {
+        guard let id = transfer?.targetAccount ?? selectedAccount else {
+            return "Default \(target.displayName) account"
+        }
+        return targetAccounts.first(where: { $0.id == id })?.label ?? id
+    }
+
+    private var sourceIsIdle: Bool { sourceStatus == "idle" }
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Palette.ground.ignoresSafeArea()
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 18) {
+                        directionHeader
+                        if transfer == nil {
+                            setup
+                        } else {
+                            transferStatus
+                        }
+                        if let errorText {
+                            errorPanel(errorText)
+                        }
+                    }
+                    .padding(20)
+                    .padding(.bottom, 92)
+                }
+            }
+            .navigationTitle("Switch harness")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Close") { dismiss() }
+                        .foregroundStyle(Palette.textDim)
+                }
+            }
+            .safeAreaInset(edge: .bottom) { actionBar }
+        }
+        .preferredColorScheme(.dark)
+        .task {
+            if let transfer, transfer.phase != .ready {
+                busy = true
+                await pollTransfer(id: transfer.id)
+            } else if transfer == nil {
+                await pollSourceUntilIdle()
+            }
+        }
+        .onDisappear { onRefresh() }
+    }
+
+    private var directionHeader: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            HStack(spacing: 12) {
+                harnessBadge(source)
+                Image(systemName: "arrow.right")
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundStyle(Palette.textFaint)
+                harnessBadge(target)
+            }
+            Text(title)
+                .font(Typography.app(22, .bold))
+                .foregroundStyle(Palette.text)
+            Text("Continue the same agent, pane, name, folder, and visible conversation in \(target.displayName).")
+                .font(Typography.app(14))
+                .foregroundStyle(Palette.textDim)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private func harnessBadge(_ harness: AgentSessionTransferHarness) -> some View {
+        HStack(spacing: 8) {
+            ZStack {
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(AgentIdentity.gradient(for: harness.rawValue))
+                    .frame(width: 30, height: 30)
+                Text(AgentIdentity.glyph(for: harness.rawValue))
+                    .font(Typography.app(14, .bold))
+                    .foregroundStyle(.white)
+            }
+            Text(harness.displayName)
+                .font(Typography.app(13, .semibold))
+                .foregroundStyle(Palette.text)
+        }
+        .padding(.vertical, 7)
+        .padding(.horizontal, 9)
+        .background(RoundedRectangle(cornerRadius: 10).fill(Palette.surface))
+        .overlay(RoundedRectangle(cornerRadius: 10).stroke(Palette.hairline, lineWidth: 1))
+    }
+
+    private var setup: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            sectionLabel("TARGET ACCOUNT")
+            Picker("Target account", selection: $selectedAccountID) {
+                Text("Default \(target.displayName) account").tag("")
+                ForEach(targetAccounts) { account in
+                    Text(account.label + (account.active ? "" : " · exhausted"))
+                        .tag(account.id)
+                }
+            }
+            .pickerStyle(.menu)
+            .tint(Palette.text)
+            .padding(.horizontal, 12)
+            .frame(maxWidth: .infinity, minHeight: 48, alignment: .leading)
+            .background(RoundedRectangle(cornerRadius: 10).fill(Palette.surface))
+            .overlay(RoundedRectangle(cornerRadius: 10).stroke(Palette.hairline, lineWidth: 1))
+
+            infoPanel(
+                icon: "shield.lefthalf.filled",
+                title: "Preparation does not stop \(source.displayName)",
+                text: "Herdr reads the source once, creates a native \(target.displayName) session, and rereads the destination file. You confirm only after the counts are ready."
+            )
+
+            if !sourceIsIdle {
+                infoPanel(
+                    icon: "hourglass",
+                    title: "Wait for this turn to finish",
+                    text: "The transcript must be still while Herdr verifies it. \(title) is \(sourceStatus ?? "not idle") right now."
+                )
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var transferStatus: some View {
+        if let transfer {
+            switch transfer.phase {
+            case .preparing:
+                progressPanel(
+                    "Preparing \(target.displayName)",
+                    "Reading and verifying both native transcripts. \(source.displayName) is still live."
+                )
+            case .ready:
+                readyReview(transfer)
+            case .verifyingCutover:
+                progressPanel(
+                    "Rechecking both transcripts",
+                    "\(source.displayName) is still live while Herdr verifies that the reviewed source and destination files are unchanged."
+                )
+            case .launchingTarget, .awaitingTarget:
+                progressPanel(
+                    "Switching to \(target.displayName)",
+                    targetReadinessText
+                )
+            case .rollingBack:
+                progressPanel(
+                    "Restoring \(source.displayName)",
+                    rollbackReadinessText
+                )
+            case .completed:
+                outcomePanel(
+                    icon: "checkmark.circle.fill", color: Palette.done,
+                    title: "Now running in \(target.displayName)",
+                    text: "The verified target owns the same pane. You can continue the conversation there."
+                )
+            case .rolledBack:
+                outcomePanel(
+                    icon: "arrow.uturn.backward.circle.fill", color: Palette.waiting,
+                    title: "Restored \(source.displayName)",
+                    text: transfer.error ?? "The target could not be verified, so Herdr restored the original session and account."
+                )
+            case .failed:
+                outcomePanel(
+                    icon: "exclamationmark.triangle.fill", color: Palette.died,
+                    title: "Transfer failed",
+                    text: transfer.error ?? "Herdr refused the transfer. Check the agent before trying again."
+                )
+            case .unrecognised(let value):
+                outcomePanel(
+                    icon: "questionmark.circle.fill", color: Palette.waiting,
+                    title: "Unknown transfer state",
+                    text: "The daemon reported \(value). Update herdrup before deciding whether the harness changed."
+                )
+            }
+        }
+    }
+
+    private func readyReview(_ transfer: AgentSessionTransferInfo) -> some View {
+        VStack(alignment: .leading, spacing: 16) {
+            outcomePanel(
+                icon: "checkmark.shield.fill", color: Palette.done,
+                title: "Ready to switch",
+                text: "\(source.displayName) is still live. Confirming interrupts it only after Herdr rechecks that both verified files are unchanged."
+            )
+
+            VStack(spacing: 0) {
+                reviewRow("Visible messages", value: "\(transfer.messageCount)", strong: true)
+                rowDivider
+                reviewRow("Target account", value: selectedAccountLabel, strong: true)
+            }
+            .background(RoundedRectangle(cornerRadius: 12).fill(Palette.surface))
+            .overlay(RoundedRectangle(cornerRadius: 12).stroke(Palette.hairline, lineWidth: 1))
+
+            sectionLabel("NOT CARRIED INTO THE VISIBLE CHAT")
+            VStack(spacing: 0) {
+                omissionRow("Tool records", transfer.omissions.toolRecords)
+                rowDivider
+                omissionRow("Reasoning records", transfer.omissions.reasoningRecords)
+                rowDivider
+                omissionRow("System records", transfer.omissions.systemRecords)
+                rowDivider
+                omissionRow("Attachments", transfer.omissions.attachmentRecords)
+                rowDivider
+                omissionRow("Metadata records", transfer.omissions.metadataRecords)
+                rowDivider
+                omissionRow("Unsupported blocks", transfer.omissions.unsupportedBlocks)
+                rowDivider
+                omissionRow("Sidechain records", transfer.omissions.sidechainRecords)
+            }
+            .background(RoundedRectangle(cornerRadius: 12).fill(Palette.surface))
+            .overlay(RoundedRectangle(cornerRadius: 12).stroke(Palette.hairline, lineWidth: 1))
+
+            Text("Only visible user and assistant text is translated. The source transcript is never modified.")
+                .font(Typography.app(12))
+                .foregroundStyle(Palette.textFaint)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    @ViewBuilder
+    private var actionBar: some View {
+        VStack(spacing: 0) {
+            Rectangle().fill(Palette.hairlineQuiet).frame(height: 1)
+            Group {
+                if transfer == nil {
+                    primaryButton(
+                        busy ? "Preparing…" : "Prepare transfer",
+                        systemImage: busy ? nil : "arrow.triangle.2.circlepath",
+                        disabled: busy || !sourceIsIdle
+                    ) { Task { await prepare() } }
+                } else if transfer?.phase == .ready {
+                    primaryButton(
+                        busy ? "Confirming…" : "Confirm switch to \(target.displayName)",
+                        systemImage: busy ? nil : "arrow.right.circle.fill",
+                        disabled: busy
+                    ) { Task { await confirm() } }
+                } else if transfer?.phase == .completed {
+                    primaryButton(
+                        "Switch back to \(transfer?.source.displayName ?? source.displayName)",
+                        systemImage: "arrow.uturn.backward.circle.fill",
+                        disabled: false
+                    ) { beginReverseTransfer() }
+                } else if transfer?.phase == .rolledBack {
+                    primaryButton(
+                        "Try switch again", systemImage: "arrow.clockwise", disabled: false
+                    ) { retryRolledBackTransfer() }
+                } else if transfer?.phase.isTerminal == true {
+                    primaryButton("Close", systemImage: nil, disabled: false) { dismiss() }
+                } else {
+                    primaryButton("Transfer in progress…", systemImage: nil, disabled: true) {}
+                }
+            }
+            .padding(.horizontal, 20)
+            .padding(.vertical, 12)
+        }
+        .background(Palette.ground.opacity(0.98))
+    }
+
+    private func primaryButton(
+        _ title: String,
+        systemImage: String?,
+        disabled: Bool,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            HStack(spacing: 8) {
+                if disabled && busy { ProgressView().tint(Palette.ground) }
+                if let systemImage { Image(systemName: systemImage) }
+                Text(title).font(Typography.app(15, .semibold))
+            }
+            .foregroundStyle(Palette.ground)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 12)
+            .background(RoundedRectangle(cornerRadius: 10).fill(Palette.text))
+            .opacity(disabled ? 0.45 : 1)
+        }
+        .buttonStyle(.plain)
+        .disabled(disabled)
+    }
+
+    private func sectionLabel(_ text: String) -> some View {
+        Text(text)
+            .font(Typography.microLabel)
+            .tracking(1.1)
+            .foregroundStyle(Palette.textFaint)
+    }
+
+    private var rowDivider: some View {
+        Rectangle().fill(Palette.hairlineQuiet).frame(height: 1).padding(.leading, 14)
+    }
+
+    private func reviewRow(_ label: String, value: String, strong: Bool) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 12) {
+            Text(label).font(Typography.app(13)).foregroundStyle(Palette.textDim)
+            Spacer(minLength: 12)
+            Text(value)
+                .font(Typography.machine(12, strong ? .semibold : .regular))
+                .foregroundStyle(strong ? Palette.text : Palette.textDim)
+                .multilineTextAlignment(.trailing)
+        }
+        .padding(.horizontal, 14).padding(.vertical, 12)
+    }
+
+    private func omissionRow(_ label: String, _ count: UInt64) -> some View {
+        reviewRow(label, value: "\(count)", strong: count > 0)
+    }
+
+    private func infoPanel(icon: String, title: String, text: String) -> some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: icon)
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundStyle(Palette.working)
+                .frame(width: 22)
+            VStack(alignment: .leading, spacing: 5) {
+                Text(title).font(Typography.app(14, .semibold)).foregroundStyle(Palette.text)
+                Text(text).font(Typography.app(13)).foregroundStyle(Palette.textDim)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(14)
+        .background(RoundedRectangle(cornerRadius: 12).fill(Palette.surface))
+        .overlay(RoundedRectangle(cornerRadius: 12).stroke(Palette.hairline, lineWidth: 1))
+    }
+
+    private func progressPanel(_ title: String, _ text: String) -> some View {
+        HStack(alignment: .top, spacing: 13) {
+            TurningRing(color: Palette.working, diameter: 22, lineWidth: 2)
+                .padding(.top, 1)
+            VStack(alignment: .leading, spacing: 6) {
+                Text(title).font(Typography.app(16, .semibold)).foregroundStyle(Palette.text)
+                Text(text).font(Typography.app(13)).foregroundStyle(Palette.textDim)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(16)
+        .background(RoundedRectangle(cornerRadius: 12).fill(Palette.surface))
+        .overlay(RoundedRectangle(cornerRadius: 12).stroke(Palette.hairline, lineWidth: 1))
+    }
+
+    private func outcomePanel(
+        icon: String, color: Color, title: String, text: String
+    ) -> some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: icon)
+                .font(.system(size: 19, weight: .semibold))
+                .foregroundStyle(color)
+                .frame(width: 24)
+            VStack(alignment: .leading, spacing: 6) {
+                Text(title).font(Typography.app(16, .semibold)).foregroundStyle(Palette.text)
+                Text(text).font(Typography.app(13)).foregroundStyle(Palette.textDim)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(16)
+        .background(RoundedRectangle(cornerRadius: 12).fill(Palette.surface))
+        .overlay(RoundedRectangle(cornerRadius: 12).stroke(Palette.hairline, lineWidth: 1))
+    }
+
+    private func errorPanel(_ text: String) -> some View {
+        outcomePanel(
+            icon: "exclamationmark.triangle.fill", color: Palette.died,
+            title: "Could not verify the transfer", text: text
+        )
+    }
+
+    private var targetReadinessText: String {
+        switch target {
+        case .claude:
+            return "Herdr is waiting for Claude Code's official integration to report the exact staged session. A mismatch restores \(source.displayName)."
+        case .codex:
+            return "Herdr is binding the exact Codex resume session and PID, then rereading the native target JSONL. The JSONL is the proof; the short observation window is not. Codex's later official report must still match."
+        }
+    }
+
+    private var rollbackReadinessText: String {
+        switch source {
+        case .claude:
+            return "The target did not take verified ownership. Herdr is reopening the original Claude Code session and waiting for its official session report."
+        case .codex:
+            return "The target did not take verified ownership. Herdr is reopening the exact original Codex session and verifying its native JSONL against that session's PID."
+        }
+    }
+
+    @MainActor
+    private func beginReverseTransfer() {
+        guard let current = transfer, current.phase == .completed else { return }
+        target = current.source
+        selectedAccountID = ""
+        transfer = nil
+        errorText = nil
+        busy = false
+        sourceStatus = nil
+        Task { await pollSourceUntilIdle() }
+    }
+
+    @MainActor
+    private func retryRolledBackTransfer() {
+        guard transfer?.phase == .rolledBack else { return }
+        selectedAccountID = ""
+        transfer = nil
+        errorText = nil
+        busy = false
+        sourceStatus = nil
+        Task { await pollSourceUntilIdle() }
+    }
+
+    @MainActor
+    private func prepare() async {
+        guard sourceIsIdle else { return }
+        busy = true
+        errorText = nil
+        do {
+            let updated = try await client.prepareAgentSessionTransfer(
+                target: agent.paneID, to: target, account: selectedAccount)
+            guard let info = updated.sessionTransfer else {
+                throw TransferSheetError.missingState
+            }
+            transfer = info
+            selectedAccountID = info.targetAccount ?? ""
+            await pollTransfer(id: info.id)
+        } catch {
+            let transportError = displayError(error)
+            if await adoptDurableTransfer(expectedID: nil, includeTerminal: false),
+               let recovered = transfer {
+                errorText = nil
+                if recovered.phase == .ready {
+                    busy = false
+                } else {
+                    await pollTransfer(id: recovered.id)
+                }
+                return
+            }
+            busy = false
+            errorText = transportError
+        }
+    }
+
+    @MainActor
+    private func confirm() async {
+        guard let current = transfer, current.phase == .ready else { return }
+        busy = true
+        errorText = nil
+        do {
+            let updated = try await client.confirmAgentSessionTransfer(
+                target: agent.paneID,
+                to: current.target,
+                account: current.targetAccount,
+                transferID: current.id)
+            guard let info = updated.sessionTransfer else {
+                throw TransferSheetError.missingState
+            }
+            transfer = info
+            await pollTransfer(id: info.id)
+        } catch {
+            let transportError = displayError(error)
+            if await adoptDurableTransfer(expectedID: current.id, includeTerminal: true),
+               let recovered = transfer {
+                if recovered.id != current.id {
+                    busy = false
+                    return
+                }
+                if recovered.phase == .ready {
+                    busy = false
+                    errorText = "Herdr still reports this transfer as ready, so confirmation was not observed. You can confirm the same transaction again."
+                } else if recovered.phase.isTerminal {
+                    busy = false
+                    errorText = nil
+                    onRefresh()
+                } else {
+                    errorText = nil
+                    await pollTransfer(id: recovered.id)
+                }
+                return
+            }
+            busy = false
+            errorText = transportError
+        }
+    }
+
+    @MainActor
+    private func adoptDurableTransfer(
+        expectedID: String?, includeTerminal: Bool
+    ) async -> Bool {
+        do {
+            guard let updatedAgent = try await client.agentList().first(where: {
+                $0.paneID == agent.paneID
+                    || ($0.terminalID != nil && $0.terminalID == agent.terminalID)
+            }), let durable = updatedAgent.sessionTransfer,
+                  includeTerminal || !durable.phase.isTerminal else {
+                return false
+            }
+            target = durable.target
+            transfer = durable
+            selectedAccountID = durable.targetAccount ?? ""
+            sourceStatus = updatedAgent.agentStatus
+            if let expectedID, durable.id != expectedID {
+                busy = false
+                errorText = "A different transfer replaced this transaction. Review the durable state shown here before taking another action."
+            }
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    @MainActor
+    private func pollTransfer(id: String) async {
+        for _ in 0..<400 {
+            guard !Task.isCancelled else { return }
+            if let current = transfer {
+                if current.id != id {
+                    busy = false
+                    return
+                }
+                if current.phase == .ready {
+                    busy = false
+                    return
+                }
+                if current.phase.isTerminal {
+                    busy = false
+                    onRefresh()
+                    return
+                }
+            }
+            await refreshTransfer(id: id)
+            try? await Task.sleep(nanoseconds: 300_000_000)
+        }
+        busy = false
+        errorText = "Herdr has not reported a final state. Close and reopen this sheet to check the same transaction. Do not assume the harness changed."
+    }
+
+    @MainActor
+    private func refreshTransfer(id: String) async {
+        do {
+            guard let updatedAgent = try await client.agentList().first(where: {
+                $0.paneID == agent.paneID || ($0.terminalID != nil && $0.terminalID == agent.terminalID)
+            }) else { return }
+            guard let updated = updatedAgent.sessionTransfer else { return }
+            guard updated.id == id else {
+                transfer = updated
+                busy = false
+                errorText = "A different transfer replaced this transaction. Close and reopen to review the current one."
+                return
+            }
+            transfer = updated
+            if updated.phase.isTerminal { errorText = nil }
+        } catch {
+            // A daemon restart can transiently drop a poll. Keep the last verified
+            // phase and retry; only the deadline above turns prolonged uncertainty
+            // into user-visible text.
+        }
+    }
+
+    @MainActor
+    private func pollSourceUntilIdle() async {
+        while !Task.isCancelled, transfer == nil, !sourceIsIdle {
+            if let updated = try? await client.agentList().first(where: {
+                $0.paneID == agent.paneID
+                    || ($0.terminalID != nil && $0.terminalID == agent.terminalID)
+            }) {
+                sourceStatus = updated.agentStatus
+            }
+            if !sourceIsIdle {
+                try? await Task.sleep(nanoseconds: 1_000_000_000)
+            }
+        }
+    }
+
+    private func displayError(_ error: Error) -> String {
+        if let apiError = error as? APIError { return apiError.description }
+        if let localError = error as? LocalizedError,
+           let description = localError.errorDescription {
+            return description
+        }
+        return String(describing: error)
+    }
+}
+
+private enum TransferSheetError: LocalizedError {
+    case missingState
+
+    var errorDescription: String? {
+        "Herdr returned no session-transfer state. The source was not treated as switched."
+    }
+}

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -1146,6 +1146,17 @@ struct TerminalHomeView: View {
         let account: CredentialAccount
     }
     @State private var swapCandidate: PendingSwap?
+    /// Capability-gated Claude Code <-> Codex transfer. Unlike a subscription
+    /// swap, this stages a translated native session and requires review before
+    /// the source runtime is interrupted.
+    private struct PendingHarnessTransfer: Identifiable {
+        let row: AgentRow
+        let target: AgentSessionTransferHarness
+        var id: String { "\(row.info.paneID):\(target.rawValue)" }
+    }
+    @State private var transferCandidate: PendingHarnessTransfer?
+    @State private var sessionTransferSupported = false
+    @State private var checkedSessionTransferCapability = false
     /// A pending rename (nil = no sheet). An agent sets its daemon `name` (a resolvable mention
     /// target — `herdr agent read <name>`); a terminal sets its pane `label` (shown in
     /// `herdr pane list`) plus the app-local row label. Identifiable so it drives a `.sheet(item:)`.
@@ -1829,6 +1840,18 @@ struct TerminalHomeView: View {
             .sheet(item: $renameTarget) { target in
                 renameSheet(for: target)
             }
+            .sheet(item: $transferCandidate) { candidate in
+                AgentSessionTransferSheet(
+                    client: client,
+                    agent: candidate.row.info,
+                    title: candidate.row.title,
+                    target: candidate.target,
+                    accounts: accounts,
+                    onRefresh: { Task { await load() } }
+                )
+                .presentationDetents([.large])
+                .presentationDragIndicator(.visible)
+            }
     }
 
     private var agentsTab: some View {
@@ -2161,6 +2184,21 @@ struct TerminalHomeView: View {
         .contentShape(Rectangle())
     }
 
+    /// Reopen a durable transaction from its recorded target even while the row's
+    /// detected agent is nil or already changed. Without a transaction, only exact
+    /// native harness kinds participate; guessing would offer a transfer the server
+    /// must refuse.
+    private func sessionTransferTarget(for info: AgentInfo) -> AgentSessionTransferHarness? {
+        if let activeOrRecordedTransfer = info.sessionTransfer {
+            return activeOrRecordedTransfer.target
+        }
+        switch info.agent?.lowercased() {
+        case "claude": return .codex
+        case "codex": return .claude
+        default: return nil
+        }
+    }
+
     private func sectionView(_ group: AgentGroup, _ rows: [AgentRow]) -> some View {
         // An active search overrides collapse — a match inside IDLE must not stay
         // hidden behind a shut section the user did not open.
@@ -2223,6 +2261,20 @@ struct TerminalHomeView: View {
                         Button {
                             restartCandidate = row
                         } label: { Label("Restart agent", systemImage: "arrow.clockwise") }
+                        // Harness transfer is deliberately not a restart shortcut. It
+                        // first builds and verifies a native destination transcript,
+                        // then opens a review sheet whose explicit confirm performs the
+                        // cutover. Local-only: the server denies filesystem-authority
+                        // transfer requests over federation.
+                        if row.info.machineID == nil,
+                           (sessionTransferSupported || row.info.sessionTransfer != nil),
+                           let target = sessionTransferTarget(for: row.info) {
+                            Button {
+                                transferCandidate = PendingHarnessTransfer(row: row, target: target)
+                            } label: {
+                                Label("Switch to \(target.displayName)", systemImage: "arrow.left.arrow.right")
+                            }
+                        }
                         // Swap = restart the agent onto a DIFFERENT credential account
                         // of the same kind (an agent runs only on its own kind's
                         // subscriptions). Shown only when the daemon reported at least
@@ -2538,6 +2590,20 @@ struct TerminalHomeView: View {
             // failure — or an older daemon without `accounts.list` — keeps the
             // last-good list rather than blanking the submenu mid-session.
             if let fetchedAccounts = try? await client.accountsList() { accounts = fetchedAccounts }
+            // Ping once per connected HomeView to feature-detect the transactional
+            // transfer API. Missing capabilities on an older daemon are a successful
+            // negative result; a transport error is retried on the next load.
+            if !checkedSessionTransferCapability {
+                do {
+                    let capabilities = try await client.serverCapabilities()
+                    sessionTransferSupported = capabilities?.agentSessionTransfer == true
+                    checkedSessionTransferCapability = true
+                } catch {
+                    // Keep the control hidden and retry on a later refresh. Existing
+                    // transfer state still makes the menu visible so a Ready/rollback
+                    // transaction can always be reopened.
+                }
+            }
             error = nil
             rejectedFingerprint = nil
             trustFailed = false

--- a/Sources/HerdrKit/HerdrClient.swift
+++ b/Sources/HerdrKit/HerdrClient.swift
@@ -68,6 +68,12 @@ public actor HerdrClient {
         try await call("accounts.list", EmptyParams(), as: AccountsListResult.self).accounts
     }
 
+    /// Feature flags from the daemon's `ping` result. `nil` capabilities means an
+    /// older daemon; callers treat every new feature as unsupported in that case.
+    public func serverCapabilities() async throws -> ServerCapabilities? {
+        try await call("ping", EmptyParams(), as: PingResult.self).capabilities
+    }
+
     struct AccountsCreateParams: Encodable {
         let kind: String
         let label: String
@@ -705,6 +711,68 @@ public actor HerdrClient {
         try await call("agent.restart", AgentRestartParams(target: target, account: account),
                        as: AgentInfoResult.self)
             .agent
+    }
+
+    /// Wire payload shared by the explicit prepare and confirm calls. False
+    /// `confirm` and nil optionals are omitted so the prepare request stays the
+    /// minimal `{ target, to, account? }` contract.
+    struct AgentTransferSessionParams: Encodable {
+        let target: String
+        let to: AgentSessionTransferHarness
+        let account: String?
+        let transferID: String?
+        let confirm: Bool
+
+        enum CodingKeys: String, CodingKey {
+            case target, to, account, confirm
+            case transferID = "transfer_id"
+        }
+
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(target, forKey: .target)
+            try container.encode(to, forKey: .to)
+            try container.encodeIfPresent(account, forKey: .account)
+            try container.encodeIfPresent(transferID, forKey: .transferID)
+            if confirm { try container.encode(true, forKey: .confirm) }
+        }
+    }
+
+    /// Stage and verify a native destination transcript while the source harness
+    /// remains live. The returned agent carries `sessionTransfer`; the caller must
+    /// review its counts before making the separate confirmation call.
+    @discardableResult
+    public func prepareAgentSessionTransfer(
+        target: String,
+        to harness: AgentSessionTransferHarness,
+        account: String? = nil
+    ) async throws -> AgentInfo {
+        try await call(
+            "agent.transfer_session",
+            AgentTransferSessionParams(
+                target: target, to: harness, account: account,
+                transferID: nil, confirm: false),
+            as: AgentInfoResult.self
+        ).agent
+    }
+
+    /// Confirm one exact prepared transfer. Herdr first returns the durable
+    /// `verifyingCutover` phase while the source stays live, then owns cutover and
+    /// rollback; this call never silently prepares a replacement transaction.
+    @discardableResult
+    public func confirmAgentSessionTransfer(
+        target: String,
+        to harness: AgentSessionTransferHarness,
+        account: String? = nil,
+        transferID: String
+    ) async throws -> AgentInfo {
+        try await call(
+            "agent.transfer_session",
+            AgentTransferSessionParams(
+                target: target, to: harness, account: account,
+                transferID: transferID, confirm: true),
+            as: AgentInfoResult.self
+        ).agent
     }
 
     struct AgentRenameParams: Encodable {

--- a/Sources/HerdrKit/Wire.swift
+++ b/Sources/HerdrKit/Wire.swift
@@ -112,6 +112,108 @@ public struct AgentArchivedInfo: Decodable, Equatable, Sendable {
     public let reason: String?
 }
 
+/// The two harnesses whose native transcript formats Herdr can translate.
+public enum AgentSessionTransferHarness: String, Codable, Equatable, Sendable {
+    case claude, codex
+
+    public var displayName: String { self == .claude ? "Claude Code" : "Codex" }
+}
+
+/// The durable two-phase transfer state reported on `AgentInfo.sessionTransfer`.
+public enum AgentSessionTransferPhase: Decodable, Equatable, Sendable {
+    case preparing
+    case ready
+    case verifyingCutover
+    case launchingTarget
+    case awaitingTarget
+    case completed
+    case rollingBack
+    case rolledBack
+    case failed
+    case unrecognised(String)
+
+    public init(from decoder: Decoder) throws {
+        let value = try decoder.singleValueContainer().decode(String.self)
+        switch value {
+        case "preparing": self = .preparing
+        case "ready": self = .ready
+        case "verifying_cutover": self = .verifyingCutover
+        case "launching_target": self = .launchingTarget
+        case "awaiting_target": self = .awaitingTarget
+        case "completed": self = .completed
+        case "rolling_back": self = .rollingBack
+        case "rolled_back": self = .rolledBack
+        case "failed": self = .failed
+        default: self = .unrecognised(value)
+        }
+    }
+
+    public var isTerminal: Bool {
+        switch self {
+        case .completed, .rolledBack, .failed, .unrecognised: return true
+        default: return false
+        }
+    }
+}
+
+/// Records intentionally omitted from the visible-message transcript. These are
+/// counts, not silent loss: the confirmation UI names every category before cutover.
+public struct AgentSessionTransferOmissions: Decodable, Equatable, Sendable {
+    public let toolRecords: UInt64
+    public let reasoningRecords: UInt64
+    public let systemRecords: UInt64
+    public let attachmentRecords: UInt64
+    public let metadataRecords: UInt64
+    public let unsupportedBlocks: UInt64
+    public let sidechainRecords: UInt64
+
+    public var total: UInt64 {
+        toolRecords + reasoningRecords + systemRecords + attachmentRecords
+            + metadataRecords + unsupportedBlocks + sidechainRecords
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case toolRecords = "tool_records"
+        case reasoningRecords = "reasoning_records"
+        case systemRecords = "system_records"
+        case attachmentRecords = "attachment_records"
+        case metadataRecords = "metadata_records"
+        case unsupportedBlocks = "unsupported_blocks"
+        case sidechainRecords = "sidechain_records"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        toolRecords = try c.decodeIfPresent(UInt64.self, forKey: .toolRecords) ?? 0
+        reasoningRecords = try c.decodeIfPresent(UInt64.self, forKey: .reasoningRecords) ?? 0
+        systemRecords = try c.decodeIfPresent(UInt64.self, forKey: .systemRecords) ?? 0
+        attachmentRecords = try c.decodeIfPresent(UInt64.self, forKey: .attachmentRecords) ?? 0
+        metadataRecords = try c.decodeIfPresent(UInt64.self, forKey: .metadataRecords) ?? 0
+        unsupportedBlocks = try c.decodeIfPresent(UInt64.self, forKey: .unsupportedBlocks) ?? 0
+        sidechainRecords = try c.decodeIfPresent(UInt64.self, forKey: .sidechainRecords) ?? 0
+    }
+}
+
+/// Reviewable transfer facts retained on the logical agent throughout prepare,
+/// cutover, rollback, and completion. `targetAccount` is deliberately echoed so
+/// reopening a prepared sheet never has to guess which account confirmation needs.
+public struct AgentSessionTransferInfo: Decodable, Equatable, Sendable, Identifiable {
+    public let id: String
+    public let source: AgentSessionTransferHarness
+    public let target: AgentSessionTransferHarness
+    public let targetAccount: String?
+    public let phase: AgentSessionTransferPhase
+    public let messageCount: UInt64
+    public let omissions: AgentSessionTransferOmissions
+    public let error: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id, source, target, phase, omissions, error
+        case targetAccount = "target_account"
+        case messageCount = "message_count"
+    }
+}
+
 public struct AgentInfo: Decodable, Equatable, Sendable, Identifiable {
     public let agent: String?
     public let agentStatus: String?
@@ -169,6 +271,9 @@ public struct AgentInfo: Decodable, Equatable, Sendable, Identifiable {
     public let account: String?
     public let accountConfigDir: String?
     public let accountUnresolved: Bool?
+    /// Present while a Claude Code/Codex transfer is staged or launching, and
+    /// retained with its final outcome. Absent on older daemons.
+    public let sessionTransfer: AgentSessionTransferInfo?
 
     /// Stable list identity. A LIVE agent is keyed on its pane id, which is unique
     /// and stable while it runs. An ARCHIVED agent has NO pane — the server empties
@@ -236,6 +341,7 @@ public struct AgentInfo: Decodable, Equatable, Sendable, Identifiable {
         case lastKnownStatus = "last_known_status"
         case accountConfigDir = "account_config_dir"
         case accountUnresolved = "account_unresolved"
+        case sessionTransfer = "session_transfer"
     }
 }
 
@@ -696,6 +802,41 @@ public struct PanePtySize: Decodable, Sendable, Equatable {
 }
 
 // MARK: - Server / staged self-update (server.staged_update / server.apply_staged_update)
+
+/// Feature flags returned by `ping`. Missing fields decode false so a newer app
+/// talking to an older daemon simply hides unsupported controls.
+public struct ServerCapabilities: Decodable, Equatable, Sendable {
+    public let liveHandoff: Bool
+    public let detachedServerDaemon: Bool
+    public let paneInputStream: Bool
+    public let agentSessionTransfer: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case liveHandoff = "live_handoff"
+        case detachedServerDaemon = "detached_server_daemon"
+        case paneInputStream = "pane_input_stream"
+        case agentSessionTransfer = "agent_session_transfer"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        liveHandoff = try c.decodeIfPresent(Bool.self, forKey: .liveHandoff) ?? false
+        detachedServerDaemon = try c.decodeIfPresent(Bool.self, forKey: .detachedServerDaemon) ?? false
+        paneInputStream = try c.decodeIfPresent(Bool.self, forKey: .paneInputStream) ?? false
+        agentSessionTransfer = try c.decodeIfPresent(Bool.self, forKey: .agentSessionTransfer) ?? false
+    }
+}
+
+struct PingResult: Decodable {
+    let version: String
+    let protocolVersion: Int
+    let capabilities: ServerCapabilities?
+
+    enum CodingKeys: String, CodingKey {
+        case version, capabilities
+        case protocolVersion = "protocol"
+    }
+}
 
 /// Result of `server.staged_update` (`type: "staged_update"`): the running daemon's version and
 /// protocol, plus the staged build when a build step has pre-staged a newer binary — `staged` is

--- a/Tests/HerdrKitTests/SessionTransferTests.swift
+++ b/Tests/HerdrKitTests/SessionTransferTests.swift
@@ -1,0 +1,129 @@
+import Foundation
+import XCTest
+@testable import HerdrKit
+
+final class SessionTransferTests: XCTestCase {
+    private final class CapturingTransport: HerdrTransport, @unchecked Sendable {
+        var requests: [String] = []
+        var transferPhase = "ready"
+
+        func roundTrip(_ requestLine: String) async throws -> String {
+            requests.append(requestLine)
+            if requestLine.contains(#""method":"ping""#) {
+                return #"{"id":"x","result":{"type":"pong","version":"0.8.2","protocol":9,"capabilities":{"live_handoff":true,"agent_session_transfer":true}}}"#
+            }
+            return SessionTransferTests.transferResponse(phase: transferPhase)
+        }
+
+        func stream(_ requestLine: String) -> AsyncThrowingStream<String, Error> {
+            AsyncThrowingStream { $0.finish() }
+        }
+    }
+
+    private struct FixedTransport: HerdrTransport {
+        let response: String
+        func roundTrip(_ requestLine: String) async throws -> String { response }
+        func stream(_ requestLine: String) -> AsyncThrowingStream<String, Error> {
+            AsyncThrowingStream { $0.finish() }
+        }
+    }
+
+    private static let omissions = #"{"tool_records":2,"reasoning_records":3,"system_records":1,"attachment_records":4,"metadata_records":5,"unsupported_blocks":6,"sidechain_records":7}"#
+
+    private static func transferResponse(phase: String) -> String {
+        #"{"id":"x","result":{"type":"agent_info","agent":{"pane_id":"w1:p1","name":"jarvis","agent":"claude","agent_status":"idle","account":"claude-main","session_transfer":{"id":"transfer-1","source":"claude","target":"codex","target_account":"codex-pro","phase":"\#(phase)","message_count":3,"omissions":\#(Self.omissions)}}}}"#
+    }
+
+    private func requestObject(_ line: String) throws -> [String: Any] {
+        try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(line.utf8)) as? [String: Any])
+    }
+
+    func testPingFeatureDetectsTransferAndDefaultsMissingFlagsFalse() async throws {
+        let enabled = try await HerdrClient(transport: CapturingTransport()).serverCapabilities()
+        XCTAssertEqual(enabled?.agentSessionTransfer, true)
+        XCTAssertEqual(enabled?.liveHandoff, true)
+        XCTAssertEqual(enabled?.paneInputStream, false)
+
+        let old = FixedTransport(response:
+            #"{"id":"x","result":{"type":"pong","version":"0.8.2","protocol":9,"capabilities":{"live_handoff":true}}}"#)
+        let oldCapabilities = try await HerdrClient(transport: old).serverCapabilities()
+        XCTAssertEqual(oldCapabilities?.agentSessionTransfer, false,
+                       "an older daemon must hide the switch instead of advertising a call it cannot serve")
+    }
+
+    func testPrepareEncodesOnlyStageFieldsAndDecodesReviewFacts() async throws {
+        let transport = CapturingTransport()
+        let agent = try await HerdrClient(transport: transport)
+            .prepareAgentSessionTransfer(target: "jarvis", to: .codex, account: "codex-pro")
+
+        let transfer = try XCTUnwrap(agent.sessionTransfer)
+        XCTAssertEqual(transfer.id, "transfer-1")
+        XCTAssertEqual(transfer.source, .claude)
+        XCTAssertEqual(transfer.target, .codex)
+        XCTAssertEqual(transfer.targetAccount, "codex-pro")
+        XCTAssertEqual(transfer.phase, .ready)
+        XCTAssertEqual(transfer.messageCount, 3)
+        XCTAssertEqual(transfer.omissions.total, 28)
+
+        let request = try requestObject(try XCTUnwrap(transport.requests.last))
+        XCTAssertEqual(request["method"] as? String, "agent.transfer_session")
+        let params = try XCTUnwrap(request["params"] as? [String: Any])
+        XCTAssertEqual(params["target"] as? String, "jarvis")
+        XCTAssertEqual(params["to"] as? String, "codex")
+        XCTAssertEqual(params["account"] as? String, "codex-pro")
+        XCTAssertNil(params["transfer_id"])
+        XCTAssertNil(params["confirm"], "prepare must never smuggle an implicit confirmation")
+    }
+
+    func testConfirmEchoesExactTransactionHarnessAndAccount() async throws {
+        let transport = CapturingTransport()
+        transport.transferPhase = "verifying_cutover"
+        let agent = try await HerdrClient(transport: transport)
+            .confirmAgentSessionTransfer(
+                target: "jarvis", to: .codex, account: "codex-pro",
+                transferID: "transfer-1")
+
+        XCTAssertEqual(agent.sessionTransfer?.phase, .verifyingCutover)
+        let request = try requestObject(try XCTUnwrap(transport.requests.last))
+        let params = try XCTUnwrap(request["params"] as? [String: Any])
+        XCTAssertEqual(params["target"] as? String, "jarvis")
+        XCTAssertEqual(params["to"] as? String, "codex")
+        XCTAssertEqual(params["account"] as? String, "codex-pro")
+        XCTAssertEqual(params["transfer_id"] as? String, "transfer-1")
+        XCTAssertEqual(params["confirm"] as? Bool, true)
+    }
+
+    func testOlderAgentInfoWithoutTransferStillDecodes() async throws {
+        let transport = FixedTransport(response:
+            #"{"id":"x","result":{"agents":[{"pane_id":"w1:p1","agent":"claude","agent_status":"idle"}]}}"#)
+        let agents = try await HerdrClient(transport: transport).agentList()
+        XCTAssertEqual(agents.count, 1)
+        XCTAssertNil(agents[0].sessionTransfer)
+    }
+
+    func testUnknownPhaseAndMissingOmissionCountersStayVisible() async throws {
+        let transport = FixedTransport(response:
+            #"{"id":"x","result":{"agents":[{"pane_id":"w1:p1","agent":"claude","agent_status":"idle","session_transfer":{"id":"transfer-2","source":"claude","target":"codex","phase":"verifying_future_state","message_count":0,"omissions":{}}}]}}"#)
+        let agents = try await HerdrClient(transport: transport).agentList()
+        let transfer = try XCTUnwrap(agents.first?.sessionTransfer)
+        XCTAssertEqual(transfer.phase, .unrecognised("verifying_future_state"))
+        XCTAssertTrue(transfer.phase.isTerminal,
+                      "a state this app cannot interpret must stop polling and demand attention")
+        XCTAssertEqual(transfer.omissions.total, 0)
+    }
+
+    func testTransferRejectionRemainsARealAPIError() async throws {
+        let transport = FixedTransport(response:
+            #"{"id":"x","error":{"code":"session_transfer_changed","message":"source changed; source stayed running"}}"#)
+        do {
+            _ = try await HerdrClient(transport: transport)
+                .confirmAgentSessionTransfer(
+                    target: "jarvis", to: .codex, transferID: "transfer-1")
+            XCTFail("a refused cutover must throw")
+        } catch let error as APIError {
+            XCTAssertEqual(error.code, "session_transfer_changed")
+            XCTAssertTrue(error.message.contains("source stayed running"))
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add a session-transfer sheet that lets a running Claude Code or Codex agent switch to the other harness without starting a blank conversation.
- Follow the backend transaction through preparation, target verification, cutover, completion, and rollback.
- Keep terminal outcomes durable so a dismissed sheet can be reopened, a rolled-back transfer can be retried, and a successful transfer can be switched back.

## Safety and behavior

- Treat the server transaction as authoritative after ambiguous transport failures instead of starting a competing transfer.
- Poll by pane or terminal identity so the sheet follows the same runtime even when pane metadata is temporarily incomplete.
- Explain target readiness and rollback in target-specific language, including the backend verification phase.
- Preserve the existing Herdrup interaction language and sheet structure.

## Validation

- Swift 6.2 Linux package tests: 406 tests, 15 skipped, 0 failures.
- SwiftUI source parse: passed.
- Native macOS type-checking is unavailable on this Linux host.

## Dependency

Depends on jerryfane/herdr#137. This UI must not ship before the backend session-transfer API it describes and drives.
