### PR TITLE
fix(onboarding): use the copyable fork installer

### DIFF
--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -298,6 +298,8 @@ struct RootView: View {
     private func mockView(_ mode: ScreenshotMock) -> some View {
         let mockClient = HerdrClient(transport: MockTransport())
         switch mode {
+        case .onboarding:
+            ConnectView { _ in }
         case .list:
             TerminalHomeView(client: mockClient, onDisconnect: {}, onTrustHostKey: { _ in false },
                              livePaneIDs: MockTransport.demoLivePaneIDs)
@@ -457,12 +459,18 @@ struct RootView: View {
 /// drift apart — a reader who follows one and then the other has to be given the same
 /// command both times.
 enum HerdrSetup {
-    /// Installs the fork on the machine: clone, build, install to `~/.local/bin`.
-    /// `install -D` creates the parent directory, so no separate `mkdir` is needed.
+    /// Installs the fork on the machine.
+    ///
+    /// ONE LINE ON PURPOSE. This was four chained commands that wrapped onto four
+    /// lines in the first-run card — a wall of text as the very first thing a new
+    /// user is asked to do. The script selects the matching prebuilt fork release,
+    /// verifies its SHA-256 checksum, and installs it under `~/.local/bin`, so the
+    /// reader does not need a source checkout, Rust, Cargo, or Zig.
+    ///
+    /// It points at the FORK, not `herdr.dev/install.sh`: upstream's installer
+    /// produces a herdr with no `api-bridge`, which this app cannot drive.
     static let installCommand =
-        "git clone https://github.com/jerryfane/herdr && cd herdr && "
-        + "cargo build --release && "
-        + "install -D -m 0755 target/release/herdr ~/.local/bin/herdr"
+        "curl -fsSL https://herdrup.themartian.app/install.sh | sh"
 }
 
 struct ConnectView: View {
@@ -474,6 +482,8 @@ struct ConnectView: View {
     /// The scan-to-connect sheet (#126) — the path that needs no key, no host address and
     /// no knowledge of what a daemon is.
     @State private var showingPairing = false
+    /// Which command was just copied, so the card can confirm it. Nil = none.
+    @State private var copiedCommand: String?
 
     var body: some View {
         ZStack {
@@ -580,20 +590,51 @@ struct ConnectView: View {
                 monoCard("herdr pair")
             }
 
-            Text("Scan the code it prints and you're connected — no keys to copy.")
+            Text("Scan the code it prints and you're connected. No keys to copy.")
                 .font(Typography.app(13)).foregroundStyle(Palette.textDim)
                 .multilineTextAlignment(.center)
         }
         .frame(maxWidth: .infinity).padding(.vertical, 16)
     }
 
+    /// A command the reader is meant to run on their computer — and can now COPY.
+    ///
+    /// It looked tappable and did nothing, which is worse than looking inert: the
+    /// obvious gesture on a command you are being told to run somewhere else is to
+    /// copy it, and this screen is a phone showing a command for a laptop, so
+    /// copy-then-paste is the whole point.
+    ///
+    /// Clipboard WRITE only (`UIPasteboard.general.string`), the same pattern as
+    /// `CopyForAgentButton` — a programmatic READ is what triggers the system paste
+    /// prompt that failed App Review under 2.1a.
     private func monoCard(_ text: String) -> some View {
-        Text(text)
-            .font(Typography.machine(13)).foregroundStyle(Palette.text)
-            .textSelection(.enabled)
+        Button {
+            UIPasteboard.general.string = text
+            UINotificationFeedbackGenerator().notificationOccurred(.success)
+            copiedCommand = text
+            // Revert the label rather than leaving a permanent "Copied", which would
+            // stop telling the truth the moment the clipboard changed.
+            Task {
+                try? await Task.sleep(nanoseconds: 1_600_000_000)
+                if copiedCommand == text { copiedCommand = nil }
+            }
+        } label: {
+            HStack(alignment: .top, spacing: 10) {
+                Text(text)
+                    .font(Typography.machine(13)).foregroundStyle(Palette.text)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .multilineTextAlignment(.leading)
+                Image(systemName: copiedCommand == text ? "checkmark" : "doc.on.doc")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(copiedCommand == text ? Palette.done : Palette.textFaint)
+                    .padding(.top, 2)
+            }
             .padding(.horizontal, 14).padding(.vertical, 10)
             .frame(maxWidth: .infinity)
             .background(Palette.surface).clipShape(RoundedRectangle(cornerRadius: 10))
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(Text(copiedCommand == text ? "Copied" : "Copy command: \(text)"))
     }
 
     private var addHostButton: some View {
@@ -5497,13 +5538,14 @@ struct PagingTestHarness: View {
 #endif
 
 enum ScreenshotMock {
-    case list, pane, settings, newAgent, scroll, ccscroll, paging, backfill, gram
+    case onboarding, list, pane, settings, newAgent, scroll, ccscroll, paging, backfill, gram
 
     static var mode: ScreenshotMock? {
         let env = ProcessInfo.processInfo.environment["HERDR_SCREENSHOT_MOCK"]?.lowercased()
         let arg = ProcessInfo.processInfo.arguments.contains("-herdrScreenshotMock")
         guard env != nil || arg else { return nil }
         switch env {
+        case "onboarding": return .onboarding
         case "pane": return .pane
         case "settings": return .settings
         case "newagent": return .newAgent

--- a/HerdrUITests/OnboardingTests.swift
+++ b/HerdrUITests/OnboardingTests.swift
@@ -1,0 +1,31 @@
+import XCTest
+
+/// Exercises the first screen's actual command buttons. The phone is showing
+/// commands intended for another machine, so tapping them must visibly confirm
+/// a copy rather than behaving like inert code blocks.
+final class OnboardingTests: XCTestCase {
+
+    override func setUp() { continueAfterFailure = false }
+
+    func testInstallAndPairCommandsAreCopyable() {
+        let app = XCUIApplication()
+        app.launchEnvironment["HERDR_SCREENSHOT_MOCK"] = "onboarding"
+        app.launch()
+
+        let install = app.buttons[
+            "Copy command: curl -fsSL https://herdrup.themartian.app/install.sh | sh"
+        ]
+        XCTAssertTrue(install.waitForExistence(timeout: 8),
+                      "the one-line fork installer should be visible and tappable")
+        install.tap()
+        XCTAssertTrue(app.buttons["Copied"].waitForExistence(timeout: 2),
+                      "tapping the installer should confirm the clipboard write")
+
+        let pair = app.buttons["Copy command: herdr pair"]
+        XCTAssertTrue(pair.waitForExistence(timeout: 3),
+                      "the pairing command should be visible and tappable")
+        pair.tap()
+        XCTAssertTrue(app.buttons["Copied"].waitForExistence(timeout: 2),
+                      "tapping the pairing command should confirm the clipboard write")
+    }
+}


### PR DESCRIPTION
The first-run screen currently presents a long source-build command and gives no tap feedback. This switches onboarding to the public one-line fork installer and makes both command cards copy on tap.

What changes:
- the installer card shows `curl -fsSL https://herdrup.themartian.app/install.sh | sh`;
- tapping either the install command or `herdr pair` copies that exact command to the clipboard;
- the tapped card shows a checkmark and `Copied` for 1.6 seconds and triggers selection haptics;
- accessibility labels and hints describe the copy action;
- a screenshot mock and UI test exercise both copyable onboarding commands.

Dependency: this PR depends on jerryfane/herdr#133 and a new fork preview built from its merged head. Do not ship this UI to TestFlight until that preview is published and `https://herdrup.themartian.app/install.sh` has been deployed and verified against it. Otherwise the new command would install an older preview with the wrong update-channel behavior.

Validation:
- the branch is based on current `main` and is clean;
- the new UI test taps both command cards and asserts the transient `Copied` state;
- Swift/Xcode are not available on this Linux host, so compilation and UI execution are delegated to macOS CI.
