### PR TITLE
ci: run TestFlight on the MacBook Air

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -32,7 +32,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: [self-hosted, macOS, ARM64]
     timeout-minutes: 45
     # EVERY signing secret lives in this ENVIRONMENT (scoped to main + v* tags), not
     # at repo level: a workflow pushed to a feature branch then cannot reach the


### PR DESCRIPTION
The owner requires Herdrup TestFlight builds to run on the fleet MacBook Air instead of GitHub-hosted `macos-latest`.

This makes the one proven fleet change used by the existing Mac build lane:

```yaml
runs-on: [self-hosted, macOS, ARM64]
```

Load-bearing deployment dependency:
- `jerryfane/herdrup` currently has zero registered self-hosted runners.
- The online `mcb-air-themartian` registration belongs to the separate `themartianapp` organization and cannot accept this personal-repository job.
- Do not merge this PR until a separate repo-scoped registration on the same Mac is online. Merging first would make TestFlight dispatches queue indefinitely on an unsatisfied label set.
- Do not dispatch TestFlight from this PR branch.

Validation:
- YAML parses successfully.
- `git diff --check` passes.
- The diff is exactly one workflow line.

Authorized PR-only scope: durable Gitmoot directive #95397. Runner registration, merge, and TestFlight dispatch remain explicitly outside this directive.
