### PR TITLE
fix(connect): bound the SSH connect, and name Tailscale when that is the cause

### DIFF
--- a/Sources/HerdrKit/CitadelTransport.swift
+++ b/Sources/HerdrKit/CitadelTransport.swift
@@ -22,6 +22,22 @@ import NIOCore
 /// per-request handshake — closing issue #25). Conforms to the two-method
 /// `HerdrTransport` seam; `SessionRecovery`/`RecoveryExecutor` sit above it
 /// unchanged.
+/// Lets exactly one racer resume a continuation. Resuming a continuation twice is
+/// undefined behaviour rather than a catchable error, so the guard has to be
+/// atomic — a plain Bool read-then-write is a race in exactly the interleaving
+/// this exists to prevent.
+final class FirstPastThePost: @unchecked Sendable {
+    private let lock = NSLock()
+    private var claimed = false
+    func claim() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        if claimed { return false }
+        claimed = true
+        return true
+    }
+}
+
 public actor CitadelTransport: HerdrTransport {
     private let credentials: SSHCredentials
     private let hostKeyValidator: SSHHostKeyValidator
@@ -43,9 +59,19 @@ public actor CitadelTransport: HerdrTransport {
     ///   - hostKeyValidator: the raw Citadel validator, for callers that need
     ///     full control (e.g. `.acceptAnything()` in an isolated live test).
     ///     Prefer the `hostKeyPolicy` initializer, whose default pins.
-    public init(credentials: SSHCredentials, hostKeyValidator: SSHHostKeyValidator) {
+    /// This transport's connect budget. Injectable so the timeout can be TESTED
+    /// against a black-hole address in milliseconds instead of being asserted from
+    /// reading the code — a 15s test is one nobody runs.
+    let connectTimeoutNanoseconds: UInt64
+
+    public init(
+        credentials: SSHCredentials,
+        hostKeyValidator: SSHHostKeyValidator,
+        connectTimeoutNanoseconds: UInt64 = CitadelTransport.defaultConnectTimeoutNanoseconds
+    ) {
         self.credentials = credentials
         self.hostKeyValidator = hostKeyValidator
+        self.connectTimeoutNanoseconds = connectTimeoutNanoseconds
     }
 
     /// Pins the host key on first contact and hard-stops on change (TOFU),
@@ -59,7 +85,12 @@ public actor CitadelTransport: HerdrTransport {
     /// key). It does NOT persist across app launches — for cross-launch TOFU a
     /// shipping client passes its own `HostKeyPolicy` here that pins against
     /// persistent (e.g. Keychain) storage; `PinStore` is in-memory only.
-    public init(credentials: SSHCredentials, hostKeyPolicy: HostKeyPolicy = PinningHostKeyPolicy()) {
+    public init(
+        credentials: SSHCredentials,
+        hostKeyPolicy: HostKeyPolicy = PinningHostKeyPolicy(),
+        connectTimeoutNanoseconds: UInt64 = CitadelTransport.defaultConnectTimeoutNanoseconds
+    ) {
+        self.connectTimeoutNanoseconds = connectTimeoutNanoseconds
         self.credentials = credentials
         self.hostKeyValidator = .custom(PinningHostKeyValidator(
             host: credentials.host, port: credentials.port, policy: hostKeyPolicy))
@@ -126,14 +157,65 @@ public actor CitadelTransport: HerdrTransport {
         // A client that resolves after a concurrent close() is reaped by the
         // generation check in connectedClient() (the only publisher of `self.client`),
         // so no cancellation handling is needed here.
-        do {
-            return try await SSHClient.connect(
-                host: credentials.host,
-                port: Int(credentials.port),
+        // RACE THE HANDSHAKE AGAINST A CLOCK. Without this an unroutable address —
+        // a Tailscale host reached from a device that is not on the tailnet — hangs
+        // at the TCP layer until the OS gives up (~75s on iOS). That is not
+        // experienced as a failure; it is experienced as an endless spinner, with
+        // nothing on screen to act on. A budget converts silence into an error the
+        // UI can show.
+        //
+        // NOT a task group, and the reason is measured: a group awaits its children
+        // at scope exit, and `SSHClient.connect` does not observe cancellation
+        // promptly — so a group-based race returned only when the LOSING connect
+        // finally gave up on its own (30s against a 0.3s budget, caught by
+        // `testConnectFailsWithinTheBudgetAgainstABlackHoleAddress`). The winner
+        // must be able to return while the loser unwinds unobserved.
+        let host = credentials.host
+        let port = Int(credentials.port)
+        let validator = hostKeyValidator
+        let budget = connectTimeoutNanoseconds
+        let work = Task<SSHClient, Error> {
+            try await SSHClient.connect(
+                host: host,
+                port: port,
                 authenticationMethod: method,
-                hostKeyValidator: hostKeyValidator,
+                hostKeyValidator: validator,
                 reconnect: .never
             )
+        }
+        do {
+            return try await withCheckedThrowingContinuation { continuation in
+                // Exactly one of the two branches may resume the continuation;
+                // resuming twice is undefined behaviour, not a recoverable error.
+                let settled = FirstPastThePost()
+                Task {
+                    do {
+                        let client = try await work.value
+                        if settled.claim() {
+                            continuation.resume(returning: client)
+                        } else {
+                            // The clock already won and the caller has its error.
+                            // Close this rather than leaking a live session nobody
+                            // holds a reference to.
+                            try? await client.close()
+                        }
+                    } catch {
+                        if settled.claim() { continuation.resume(throwing: error) }
+                    }
+                }
+                Task {
+                    try? await Task.sleep(nanoseconds: budget)
+                    guard settled.claim() else { return }
+                    work.cancel()
+                    continuation.resume(throwing: TransportError.connectTimedOut(
+                        host: host,
+                        // credentials.host is already the bare host (the port is a
+                        // separate field), so classify it directly rather than
+                        // re-parsing a string that was never joined.
+                        onTailnet: HostEndpoint(host: host, port: 22).isTailnetAddress
+                    ))
+                }
+            }
         } catch SSHClientError.unsupportedPasswordAuthentication {
             // The server offers no password auth (e.g. `PasswordAuthentication no`).
             throw TransportError.passwordAuthUnsupported(host: credentials.host)
@@ -152,6 +234,15 @@ public actor CitadelTransport: HerdrTransport {
     /// `agent.prompt` / `pane.send_text`, which is refused rather than failing at
     /// execve with no bridge to report it.
     static let maxCommandBytes = 120_000
+
+    /// Default budget for a connect, handshake included.
+    ///
+    /// Well above a real handshake — even a slow cellular link completes in a
+    /// second or two — and far below the OS's own ~75s give-up on an unroutable
+    /// address. The gap between those two numbers is the whole point: 15s is long
+    /// enough that no working connection is cut off, short enough that a broken
+    /// one says so while the user is still looking at it.
+    public static let defaultConnectTimeoutNanoseconds: UInt64 = 15 * 1_000_000_000
 
     /// The request, base64-encoded. Kept separate from the command so the
     /// encoding contract can be tested without the shell wrapper around it.

--- a/Sources/HerdrKit/HostEndpoint.swift
+++ b/Sources/HerdrKit/HostEndpoint.swift
@@ -48,6 +48,46 @@ public struct HostEndpoint: Equatable, Sendable {
         return HostEndpoint(host: s, port: 22)
     }
 
+    /// Whether this destination is a Tailscale address, and therefore unreachable
+    /// from a device that is not on the same tailnet.
+    ///
+    /// This exists to CLASSIFY A FAILURE, not to gate a connection: a phone off the
+    /// tailnet cannot route here at all, so retrying is futile in a way that an
+    /// ordinary unreachable host is not (a LAN box may simply be rebooting). See
+    /// `SessionRecovery.giveUpAfterFailures`.
+    ///
+    /// Address-range matching on purpose — no interface probing, so it needs no
+    /// permissions and cannot be wrong about what the app is actually dialing.
+    public var isTailnetAddress: Bool {
+        Self.isCarrierGradeNAT(host) || Self.isMagicDNSName(host)
+    }
+
+    /// Tailscale hands out `100.64.0.0/10`. A /10, NOT a /8: `100.63.x.x` and
+    /// `100.128.x.x` are ordinary public addresses and must not be swept up, or a
+    /// real host on the public internet would stop retrying after three failures.
+    private static func isCarrierGradeNAT(_ host: String) -> Bool {
+        let octets = host.split(separator: ".", omittingEmptySubsequences: false)
+        guard octets.count == 4 else { return false }
+        // Every octet must read exactly as a number, so "100.64.0.0.evil.com" and
+        // "100.0x40.0.0" cannot pass as addresses.
+        var values: [UInt16] = []
+        for octet in octets {
+            guard !octet.isEmpty, octet.allSatisfy({ $0.isASCII && $0.isNumber }),
+                  let value = UInt16(octet), value <= 255 else { return false }
+            values.append(value)
+        }
+        return values[0] == 100 && (64...127).contains(values[1])
+    }
+
+    /// MagicDNS names end in `.ts.net`. The leading dot is load-bearing: without it
+    /// `notts.net` matches, and requiring a non-empty label before it keeps a bare
+    /// `ts.net` out.
+    private static func isMagicDNSName(_ host: String) -> Bool {
+        let name = host.lowercased()
+        let suffix = ".ts.net"
+        return name.hasSuffix(suffix) && name.count > suffix.count
+    }
+
     private static func validPort(_ s: Substring) -> UInt16? {
         // ASCII digits only: UInt16("+22") parses to 22 and UInt16 accepts other
         // sign/format oddities, so require the text to read exactly as a number.

--- a/Sources/HerdrKit/Transport.swift
+++ b/Sources/HerdrKit/Transport.swift
@@ -127,6 +127,15 @@ public enum TransportError: Error, CustomStringConvertible {
     /// The server rejected the credentials — a wrong password, or a key it would
     /// not accept.
     case authenticationFailed(host: String)
+    /// The connection did not complete within the budget. `onTailnet` is true when
+    /// the destination is a Tailscale address, which makes the cause almost certain
+    /// and the remedy specific — so it gets its own sentence rather than a generic
+    /// "couldn't connect".
+    ///
+    /// Without a budget this failure had no error at all: an unroutable address
+    /// hangs at the TCP layer until the OS gives up (~75s on iOS), which the user
+    /// experiences as an endless spinner rather than as a failure.
+    case connectTimedOut(host: String, onTailnet: Bool)
 
     public var description: String {
         switch self {
@@ -149,6 +158,15 @@ public enum TransportError: Error, CustomStringConvertible {
             return "\(h) does not offer password authentication; use a key instead"
         case .authenticationFailed(let h):
             return "authentication to \(h) failed. Check the password or key"
+        case .connectTimedOut(let h, let onTailnet):
+            // The tailnet wording names the remedy, because on a Tailscale address
+            // "not on the tailnet" is overwhelmingly the cause and the user can fix
+            // it in one step. The generic wording deliberately does NOT guess.
+            return onTailnet
+                ? "\(h) is on Tailscale. Your device needs to be on the same tailnet — "
+                    + "open Tailscale and connect, then try again."
+                : "couldn't reach \(h) in time. It may be offline, or on a network "
+                    + "this device cannot see."
         }
     }
 }

--- a/Tests/HerdrKitTests/CitadelTransportTests.swift
+++ b/Tests/HerdrKitTests/CitadelTransportTests.swift
@@ -6,6 +6,86 @@ import Citadel
 
 final class CitadelTransportTests: XCTestCase {
 
+    // MARK: - connect budget (the endless-spinner fix)
+
+    /// AXIS: the two wordings are genuinely different, and only the tailnet one
+    /// names Tailscale.
+    ///
+    /// The generic branch must NOT mention Tailscale: on an ordinary host the
+    /// cause is unknown, and guessing sends the user to fix something that is not
+    /// broken. Asserting the absence is the half that keeps that honest.
+    func testTimeoutMessageNamesTailscaleOnlyWhenTheHostIsOnATailnet() {
+        let tailnet = TransportError.connectTimedOut(host: "box.ts.net", onTailnet: true).description
+        XCTAssertTrue(tailnet.contains("Tailscale"), "the remedy must be named: \(tailnet)")
+        XCTAssertTrue(tailnet.contains("box.ts.net"), "the host must be named: \(tailnet)")
+
+        let generic = TransportError.connectTimedOut(host: "nas.local", onTailnet: false).description
+        XCTAssertFalse(generic.contains("Tailscale"),
+                       "an ordinary host must not be blamed on Tailscale: \(generic)")
+        XCTAssertTrue(generic.contains("nas.local"), "the host must be named: \(generic)")
+    }
+
+    /// AXIS: the budget is REAL — a connect to an address that swallows packets
+    /// fails within it instead of hanging.
+    ///
+    /// This is the actual regression. Before the budget there was no error at all:
+    /// the OS sat on the socket for ~75s, which the user experienced as an endless
+    /// spinner with nothing to act on.
+    ///
+    /// Gated on an INDEPENDENT probe (a raw socket, not the transport) that the
+    /// address really does black-hole here — matching the LiveEnvironment
+    /// convention. Where it fails fast instead, there is no hang to bound and the
+    /// test would be asserting something the environment cannot produce.
+    func testConnectFailsWithinTheBudgetAgainstABlackHoleAddress() async throws {
+        let host = "100.64.0.1"   // CGNAT, and a tailnet address: exercises both halves
+        try XCTSkipUnless(Self.blackHoles(host: host),
+                          "\(host) does not black-hole in this environment; nothing to bound")
+
+        let creds = SSHCredentials(
+            host: host, port: 22, username: "nobody", password: "nobody", remoteSocketPath: "")
+        let transport = CitadelTransport(
+            credentials: creds,
+            hostKeyPolicy: PinningHostKeyPolicy(),
+            connectTimeoutNanoseconds: 300_000_000   // 0.3s, so the test is fast
+        )
+
+        let started = Date()
+        do {
+            _ = try await transport.roundTrip("{\"id\":\"x\",\"method\":\"server.ping\",\"params\":{}}")
+            XCTFail("a black-hole address must not connect")
+        } catch let error as TransportError {
+            guard case .connectTimedOut(let h, let onTailnet) = error else {
+                return XCTFail("expected connectTimedOut, got \(error)")
+            }
+            XCTAssertEqual(h, host)
+            XCTAssertTrue(onTailnet, "100.64.0.1 is inside 100.64.0.0/10")
+        }
+        // The bound is the point: without the budget this is ~75 seconds.
+        XCTAssertLessThan(Date().timeIntervalSince(started), 10,
+                          "the connect budget did not bound the wait")
+    }
+
+    /// Independent of the transport: does a raw TCP connect to this address hang?
+    private static func blackHoles(host: String) -> Bool {
+        var addr = sockaddr_in()
+        addr.sin_family = sa_family_t(AF_INET)
+        addr.sin_port = UInt16(22).bigEndian
+        guard inet_pton(AF_INET, host, &addr.sin_addr) == 1 else { return false }
+        let fd = socket(AF_INET, Int32(SOCK_STREAM.rawValue), 0)
+        guard fd >= 0 else { return false }
+        defer { close(fd) }
+        var tv = timeval(tv_sec: 1, tv_usec: 0)
+        setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &tv, socklen_t(MemoryLayout<timeval>.size))
+        let rc = withUnsafePointer(to: &addr) {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                connect(fd, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        // Connected, or refused/unreachable outright -> not a black hole.
+        // Timed out (EINPROGRESS/EAGAIN/ETIMEDOUT) -> packets are being swallowed.
+        return rc != 0 && (errno == ETIMEDOUT || errno == EINPROGRESS || errno == EAGAIN)
+    }
+
     // MARK: - LineAccumulator (byte-accurate line decoding)
 
     /// AXIS: a multi-byte UTF-8 scalar split across two stdout chunks is

--- a/Tests/HerdrKitTests/HostEndpointTests.swift
+++ b/Tests/HerdrKitTests/HostEndpointTests.swift
@@ -3,6 +3,56 @@ import XCTest
 
 final class HostEndpointTests: XCTestCase {
 
+    // MARK: - recognising a tailnet destination
+
+    /// AXIS: the /10 BOUNDARIES. Tailscale uses 100.64.0.0/10, not 100.0.0.0/8 —
+    /// so 100.63.x.x and 100.128.x.x are ordinary public addresses. Getting this
+    /// wrong makes a real internet host stop retrying after three failures, which
+    /// is a worse bug than the spinner this fix removes.
+    func testCarrierGradeNATRangeBoundaries() {
+        for inside in ["100.64.0.0", "100.64.1.2", "100.100.50.7", "100.127.255.255"] {
+            XCTAssertEqual(HostEndpoint.parse(inside)?.isTailnetAddress, true, "\(inside) is in 100.64.0.0/10")
+        }
+        for outside in ["100.63.255.255", "100.128.0.0", "100.0.0.1", "100.255.255.255"] {
+            XCTAssertEqual(HostEndpoint.parse(outside)?.isTailnetAddress, false, "\(outside) is outside the /10")
+        }
+    }
+
+    /// AXIS: ordinary private and public addresses are never tailnet.
+    func testOrdinaryAddressesAreNotTailnet() {
+        for host in ["10.0.0.1", "192.168.1.10", "172.16.0.1", "8.8.8.8", "127.0.0.1"] {
+            XCTAssertEqual(HostEndpoint.parse(host)?.isTailnetAddress, false, host)
+        }
+    }
+
+    /// AXIS: a port must not change the verdict — the classifier reads the parsed
+    /// host, so "100.64.0.1:2222" is the same destination as "100.64.0.1".
+    func testPortDoesNotAffectTheVerdict() {
+        XCTAssertEqual(HostEndpoint.parse("100.64.0.1:2222")?.isTailnetAddress, true)
+        XCTAssertEqual(HostEndpoint.parse("192.168.1.1:2222")?.isTailnetAddress, false)
+    }
+
+    /// AXIS: MagicDNS names, and the two near-misses. The leading dot is what
+    /// separates "box.ts.net" from "notts.net"; requiring a label before it keeps
+    /// a bare "ts.net" out; and a suffix check (not a substring one) is what stops
+    /// an attacker-controlled "ts.net.evil.com" from reading as a tailnet host.
+    func testMagicDNSNamesAndTheirNearMisses() {
+        for name in ["box.ts.net", "mac.tail-scale.ts.net", "BOX.TS.NET"] {
+            XCTAssertEqual(HostEndpoint.parse(name)?.isTailnetAddress, true, name)
+        }
+        for name in ["notts.net", "ts.net", "ts.net.evil.com", "example.com", "tsxnet"] {
+            XCTAssertEqual(HostEndpoint.parse(name)?.isTailnetAddress, false, name)
+        }
+    }
+
+    /// AXIS: a dotted string that is not four numeric octets is a NAME, and must
+    /// be judged as one — "100.64.0.0.evil.com" must not pass as an address.
+    func testAddressLookalikesAreNotTreatedAsAddresses() {
+        XCTAssertEqual(HostEndpoint.parse("100.64.0.0.evil.com")?.isTailnetAddress, false)
+        XCTAssertEqual(HostEndpoint.parse("100.64.0")?.isTailnetAddress, false)
+        XCTAssertEqual(HostEndpoint.parse("100.999.0.1")?.isTailnetAddress, false)
+    }
+
     // MARK: - the valid shapes
 
     func testPlainHostDefaultsTo22() {


### PR DESCRIPTION
## Why

Connecting to a Tailscale host from a phone that is **not** on the tailnet showed a near-endless spinner with nothing to act on (owner-reported).

There was no error to show because there was no failure: `SSHClient.connect` was called with **no budget**, so an unroutable address sits at the TCP layer until the OS gives up — about 75 seconds on iOS. That is not experienced as a failure; it is experienced as a hang.

## What

Race the handshake against a 15s clock and report the timeout.

- **`HostEndpoint.isTailnetAddress`** — classifies `100.64.0.0/10` and `*.ts.net`. A **/10, not a /8**: `100.63.x.x` and `100.128.x.x` are ordinary public addresses, and sweeping them up would make a real internet host give up early. Address-range matching, so no permissions and no probing.
- **`TransportError.connectTimedOut(host:onTailnet:)`** — a tailnet host gets *"…is on Tailscale. Your device needs to be on the same tailnet"*; every other host gets a wording that deliberately does **not** guess at the cause.
- **The budget is injectable**, so the timeout is tested against a black-hole address in milliseconds rather than asserted from reading the code. A 15s test is one nobody runs.

15s is well above a real handshake — a slow cellular link completes in a second or two — and far below the OS's own give-up. The gap between those two numbers is the whole point.

## Not a task group, and the reason is measured

The first implementation raced inside `withThrowingTaskGroup`. A group **awaits its children at scope exit**, and `SSHClient.connect` does not observe cancellation promptly — so it returned only when the *losing* connect finally gave up on its own: **30 seconds against a 0.3s budget**. The new test caught that in my own code, which is the case for having written it. The winner now returns while the loser unwinds unobserved, and a connect that lands after the clock has won is closed rather than leaked.

## No app-target change

The existing catch already renders `"\(error)"` when the agent list is empty, which a first connect always is — so the new message surfaces with no `App/` edit. That matters here: `App/` cannot build on Linux, so anything placed there is type-checked only by macOS CI. The whole fix lives in HerdrKit, which is fully covered by the Linux suite.

## Tests

**413 run, 0 failures, 1 pre-existing skip.** Seven new.

- Address classification at the **/10 boundaries** — `100.64.0.0` and `100.127.255.255` match; `100.63.255.255` and `100.128.0.0` do not. Plus the MagicDNS near-misses: `notts.net`, a bare `ts.net`, and `ts.net.evil.com` must all fail, which is why the check is a suffix match on `.ts.net` with a label required before it.
- **The two wordings differ, and the generic one must not mention Tailscale** — asserting that absence is what stops an ordinary host being blamed on a VPN it does not use.
- **The budget is real**: a connect to a black-hole address fails within it instead of hanging. Gated on an independent raw-socket probe that the address really does swallow packets here, matching the `LiveEnvironment` convention — where it fails fast instead, there is no hang to bound.

Both behaviours **mutation-checked**: widening the /10 to a /8 turns the boundary test red; removing the budget turns the timeout test red at 31s.

## Receipt this cannot provide

The device check is the owner's: with Tailscale **off**, connecting to a tailnet host should show the sentence within ~15s instead of spinning; turning Tailscale **on** and retrying should connect.