### PR TITLE
fix(onboarding): clarify pairing prerequisites and qr fallback

### DIFF
--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -300,6 +300,11 @@ struct RootView: View {
         switch mode {
         case .onboarding:
             ConnectView { _ in }
+        case .pairingGuidance:
+            ZStack {
+                Palette.ground.ignoresSafeArea()
+                PairingCommandGuidance().padding(24)
+            }
         case .list:
             TerminalHomeView(client: mockClient, onDisconnect: {}, onTrustHostKey: { _ in false },
                              livePaneIDs: MockTransport.demoLivePaneIDs)
@@ -471,6 +476,14 @@ enum HerdrSetup {
     /// produces a herdr with no `api-bridge`, which this app cannot drive.
     static let installCommand =
         "curl -fsSL https://herdrup.themartian.app/install.sh | sh"
+    static let pairCommand = "herdr pair"
+    static let openQRCommand = "herdr pair --open"
+    static let saveQRCommand = "herdr pair --qr-file ~/Desktop/herdr-pair.svg"
+
+    static let tailscalePrerequisite =
+        "Tailscale is connected on this iPhone and your computer."
+    static let sshPrerequisite =
+        "SSH is enabled on the computer. On Mac, turn on Remote Login."
 }
 
 struct ConnectView: View {
@@ -580,14 +593,31 @@ struct ConnectView: View {
             Text("herdrup controls coding agents running on your computer.")
                 .font(Typography.app(15, .semibold)).foregroundStyle(Palette.text)
                 .multilineTextAlignment(.center)
-            Text("It needs herdr installed there first. On your computer, run:")
+
+            VStack(alignment: .leading, spacing: 7) {
+                Text("BEFORE PAIRING")
+                    .font(Typography.microLabel).tracking(1.1)
+                    .foregroundStyle(Palette.textFaint)
+                prerequisiteRow(
+                    HerdrSetup.tailscalePrerequisite,
+                    systemImage: "network",
+                    identifier: "pairing-prerequisite-tailscale")
+                prerequisiteRow(
+                    HerdrSetup.sshPrerequisite,
+                    systemImage: "lock.open",
+                    identifier: "pairing-prerequisite-ssh")
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.vertical, 2)
+
+            Text("Then, on your computer, run:")
                 .font(Typography.app(13)).foregroundStyle(Palette.textDim)
                 .multilineTextAlignment(.center)
 
             VStack(spacing: 8) {
                 monoCard(HerdrSetup.installCommand)
                 Text("then").font(Typography.app(12)).foregroundStyle(Palette.textFaint)
-                monoCard("herdr pair")
+                monoCard(HerdrSetup.pairCommand)
             }
 
             Text("Scan the code it prints and you're connected. No keys to copy.")
@@ -595,6 +625,21 @@ struct ConnectView: View {
                 .multilineTextAlignment(.center)
         }
         .frame(maxWidth: .infinity).padding(.vertical, 16)
+    }
+
+    private func prerequisiteRow(_ text: String, systemImage: String, identifier: String) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 9) {
+            Image(systemName: systemImage)
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(Palette.textFaint)
+                .frame(width: 15)
+            Text(text)
+                .font(Typography.app(12.5))
+                .foregroundStyle(Palette.textDim)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityIdentifier(identifier)
     }
 
     /// A command the reader is meant to run on their computer — and can now COPY.
@@ -5538,7 +5583,7 @@ struct PagingTestHarness: View {
 #endif
 
 enum ScreenshotMock {
-    case onboarding, list, pane, settings, newAgent, scroll, ccscroll, paging, backfill, gram
+    case onboarding, pairingGuidance, list, pane, settings, newAgent, scroll, ccscroll, paging, backfill, gram
 
     static var mode: ScreenshotMock? {
         let env = ProcessInfo.processInfo.environment["HERDR_SCREENSHOT_MOCK"]?.lowercased()
@@ -5546,6 +5591,7 @@ enum ScreenshotMock {
         guard env != nil || arg else { return nil }
         switch env {
         case "onboarding": return .onboarding
+        case "pairing-guidance": return .pairingGuidance
         case "pane": return .pane
         case "settings": return .settings
         case "newagent": return .newAgent

--- a/App/PairingSheet.swift
+++ b/App/PairingSheet.swift
@@ -112,19 +112,8 @@ struct PairingSheet: View {
             .clipShape(RoundedRectangle(cornerRadius: 16))
             .padding(.horizontal, 20)
 
-            VStack(spacing: 8) {
-                Text("On your computer, run").font(Typography.app(13))
-                    .foregroundStyle(Palette.textDim)
-                Text("herdr pair").font(Typography.machine(16, .semibold))
-                    .foregroundStyle(Palette.text)
-                    .padding(.horizontal, 14).padding(.vertical, 8)
-                    .background(Palette.surface)
-                    .clipShape(RoundedRectangle(cornerRadius: 10))
-                Text("then point the camera at the code it prints.")
-                    .font(Typography.app(13)).foregroundStyle(Palette.textDim)
-            }
-            .multilineTextAlignment(.center)
-            .padding(20)
+            PairingCommandGuidance()
+                .padding(20)
         }
     }
 
@@ -192,5 +181,42 @@ struct PairingSheet: View {
     private func openSettings() {
         guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
         UIApplication.shared.open(url)
+    }
+}
+
+/// The command help below the camera, split out so the exact first-run guidance has a
+/// deterministic UI-test surface without requiring camera hardware in CI.
+struct PairingCommandGuidance: View {
+    var body: some View {
+        VStack(spacing: 8) {
+            Text("On your computer, run")
+                .font(Typography.app(13))
+                .foregroundStyle(Palette.textDim)
+            Text(HerdrSetup.pairCommand)
+                .font(Typography.machine(16, .semibold))
+                .foregroundStyle(Palette.text)
+                .padding(.horizontal, 14).padding(.vertical, 8)
+                .background(Palette.surface)
+                .clipShape(RoundedRectangle(cornerRadius: 10))
+            Text("then point the camera at the code it prints.")
+                .font(Typography.app(13)).foregroundStyle(Palette.textDim)
+
+            VStack(spacing: 3) {
+                Text("QR looks distorted? Open a clean version with")
+                Text(HerdrSetup.openQRCommand)
+                    .font(Typography.machine(12, .medium))
+                    .foregroundStyle(Palette.text)
+                Text("Or save an SVG with")
+                    .padding(.top, 2)
+                Text(HerdrSetup.saveQRCommand)
+                    .font(Typography.machine(11, .medium))
+                    .foregroundStyle(Palette.text)
+            }
+            .font(Typography.app(11.5))
+            .foregroundStyle(Palette.textFaint)
+            .accessibilityElement(children: .combine)
+            .accessibilityIdentifier("pairing-qr-fallback")
+        }
+        .multilineTextAlignment(.center)
     }
 }

--- a/HerdrUITests/OnboardingTests.swift
+++ b/HerdrUITests/OnboardingTests.swift
@@ -12,6 +12,15 @@ final class OnboardingTests: XCTestCase {
         app.launchEnvironment["HERDR_SCREENSHOT_MOCK"] = "onboarding"
         app.launch()
 
+        XCTAssertTrue(
+            app.descendants(matching: .any)["pairing-prerequisite-tailscale"]
+                .waitForExistence(timeout: 8),
+            "the first screen should name the two-device Tailscale prerequisite")
+        XCTAssertTrue(
+            app.descendants(matching: .any)["pairing-prerequisite-ssh"]
+                .waitForExistence(timeout: 3),
+            "the first screen should name SSH and macOS Remote Login")
+
         let install = app.buttons[
             "Copy command: curl -fsSL https://herdrup.themartian.app/install.sh | sh"
         ]
@@ -27,5 +36,19 @@ final class OnboardingTests: XCTestCase {
         pair.tap()
         XCTAssertTrue(app.buttons["Copied"].waitForExistence(timeout: 2),
                       "tapping the pairing command should confirm the clipboard write")
+    }
+
+    func testScannerExplainsBothCleanQRAlternatives() {
+        let app = XCUIApplication()
+        app.launchEnvironment["HERDR_SCREENSHOT_MOCK"] = "pairing-guidance"
+        app.launch()
+
+        let fallback = app.descendants(matching: .any)["pairing-qr-fallback"]
+        XCTAssertTrue(fallback.waitForExistence(timeout: 8),
+                      "scanner guidance should explain what to do with a distorted QR")
+        XCTAssertTrue(fallback.label.contains("herdr pair --open"),
+                      "scanner guidance should offer a clean opened QR")
+        XCTAssertTrue(fallback.label.contains("--qr-file"),
+                      "scanner guidance should offer an SVG file")
     }
 }


### PR DESCRIPTION
## Summary

- keep the onboarding flow to two copyable commands: install Herdr, then run `herdr pair`
- name the two real prerequisites: Tailscale on both devices and SSH, called Remote Login on macOS
- make the scanner explain `herdr pair --open` and `herdr pair --qr-file ~/Desktop/herdr-pair.svg` when terminal QR rendering is distorted
- add UI coverage for prerequisite copy, tap-to-copy commands, and both QR fallback options

## Dependency

Depends on jerryfane/herdr#148. Do not ship this UI before that PR lands because the app describes CLI options introduced there.

## Validation

- source and staged-diff checks passed
- UI tests were added for the changed onboarding and scanner surfaces
- Swift and Xcode are unavailable on the Linux implementation host; macOS build and UI validation are delegated to this PR's CI
