### PR TITLE
fix(release): bump version to 1.0.2

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -195,7 +195,7 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.jerryfane.herdr
-        MARKETING_VERSION: "1.0.1"
+        MARKETING_VERSION: "1.0.2"
         CURRENT_PROJECT_VERSION: "1"
         SWIFT_VERSION: "5.9"
         GENERATE_INFOPLIST_FILE: NO
@@ -300,7 +300,7 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.jerryfane.herdr.widgets
-        MARKETING_VERSION: "1.0.1"
+        MARKETING_VERSION: "1.0.2"
         CURRENT_PROJECT_VERSION: "1"
         SWIFT_VERSION: "5.9"
         GENERATE_INFOPLIST_FILE: NO


### PR DESCRIPTION
## Summary
- advance the app release train from 1.0.1 to 1.0.2
- keep the app and widget marketing versions aligned

## Reason
TestFlight run 33336942373 built and signed build 114 successfully, but App Store Connect rejected the upload with errors 90186 and 90062 because version 1.0.1 is closed after approval.

## Validation
- both MARKETING_VERSION settings resolve to 1.0.2
- git diff --check passes

This PR contains only the release-version bump required to upload the already-approved OMP harness-switching build.