### PR TITLE
feat: add omp harness switching

### DIFF
--- a/App/AgentSessionTransferSheet.swift
+++ b/App/AgentSessionTransferSheet.swift
@@ -1,7 +1,7 @@
 import HerdrKit
 import SwiftUI
 
-/// Two-phase Claude Code <-> Codex transfer. Preparing is non-destructive: Herdr
+/// Two-phase native harness transfer. Preparing is non-destructive: Herdr
 /// builds and rereads the destination transcript while this agent stays live. The
 /// user sees the exact visible-message and omission counts before confirmation.
 struct AgentSessionTransferSheet: View {
@@ -12,6 +12,7 @@ struct AgentSessionTransferSheet: View {
     let onRefresh: () -> Void
 
     @Environment(\.dismiss) private var dismiss
+    @State private var source: AgentSessionTransferHarness
     @State private var target: AgentSessionTransferHarness
     @State private var selectedAccountID: String
     @State private var transfer: AgentSessionTransferInfo?
@@ -23,6 +24,7 @@ struct AgentSessionTransferSheet: View {
         client: HerdrClient,
         agent: AgentInfo,
         title: String,
+        source: AgentSessionTransferHarness,
         target: AgentSessionTransferHarness,
         accounts: [CredentialAccount],
         onRefresh: @escaping () -> Void
@@ -34,17 +36,16 @@ struct AgentSessionTransferSheet: View {
         self.onRefresh = onRefresh
 
         let existing = agent.sessionTransfer.flatMap { info -> AgentSessionTransferInfo? in
-            guard info.target == target else { return nil }
+            guard !info.phase.isConclusive,
+                  info.source == source,
+                  info.target == target else { return nil }
             return info
         }
+        _source = State(initialValue: source)
         _target = State(initialValue: target)
         _transfer = State(initialValue: existing)
         _selectedAccountID = State(initialValue: existing?.targetAccount ?? "")
         _sourceStatus = State(initialValue: agent.agentStatus)
-    }
-
-    private var source: AgentSessionTransferHarness {
-        target == .codex ? .claude : .codex
     }
 
     private var targetAccounts: [CredentialAccount] {
@@ -426,6 +427,10 @@ struct AgentSessionTransferSheet: View {
             return "Herdr is waiting for Claude Code's official integration to report the exact staged session. A mismatch restores \(source.displayName)."
         case .codex:
             return "Herdr is binding the exact Codex resume session and PID, then rereading the native target JSONL. The JSONL is the proof; the short observation window is not. Codex's later official report must still match."
+        case .omp:
+            return "Herdr is binding the exact OMP session path, active leaf, and PID, then rereading the native target tree. The transcript is the proof; the short observation window is not."
+        case .unrecognised(let harness):
+            return "Herdr cannot verify the unrecognised target harness \(harness)."
         }
     }
 
@@ -435,12 +440,17 @@ struct AgentSessionTransferSheet: View {
             return "The target did not take verified ownership. Herdr is reopening the original Claude Code session and waiting for its official session report."
         case .codex:
             return "The target did not take verified ownership. Herdr is reopening the exact original Codex session and verifying its native JSONL against that session's PID."
+        case .omp:
+            return "The target did not take verified ownership. Herdr is reopening the exact original OMP session path and verifying its active leaf and native tree against that session's PID."
+        case .unrecognised(let harness):
+            return "The target did not take verified ownership. Herdr cannot automatically verify rollback for the unrecognised source harness \(harness)."
         }
     }
 
     @MainActor
     private func beginReverseTransfer() {
         guard let current = transfer, current.phase == .completed else { return }
+        source = current.target
         target = current.source
         selectedAccountID = ""
         transfer = nil
@@ -472,8 +482,7 @@ struct AgentSessionTransferSheet: View {
             guard let info = updated.sessionTransfer else {
                 throw TransferSheetError.missingState
             }
-            transfer = info
-            selectedAccountID = info.targetAccount ?? ""
+            synchronizeTransfer(info, agentStatus: updated.agentStatus)
             await pollTransfer(id: info.id)
         } catch {
             let transportError = displayError(error)
@@ -506,7 +515,7 @@ struct AgentSessionTransferSheet: View {
             guard let info = updated.sessionTransfer else {
                 throw TransferSheetError.missingState
             }
-            transfer = info
+            synchronizeTransfer(info, agentStatus: updated.agentStatus)
             await pollTransfer(id: info.id)
         } catch {
             let transportError = displayError(error)
@@ -543,13 +552,10 @@ struct AgentSessionTransferSheet: View {
                 $0.paneID == agent.paneID
                     || ($0.terminalID != nil && $0.terminalID == agent.terminalID)
             }), let durable = updatedAgent.sessionTransfer,
-                  includeTerminal || !durable.phase.isTerminal else {
+                  includeTerminal || !durable.phase.isConclusive else {
                 return false
             }
-            target = durable.target
-            transfer = durable
-            selectedAccountID = durable.targetAccount ?? ""
-            sourceStatus = updatedAgent.agentStatus
+            synchronizeTransfer(durable, agentStatus: updatedAgent.agentStatus)
             if let expectedID, durable.id != expectedID {
                 busy = false
                 errorText = "A different transfer replaced this transaction. Review the durable state shown here before taking another action."
@@ -594,18 +600,30 @@ struct AgentSessionTransferSheet: View {
             }) else { return }
             guard let updated = updatedAgent.sessionTransfer else { return }
             guard updated.id == id else {
-                transfer = updated
+                synchronizeTransfer(updated, agentStatus: updatedAgent.agentStatus)
                 busy = false
                 errorText = "A different transfer replaced this transaction. Close and reopen to review the current one."
                 return
             }
-            transfer = updated
+            synchronizeTransfer(updated, agentStatus: updatedAgent.agentStatus)
             if updated.phase.isTerminal { errorText = nil }
         } catch {
             // A daemon restart can transiently drop a poll. Keep the last verified
             // phase and retry; only the deadline above turns prolonged uncertainty
             // into user-visible text.
         }
+    }
+
+    @MainActor
+    private func synchronizeTransfer(
+        _ durable: AgentSessionTransferInfo,
+        agentStatus: String?
+    ) {
+        source = durable.source
+        target = durable.target
+        selectedAccountID = durable.targetAccount ?? ""
+        sourceStatus = agentStatus
+        transfer = durable
     }
 
     @MainActor

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -1232,16 +1232,20 @@ struct TerminalHomeView: View {
         let account: CredentialAccount
     }
     @State private var swapCandidate: PendingSwap?
-    /// Capability-gated Claude Code <-> Codex transfer. Unlike a subscription
+    /// Capability-gated native harness transfer. Unlike a subscription
     /// swap, this stages a translated native session and requires review before
     /// the source runtime is interrupted.
     private struct PendingHarnessTransfer: Identifiable {
         let row: AgentRow
+        let source: AgentSessionTransferHarness
         let target: AgentSessionTransferHarness
-        var id: String { "\(row.info.paneID):\(target.rawValue)" }
+        var id: String {
+            "\(row.info.paneID):\(source.rawValue):\(target.rawValue)"
+        }
     }
     @State private var transferCandidate: PendingHarnessTransfer?
     @State private var sessionTransferSupported = false
+    @State private var sessionTransferHarnesses: Set<AgentSessionTransferHarness> = []
     @State private var checkedSessionTransferCapability = false
     /// A pending rename (nil = no sheet). An agent sets its daemon `name` (a resolvable mention
     /// target — `herdr agent read <name>`); a terminal sets its pane `label` (shown in
@@ -1931,6 +1935,7 @@ struct TerminalHomeView: View {
                     client: client,
                     agent: candidate.row.info,
                     title: candidate.row.title,
+                    source: candidate.source,
                     target: candidate.target,
                     accounts: accounts,
                     onRefresh: { Task { await load() } }
@@ -2274,14 +2279,28 @@ struct TerminalHomeView: View {
     /// detected agent is nil or already changed. Without a transaction, only exact
     /// native harness kinds participate; guessing would offer a transfer the server
     /// must refuse.
-    private func sessionTransferTarget(for info: AgentInfo) -> AgentSessionTransferHarness? {
-        if let activeOrRecordedTransfer = info.sessionTransfer {
-            return activeOrRecordedTransfer.target
+    private func sessionTransferSource(for info: AgentInfo) -> AgentSessionTransferHarness? {
+        if let activeTransfer = info.sessionTransfer,
+           !activeTransfer.phase.isConclusive {
+            return activeTransfer.source
         }
         switch info.agent?.lowercased() {
-        case "claude": return .codex
-        case "codex": return .claude
+        case "claude": return .claude
+        case "codex": return .codex
+        case "omp": return .omp
         default: return nil
+        }
+    }
+
+    private func sessionTransferTargets(for info: AgentInfo) -> [AgentSessionTransferHarness] {
+        if let activeTransfer = info.sessionTransfer,
+           !activeTransfer.phase.isConclusive {
+            return [activeTransfer.target]
+        }
+        guard let source = sessionTransferSource(for: info),
+              sessionTransferHarnesses.contains(source) else { return [] }
+        return [AgentSessionTransferHarness.claude, .codex, .omp].filter {
+            $0 != source && sessionTransferHarnesses.contains($0)
         }
     }
 
@@ -2352,13 +2371,32 @@ struct TerminalHomeView: View {
                         // then opens a review sheet whose explicit confirm performs the
                         // cutover. Local-only: the server denies filesystem-authority
                         // transfer requests over federation.
+                        let transferTargets = sessionTransferTargets(for: row.info)
+                        let hasActiveTransfer = row.info.sessionTransfer
+                            .map { !$0.phase.isConclusive } ?? false
                         if row.info.machineID == nil,
-                           (sessionTransferSupported || row.info.sessionTransfer != nil),
-                           let target = sessionTransferTarget(for: row.info) {
-                            Button {
-                                transferCandidate = PendingHarnessTransfer(row: row, target: target)
+                           (sessionTransferSupported || hasActiveTransfer),
+                           let source = sessionTransferSource(for: row.info),
+                           !transferTargets.isEmpty {
+                            Menu {
+                                ForEach(transferTargets, id: \.rawValue) { target in
+                                    Button {
+                                        transferCandidate = PendingHarnessTransfer(
+                                            row: row,
+                                            source: source,
+                                            target: target
+                                        )
+                                    } label: {
+                                        Label(target.displayName, systemImage: "arrow.right")
+                                    }
+                                }
                             } label: {
-                                Label("Switch to \(target.displayName)", systemImage: "arrow.left.arrow.right")
+                                Label(
+                                    transferTargets.count == 1
+                                        ? "Switch to \(transferTargets[0].displayName)"
+                                        : "Switch harness",
+                                    systemImage: "arrow.left.arrow.right"
+                                )
                             }
                         }
                         // Swap = restart the agent onto a DIFFERENT credential account
@@ -2683,6 +2721,24 @@ struct TerminalHomeView: View {
                 do {
                     let capabilities = try await client.serverCapabilities()
                     sessionTransferSupported = capabilities?.agentSessionTransfer == true
+                    if sessionTransferSupported {
+                        if let advertised = capabilities?.agentSessionTransferHarnesses {
+                            sessionTransferHarnesses = Set(advertised.filter { harness in
+                                switch harness {
+                                case .claude, .codex, .omp:
+                                    return true
+                                case .unrecognised:
+                                    return false
+                                }
+                            })
+                        } else {
+                            // Older transfer-capable daemons predate the explicit
+                            // list and support exactly Claude Code and Codex.
+                            sessionTransferHarnesses = [.claude, .codex]
+                        }
+                    } else {
+                        sessionTransferHarnesses = []
+                    }
                     checkedSessionTransferCapability = true
                 } catch {
                     // Keep the control hidden and retry on a later refresh. Existing

--- a/Sources/HerdrKit/Wire.swift
+++ b/Sources/HerdrKit/Wire.swift
@@ -112,11 +112,47 @@ public struct AgentArchivedInfo: Decodable, Equatable, Sendable {
     public let reason: String?
 }
 
-/// The two harnesses whose native transcript formats Herdr can translate.
-public enum AgentSessionTransferHarness: String, Codable, Equatable, Sendable {
-    case claude, codex
+/// A native harness whose visible transcript Herdr can translate. Unknown
+/// values remain decodable so a newer daemon cannot break the entire agent list
+/// on an older app.
+public enum AgentSessionTransferHarness: Codable, Hashable, Sendable {
+    case claude
+    case codex
+    case omp
+    case unrecognised(String)
 
-    public var displayName: String { self == .claude ? "Claude Code" : "Codex" }
+    public init(from decoder: Decoder) throws {
+        let value = try decoder.singleValueContainer().decode(String.self)
+        switch value {
+        case "claude": self = .claude
+        case "codex": self = .codex
+        case "omp": self = .omp
+        default: self = .unrecognised(value)
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(rawValue)
+    }
+
+    public var rawValue: String {
+        switch self {
+        case .claude: "claude"
+        case .codex: "codex"
+        case .omp: "omp"
+        case .unrecognised(let value): value
+        }
+    }
+
+    public var displayName: String {
+        switch self {
+        case .claude: "Claude Code"
+        case .codex: "Codex"
+        case .omp: "Oh My Pi"
+        case .unrecognised(let value): value
+        }
+    }
 }
 
 /// The durable two-phase transfer state reported on `AgentInfo.sessionTransfer`.
@@ -151,6 +187,16 @@ public enum AgentSessionTransferPhase: Decodable, Equatable, Sendable {
     public var isTerminal: Bool {
         switch self {
         case .completed, .rolledBack, .failed, .unrecognised: return true
+        default: return false
+        }
+    }
+
+    /// A known final state after which starting a new transfer is safe. An
+    /// unknown phase stops polling, but remains durable and visible because an
+    /// older app cannot prove that the transaction has finished.
+    public var isConclusive: Bool {
+        switch self {
+        case .completed, .rolledBack, .failed: return true
         default: return false
         }
     }
@@ -810,12 +856,17 @@ public struct ServerCapabilities: Decodable, Equatable, Sendable {
     public let detachedServerDaemon: Bool
     public let paneInputStream: Bool
     public let agentSessionTransfer: Bool
+    /// Nil means the daemon predates explicit harness advertisement and uses
+    /// the legacy Claude/Codex pair. An explicit list, including an empty or
+    /// future-only one, must not be replaced with that fallback.
+    public let agentSessionTransferHarnesses: [AgentSessionTransferHarness]?
 
     enum CodingKeys: String, CodingKey {
         case liveHandoff = "live_handoff"
         case detachedServerDaemon = "detached_server_daemon"
         case paneInputStream = "pane_input_stream"
         case agentSessionTransfer = "agent_session_transfer"
+        case agentSessionTransferHarnesses = "agent_session_transfer_harnesses"
     }
 
     public init(from decoder: Decoder) throws {
@@ -824,6 +875,10 @@ public struct ServerCapabilities: Decodable, Equatable, Sendable {
         detachedServerDaemon = try c.decodeIfPresent(Bool.self, forKey: .detachedServerDaemon) ?? false
         paneInputStream = try c.decodeIfPresent(Bool.self, forKey: .paneInputStream) ?? false
         agentSessionTransfer = try c.decodeIfPresent(Bool.self, forKey: .agentSessionTransfer) ?? false
+        agentSessionTransferHarnesses = try c.decodeIfPresent(
+            [AgentSessionTransferHarness].self,
+            forKey: .agentSessionTransferHarnesses
+        )
     }
 }
 

--- a/Tests/HerdrKitTests/SessionTransferTests.swift
+++ b/Tests/HerdrKitTests/SessionTransferTests.swift
@@ -10,7 +10,7 @@ final class SessionTransferTests: XCTestCase {
         func roundTrip(_ requestLine: String) async throws -> String {
             requests.append(requestLine)
             if requestLine.contains(#""method":"ping""#) {
-                return #"{"id":"x","result":{"type":"pong","version":"0.8.2","protocol":9,"capabilities":{"live_handoff":true,"agent_session_transfer":true}}}"#
+                return #"{"id":"x","result":{"type":"pong","version":"0.8.2","protocol":9,"capabilities":{"live_handoff":true,"agent_session_transfer":true,"agent_session_transfer_harnesses":["claude","codex","omp"]}}}"#
             }
             return SessionTransferTests.transferResponse(phase: transferPhase)
         }
@@ -44,12 +44,25 @@ final class SessionTransferTests: XCTestCase {
         XCTAssertEqual(enabled?.agentSessionTransfer, true)
         XCTAssertEqual(enabled?.liveHandoff, true)
         XCTAssertEqual(enabled?.paneInputStream, false)
+        XCTAssertEqual(enabled?.agentSessionTransferHarnesses, [.claude, .codex, .omp])
 
         let old = FixedTransport(response:
             #"{"id":"x","result":{"type":"pong","version":"0.8.2","protocol":9,"capabilities":{"live_handoff":true}}}"#)
         let oldCapabilities = try await HerdrClient(transport: old).serverCapabilities()
         XCTAssertEqual(oldCapabilities?.agentSessionTransfer, false,
                        "an older daemon must hide the switch instead of advertising a call it cannot serve")
+        XCTAssertNil(oldCapabilities?.agentSessionTransferHarnesses)
+    }
+
+    func testPrepareEncodesOmpAsANativeTransferTarget() async throws {
+        let transport = CapturingTransport()
+        _ = try await HerdrClient(transport: transport)
+            .prepareAgentSessionTransfer(target: "jarvis", to: .omp, account: "omp-main")
+
+        let request = try requestObject(try XCTUnwrap(transport.requests.last))
+        let params = try XCTUnwrap(request["params"] as? [String: Any])
+        XCTAssertEqual(params["to"] as? String, "omp")
+        XCTAssertEqual(params["account"] as? String, "omp-main")
     }
 
     func testPrepareEncodesOnlyStageFieldsAndDecodesReviewFacts() async throws {
@@ -110,7 +123,28 @@ final class SessionTransferTests: XCTestCase {
         XCTAssertEqual(transfer.phase, .unrecognised("verifying_future_state"))
         XCTAssertTrue(transfer.phase.isTerminal,
                       "a state this app cannot interpret must stop polling and demand attention")
+        XCTAssertFalse(transfer.phase.isConclusive,
+                       "an unknown durable state must remain visible instead of permitting a new transfer")
         XCTAssertEqual(transfer.omissions.total, 0)
+    }
+
+    func testUnknownHarnessDoesNotBreakAgentListDecoding() async throws {
+        let transport = FixedTransport(response:
+            #"{"id":"x","result":{"agents":[{"pane_id":"w1:p1","agent":"future","agent_status":"idle","session_transfer":{"id":"transfer-3","source":"omp","target":"future-harness","phase":"completed","message_count":1,"omissions":{}}}]}}"#)
+        let agents = try await HerdrClient(transport: transport).agentList()
+        let transfer = try XCTUnwrap(agents.first?.sessionTransfer)
+        XCTAssertEqual(transfer.source, .omp)
+        XCTAssertEqual(transfer.target, .unrecognised("future-harness"))
+    }
+
+    func testUnknownAdvertisedHarnessDoesNotBreakCapabilityDecoding() async throws {
+        let transport = FixedTransport(response:
+            #"{"id":"x","result":{"type":"pong","version":"0.8.2","protocol":9,"capabilities":{"agent_session_transfer":true,"agent_session_transfer_harnesses":["claude","omp","future-harness"]}}}"#)
+        let capabilities = try await HerdrClient(transport: transport).serverCapabilities()
+        XCTAssertEqual(
+            capabilities?.agentSessionTransferHarnesses,
+            [.claude, .omp, .unrecognised("future-harness")]
+        )
     }
 
     func testTransferRejectionRemainsARealAPIError() async throws {


### PR DESCRIPTION
## Summary

- add Oh My Pi as a source and destination in the existing harness-switch UI
- show a target menu when more than one compatible harness is available
- decode unknown future harness values without breaking the agent list
- use the daemon's advertised harness list, while preserving the legacy Claude/Codex fallback only when that field is absent
- treat completed, rolled-back, and failed transfers as terminal so the same agent can immediately transfer in another direction

## Dependency

Depends on jerryfane/herdr#153. Do not ship this UI as describing OMP transfer until that backend is available in the daemon build.

The ordering is backward compatible:

- with an older transfer-capable daemon, the absent harness list exposes only Claude Code and Codex
- an explicit empty or future-only harness list does not incorrectly fall back to Claude/Codex
- unknown harness strings remain decodable but are not offered as actions

## Verification

- `git diff --check`: passed
- added HerdrKit coverage for OMP request encoding, advertised harness decoding, and unknown future harness values
- Linux has no Swift/Xcode toolchain in this checkout, so the macOS `build-and-uitest` check is the load-bearing compile and test gate for this PR
- backend disposable E2E passed in both new directions: Claude Code -> OMP and OMP -> Claude Code, with exact two-message transcript restoration

Implemented by HERDR-APP-2.
