### PR TITLE
feat(terminal): restore text selection, direct typing, and a visible jump-to-tail

### DIFF
--- a/App/GesturesHelpView.swift
+++ b/App/GesturesHelpView.swift
@@ -1,11 +1,12 @@
 import SwiftUI
 
-/// A first-run tutorial that teaches the app's gestures — the ones that aren't
-/// obvious because they have no on-screen affordance (swipe between agents, edge
-/// swipe back, double-tap to tail, press-and-hold to act). Shown once on first
-/// launch (gated by `@AppStorage("hasSeenGesturesHelp")`) and re-openable any time
-/// from the "Gestures" tab. Presented through the app's single `activeCover` sheet,
-/// so it inherits the swipe-down-to-dismiss grabber like Settings and Gram.
+/// A first-run tutorial that teaches the app's gestures, the ones that aren't obvious
+/// because they have no on-screen affordance (edge swipe back, double- and triple-tap
+/// to select terminal text, two-finger tap to jump to the newest output,
+/// press-and-hold to act). Shown once on first launch (gated by
+/// `@AppStorage("hasSeenGesturesHelp")`) and re-openable any time from the "Gestures"
+/// tab. Presented through the app's single `activeCover` sheet, so it inherits the
+/// swipe-down-to-dismiss grabber like Settings and Gram.
 struct GesturesHelpView: View {
     var onClose: () -> Void
 
@@ -22,18 +23,21 @@ struct GesturesHelpView: View {
         .init(symbol: "hand.tap",
               title: "Tap an agent",
               detail: "Opens its live terminal."),
-        .init(symbol: "arrow.left.and.right",
-              title: "Swipe left or right",
-              detail: "Moves to the next or previous agent's terminal."),
         .init(symbol: "chevron.backward",
               title: "Swipe in from the left edge",
               detail: "Goes back to the agents list."),
-        .init(symbol: "arrow.down.to.line",
-              title: "Double-tap the terminal",
-              detail: "Jumps to the newest output."),
         .init(symbol: "arrow.up.and.down",
               title: "Drag up and down",
               detail: "Scrolls back through the terminal history."),
+        .init(symbol: "hand.tap",
+              title: "Double-tap the terminal",
+              detail: "Selects a word. Drag the handles to extend it, then Copy."),
+        .init(symbol: "text.alignleft",
+              title: "Triple-tap the terminal",
+              detail: "Selects the whole line."),
+        .init(symbol: "arrow.down.to.line",
+              title: "Two-finger tap the terminal",
+              detail: "Jumps to the newest output."),
         .init(symbol: "hand.point.up.left",
               title: "Press and hold an agent",
               detail: "Stops it."),

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -3373,6 +3373,17 @@ struct TerminalPaneContent: View {
     /// Focus of the reply field, so the software keyboard can be DISMISSED — via the
     /// keyboard-toolbar chevron or a tap on the (read-only) terminal.
     @FocusState private var replyFocused: Bool
+    /// Terminal-input focus is explicit on touch devices. A terminal tap enables
+    /// direct PTY typing; reply submission and keyboard collapse clear it so the
+    /// software keyboard can genuinely dismiss instead of immediately moving focus
+    /// back to the terminal.
+    @State private var terminalInputFocused = false
+    /// Incremented to ask the pane to jump to its newest output. LiveTerminalView
+    /// performs exactly one jump per increment.
+    @State private var jumpToTailToken = 0
+    /// False while the pane is scrolled away from its newest output. Drives the
+    /// "Latest" pill. Starts true so the pill stays hidden until the reader scrolls.
+    @State private var terminalAtTail = true
     /// One-time gate for the "switch Claude Code to smooth (classic) scrolling" banner.
     /// Persisted app-wide via UserDefaults, so once the reader answers it once — Switch
     /// OR dismiss, for ANY Claude Code pane — it never shows again. See `showTuiBanner`.
@@ -3468,16 +3479,16 @@ struct TerminalPaneContent: View {
                 // Code panes only, shown at most once (see showTuiBanner).
                 if showTuiBanner { tuiBanner }
                 // The live terminal: a real SwiftTerm VT fed by the pane.stream raw
-                // byte firehose (#40), full-bleed as the machine ground. Read-only —
-                // input stays on the keycaps + reply bar below (sendText/sendKeys/
-                // prompt), never routed through the terminal itself.
+                // byte firehose (#40), full-bleed as the machine ground. A terminal
+                // tap enables direct PTY input; the reply bar remains the deliberate
+                // prompt path for agent messages.
                 LiveTerminalView(client: client, paneID: paneID,
                                  onNavigate: onNavigate, isForeground: isForeground,
-                                 // iPad + hardware keyboard: let the terminal hold key focus so keys
-                                 // drive the PTY directly — but yield focus while the reply field is
-                                 // focused, and never on iPhone (the terminal can't become first
-                                 // responder there, so this is inert).
-                                 wantsTerminalKeyFocus: isForeground && !replyFocused,
+                                 wantsTerminalKeyFocus: isForeground && !replyFocused
+                                     && (terminalInputFocused || UIDevice.current.userInterfaceIdiom == .pad),
+                                 onTerminalFocusRequest: { terminalInputFocused = true },
+                                 jumpToTailToken: jumpToTailToken,
+                                 onTailStateChange: { terminalAtTail = $0 },
                                  fontSize: CGFloat(terminalFontSize),
                                  // A federated/remote pane routes key-drive input via pane.send_text
                                  // (home can't proxy the persistent pane.input.stream channel). (#139)
@@ -3490,9 +3501,16 @@ struct TerminalPaneContent: View {
                     .padding(.horizontal, 8)
                     // NOTE: do NOT attach a SwiftUI .onTapGesture here. A tap gesture on
                     // this UIViewRepresentable competes with the wrapped UIScrollView's
-                    // native pan and starves the terminal of scroll drags (it broke
-                    // scrolling in v0.1.5). Keyboard dismissal lives on the reply bar's
-                    // own collapse button instead (see replyBar).
+                    // native pan and starves terminal scroll drags. LiveTerminalView's
+                    // UIKit recognizer owns the explicit direct-input tap instead.
+                    // A visible, one-finger replacement for the double tap that used to
+                    // jump to the tail (given back to SwiftTerm, which needs it for word
+                    // select). An OVERLAY, not a gesture, for the reason stated above:
+                    // only the pill itself hit-tests, taps elsewhere reach the terminal.
+                    .overlay(alignment: .bottomTrailing) {
+                        if !terminalAtTail { jumpToLatestPill }
+                    }
+                    .animation(.easeInOut(duration: 0.15), value: terminalAtTail)
                 if let note = actionNote {
                     Text(note).font(Typography.app(12)).foregroundStyle(Palette.textDim)
                         .frame(maxWidth: .infinity, alignment: .leading).padding(.horizontal, 16).padding(.vertical, 4)
@@ -3512,10 +3530,15 @@ struct TerminalPaneContent: View {
             await refresh()
             await deliverPrefillIfNeeded()
         }
-        // Re-resolve status each time the pane returns to the front; drop the keyboard when it
-        // backgrounds so a hidden keep-mounted pane can't hold the software keyboard.
+        // Re-resolve status each time the pane returns to the front; drop either
+        // keyboard owner when it backgrounds so a hidden keep-mounted pane cannot
+        // retain the software keyboard.
         .onChange(of: isForeground) { _, nowFront in
-            if nowFront { Task { await refresh() } } else { replyFocused = false }
+            if nowFront { Task { await refresh() }
+            } else {
+                replyFocused = false
+                terminalInputFocused = false
+            }
         }
         // When the app returns to the foreground after a real background, reseed the
         // FRONT pane the same way the header refresh button does (bump streamGen →
@@ -3676,6 +3699,23 @@ struct TerminalPaneContent: View {
         }
     }
 
+    /// Shown only while the pane is scrolled away from its newest output, so it is out
+    /// of the way the rest of the time. Uses the app's primary ink-fill treatment, the
+    /// same one the send arrow and the banner's Switch button use.
+    private var jumpToLatestPill: some View {
+        Button { jumpToTailToken += 1 } label: {
+            HStack(spacing: 6) {
+                Image(systemName: "arrow.down.to.line").font(.system(size: 11, weight: .semibold))
+                Text("Latest").font(Typography.app(12, .semibold))
+            }
+            .foregroundStyle(Palette.ground)
+            .padding(.horizontal, 12).padding(.vertical, 7)
+            .background(Palette.text).clipShape(Capsule())
+        }
+        .padding(.trailing, 16).padding(.bottom, 12)
+        .accessibilityLabel(Text("Jump to latest output"))
+    }
+
     // MARK: classic-renderer banner
 
     /// The one-time offer to switch Claude Code from its laggy fullscreen renderer to the
@@ -3786,13 +3826,28 @@ struct TerminalPaneContent: View {
                 // cursor key there, not a scroll — hence the two Ctrl jumps for scrolling).
                 keyCap(label: "end", key: "End")
                 rawCap(symbol: "arrow.up.to.line", sequence: "\u{1b}[1;5H")
-                rawCap(symbol: "arrow.down.to.line", sequence: "\u{1b}[1;5F")
+                // Jump to the newest output. Routed through the pane rather than a raw
+                // byte sequence, so a plain shell scrolls its own scrollback while a
+                // mouse-mode agent gets Ctrl+End. Deliberately NOT disabled on
+                // `sending || pendingPrefill` like the keycaps: this is local view
+                // navigation, not input to the agent.
+                Button { jumpToTailToken += 1 } label: {
+                    Image(systemName: "arrow.down.to.line").font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(Palette.textDim)
+                        .padding(.horizontal, 10)
+                        .frame(minWidth: 44, minHeight: 34)
+                        .background(Palette.surface).clipShape(RoundedRectangle(cornerRadius: 8))
+                }
+                .accessibilityLabel(Text("Jump to latest output"))
                 keyCap(label: "tab", key: "Tab")
                 // Shift+Tab (CBT / back-tab, ESC[Z) — cycles Claude-Code modes. A
                 // raw escape sequence, not a named key: delivered verbatim to the PTY.
                 rawCap(label: "S-Tab", sequence: "\u{1b}[Z")
                 // Sticky Ctrl: arm, then the next typed char becomes its control byte.
                 ctrlCap
+                // ^P (previous prompt/history) — a one-tap control sequence for
+                // navigating OMP's prompt history without first arming Ctrl.
+                rawCap(label: "^P", sequence: "\u{10}")
                 // ^C (interrupt) — the common one-tap case; a raw control byte.
                 rawCap(label: "^C", sequence: "\u{03}")
                 // The submit affordance rawKeys needs — typing never submits, so
@@ -3865,7 +3920,10 @@ struct TerminalPaneContent: View {
             // `.keyboard` accessory toolbar: that toolbar floated on top of the send
             // button. Matched to the send button's circular footprint.
             if replyFocused {
-                Button { replyFocused = false } label: {
+                Button {
+                    replyFocused = false
+                    terminalInputFocused = false
+                } label: {
                     Image(systemName: "keyboard.chevron.compact.down")
                         .font(.system(size: 15, weight: .semibold))
                         .foregroundStyle(Palette.textDim)
@@ -3887,13 +3945,14 @@ struct TerminalPaneContent: View {
                     handleReplyChange(old: oldValue, new: newValue)
                 }
                 .submitLabel(.send)
-                // Hardware Return submits, exactly like tapping the send arrow. Guarded by
-                // `canSend` (mirrors the arrow's `.disabled(!canSend)`) so an empty/whitespace box
-                // is a true no-op and a fast second Return can't double-fire mid-send. Re-assert
-                // focus so the box stays ready for the next line — SwiftUI otherwise drops first
-                // responder on submit, which would hand key focus back to the terminal
-                // (wantsTerminalKeyFocus = isForeground && !replyFocused).
-                .onSubmit { if canSend { sendTapped() }; replyFocused = true }
+                // Return sends the reply then releases both input owners on iPhone and
+                // iPad, so the software keyboard dismisses instead of re-focusing the
+                // terminal. A terminal tap explicitly re-enables direct PTY input.
+                .onSubmit {
+                    if canSend { sendTapped() }
+                    replyFocused = false
+                    terminalInputFocused = false
+                }
             // Dictate into the reply (on-device). isActive: isForeground stops the mic
             // if this pane stops being the front one (no hot mic behind a hidden pane);
             // onStart disarms any pending ctrl chord and `replyDictating` suppresses the

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -3489,6 +3489,9 @@ struct TerminalPaneContent: View {
                                  onTerminalFocusRequest: { terminalInputFocused = true },
                                  jumpToTailToken: jumpToTailToken,
                                  onTailStateChange: { terminalAtTail = $0 },
+                                 // The host's current belief, so a `streamGen` remount seeds a
+                                 // fresh Coordinator instead of replaying the last jump.
+                                 isAtTail: terminalAtTail,
                                  fontSize: CGFloat(terminalFontSize),
                                  // A federated/remote pane routes key-drive input via pane.send_text
                                  // (home can't proxy the persistent pane.input.stream channel). (#139)

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -3378,6 +3378,10 @@ struct TerminalPaneContent: View {
     /// software keyboard can genuinely dismiss instead of immediately moving focus
     /// back to the terminal.
     @State private var terminalInputFocused = false
+    /// Set true by the collapse chevron for the body pass that follows, then cleared. Without it a
+    /// deliberate collapse is indistinguishable from any other pass where the terminal simply does
+    /// not want key focus, and the resign is refused while a selection is held.
+    @State private var terminalCollapseRequested = false
     /// Incremented to ask the pane to jump to its newest output. LiveTerminalView
     /// performs exactly one jump per increment.
     @State private var jumpToTailToken = 0
@@ -3486,6 +3490,9 @@ struct TerminalPaneContent: View {
                                  onNavigate: onNavigate, isForeground: isForeground,
                                  wantsTerminalKeyFocus: isForeground && !replyFocused
                                      && (terminalInputFocused || UIDevice.current.userInterfaceIdiom == .pad),
+                                 // Set by the collapse chevron so the resign in updateUIView can
+                                 // tell a deliberate dismissal from an incidental body pass.
+                                 collapseRequested: terminalCollapseRequested,
                                  onTerminalFocusRequest: { terminalInputFocused = true },
                                  jumpToTailToken: jumpToTailToken,
                                  onTailStateChange: { terminalAtTail = $0 },
@@ -3937,8 +3944,13 @@ struct TerminalPaneContent: View {
             // the responder. A control that visibly does nothing is worse than an absent one.
             if replyFocused || (terminalInputFocused && UIDevice.current.userInterfaceIdiom == .phone) {
                 Button {
+                    // Mark the collapse as DELIBERATE before dropping the flags, so the resign in
+                    // updateUIView is allowed to run even while a word is selected. Cleared on the
+                    // next runloop turn so it cannot leak into unrelated passes.
+                    terminalCollapseRequested = true
                     replyFocused = false
                     terminalInputFocused = false
+                    DispatchQueue.main.async { terminalCollapseRequested = false }
                 } label: {
                     Image(systemName: "keyboard.chevron.compact.down")
                         .font(.system(size: 15, weight: .semibold))

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -6219,10 +6219,32 @@ struct MockTransport: HerdrTransport {
     }
 
     func stream(_ requestLine: String) -> AsyncThrowingStream<String, Error> {
-        // `pane.stream` (the live terminal): reply with the stream_started ack, then
-        // a reset seed, then finish — so the DEBUG pane shows a rendered SwiftTerm
-        // terminal, not an empty one. The scrollback seed (UI test) feeds 200 lines so
-        // there is real history to scroll; the default seed is the short screenshot one.
+        // `pane.stream` (the live terminal): reply with the stream_started ack, then a reset
+        // seed, then STAY OPEN — so the DEBUG pane shows a rendered SwiftTerm terminal, not an
+        // empty one. The scrollback seed (UI test) feeds 200 lines so there is real history to
+        // scroll; the default seed is the short screenshot one.
+        //
+        // IT MUST NOT FINISH, and finishing was a real fixture defect with a long tail. A live
+        // `pane.stream` never ends, so the app treats an ended stream as a DROP and reconnects
+        // with capped backoff — correct product behaviour. Against a mock that finished
+        // immediately, every reconnect re-delivered the reset and appended another 200 lines,
+        // forever. Measured in CI at head 18e1daca: the probe reported ydisp=3598 in one pass and
+        // ydisp=3777 in the next, a buffer of thousands of lines in a fixture that seeds 200, and
+        // growing by one seed per reconnect between passes.
+        //
+        // The consequences all looked like unrelated bugs:
+        //   - The scroll view's contentSize tracked roughly 200 lines while `yDisp` ran past 3500,
+        //     so a tap resolved to buffer row 186 while the DRAWN window was 3598...3621. The
+        //     selection was real and off-screen, which is why the highlight was never painted and
+        //     why four rounds of hunting in SwiftTerm's renderer found nothing wrong with it.
+        //   - `testBackfillMakesHistoryScrollable`'s "terminal is static when untouched" premise
+        //     failed at diff 0.08549 against a 0.02 ceiling, because content genuinely kept
+        //     arriving.
+        //
+        // Not finishing is sufficient: the stream's storage holds the continuation for as long as
+        // the consumer iterates, so the pane simply waits for frames that never come — exactly
+        // what a quiet live pane looks like. This is what the ccDriver branch below has always
+        // done, for the same reason.
         if requestLine.contains("pane.stream") {
             if let driver = ccDriver {
                 // Claude-Code stand-in: keep the stream OPEN so the driver can push
@@ -6236,7 +6258,7 @@ struct MockTransport: HerdrTransport {
             return AsyncThrowingStream { continuation in
                 continuation.yield(Self.paneStreamAck)
                 continuation.yield(reset)
-                continuation.finish()
+                // DELIBERATELY NO finish(): see above. A finished stream is a dropped stream.
             }
         }
         return AsyncThrowingStream { $0.finish() }

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -3961,23 +3961,28 @@ struct TerminalPaneContent: View {
                     handleReplyChange(old: oldValue, new: newValue)
                 }
                 .submitLabel(.send)
-                // Return sends the reply, then releases the input owners ONLY on iPhone,
-                // where doing so dismisses the software keyboard. On iPad it must NOT
-                // release them: `wantsTerminalKeyFocus` carries `|| idiom == .pad`, so
-                // clearing both owners there does not dismiss anything (a Magic Keyboard
-                // cannot be dismissed) and instead hands key focus straight to the
-                // terminal, sending everything typed after Return to the agent's shell as
-                // raw keystrokes instead of composing the next reply. The reply field
-                // therefore KEEPS focus on iPad, which is what the pre-PR code did.
+                // Return sends the reply and releases only the TERMINAL's claim on key input,
+                // keeping the reply field focused on every idiom — which is what the pre-PR code
+                // did, and why.
+                //
+                // The problem this has to solve is `wantsTerminalKeyFocus`, which carries
+                // `|| idiom == .pad`: if Return clears BOTH owners, that disjunct re-asserts on
+                // iPad and hands key focus to the terminal, so everything typed after Return goes
+                // to the agent's shell as raw keystrokes instead of composing the next reply.
+                // Clearing `terminalInputFocused` alone fixes that without touching the field.
+                //
+                // AN EARLIER VERSION OF THIS ALSO CLEARED `replyFocused` ON iPHONE, to dismiss the
+                // software keyboard. A review pointed out the cost: the reader then has to tap the
+                // field again for every subsequent message, and pre-PR behaviour deliberately kept
+                // focus so a back-and-forth exchange did not cost a tap per message. Dismissal was
+                // a side effect of needing to release the terminal, not a goal, and this PR already
+                // adds the affordance for doing it on purpose — the collapse chevron now renders
+                // for a terminal-raised keyboard too. So the keyboard stays up and the reader
+                // decides when it goes.
                 .onSubmit {
                     if canSend { sendTapped() }
-                    if UIDevice.current.userInterfaceIdiom == .pad {
-                        replyFocused = true
-                        terminalInputFocused = false
-                    } else {
-                        replyFocused = false
-                        terminalInputFocused = false
-                    }
+                    replyFocused = true
+                    terminalInputFocused = false
                 }
             // Dictate into the reply (on-device). isActive: isForeground stops the mic
             // if this pane stops being the front one (no hot mic behind a hidden pane);
@@ -6258,7 +6263,38 @@ struct MockTransport: HerdrTransport {
             return AsyncThrowingStream { continuation in
                 continuation.yield(Self.paneStreamAck)
                 continuation.yield(reset)
-                // DELIBERATELY NO finish(): see above. A finished stream is a dropped stream.
+                // AND THEN KEEP PINGING, because silence is not the same as being alive.
+                //
+                // Removing finish() stopped the reconnect-on-stream-end loop, but left this mock
+                // MUTE — and the app's stall watchdog treats a mute stream as a stuck one. It
+                // polls every 5s and, at 50s without any event (streamStuckTimeout), writes
+                // "no response for 50s; reconnecting…" into the terminal and re-runs start(),
+                // which delivers another ack and another 200-line reset. So the re-seed returned
+                // by a slower route: a review measured testTerminalScrollsWhenSwiped taking 85.5s
+                // against this fixture with the pane mounted from launch, which is well past the
+                // 50s threshold.
+                //
+                // A real daemon pings about every 20s, which is what the 50s timeout is sized
+                // against (2.5x, so one dropped ping is tolerated). The fixture now does the same
+                // thing, and `.ping` is a first-class frame in the wire protocol
+                // (HerdrKit/Wire.swift:649, decoded at :705) carrying nothing but seq and epoch —
+                // so it refreshes lastStreamActivity without touching the emulator, the buffer, or
+                // the rendered frame. That last property matters: several UI tests assert the
+                // terminal is byte-identical when untouched, so a keepalive that DREW anything
+                // would trade one false failure for another.
+                let pings = Task {
+                    var seq: UInt64 = 1
+                    while !Task.isCancelled {
+                        try? await Task.sleep(nanoseconds: 20_000_000_000)   // 20s, like the server
+                        guard !Task.isCancelled else { break }
+                        continuation.yield(Self.paneStreamPing(seq: seq, epoch: 7))
+                        seq += 1
+                    }
+                }
+                // Stop pinging when the consumer goes away, so a torn-down pane does not leave a
+                // timer running for the life of the process.
+                continuation.onTermination = { _ in pings.cancel() }
+                // DELIBERATELY NO finish(): a finished stream is a dropped stream. See above.
             }
         }
         return AsyncThrowingStream { $0.finish() }
@@ -6373,6 +6409,15 @@ struct MockTransport: HerdrTransport {
         #"{"stream":"pane.bytes","frame":"reset","seq":0,"epoch":7,"cols":80,"rows":24,"data_b64":"G1syShtbSBtbMTszODs1OzM5bWhlcmRyG1swbSBsaXZlIHRlcm1pbmFsIOKAlCBtb2NrIHJlbmRlcg0KDQokIGhlcmRyIGFnZW50IGF0dGFjaCBqYXJ2aXMNCj4gUmFuIDE0NiB0ZXN0cywgMCBmYWlsdXJlcw0KDQpbZGVtbyBkYXRhIOKAlCBubyBsaXZlIGNvbm5lY3Rpb25dDQo="}"#
     static let panePtySize =
         #"{"id":"mock","result":{"type":"pane_pty_size","pane_id":"w1:p1","cols":80,"rows":24,"locked":false}}"#
+
+    /// A keepalive `pane.stream` ping, the frame a real daemon sends about every 20s and the one
+    /// the 50s stall watchdog is sized against. Carries only `seq` and `epoch`
+    /// (HerdrKit/Wire.swift:705 decodes exactly those), so it proves the stream is alive without
+    /// touching the emulator or changing a single rendered pixel — which several UI tests depend
+    /// on, since they assert the terminal is byte-identical while untouched.
+    static func paneStreamPing(seq: UInt64, epoch: UInt64) -> String {
+        #"{"stream":"pane.bytes","frame":"ping","seq":\#(seq),"epoch":\#(epoch)}"#
+    }
 
     /// A decoded blocked agent for the pane screenshot: status "blocked" groups
     /// as NEEDS YOU, so the pane renders its status badge. No composer field, so

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -6254,9 +6254,27 @@ struct MockTransport: HerdrTransport {
             if let driver = ccDriver {
                 // Claude-Code stand-in: keep the stream OPEN so the driver can push
                 // redraws in response to wheel events the app sends.
+                //
+                // IT PINGS TOO, for the same reason the plain branch does. A review flagged this
+                // branch as the remaining instance of the defect class the plain branch just fixed:
+                // held open but SILENT, so a ccDriver pane left idle past the 50s stall
+                // watchdog would be re-seeded mid-test. No current test mounts one that long, so
+                // this is latent rather than active — which is exactly when it is cheap to close,
+                // and leaving one branch of a two-branch function wrong is how the plain branch's
+                // bug survived as long as it did.
                 return AsyncThrowingStream { continuation in
                     continuation.yield(Self.paneStreamAck)
                     driver.attach(continuation)
+                    let pings = Task {
+                        var seq: UInt64 = 1
+                        while !Task.isCancelled {
+                            try? await Task.sleep(nanoseconds: 20_000_000_000)   // 20s, like the server
+                            guard !Task.isCancelled else { break }
+                            continuation.yield(Self.paneStreamPing(seq: seq, epoch: 7))
+                            seq += 1
+                        }
+                    }
+                    continuation.onTermination = { _ in pings.cancel() }
                 }
             }
             let reset = scrollback ? Self.scrollbackResetFrame() : Self.paneStreamReset

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -3378,10 +3378,14 @@ struct TerminalPaneContent: View {
     /// software keyboard can genuinely dismiss instead of immediately moving focus
     /// back to the terminal.
     @State private var terminalInputFocused = false
-    /// Set true by the collapse chevron for the body pass that follows, then cleared. Without it a
+    /// Incremented by the collapse chevron to request a DELIBERATE collapse. Without it a
     /// deliberate collapse is indistinguishable from any other pass where the terminal simply does
     /// not want key focus, and the resign is refused while a selection is held.
-    @State private var terminalCollapseRequested = false
+    ///
+    /// A TOKEN, not a bool set for "the next pass" — see `LiveTerminalView.consumeCollapse`. The
+    /// bool version cleared itself in `DispatchQueue.main.async`, which drains BEFORE SwiftUI's
+    /// update flush, so the pane read it as already false and the collapse never happened.
+    @State private var terminalCollapseToken = 0
     /// Incremented to ask the pane to jump to its newest output. LiveTerminalView
     /// performs exactly one jump per increment.
     @State private var jumpToTailToken = 0
@@ -3492,7 +3496,7 @@ struct TerminalPaneContent: View {
                                      && (terminalInputFocused || UIDevice.current.userInterfaceIdiom == .pad),
                                  // Set by the collapse chevron so the resign in updateUIView can
                                  // tell a deliberate dismissal from an incidental body pass.
-                                 collapseRequested: terminalCollapseRequested,
+                                 collapseToken: terminalCollapseToken,
                                  onTerminalFocusRequest: { terminalInputFocused = true },
                                  jumpToTailToken: jumpToTailToken,
                                  onTailStateChange: { terminalAtTail = $0 },
@@ -3945,12 +3949,12 @@ struct TerminalPaneContent: View {
             if replyFocused || (terminalInputFocused && UIDevice.current.userInterfaceIdiom == .phone) {
                 Button {
                     // Mark the collapse as DELIBERATE before dropping the flags, so the resign in
-                    // updateUIView is allowed to run even while a word is selected. Cleared on the
-                    // next runloop turn so it cannot leak into unrelated passes.
-                    terminalCollapseRequested = true
+                    // updateUIView is allowed to run even while a word is selected. No reset: the
+                    // pane consumes the token exactly once, so there is nothing to leak into
+                    // unrelated passes and no async hop that can race the pass it was meant for.
+                    terminalCollapseToken += 1
                     replyFocused = false
                     terminalInputFocused = false
-                    DispatchQueue.main.async { terminalCollapseRequested = false }
                 } label: {
                     Image(systemName: "keyboard.chevron.compact.down")
                         .font(.system(size: 15, weight: .semibold))

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -3928,7 +3928,14 @@ struct TerminalPaneContent: View {
             // with no dismiss affordance at all: a reader who tapped once to select and
             // copy a line could only put it down by first focusing the reply field to make
             // this button appear, and then pressing it.
-            if replyFocused || terminalInputFocused {
+            //
+            // ...AND THAT DISJUNCT IS iPHONE-ONLY, because on iPad it produced a DEAD BUTTON.
+            // `terminalInputFocused` goes true on any terminal tap, but the iPad terminal's
+            // inputView is a zero-frame view, so no keyboard ever appeared for it to collapse;
+            // pressing it cleared both flags and then `wantsTerminalKeyFocus` re-asserted
+            // through its own `|| idiom == .pad` disjunct and the terminal immediately retook
+            // the responder. A control that visibly does nothing is worse than an absent one.
+            if replyFocused || (terminalInputFocused && UIDevice.current.userInterfaceIdiom == .phone) {
                 Button {
                     replyFocused = false
                     terminalInputFocused = false

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -3918,11 +3918,17 @@ struct TerminalPaneContent: View {
 
     private var replyBar: some View {
         HStack(spacing: 8) {
-            // Collapse-keyboard button — shown only while the keyboard is up. It lives
-            // INSIDE the bar's HStack (laid out beside the field/send), NOT in a
-            // `.keyboard` accessory toolbar: that toolbar floated on top of the send
-            // button. Matched to the send button's circular footprint.
-            if replyFocused {
+            // Collapse-keyboard button — shown while EITHER input owner holds the
+            // keyboard. It lives INSIDE the bar's HStack (laid out beside the field/send),
+            // NOT in a `.keyboard` accessory toolbar: that toolbar floated on top of the
+            // send button. Matched to the send button's circular footprint.
+            //
+            // `terminalInputFocused` is in the condition because a TERMINAL tap raises the
+            // software keyboard too, and gating on `replyFocused` alone left that keyboard
+            // with no dismiss affordance at all: a reader who tapped once to select and
+            // copy a line could only put it down by first focusing the reply field to make
+            // this button appear, and then pressing it.
+            if replyFocused || terminalInputFocused {
                 Button {
                     replyFocused = false
                     terminalInputFocused = false
@@ -3948,13 +3954,23 @@ struct TerminalPaneContent: View {
                     handleReplyChange(old: oldValue, new: newValue)
                 }
                 .submitLabel(.send)
-                // Return sends the reply then releases both input owners on iPhone and
-                // iPad, so the software keyboard dismisses instead of re-focusing the
-                // terminal. A terminal tap explicitly re-enables direct PTY input.
+                // Return sends the reply, then releases the input owners ONLY on iPhone,
+                // where doing so dismisses the software keyboard. On iPad it must NOT
+                // release them: `wantsTerminalKeyFocus` carries `|| idiom == .pad`, so
+                // clearing both owners there does not dismiss anything (a Magic Keyboard
+                // cannot be dismissed) and instead hands key focus straight to the
+                // terminal, sending everything typed after Return to the agent's shell as
+                // raw keystrokes instead of composing the next reply. The reply field
+                // therefore KEEPS focus on iPad, which is what the pre-PR code did.
                 .onSubmit {
                     if canSend { sendTapped() }
-                    replyFocused = false
-                    terminalInputFocused = false
+                    if UIDevice.current.userInterfaceIdiom == .pad {
+                        replyFocused = true
+                        terminalInputFocused = false
+                    } else {
+                        replyFocused = false
+                        terminalInputFocused = false
+                    }
                 }
             // Dictate into the reply (on-device). isActive: isForeground stops the mic
             // if this pane stops being the front one (no hot mic behind a hidden pane);

--- a/App/LiveTerminalView.swift
+++ b/App/LiveTerminalView.swift
@@ -58,6 +58,11 @@ struct LiveTerminalView: UIViewRepresentable {
     /// On iPhone this opens the software keyboard; on iPad it takes effect only with a
     /// hardware keyboard. Refreshed on every update.
     var wantsTerminalKeyFocus: Bool = false
+    /// True for the one body pass that follows a DELIBERATE collapse (the reply bar's chevron), as
+    /// opposed to the many incidental passes that also see `wantsTerminalKeyFocus == false`. Only a
+    /// deliberate collapse may resign the responder while a selection is held: see the resign
+    /// branch in `updateUIView` for what went wrong when the two were indistinguishable.
+    var collapseRequested: Bool = false
     /// Called after a terminal tap requests direct PTY input. The parent owns the
     /// SwiftUI focus state so a reply submission can dismiss the keyboard reliably.
     var onTerminalFocusRequest: () -> Void = {}
@@ -135,7 +140,24 @@ struct LiveTerminalView: UIViewRepresentable {
             if !uiView.isFirstResponder { _ = uiView.becomeFirstResponder() }
         } else {
             if !isForeground { uiView.clearSelection() }
-            if uiView.isFirstResponder, !isForeground || !uiView.hasActiveSelection {
+            // THE SELECTION GUARD MUST NOT OUTRANK AN EXPLICIT COLLAPSE, and it did.
+            //
+            // `!uiView.hasActiveSelection` exists so an incidental SwiftUI body pass cannot yank
+            // the responder mid-selection and take the Copy menu with it. But the collapse chevron
+            // reaches this same else-branch by clearing both focus flags, and while a word was
+            // selected the guard refused the resign — so the keyboard stayed up, and because
+            // clearing the flags also hides the chevron, its only dismiss affordance vanished with
+            // it. The reader was left with a keyboard over 40% of the pane and no way down.
+            // Measured and reported by review; the chevron was the feature added to fix exactly
+            // this class of problem, so it failing in the PR's own headline flow is the worst place
+            // for it.
+            //
+            // `collapseRequested` distinguishes the two cases: an incidental pass still respects
+            // the selection, while a deliberate collapse resigns regardless and keeps the
+            // selection intact in the model. Resigning hides the system Copy menu, which is the
+            // honest consequence of asking for the keyboard to go away — and the selection is
+            // still there, so a double tap re-presents it without re-selecting.
+            if uiView.isFirstResponder, !isForeground || collapseRequested || !uiView.hasActiveSelection {
                 uiView.resignFirstResponder()
             }
         }
@@ -1468,6 +1490,23 @@ struct LiveTerminalView: UIViewRepresentable {
         /// which stays the single publisher and dedupes, so the two sources cannot double-publish.
         func scrolled(source: TerminalView, position: Double) {
             guard let view else { return }
+            // THE ALT SCREEN HAS NO MEANINGFUL POSITION, so do not publish one.
+            //
+            // AppleTerminalView.scrollPosition short-circuits to 0 whenever the display buffer is
+            // the alternate one (st_apple.swift:2012), while Terminal.scroll() notifies the delegate
+            // unconditionally including on that buffer (Terminal.swift:5434). So on a Claude Code
+            // pane this callback saw position 0 on EVERY output frame, and whenever the emulator
+            // grid exceeded the laid-out view — the window before PTY-size negotiation settles, or a
+            // co-viewer reclaiming the size — canScroll was true and atTail latched FALSE. The pill
+            // pinned itself visible on a TUI pane where it cannot mean anything, and tapping it was
+            // undone by the next frame. Reported by review as plausible; the short-circuit and the
+            // unconditional notify are both verified in the pinned source, so the guard is cheap
+            // insurance either way. A TUI pane keeps its own viewport and is served by
+            // jumpToTail's Ctrl+End path, not by this pill.
+            if view.getTerminal().isCurrentBufferAlternate {
+                reportTailState(atTail: true)
+                return
+            }
             let canScroll = view.contentSize.height > view.bounds.height + 1
             reportTailState(atTail: !canScroll || position >= 0.999)
         }
@@ -1510,8 +1549,18 @@ struct LiveTerminalView: UIViewRepresentable {
                 let maxOffset = scroll.contentSize.height - scroll.bounds.height
                 Task { @MainActor [weak self] in
                     guard let self, !self.stopped else { return }
-                    // `cellPixels()` returns UInt32, so convert rather than mixing numeric types.
-                    let slack = CGFloat(max(self.cellPixels().height, 1))
+                    // HALF a cell, matching SwiftTerm's own auto-follow threshold rather than a
+                    // number I picked. syncYDispFromContentOffset re-engages auto-follow only within
+                    // max(contentOffsetTolerance, cellDimension.height / 2) (iOSTerminalView.swift
+                    // :1612-1613). A full cell of slack left a HALF-CELL BAND where this reported
+                    // at-tail and hid the pill while userScrolling was still true — new output would
+                    // not scroll into view and the one affordance for getting back was gone. On a
+                    // busy pane the delegate path corrects it on the next line; on a quiet pane it
+                    // persists, which is precisely the case the pill exists for. Reported by review,
+                    // along with the fact that my comment claiming this used "the same arithmetic" as
+                    // the delegate path was wrong: the delegate compares a 0...1 position, this
+                    // compares offsets, and they agreed only approximately.
+                    let slack = CGFloat(max(self.cellPixels().height, 2)) / 2
                     let canScroll = maxOffset > 1
                     self.reportTailState(atTail: !canScroll || offsetY >= maxOffset - slack)
                 }

--- a/App/LiveTerminalView.swift
+++ b/App/LiveTerminalView.swift
@@ -761,14 +761,33 @@ struct LiveTerminalView: UIViewRepresentable {
                 selectionProbe = probe
             }
             // `getSelection()` returns the selected TEXT as `String?` (AppleTerminalView.swift
-            // :2535) — my first version called `.getSelectedText()` on it, which is the
-            // SelectionService method and does not exist here. Only the LENGTH is published.
+            // :2535) — an earlier version called `.getSelectedText()` on it, which is the
+            // SelectionService method and does not exist here.
+            //
+            // THE TEXT ITSELF IS PUBLISHED, and it is the measurement that matters. Every
+            // hypothesis for "SwiftTerm holds a selection and nothing is painted" has now been
+            // eliminated by READING: the rows resolve to the same buffer-absolute space
+            // (contentOffset.y == yDisp * cellHeight), the paint loop does consume
+            // `.selectionBackgroundColor`, and `selectionChanged` does call `setNeedsDisplay`
+            // on both the Metal and CoreGraphics paths. So one of those readings is wrong, and
+            // the one runtime fact no public API exposes is WHICH LINE the selection landed on.
+            //
+            // The fixture answers it: the mock seeds uniquely numbered lines
+            // ("SCROLLTEST line 007  the quick brown fox…") and `selectWordOrExpression`
+            // treats digits as a selectable word, so a tap aimed at the number yields the line
+            // number as the selected text. If the test taps a line the view is showing and the
+            // probe reports a number from far outside the visible window, the tap's row space
+            // is wrong; if it reports a visible number, the row space is fine and the defect is
+            // in the drawing after all. Either answer kills a hypothesis rather than adding one.
+            //
+            // Safe to publish: this text is synthetic fixture content in a UI-test-only build,
+            // never a real pane's output.
             let active = view.hasActiveSelection
-            let length = view.getSelection()?.count ?? 0
+            let selected = view.getSelection() ?? ""
             let term = view.getTerminal()
             probe.accessibilityLabel =
-                "sel=\(active ? 1 : 0) len=\(length) rows=\(term.rows) "
-                + "cols=\(term.cols) resizes=\(resizeCount)"
+                "sel=\(active ? 1 : 0) len=\(selected.count) text=<\(selected)> "
+                + "rows=\(term.rows) cols=\(term.cols) resizes=\(resizeCount)"
         }
 
         func stop() {

--- a/App/LiveTerminalView.swift
+++ b/App/LiveTerminalView.swift
@@ -530,34 +530,50 @@ struct LiveTerminalView: UIViewRepresentable {
             view.addGestureRecognizer(focusTap)
             // MENU TAP: repositions the Copy menu SwiftTerm puts in the wrong place, and
             // does nothing else. A review measured the menu overlapping the pane header —
-            // the back chevron, the title, the NEEDS YOU badge and the refresh icon.
+            // the back chevron, the title, the NEEDS YOU badge and the refresh icon — by
+            // downloading a CI artifact and looking at it. THAT MEASUREMENT IS THE FACT HERE.
             //
-            // The cause is upstream and it is a coordinate-space bug:
-            // `makeContextMenuRegionForSelection()` builds its avoid-rect as
-            // `CGRect(y: CGFloat(selection.start.row) * cellDimension.height, ...)` from a
-            // BUFFER position, while the renderer correctly subtracts `yDisp` when it draws.
-            // With scrollback that y is thousands of points below the view, so UIMenuController
-            // clamps the menu to the top of the window. `makeContextMenuRegionForTap(point:)`
-            // is view-relative and correct, which is why long-press places the menu properly.
-            // This PR is what makes the double-tap menu reachable on iPhone, so it ships the
-            // defect and owns fixing it.
+            // THE MECHANISM IS NOT SETTLED. I previously wrote that
+            // `makeContextMenuRegionForSelection()` builds its avoid-rect from a BUFFER row
+            // while the renderer subtracts `yDisp`. A second reviewer traced the same path and
+            // could not confirm it: on iOS the TerminalView IS the scroll view, and
+            // `calculateTapHit` returns content-space rows — the same space
+            // `makeContextMenuRegionForTap(point:)` uses — so the mismatch is not visible in
+            // that path. So the defect is observed and the cause is unproven, and the real fix
+            // may belong upstream. This re-present is a targeted workaround, not a diagnosis.
             //
-            // A DEDICATED 2-TAP RECOGNIZER, not a branch inside `focusTap`. focusTap fires on
-            // tap 1 AND tap 2, so gating there would need to know whether SwiftTerm's handler
-            // had already run — the exact undocumented ordering this file's tap split exists to
-            // stop depending on. This one fires only on tap 2 by construction, and the async
-            // hop guarantees SwiftTerm's `doubleTap` has finished whichever order UIKit chose,
-            // because both handlers run in the same runloop turn and this block runs after it.
+            // IT MUST WAIT FOR THE TRIPLE TAP, and this is what made the first version INERT.
+            // SwiftTerm defers `doubleTap` behind `tripleTap.require(toFail:)`
+            // (iOSTerminalView.swift:1078), so its selection lands about one multi-tap timeout
+            // — roughly 0.3s — AFTER tap 2's touch-up. A recognizer with no failure requirement
+            // fires immediately, so the async hop ran BEFORE any selection existed, found
+            // `hasActiveSelection` false and returned: on a fresh double tap the menu stayed
+            // over the header, and on a re-double-tap SwiftTerm's own later presentation won
+            // anyway. Final placement was SwiftTerm's in every case. Mirroring the same
+            // `require(toFail:)` loop `clearTap` uses puts this after SwiftTerm's own handler,
+            // and also stops it firing on tap 2 of a TRIPLE tap.
             //
-            // It re-presents only; `showStandardContextMenu(at:)` computes a region and a hit
-            // and shows the menu, and does not re-select, so the word SwiftTerm just selected
-            // survives. It takes no responder and requires nothing to fail, so it cannot
-            // starve or reorder the existing chain. Declared BEFORE `clearTap` so that
-            // recognizer's "every 2-tap recognizer must fail" loop keeps meaning exactly that.
+            // It re-presents only and does not re-select, so the word SwiftTerm just selected
+            // survives. `showStandardContextMenu(at:)` DOES call `becomeFirstResponder()`
+            // (iOSTerminalView.swift:1392-1396) — an earlier comment here claimed it takes no
+            // responder and that was simply false. The practical effect is small, since on
+            // iPhone `focusTap` already holds the responder and on iPad the terminal's
+            // inputView is zero-frame, but it does bypass the `wantsTerminalKeyFocus` gate, so
+            // the hop's `foreground`/`stopped` guards are load-bearing rather than belt-and-braces.
+            //
+            // Declared BEFORE `clearTap` so that recognizer's "every 2-tap recognizer must
+            // fail" loop keeps meaning exactly that.
             let menuTap = UITapGestureRecognizer(target: self, action: #selector(handleMenuRepositionTap(_:)))
             menuTap.numberOfTapsRequired = 2
             menuTap.delegate = self
             menuTap.cancelsTouchesInView = false
+            // SwiftTerm's tripleTap is its only 3-tap recognizer; requiring it to fail is what
+            // orders this after SwiftTerm's own doubleTap handler.
+            for gr in view.gestureRecognizers ?? [] {
+                if let t = gr as? UITapGestureRecognizer, t.numberOfTapsRequired == 3 {
+                    menuTap.require(toFail: t)
+                }
+            }
             view.addGestureRecognizer(menuTap)
             // CLEAR TAP: requires SwiftTerm's 2-tap recognizer to fail, exactly as
             // SwiftTerm guards its own `singleTap` (setupGestures does
@@ -688,30 +704,71 @@ struct LiveTerminalView: UIViewRepresentable {
             guard !stopped, foreground, gr.state == .ended, let view else { return }
             guard view.hasActiveSelection else { return }
             view.clearSelection()
+            // So a test can distinguish "the clear reached the view" from "the highlight
+            // happened to stop being drawn". No-op outside UI-test builds.
+            publishSelectionProbe()
         }
 
-        /// Re-present the Copy menu at the TAP POINT, because SwiftTerm positions the
-        /// double-tap menu from a buffer-relative rect and UIMenuController then clamps it
-        /// over the pane header (see the `menuTap` comment in `attach`).
-        ///
-        /// The async hop is the whole reason this is order-independent: SwiftTerm's `doubleTap`
-        /// and this recognizer both fire in the same runloop turn in an order UIKit does not
-        /// document, and this block runs after that turn, so the selection and SwiftTerm's own
-        /// (mis-placed) presentation have both already happened.
+        /// Re-present the Copy menu at the TAP POINT. Ordered AFTER SwiftTerm's own handler by
+        /// `menuTap.require(toFail: tripleTap)` — see the `menuTap` comment in `attach` for why
+        /// the first version, which had no failure requirement, was inert.
         ///
         /// Guarded on a selection actually existing, so a double tap that selects nothing —
         /// blank space past the end of a line yields an EMPTY range, which SwiftTerm still
         /// marks active but paints nothing — does not get a menu moved onto it. `foreground`
         /// is re-checked inside the hop: a pane can be backgrounded between the tap and the
-        /// hop, and a hidden pane must not present a menu.
+        /// hop, and a hidden pane must not present a menu. Those guards also bound
+        /// `showStandardContextMenu(at:)`'s undocumented `becomeFirstResponder()`, which
+        /// bypasses the `wantsTerminalKeyFocus` gate.
         @objc private func handleMenuRepositionTap(_ gr: UITapGestureRecognizer) {
             guard !stopped, foreground, gr.state == .ended, let view else { return }
             let point = gr.location(in: view)
             DispatchQueue.main.async { [weak self] in
-                guard let self, !self.stopped, self.foreground, let view = self.view else { return }
-                guard view.hasActiveSelection else { return }
+                guard let self, !self.stopped, let view = self.view else { return }
+                self.publishSelectionProbe()   // records state even when the guards below refuse
+                guard self.foreground, view.hasActiveSelection else { return }
                 view.showStandardContextMenu(at: point)
             }
+        }
+
+        /// THE SELECTION PROBE — the instrument, and it exists because four consecutive CI runs
+        /// of the selection receipt failed on my own measurement rather than on the product,
+        /// and two confident diagnoses of why were both wrong.
+        ///
+        /// A UI test can only see PIXELS, so "no highlight" cannot distinguish between: the
+        /// double tap never selected anything, it selected an EMPTY range, a resize wiped the
+        /// selection (`processSizeChange` sets `selection.active = false` on any rows/cols
+        /// change, AppleTerminalView.swift:232), or the selection exists and simply is not
+        /// painted the colour the detector looks for. Those have different fixes and I have
+        /// been guessing between them. This publishes the state itself into an accessibility
+        /// element so the test reads SwiftTerm's answer instead of inferring one.
+        ///
+        /// UI-TEST BUILDS ONLY. Gated on the same `HERDR_SCREENSHOT_MOCK` launch environment
+        /// the mock transport uses, so a real build never allocates it, never attaches it to the
+        /// view tree, and cannot expose terminal contents to the accessibility layer. The label
+        /// carries the SELECTED LENGTH, never the selected text.
+        private func publishSelectionProbe() {
+            guard ProcessInfo.processInfo.environment["HERDR_SCREENSHOT_MOCK"] != nil,
+                  let view else { return }
+            let probe: UIView
+            if let existing = selectionProbe {
+                probe = existing
+            } else {
+                probe = UIView(frame: .zero)
+                probe.isAccessibilityElement = true
+                probe.accessibilityIdentifier = "terminal-selection-probe"
+                view.addSubview(probe)
+                selectionProbe = probe
+            }
+            // `getSelection()` returns the selected TEXT as `String?` (AppleTerminalView.swift
+            // :2535) — my first version called `.getSelectedText()` on it, which is the
+            // SelectionService method and does not exist here. Only the LENGTH is published.
+            let active = view.hasActiveSelection
+            let length = view.getSelection()?.count ?? 0
+            let term = view.getTerminal()
+            probe.accessibilityLabel =
+                "sel=\(active ? 1 : 0) len=\(length) rows=\(term.rows) "
+                + "cols=\(term.cols) resizes=\(resizeCount)"
         }
 
         func stop() {
@@ -1122,6 +1179,11 @@ struct LiveTerminalView: UIViewRepresentable {
         /// resizes the SHARED PTY (see `sendPTYSize`): one winsize per pane, so a
         /// co-viewing desktop reflows to the phone's grid until it re-asserts.
         func sizeChanged(source: TerminalView, newCols: Int, newRows: Int) {
+            // Counted for the UI-test probe only: SwiftTerm's `processSizeChange` clears any
+            // active selection on a rows/cols change, so a resize landing AFTER a word select
+            // silently destroys it. The count lets a test say "the selection was wiped" rather
+            // than "no selection appeared", which are different bugs with different fixes.
+            resizeCount += 1
             sendPTYSize(cols: newCols, rows: newRows)
         }
 
@@ -1321,6 +1383,15 @@ struct LiveTerminalView: UIViewRepresentable {
         /// The alt-screen scroll pan recognizer, disabled on teardown so a drag can't
         /// send bytes to a pane that has exited/been replaced.
         private var scrollPan: UIPanGestureRecognizer?
+        /// UI-TEST ONLY diagnostic element (see `publishSelectionProbe`). Nil in every build
+        /// that does not launch with `HERDR_SCREENSHOT_MOCK`, so a shipped app neither
+        /// allocates it nor exposes it to the accessibility layer.
+        private var selectionProbe: UIView?
+        /// How many times SwiftTerm has reported a grid change. Published by the probe because
+        /// `processSizeChange` clears the selection on any rows/cols change, so a resize
+        /// arriving late is one of the candidate explanations for a selection that vanishes —
+        /// and a count is how a test tells that apart from a selection never made.
+        private var resizeCount = 0
         /// Serialized scroll-send queue: bytes waiting to go to the agent, drained one
         /// send at a time by `scrollSendTask` — so a fast drag coalesces into batched
         /// writes instead of a flood of concurrent, possibly-reordered SSH channels.

--- a/App/LiveTerminalView.swift
+++ b/App/LiveTerminalView.swift
@@ -20,21 +20,18 @@ private final class ResumeGate: @unchecked Sendable {
     }
 }
 
-/// A read-only, LIVE SwiftTerm terminal for a herdr pane (#40). It consumes
+/// A live SwiftTerm terminal for a herdr pane (#40). It consumes
 /// `client.streamTerminal(pane:)` — herdr's raw PTY byte firehose — and feeds the
 /// bytes to a real VT emulator, so the phone renders a grid-faithful terminal
 /// instead of a reflowed snapshot.
 ///
-/// READ-ONLY for keyboard/typed input on iPhone/touch: the view never becomes first
-/// responder (no keyboard) and its delegate `send` early-returns, so SwiftTerm keystrokes
-/// are never routed to the PTY. Command/message input stays on the reply/Send + keycap
-/// affordances in `TerminalPaneContent` (`sendText`/`sendKeys`/`prompt`). Two input
-/// exceptions: (1) SCROLL — a pan on the alternate screen sends constrained wheel/arrow
-/// sequences to the agent so its full-screen view can scroll (see `handleScrollPan`) —
-/// never a keystroke; and (2) iPad KEY DRIVE — on iPad with a hardware keyboard the view
-/// becomes first responder and `send` forwards SwiftTerm's key→bytes to the PTY, so a Magic
-/// Keyboard types straight into the terminal (see `ReadOnlyTerminalView.keyDriveEnabled`).
-/// iPhone and touch behaviour are unchanged.
+/// iPhone, iPad, and hardware keyboards can drive the terminal directly. On iPhone,
+/// the terminal becomes first responder when the reply field is not focused and shows
+/// the software keyboard; SwiftTerm's delegate forwards its key→bytes translation to
+/// the PTY. The reply/Send bar remains the deliberate path for agent prompts and saved
+/// messages. SCROLL remains constrained: a pan on the alternate screen sends
+/// wheel/arrow sequences to the agent (see `handleScrollPan`), never a keystroke.
+/// iPad accepts direct terminal keys only while a hardware keyboard is present.
 ///
 /// Geometry: the view reports its own laid-out grid to the server via `setPTYSize`
 /// so the stream is generated at the phone's width. While the terminal view is open
@@ -58,10 +55,19 @@ struct LiveTerminalView: UIViewRepresentable {
     /// lock lifecycle changes — the stream and the SwiftTerm view stay warm.
     var isForeground: Bool = true
     /// Whether the terminal itself should hold keyboard focus (drive keys straight to the PTY).
-    /// Only ever true on iPad with a hardware keyboard AND when the reply field is not focused;
-    /// on iPhone the terminal cannot become first responder, so this is inert (see
-    /// `ReadOnlyTerminalView.keyDriveEnabled`). Refreshed on every update.
+    /// On iPhone this opens the software keyboard; on iPad it takes effect only with a
+    /// hardware keyboard. Refreshed on every update.
     var wantsTerminalKeyFocus: Bool = false
+    /// Called after a terminal tap requests direct PTY input. The parent owns the
+    /// SwiftUI focus state so a reply submission can dismiss the keyboard reliably.
+    var onTerminalFocusRequest: () -> Void = {}
+    /// Bumped by the host to jump this pane to its newest output. `updateUIView`
+    /// compares it against the value the Coordinator last executed, so each
+    /// increment performs exactly one jump.
+    var jumpToTailToken: Int = 0
+    /// Reports whether the pane is parked at its newest output. Invoked ONLY when
+    /// the value changes, so it cannot re-render SwiftUI on every scroll frame.
+    var onTailStateChange: (Bool) -> Void = { _ in }
     /// Terminal font size in points (the `terminal.fontSize` preference). Applied
     /// in-place via `Coordinator.applyFont` when it changes — re-lays-out the grid,
     /// no view recreation.
@@ -80,6 +86,7 @@ struct LiveTerminalView: UIViewRepresentable {
         let view = ReadOnlyTerminalView(frame: .zero, font: context.coordinator.paneFont)
         context.coordinator.onNavigate = onNavigate
         context.coordinator.isFederated = isFederated
+        context.coordinator.onTerminalFocusRequest = onTerminalFocusRequest
         context.coordinator.attach(view)
         return view
     }
@@ -87,14 +94,17 @@ struct LiveTerminalView: UIViewRepresentable {
     func updateUIView(_ uiView: ReadOnlyTerminalView, context: Context) {
         context.coordinator.onNavigate = onNavigate
         context.coordinator.isFederated = isFederated
+        context.coordinator.onTerminalFocusRequest = onTerminalFocusRequest
+        context.coordinator.onTailStateChange = onTailStateChange
+        context.coordinator.performJumpToTail(ifTokenChanged: jumpToTailToken)
         context.coordinator.setForeground(isForeground)
-        // Drive terminal KEY focus from SwiftUI intent (iPad key-drive only). The resign is
-        // gated on keyDriveEnabled so it manages ONLY key-drive focus: on iPhone/touch the view
-        // may hold first-responder status transiently for a TEXT SELECTION, and we must not yank
-        // it out from under an active selection on the next SwiftUI update.
+        // Drive terminal key focus from SwiftUI intent. The resign is gated on
+        // `keyDriveEnabled` so it manages only writable-terminal focus, and on
+        // `hasActiveSelection` so a SwiftUI body pass cannot yank first responder
+        // out from under a live selection (resigning hides the Copy menu).
         if wantsTerminalKeyFocus {
-            if !uiView.isFirstResponder { _ = uiView.becomeFirstResponder() }
-        } else if uiView.keyDriveEnabled, uiView.isFirstResponder {
+            if uiView.keyDriveEnabled && !uiView.isFirstResponder { _ = uiView.becomeFirstResponder() }
+        } else if uiView.keyDriveEnabled, uiView.isFirstResponder, !uiView.hasActiveSelection {
             uiView.resignFirstResponder()
         }
         context.coordinator.applyFont(size: fontSize)
@@ -104,12 +114,10 @@ struct LiveTerminalView: UIViewRepresentable {
         coordinator.stop()
     }
 
-    /// A `TerminalView` that is read-only for keyboard input on iPhone/touch — display +
-    /// scroll only. Blocking first-responder status is what keeps it observe-only: no keyboard
-    /// appears and no keystroke can reach the PTY input path. The ONE exception is iPad with a
-    /// hardware keyboard (`keyDriveEnabled`): there the view DOES become first responder and its
-    /// `send` delegate forwards SwiftTerm's key→bytes translation to the PTY, so a Magic Keyboard
-    /// drives the terminal like a real one. iPhone and touch behaviour are unchanged.
+    /// A `TerminalView` that accepts terminal input on iPhone and on iPad with a
+    /// hardware keyboard. On iPhone its normal UIKit input view is retained so the
+    /// software keyboard can type directly into the PTY. An iPad without a hardware
+    /// keyboard stays selection-and-copy only.
     ///
     /// SCROLL is the LIBRARY's job now. On a normal (shell) buffer the reader
     /// finger-scrolls the retained scrollback through SwiftTerm's own `UIScrollView`,
@@ -124,25 +132,17 @@ struct LiveTerminalView: UIViewRepresentable {
     /// (`Coordinator.handleScrollPan`), which sends wheel/arrow scroll INTO a
     /// full-screen TUI that keeps no scrollback of its own.
     final class ReadOnlyTerminalView: TerminalView {
-        /// KEY DRIVE (hardware keys → PTY) is allowed only on iPad with a PHYSICAL keyboard:
-        /// the `.pad` idiom (NOT horizontalSizeClass — an iPhone Max in landscape is regular
-        /// width and must stay read-only) AND a coalesced hardware keyboard. This gates the
-        /// `send` delegate, so keystrokes reach the PTY ONLY under key drive — independently of
-        /// first-responder status below.
+        /// Direct terminal input is available on iPhone through the software keyboard
+        /// and on iPad through a physical keyboard. A large iPhone in landscape must
+        /// still use the phone path, so this keys off idiom rather than size class.
         var keyDriveEnabled: Bool {
-            UIDevice.current.userInterfaceIdiom == .pad && GCKeyboard.coalesced != nil
+            UIDevice.current.userInterfaceIdiom == .phone
+                || (UIDevice.current.userInterfaceIdiom == .pad && GCKeyboard.coalesced != nil)
         }
-        /// First responder is allowed on EVERY platform, because SwiftTerm's text selection
-        /// (long-press word-select, drag-to-extend, the Copy callout) requires it. This does NOT
-        /// make the pane writable: keystroke routing stays gated on `keyDriveEnabled` in the
-        /// `send` delegate, and the zero-frame `emptyInputView` below means no soft keyboard ever
-        /// appears. Net effect on iPhone: the terminal can be selected and copied, never typed into.
+        /// First responder is allowed on every platform because SwiftTerm text selection
+        /// requires it. On iPhone it also presents the software keyboard; on iPad without
+        /// a hardware keyboard, input remains disabled by `keyDriveEnabled`.
         override var canBecomeFirstResponder: Bool { true }
-        override func becomeFirstResponder() -> Bool { super.becomeFirstResponder() }
-        /// Zero-frame input view so becoming first responder shows NO soft keyboard — hardware
-        /// keys still arrive via UIKeyInput/pressesBegan. SwiftTerm declares `inputView` and
-        /// `inputAccessoryView` as `public override` (NOT `open`), so this module cannot re-override
-        /// them; we SET them in init instead (they expose public setters).
         private let emptyInputView = UIView(frame: .zero)
 
         override init(frame: CGRect, font: UIFont?) {
@@ -151,10 +151,11 @@ struct LiveTerminalView: UIViewRepresentable {
             // flush and the library's scroll-offset math (`maxContentOffsetY`) free of a
             // shifting safe-area / keyboard inset.
             contentInsetAdjustmentBehavior = .never
-            // Suppress the soft keyboard + SwiftTerm's TerminalAccessory bar while keeping HARDWARE
-            // keys flowing. `setupAccessoryView()` (which installs the accessory) runs once during
-            // super.init's setup, so overwriting these here sticks.
-            inputView = emptyInputView
+            // Keep iPhone's system keyboard. On iPad, suppress a software keyboard while
+            // preserving hardware-key delivery and selection/copy behavior.
+            if UIDevice.current.userInterfaceIdiom != .phone {
+                inputView = emptyInputView
+            }
             inputAccessoryView = nil
         }
         required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
@@ -275,6 +276,18 @@ struct LiveTerminalView: UIViewRepresentable {
         /// Page-between-agents callback (see `LiveTerminalView.onNavigate`), refreshed
         /// by `updateUIView`. +1 = next agent, -1 = previous.
         var onNavigate: ((Int) -> Void)?
+        /// Requests SwiftUI terminal-input focus after a tap. The parent controls
+        /// actual responder ownership so it can dismiss the keyboard after Send.
+        var onTerminalFocusRequest: (() -> Void)?
+        /// Publishes tail state to the host (see `LiveTerminalView.onTailStateChange`).
+        /// Refreshed by `updateUIView`.
+        var onTailStateChange: ((Bool) -> Void)?
+        /// Last `jumpToTailToken` this Coordinator executed, so one increment performs
+        /// exactly one jump even though `updateUIView` runs on every body pass.
+        private var lastJumpToTailToken = 0
+        /// Last value published through `onTailStateChange`. Starts true so a pane that
+        /// has never been scrolled publishes nothing.
+        private var lastReportedAtTail = true
 
         /// Per-pane geometry-ownership generation. Each `attach` for a pane id bumps this and
         /// records the value it claimed; the releasing `lock:false` — which can be DELAYED
@@ -423,21 +436,29 @@ struct LiveTerminalView: UIViewRepresentable {
             pan.delegate = self
             view.addGestureRecognizer(pan)
             scrollPan = pan
-            // Double-tap → jump to the live tail. A UIKit recognizer (NOT a SwiftUI
-            // .onTapGesture, which starves the scroll pan — HerdrApp.swift note).
-            let doubleTap = UITapGestureRecognizer(target: self, action: #selector(handleDoubleTap(_:)))
-            doubleTap.numberOfTapsRequired = 2
-            doubleTap.delegate = self
-            view.addGestureRecognizer(doubleTap)
-            // SUPERSEDE SwiftTerm's own double-tap (word-select): make it wait for ours to
-            // FAIL, so a double-tap jumps to the tail without starting a word selection and
-            // its lingering selection pan (which would otherwise fight the next scroll on an
-            // idle shell pane — SwiftTerm's doubleTap has no read-only guard).
-            for gr in view.gestureRecognizers ?? [] where gr !== doubleTap {
+            // Two-finger tap jumps to the live tail. Every SwiftTerm recognizer is
+            // single-finger, so this needs no failure requirement and costs single,
+            // double and triple tap nothing. The single-finger double tap is LEFT TO
+            // SwiftTerm: it is the only gesture that word-selects AND installs the
+            // drag-to-extend pan, so taking it over removed selection entirely.
+            let twoFingerTap = UITapGestureRecognizer(target: self, action: #selector(handleTwoFingerTap(_:)))
+            twoFingerTap.numberOfTouchesRequired = 2
+            twoFingerTap.delegate = self
+            twoFingerTap.cancelsTouchesInView = false
+            view.addGestureRecognizer(twoFingerTap)
+            // Single tap clears a selection, else takes typing focus. It must defer to
+            // SwiftTerm's own double tap exactly as SwiftTerm's singleTap does, or tap 1
+            // of a word-select would fire it. SwiftTerm's doubleTap already requires its
+            // tripleTap, so requiring the 2-tap recognizer inherits the whole chain.
+            let singleTap = UITapGestureRecognizer(target: self, action: #selector(handleTerminalTap(_:)))
+            singleTap.delegate = self
+            singleTap.cancelsTouchesInView = false
+            for gr in view.gestureRecognizers ?? [] {
                 if let t = gr as? UITapGestureRecognizer, t.numberOfTapsRequired == 2 {
-                    t.require(toFail: doubleTap)
+                    singleTap.require(toFail: t)
                 }
             }
+            view.addGestureRecognizer(singleTap)
             // (Removed: the horizontal swipe-between-agents recognizers. A finger/mouse drag to
             // SELECT text was triggering them and paging to an unwanted agent; agent switching
             // stays fully reachable via the list/sidebar, and their removal frees horizontal drag
@@ -447,14 +468,19 @@ struct LiveTerminalView: UIViewRepresentable {
             start()
         }
 
-        /// Double-tap the terminal → jump to the live tail. A mouse-mode/alt agent
-        /// (Claude Code) captures the wheel and keeps its own viewport, so send it
-        /// Ctrl+End (`ESC[1;5F` → scroll-to-bottom + re-enable auto-follow) — read-only,
-        /// exactly like the scroll bytes, never a keystroke. A plain shell has native
+        /// Jump the pane to its newest output. A mouse-mode or alt-screen agent (Claude
+        /// Code) captures the wheel and keeps its own viewport, so send it Ctrl+End
+        /// (`ESC[1;5F`, scroll-to-bottom plus re-enable auto-follow), read-only exactly
+        /// like the scroll bytes and never a keystroke. A plain shell has native
         /// SwiftTerm scrollback, so jump its UIScrollView to the maximum offset.
-        @objc private func handleDoubleTap(_ gr: UITapGestureRecognizer) {
+        ///
+        /// Deliberately NOT annotated `@MainActor`, matching `applyFont`: it is called
+        /// from `updateUIView` and from a UIKit gesture handler, both already on the
+        /// main thread, and the async send hops explicitly.
+        func jumpToTail() {
             guard !stopped, let view else { return }
-            if view.getTerminal().isCurrentBufferAlternate || view.getTerminal().mouseMode != .off {
+            let term = view.getTerminal()
+            if term.isCurrentBufferAlternate || term.mouseMode != .off {
                 Task { @MainActor [weak self] in
                     guard let self, !self.stopped else { return }
                     _ = try? await self.client.sendText(pane: self.paneID, text: "\u{1b}[1;5F")
@@ -467,6 +493,53 @@ struct LiveTerminalView: UIViewRepresentable {
                 let maxY = max(0, view.contentSize.height - view.bounds.height)
                 view.setContentOffset(CGPoint(x: 0, y: maxY), animated: false)
             }
+            reportTailState(atTail: true)
+        }
+
+        /// Executes one jump per token increment. `updateUIView` runs on every SwiftUI
+        /// body pass, so the token comparison is what makes this idempotent.
+        func performJumpToTail(ifTokenChanged token: Int) {
+            guard token != lastJumpToTailToken else { return }
+            lastJumpToTailToken = token
+            jumpToTail()
+        }
+
+        /// Publishes tail state to the host, and ONLY on a change, so scrolling cannot
+        /// re-render SwiftUI on every frame.
+        ///
+        /// The publish is deferred one main-queue turn on purpose. `performJumpToTail`
+        /// runs INSIDE `updateUIView`, and the jump reports `atTail: true`, so a
+        /// synchronous call would mutate SwiftUI `@State` during a view update, which
+        /// SwiftUI warns about and can re-enter. The dedupe above stays synchronous, so
+        /// deferring cannot publish a stale duplicate.
+        private func reportTailState(atTail: Bool) {
+            guard atTail != lastReportedAtTail else { return }
+            lastReportedAtTail = atTail
+            let publish = onTailStateChange
+            DispatchQueue.main.async { publish?(atTail) }
+        }
+
+        @objc private func handleTwoFingerTap(_ gr: UITapGestureRecognizer) {
+            guard gr.state == .ended else { return }
+            jumpToTail()
+        }
+
+        /// A single tap first CLEARS an active selection, and takes typing focus only
+        /// when nothing was selected. SwiftTerm's own singleTap does the clear too, but
+        /// only when the view is ALREADY first responder (`if isFirstResponder { ... }
+        /// else { becomeFirstResponder() }`), so on an unfocused pane the tap was spent
+        /// taking focus and the selection survived. `clearSelection()` flips
+        /// `SelectionService.active`, whose setter notifies `selectionChanged(source:)`,
+        /// which calls `setNeedsDisplay` and `disableSelectionPanGesture()`, so one call
+        /// both redraws and removes the lazy extend pan.
+        @objc private func handleTerminalTap(_ gr: UITapGestureRecognizer) {
+            guard !stopped, gr.state == .ended, let view else { return }
+            if view.hasActiveSelection {
+                view.clearSelection()
+                return   // a tap that dismisses a selection must not also raise the keyboard
+            }
+            guard view.keyDriveEnabled else { return }
+            onTerminalFocusRequest?()
         }
 
         func stop() {
@@ -971,16 +1044,12 @@ struct LiveTerminalView: UIViewRepresentable {
             return (UInt32(max(1, advance.rounded())), UInt32(max(1, lineHeight.rounded())))
         }
 
-        // MARK: TerminalViewDelegate — read-only, so most are inert
+        // MARK: TerminalViewDelegate — terminal input
 
-        /// KEY DRIVE (iPad + hardware keyboard only): forward SwiftTerm's own key→bytes
-        /// translation to the PTY. DOUBLE-GATED — the view must be `keyDriveEnabled` AND the
-        /// current first responder — so on iPhone/touch (where the view never becomes first
-        /// responder) this stays a no-op and no keystroke or SwiftTerm-generated mouse byte is
-        /// ever routed to the PTY, exactly as before. Serialized through `enqueueInput` for the
-        /// same reason `emitScroll` serializes: batch a fast key burst into one send instead of a
-        /// flood of concurrent, possibly-reordered SSH channels. (The alt-screen SCROLL path in
-        /// `handleScrollPan` still writes wheel/arrow sequences directly via `sendText`.)
+        /// Forward SwiftTerm's key→bytes translation to the PTY whenever direct input
+        /// is enabled and the terminal owns focus. This includes iPhone software-keyboard
+        /// input and iPad hardware-keyboard input. Serialized through `enqueueInput` so
+        /// a fast key burst becomes ordered batches rather than concurrent channels.
         func send(source: TerminalView, data: ArraySlice<UInt8>) {
             guard !stopped, let v = view, v.keyDriveEnabled, v.isFirstResponder else { return }
             enqueueInput(String(decoding: data, as: UTF8.self))
@@ -1053,7 +1122,14 @@ struct LiveTerminalView: UIViewRepresentable {
             }
             _ = try? await self.client.sendText(pane: self.paneID, text: batch)
         }
-        func scrolled(source: TerminalView, position: Double) {}
+        /// SwiftTerm reports a 0...1 scroll position (`TerminalViewDelegate.scrolled`).
+        /// A pane whose content fits the viewport can never be scrolled away from the
+        /// tail, so treat it as parked; otherwise it is at the tail only at the bottom.
+        func scrolled(source: TerminalView, position: Double) {
+            guard let view else { return }
+            let canScroll = view.contentSize.height > view.bounds.height + 1
+            reportTailState(atTail: !canScroll || position >= 0.999)
+        }
         func setTerminalTitle(source: TerminalView, title: String) {}
         func hostCurrentDirectoryUpdate(source: TerminalView, directory: String?) {}
         func requestOpenLink(source: TerminalView, link: String, params: [String: String]) {}
@@ -1193,6 +1269,18 @@ struct LiveTerminalView: UIViewRepresentable {
         /// lets our handler drive the agent scroll.
         func gestureRecognizer(_ g: UIGestureRecognizer,
                                shouldRecognizeSimultaneouslyWith other: UIGestureRecognizer) -> Bool { true }
+
+        /// The agent-scroll pan must not BEGIN when it has nothing to do, or when it
+        /// would fight a selection. On a plain shell pane `handleScrollPan` returns early
+        /// anyway; while a selection is active the drag belongs to SwiftTerm's lazily
+        /// installed drag-to-extend pan, which has no delegate of its own and so cannot
+        /// defend itself. Only this recognizer is gated, so the taps always begin.
+        func gestureRecognizerShouldBegin(_ g: UIGestureRecognizer) -> Bool {
+            guard g === scrollPan else { return true }
+            guard let view, !view.hasActiveSelection else { return false }
+            let term = view.getTerminal()
+            return term.isCurrentBufferAlternate || term.mouseMode != .off
+        }
 
         // MARK: palette helpers
 

--- a/App/LiveTerminalView.swift
+++ b/App/LiveTerminalView.swift
@@ -453,13 +453,21 @@ struct LiveTerminalView: UIViewRepresentable {
             // / Claude-Code wheel scroll is unaffected.
             view.allowMouseReporting = false
             // Track hardware-keyboard connect/disconnect so key-drive focus follows the keyboard.
-            // On connect the front pane becomes first responder (iPad-gated by keyDriveEnabled);
+            // On connect the front pane becomes first responder (gated by keyDriveEnabled);
             // on disconnect it resigns. Tokens removed in stop().
             keyboardObservers.append(
                 NotificationCenter.default.addObserver(forName: .GCKeyboardDidConnect, object: nil, queue: .main) { [weak self, weak view] _ in
-                    // keyDriveEnabled gate keeps this iPad-only (a BT keyboard on iPhone is a no-op,
-                    // preserving the read-only path). A keyboard attached MID-session also needs
-                    // mouse reporting off, or a tap could leak a mouse report through the now-live send.
+                    // NOT iPAD-ONLY ANY MORE. This comment used to say the keyDriveEnabled gate
+                    // "keeps this iPad-only (a BT keyboard on iPhone is a no-op, preserving the
+                    // read-only path)". That described the world before this PR: keyDriveEnabled
+                    // now includes .phone, so a Bluetooth keyboard connecting to an iPHONE also
+                    // makes the terminal first responder and drives the PTY. That follows from
+                    // iPhone typing being the feature, so it is intended — but it is UNVERIFIED,
+                    // since nothing here has been exercised with a BT keyboard on a phone, and a
+                    // comment claiming the old behaviour would have hidden that. Caught by review.
+                    //
+                    // A keyboard attached MID-session also needs mouse reporting off, or a tap
+                    // could leak a mouse report through the now-live send.
                     guard let self, let view, self.foreground, view.keyDriveEnabled else { return }
                     view.allowMouseReporting = false
                     _ = view.becomeFirstResponder()

--- a/App/LiveTerminalView.swift
+++ b/App/LiveTerminalView.swift
@@ -190,6 +190,26 @@ struct LiveTerminalView: UIViewRepresentable {
             }
             inputAccessoryView = nil
         }
+
+        /// EMULATOR REPLIES ARE NOT USER INPUT, and this pane is never the primary viewer
+        /// of its PTY, so it must not answer the host.
+        ///
+        /// SwiftTerm funnels two different things into ONE delegate callback. Typed input
+        /// arrives via `AppleTerminalView.send(data:)`, which calls `recordUserInput()`
+        /// first. Emulator-GENERATED answers arrive through THIS `open` TerminalDelegate
+        /// bridge (`iOSTerminalView.swift:1408`): focus reports CSI I and CSI O, DA, DSR
+        /// and CPR replies, OSC colour and OSC 52 answers, CSI-t window reports.
+        ///
+        /// Before iPhone typing existed, the delegate dropped everything on this idiom, so
+        /// none of it left the phone. Enabling typing enabled the replies with it, and the
+        /// desktop herdr owns the same PTY and already answers those queries, so a second
+        /// answerer produces duplicate or contradictory replies to one host request.
+        ///
+        /// Overriding here drops ONLY the reply bridge; typed input never comes through
+        /// this method, so it is untouched. Applied on EVERY idiom, not just phone: iPad
+        /// with a hardware keyboard has been forwarding these since key drive shipped, and
+        /// a co-viewer answering for the primary is wrong there for the same reason.
+        override func send(source: Terminal, data: ArraySlice<UInt8>) {}
         required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
     }
 

--- a/App/LiveTerminalView.swift
+++ b/App/LiveTerminalView.swift
@@ -108,16 +108,25 @@ struct LiveTerminalView: UIViewRepresentable {
         context.coordinator.onTailStateChange = onTailStateChange
         context.coordinator.performJumpToTail(ifTokenChanged: jumpToTailToken)
         context.coordinator.setForeground(isForeground)
-        // Drive terminal key focus from SwiftUI intent.
+        // Drive terminal responder ownership from SwiftUI intent.
         //
-        // A BACKGROUNDED pane always resigns, and drops its selection with it: a hidden
-        // pane holding a writable responder could otherwise take keystrokes for an agent
-        // nobody is looking at, because panes stay mounted and the `send` delegate is not
-        // foreground-gated by itself. Only a FOREGROUND pane mid-selection keeps its
-        // responder, which is what stops a SwiftUI body pass from hiding the Copy menu.
+        // RESPONDER OWNERSHIP AND KEY ROUTING ARE SEPARATE CONCERNS, and conflating them
+        // cost the Copy menu on iPad without a hardware keyboard: gating the *become* on
+        // `keyDriveEnabled` meant the responder was never taken there, and SwiftTerm's
+        // `doubleTap` selects without taking it either, so `canPerformAction` refused Copy.
+        // Owning the responder is free on every platform: iPhone shows its keyboard
+        // (which is wanted, it is how you type), and every other idiom has the zero-frame
+        // `emptyInputView`, so nothing appears. KEY ROUTING stays gated on
+        // `keyDriveEnabled` inside the `send` delegate, which is the only place it belongs.
+        //
+        // A BACKGROUNDED pane always resigns and drops its selection: a hidden pane
+        // holding a writable responder could otherwise take keystrokes for an agent nobody
+        // is looking at, because panes stay mounted. Ungated by idiom too, so the
+        // behaviour no longer differs by platform. Only a FOREGROUND pane mid-selection
+        // keeps its responder, which is what stops a SwiftUI body pass from hiding Copy.
         if wantsTerminalKeyFocus {
-            if uiView.keyDriveEnabled && !uiView.isFirstResponder { _ = uiView.becomeFirstResponder() }
-        } else if uiView.keyDriveEnabled, uiView.isFirstResponder {
+            if !uiView.isFirstResponder { _ = uiView.becomeFirstResponder() }
+        } else if uiView.isFirstResponder {
             if !isForeground {
                 uiView.clearSelection()
                 uiView.resignFirstResponder()
@@ -558,7 +567,11 @@ struct LiveTerminalView: UIViewRepresentable {
         }
 
         @objc private func handleTwoFingerTap(_ gr: UITapGestureRecognizer) {
-            guard gr.state == .ended else { return }
+            // `foreground` is defence in depth. Today a backgrounded pane is unreachable
+            // because the keep-alive container renders it `opacity(0)` and
+            // `allowsHitTesting(false)`, but this handler SENDS BYTES, so it should not
+            // depend on a host layout decision staying the way it is.
+            guard !stopped, foreground, gr.state == .ended else { return }
             jumpToTail()
         }
 
@@ -576,7 +589,10 @@ struct LiveTerminalView: UIViewRepresentable {
                 view.clearSelection()
                 return   // a tap that dismisses a selection must not also raise the keyboard
             }
-            guard view.keyDriveEnabled else { return }
+            // No `keyDriveEnabled` gate here. Taking the responder is what makes Copy
+            // available on SwiftTerm's double tap, which selects WITHOUT taking it, and it
+            // costs nothing on an idiom that cannot type (zero-frame `emptyInputView`).
+            // Whether keys actually route to the PTY is decided in `send`, not here.
             onTerminalFocusRequest?()
         }
 
@@ -1216,7 +1232,12 @@ struct LiveTerminalView: UIViewRepresentable {
             if gr.state == .ended || gr.state == .cancelled || gr.state == .failed {
                 view?.isScrollEnabled = true
             }
-            guard !stopped, let view else { return }   // teardown began — send nothing further
+            // `foreground` is defence in depth for the same reason as the two-finger tap:
+            // this path SENDS BYTES, and it should not rely on the keep-alive container
+            // continuing to make backgrounded panes non-hit-testable. Placed AFTER the
+            // isScrollEnabled restore above, so a pane backgrounded mid-drag still gets its
+            // native scroll back rather than being stranded disabled.
+            guard !stopped, foreground, let view else { return }   // teardown or hidden: send nothing
             let term = view.getTerminal()
             // omp (normal buffer + mouse off) scrolls natively; everything else we drive.
             guard term.isCurrentBufferAlternate || term.mouseMode != .off else { return }

--- a/App/LiveTerminalView.swift
+++ b/App/LiveTerminalView.swift
@@ -591,6 +591,7 @@ struct LiveTerminalView: UIViewRepresentable {
             for gr in view.gestureRecognizers ?? [] {
                 if let t = gr as? UITapGestureRecognizer, t.numberOfTapsRequired == 2 {
                     clearTap.require(toFail: t)
+                    clearTapRequirementCount += 1
                 }
             }
             view.addGestureRecognizer(clearTap)
@@ -715,6 +716,13 @@ struct LiveTerminalView: UIViewRepresentable {
         /// `disableSelectionPanGesture()`, so one call both redraws and removes the lazy
         /// extend pan.
         @objc private func handleClearSelectionTap(_ gr: UITapGestureRecognizer) {
+            // PUBLISHES AT ENTRY, before any guard, because the previous round could not tell
+            // "this handler never ran" from "it ran and bailed". CI reported pub=focusTap with the
+            // selection still active, which proved the touch reached the terminal and that clearTap
+            // produced nothing — but not which of those two it was. An entry publish separates
+            // them: pub=clearTapEntry means the recognizer fired and something below refused,
+            // pub=focusTap still means the recognizer itself never recognized.
+            publishSelectionProbe("clearTapEntry(state=\(gr.state.rawValue) requires=\(clearTapRequirementCount))")
             guard !stopped, foreground, gr.state == .ended, let view else { return }
             guard view.hasActiveSelection else { return }
             view.clearSelection()
@@ -1517,6 +1525,10 @@ struct LiveTerminalView: UIViewRepresentable {
         private var selectionProbe: UIView?
         /// Monotonic publish counter for the probe, so a reading can be told apart from a stale one.
         private var probePublishCount = 0
+        /// How many 2-tap recognizers `clearTap` was made to require the failure of, captured at
+        /// attach. Published by the probe so a test can see whether that chain was wired as
+        /// intended rather than inferring it from behaviour.
+        private var clearTapRequirementCount = 0
         /// How many times SwiftTerm has reported a grid change. Published by the probe because
         /// `processSizeChange` clears the selection on any rows/cols change, so a resize
         /// arriving late is one of the candidate explanations for a selection that vanishes —

--- a/App/LiveTerminalView.swift
+++ b/App/LiveTerminalView.swift
@@ -279,6 +279,11 @@ struct LiveTerminalView: UIViewRepresentable {
         /// defeat the release (review HIGH). Once stopped, `sendPTYSize` is inert.
         private var stopped = false
 
+        /// KVO token for the terminal's `contentOffset`, which is the only signal a FINGER scroll
+        /// produces that this layer can see. Retained because an `NSKeyValueObservation` stops
+        /// observing the moment it is released; invalidated in `stop()`.
+        private var offsetObservation: NSKeyValueObservation?
+
         /// Scrollback backfill: the in-flight `read` (source=.recent, ANSI) fetching history
         /// produced BEFORE the live stream connected, resolved to ANSI bytes (nil on empty /
         /// error / timeout). The FIRST reset awaits it once, to prepend history above the seed.
@@ -594,6 +599,9 @@ struct LiveTerminalView: UIViewRepresentable {
             // stays fully reachable via the list/sidebar, and their removal frees horizontal drag
             // for SwiftTerm's drag-to-extend selection. `onNavigate` is left wired but unused.)
             style(view)
+            // The finger-scroll half of the Latest pill's tail state. Wired here, after the
+            // gestures, so it is live for the reader's very first drag — the pill's primary case.
+            observeContentOffset(view)
             startBackfill()   // fetch history CONCURRENTLY with the stream; the first reset awaits it
             start()
         }
@@ -743,11 +751,24 @@ struct LiveTerminalView: UIViewRepresentable {
         /// been guessing between them. This publishes the state itself into an accessibility
         /// element so the test reads SwiftTerm's answer instead of inferring one.
         ///
-        /// UI-TEST BUILDS ONLY. Gated on the same `HERDR_SCREENSHOT_MOCK` launch environment
-        /// the mock transport uses, so a real build never allocates it, never attaches it to the
-        /// view tree, and cannot expose terminal contents to the accessibility layer. The label
-        /// carries the SELECTED LENGTH, never the selected text.
+        /// DEBUG BUILDS ONLY, AND THE PREVIOUS VERSION OF THIS PARAGRAPH WAS FALSE. It claimed the
+        /// label "carries the SELECTED LENGTH, never the selected text" while the code fourteen
+        /// lines below published the text, and the paragraph fourteen lines below said so — the
+        /// same comment contradicted itself, and the wrong half was the safety claim. A review
+        /// caught it.
+        ///
+        /// The runtime env check was also the ONLY gate. `MockTransport` and `ScreenshotMock` live
+        /// inside `#if DEBUG`, but this file had no `#if DEBUG` anywhere, so the probe compiled
+        /// into Release and a Release build launched with `HERDR_SCREENSHOT_MOCK` set would route
+        /// to a REAL pane while the probe attached to the view tree and published that pane's
+        /// selected text to the accessibility layer. Now compiled out entirely, so the env var is
+        /// defence in depth rather than the whole defence.
+        ///
+        /// What it publishes: sel, len, the selected TEXT, rows, cols, ydisp and a resize count.
+        /// The text is deliberate and is what made the row-space defect findable; it is safe only
+        /// because this cannot exist outside a DEBUG build fed by the canned mock transport.
         private func publishSelectionProbe() {
+            #if DEBUG
             guard ProcessInfo.processInfo.environment["HERDR_SCREENSHOT_MOCK"] != nil,
                   let view else { return }
             let probe: UIView
@@ -805,10 +826,13 @@ struct LiveTerminalView: UIViewRepresentable {
                 "sel=\(active ? 1 : 0) len=\(selected.count) text=<\(selected)> "
                 + "rows=\(term.rows) cols=\(term.cols) ydisp=\(term.buffer.yDisp) "
                 + "resizes=\(resizeCount)"
+            #endif
         }
 
         func stop() {
             stopped = true                  // no new resize/scroll may start after this
+            offsetObservation?.invalidate() // no tail-state publish from a torn-down pane
+            offsetObservation = nil
             view?.terminalDelegate = nil    // stop further SwiftTerm callbacks (sizeChanged)
             view?.isScrollEnabled = true    // restore native scroll if we disabled it mid-drag
                                             // (stop() also runs on .exited while on screen)
@@ -1399,6 +1423,20 @@ struct LiveTerminalView: UIViewRepresentable {
         /// SwiftTerm reports a 0...1 scroll position (`TerminalViewDelegate.scrolled`).
         /// A pane whose content fits the viewport can never be scrolled away from the
         /// tail, so treat it as parked; otherwise it is at the tail only at the bottom.
+        ///
+        /// THIS CALLBACK IS NOT ENOUGH ON ITS OWN, and relying on it shipped a broken Latest pill.
+        /// On iOS the only route to `terminalDelegate?.scrolled` is
+        /// `TerminalView.scrolled(source:yDisp:)` (iOSTerminalView.swift:1481), invoked solely from
+        /// `Terminal.scroll()` — i.e. when OUTPUT scrolls the buffer. A FINGER scroll takes a
+        /// different path entirely: `contentOffset.didSet` calls `syncYDispFromContentOffset()`,
+        /// which calls `Terminal.setViewYDisp(row)`, which assigns `buffer.yDisp` and notifies
+        /// NOBODY (Terminal.swift:5616-5619). So dragging back through scrollback on a quiet pane
+        /// never reached this method, `reportTailState(atTail: false)` never ran, and the pill that
+        /// exists to get the reader back to the live tail never appeared — in exactly the case a
+        /// reader needs it. Found by review, not by the receipt, because no test asserted the pill.
+        ///
+        /// `observeContentOffset()` covers the finger path. Both funnel through `reportTailState`,
+        /// which stays the single publisher and dedupes, so the two sources cannot double-publish.
         func scrolled(source: TerminalView, position: Double) {
             guard let view else { return }
             let canScroll = view.contentSize.height > view.bounds.height + 1
@@ -1412,6 +1450,45 @@ struct LiveTerminalView: UIViewRepresentable {
         /// later version added one). No-op: the read-only terminal never copies.
         func clipboardCopy(source: TerminalView, content: Data) {}
 
+        // MARK: finger-scroll tail state — the Latest pill's other half
+
+        /// KVO on the terminal's own `contentOffset`, which is the ONLY signal a finger scroll
+        /// produces that this layer can see (see `scrolled(source:position:)` for why the delegate
+        /// callback never fires on that path).
+        ///
+        /// KVO AND NOT THE SCROLL DELEGATE, deliberately. `TerminalView` is a `UIScrollView` that
+        /// declares `UIScrollViewDelegate` conformance and relies on being its own delegate;
+        /// assigning `view.delegate = self` to get `scrollViewDidScroll` would take that over, and
+        /// this repo has already paid for that once — the project notes record scrolling broken for
+        /// roughly seven builds after claiming SwiftTerm's scroll delegate. Observation is additive
+        /// and cannot displace anything.
+        ///
+        /// The tail test is the same arithmetic the delegate path uses, expressed in offsets
+        /// instead of a 0...1 position, so the two agree at the boundary: a pane whose content fits
+        /// cannot be scrolled away from the tail and is therefore always parked; otherwise it is at
+        /// the tail within one cell of the bottom. One cell rather than one point because
+        /// `contentOffset` lands on fractional values mid-deceleration, and a stricter bound made
+        /// the pill flicker on and off during a flick.
+        private func observeContentOffset(_ view: TerminalView) {
+            offsetObservation = view.observe(\.contentOffset, options: [.new]) { scroll, _ in
+                // Read the geometry SYNCHRONOUSLY, on whatever thread KVO fired on, then hop —
+                // matching this file's existing convention (`Task { @MainActor [weak self] }`) so
+                // Coordinator state is only ever touched on the main actor. Deliberately NOT
+                // `MainActor.assumeIsolated`: Coordinator is a plain NSObject rather than an
+                // actor-isolated type, and assumeIsolated TRAPS if the assumption is wrong, which
+                // would turn a diagnostic nicety into a crash on whatever thread UIKit chose.
+                let offsetY = scroll.contentOffset.y
+                let maxOffset = scroll.contentSize.height - scroll.bounds.height
+                Task { @MainActor [weak self] in
+                    guard let self, !self.stopped else { return }
+                    // `cellPixels()` returns UInt32, so convert rather than mixing numeric types.
+                    let slack = CGFloat(max(self.cellPixels().height, 1))
+                    let canScroll = maxOffset > 1
+                    self.reportTailState(atTail: !canScroll || offsetY >= maxOffset - slack)
+                }
+            }
+        }
+
         // MARK: alt-screen scroll — drag to scroll the AGENT's own view
 
         /// Accumulated vertical drag since the last emitted scroll tick.
@@ -1419,9 +1496,11 @@ struct LiveTerminalView: UIViewRepresentable {
         /// The alt-screen scroll pan recognizer, disabled on teardown so a drag can't
         /// send bytes to a pane that has exited/been replaced.
         private var scrollPan: UIPanGestureRecognizer?
-        /// UI-TEST ONLY diagnostic element (see `publishSelectionProbe`). Nil in every build
-        /// that does not launch with `HERDR_SCREENSHOT_MOCK`, so a shipped app neither
-        /// allocates it nor exposes it to the accessibility layer.
+        /// DEBUG-ONLY diagnostic element (see `publishSelectionProbe`, which is compiled out
+        /// entirely in Release). Also nil in a DEBUG build that does not launch with
+        /// `HERDR_SCREENSHOT_MOCK`, so it neither allocates nor reaches the accessibility layer
+        /// outside a UI-test run. The property itself is left ungated because nothing assigns it
+        /// outside that block; an unused optional costs a word and one `#if` less to get wrong.
         private var selectionProbe: UIView?
         /// How many times SwiftTerm has reported a grid change. Published by the probe because
         /// `processSizeChange` clears the selection on any rows/cols change, so a resize

--- a/App/LiveTerminalView.swift
+++ b/App/LiveTerminalView.swift
@@ -106,8 +106,11 @@ struct LiveTerminalView: UIViewRepresentable {
         context.coordinator.isFederated = isFederated
         context.coordinator.onTerminalFocusRequest = onTerminalFocusRequest
         context.coordinator.onTailStateChange = onTailStateChange
-        context.coordinator.performJumpToTail(ifTokenChanged: jumpToTailToken)
+        // setForeground BEFORE performJumpToTail, deliberately. The jump sends bytes and is
+        // now foreground-guarded, and a guard that reads a flag this pass has not yet
+        // written is not a guard at all.
         context.coordinator.setForeground(isForeground)
+        context.coordinator.performJumpToTail(ifTokenChanged: jumpToTailToken)
         // Drive terminal responder ownership from SwiftUI intent.
         //
         // RESPONDER OWNERSHIP AND KEY ROUTING ARE SEPARATE CONCERNS, and conflating them
@@ -119,18 +122,20 @@ struct LiveTerminalView: UIViewRepresentable {
         // `emptyInputView`, so nothing appears. KEY ROUTING stays gated on
         // `keyDriveEnabled` inside the `send` delegate, which is the only place it belongs.
         //
-        // A BACKGROUNDED pane always resigns and drops its selection: a hidden pane
-        // holding a writable responder could otherwise take keystrokes for an agent nobody
-        // is looking at, because panes stay mounted. Ungated by idiom too, so the
-        // behaviour no longer differs by platform. Only a FOREGROUND pane mid-selection
-        // keeps its responder, which is what stops a SwiftUI body pass from hiding Copy.
+        // A BACKGROUNDED pane drops its selection UNCONDITIONALLY and resigns if it holds
+        // the responder. The clear sits OUTSIDE the first-responder test on purpose: nested
+        // inside it, a pane holding a selection WITHOUT the responder kept it across
+        // backgrounding, so the sentence above was still not literally true. That is the
+        // third time this claim has been written wider than the code, so the code now
+        // matches the claim instead of the comment being narrowed again.
+        //
+        // Only a FOREGROUND pane mid-selection keeps its responder, which is what stops a
+        // SwiftUI body pass from hiding the Copy menu.
         if wantsTerminalKeyFocus {
             if !uiView.isFirstResponder { _ = uiView.becomeFirstResponder() }
-        } else if uiView.isFirstResponder {
-            if !isForeground {
-                uiView.clearSelection()
-                uiView.resignFirstResponder()
-            } else if !uiView.hasActiveSelection {
+        } else {
+            if !isForeground { uiView.clearSelection() }
+            if uiView.isFirstResponder, !isForeground || !uiView.hasActiveSelection {
                 uiView.resignFirstResponder()
             }
         }
@@ -483,18 +488,40 @@ struct LiveTerminalView: UIViewRepresentable {
             twoFingerTap.delegate = self
             twoFingerTap.cancelsTouchesInView = false
             view.addGestureRecognizer(twoFingerTap)
-            // Single tap clears a selection, else takes typing focus. It deliberately does
-            // NOT `require(toFail:)` SwiftTerm's double tap: SwiftTerm's `doubleTap`
-            // selects and presents its Copy menu WITHOUT calling `becomeFirstResponder`
-            // (only its long-press path does), and `canPerformAction` gates Copy on being
-            // first responder. Firing on tap 1 is what establishes the responder in time
-            // for tap 2's menu to offer Copy. Tap 1 is harmless otherwise: with nothing
-            // selected it only takes focus, and with something selected clearing it is
-            // exactly what a tap should do before a fresh word select.
-            let singleTap = UITapGestureRecognizer(target: self, action: #selector(handleTerminalTap(_:)))
-            singleTap.delegate = self
-            singleTap.cancelsTouchesInView = false
-            view.addGestureRecognizer(singleTap)
+            // TWO TAP RECOGNIZERS, ONE JOB EACH, and the split is load-bearing.
+            //
+            // A single recognizer doing both jobs DESTROYS THE SELECTION IT EXISTS TO
+            // ENABLE. It must not `require(toFail:)` SwiftTerm's double tap, because
+            // SwiftTerm's `doubleTap` selects and presents its Copy menu WITHOUT calling
+            // `becomeFirstResponder` (only its long press does) while `canPerformAction`
+            // gates Copy on being first responder, so firing on tap 1 is the only thing
+            // that makes Copy available. But without that failure requirement it ALSO
+            // fires on tap 2, and clearing a selection there wipes the word SwiftTerm just
+            // selected on the same touch-up. Both recognizers live on the same view with
+            // `shouldRecognizeSimultaneouslyWith` true and UIKit does not document their
+            // relative order, so it was a coin toss on whether word select survived.
+            //
+            // FOCUS TAP: no failure requirement, so it fires on tap 1 and establishes the
+            // responder in time for tap 2's menu. Taking focus is idempotent, so firing
+            // again on tap 2 costs nothing.
+            let focusTap = UITapGestureRecognizer(target: self, action: #selector(handleFocusTap(_:)))
+            focusTap.delegate = self
+            focusTap.cancelsTouchesInView = false
+            view.addGestureRecognizer(focusTap)
+            // CLEAR TAP: requires SwiftTerm's 2-tap recognizer to fail, exactly as
+            // SwiftTerm guards its own `singleTap` (setupGestures does
+            // `singleTap.require(toFail: doubleTap)` for this very reason). So it can only
+            // fire on a GENUINE single tap, never on tap 2 of a word select. SwiftTerm's
+            // doubleTap already requires its tripleTap, so this inherits the whole chain.
+            let clearTap = UITapGestureRecognizer(target: self, action: #selector(handleClearSelectionTap(_:)))
+            clearTap.delegate = self
+            clearTap.cancelsTouchesInView = false
+            for gr in view.gestureRecognizers ?? [] {
+                if let t = gr as? UITapGestureRecognizer, t.numberOfTapsRequired == 2 {
+                    clearTap.require(toFail: t)
+                }
+            }
+            view.addGestureRecognizer(clearTap)
             // (Removed: the horizontal swipe-between-agents recognizers. A finger/mouse drag to
             // SELECT text was triggering them and paging to an unwanted agent; agent switching
             // stays fully reachable via the list/sidebar, and their removal frees horizontal drag
@@ -514,7 +541,11 @@ struct LiveTerminalView: UIViewRepresentable {
         /// from `updateUIView` and from a UIKit gesture handler, both already on the
         /// main thread, and the async send hops explicitly.
         func jumpToTail() {
-            guard !stopped, let view else { return }
+            // `foreground` here too, matching the two byte-sending gesture handlers. Reached
+            // from `updateUIView` as well as from the two-finger tap, which is why
+            // `setForeground` now runs BEFORE `performJumpToTail`: guarding on a flag this
+            // pass has not yet written would guard nothing.
+            guard !stopped, foreground, let view else { return }
             let term = view.getTerminal()
             if term.isCurrentBufferAlternate || term.mouseMode != .off {
                 // Report the tail ONLY once the send has actually landed. Reporting up
@@ -575,25 +606,37 @@ struct LiveTerminalView: UIViewRepresentable {
             jumpToTail()
         }
 
-        /// A single tap first CLEARS an active selection, and takes typing focus only
-        /// when nothing was selected. SwiftTerm's own singleTap does the clear too, but
-        /// only when the view is ALREADY first responder (`if isFirstResponder { ... }
-        /// else { becomeFirstResponder() }`), so on an unfocused pane the tap was spent
-        /// taking focus and the selection survived. `clearSelection()` flips
-        /// `SelectionService.active`, whose setter notifies `selectionChanged(source:)`,
-        /// which calls `setNeedsDisplay` and `disableSelectionPanGesture()`, so one call
-        /// both redraws and removes the lazy extend pan.
-        @objc private func handleTerminalTap(_ gr: UITapGestureRecognizer) {
-            guard !stopped, foreground, gr.state == .ended, let view else { return }
-            if view.hasActiveSelection {
-                view.clearSelection()
-                return   // a tap that dismisses a selection must not also raise the keyboard
-            }
-            // No `keyDriveEnabled` gate here. Taking the responder is what makes Copy
-            // available on SwiftTerm's double tap, which selects WITHOUT taking it, and it
-            // costs nothing on an idiom that cannot type (zero-frame `emptyInputView`).
-            // Whether keys actually route to the PTY is decided in `send`, not here.
+        /// Establishes responder ownership, and NOTHING else. Fires on tap 1 of any tap
+        /// sequence because it carries no failure requirement, which is the only way the
+        /// responder exists in time for SwiftTerm's double-tap menu to offer Copy:
+        /// SwiftTerm's `doubleTap` selects without becoming first responder, and
+        /// `canPerformAction` returns `selection.active` for Copy only to a responder.
+        ///
+        /// Deliberately does NOT clear a selection. Clearing here fired on tap 2 as well
+        /// and wiped the word SwiftTerm had just selected on the same touch-up.
+        ///
+        /// No `keyDriveEnabled` gate: owning the responder costs nothing on an idiom that
+        /// cannot type (zero-frame `emptyInputView`), and whether keys reach the PTY is
+        /// decided in `send`.
+        @objc private func handleFocusTap(_ gr: UITapGestureRecognizer) {
+            guard !stopped, foreground, gr.state == .ended else { return }
             onTerminalFocusRequest?()
+        }
+
+        /// Clears an active selection on a GENUINE single tap. Guarded by
+        /// `require(toFail:)` against SwiftTerm's 2-tap recognizer at attach time, so it
+        /// cannot fire on tap 2 of a word select.
+        ///
+        /// SwiftTerm's own singleTap clears too, but only when the view is ALREADY first
+        /// responder, so on an unfocused pane its tap was spent taking focus and the
+        /// selection survived. `clearSelection()` flips `SelectionService.active`, whose
+        /// setter notifies `selectionChanged(source:)`, which calls `setNeedsDisplay` and
+        /// `disableSelectionPanGesture()`, so one call both redraws and removes the lazy
+        /// extend pan.
+        @objc private func handleClearSelectionTap(_ gr: UITapGestureRecognizer) {
+            guard !stopped, foreground, gr.state == .ended, let view else { return }
+            guard view.hasActiveSelection else { return }
+            view.clearSelection()
         }
 
         func stop() {

--- a/App/LiveTerminalView.swift
+++ b/App/LiveTerminalView.swift
@@ -58,11 +58,12 @@ struct LiveTerminalView: UIViewRepresentable {
     /// On iPhone this opens the software keyboard; on iPad it takes effect only with a
     /// hardware keyboard. Refreshed on every update.
     var wantsTerminalKeyFocus: Bool = false
-    /// True for the one body pass that follows a DELIBERATE collapse (the reply bar's chevron), as
-    /// opposed to the many incidental passes that also see `wantsTerminalKeyFocus == false`. Only a
-    /// deliberate collapse may resign the responder while a selection is held: see the resign
-    /// branch in `updateUIView` for what went wrong when the two were indistinguishable.
-    var collapseRequested: Bool = false
+    /// Bumped by the reply bar's chevron to request a DELIBERATE collapse, as opposed to the many
+    /// incidental body passes that also see `wantsTerminalKeyFocus == false`. Only a deliberate
+    /// collapse may resign the responder while a selection is held: see the resign branch in
+    /// `updateUIView`, both for what went wrong when the two were indistinguishable and for why
+    /// this is a monotonic token rather than a bool the host resets.
+    var collapseToken: Int = 0
     /// Called after a terminal tap requests direct PTY input. The parent owns the
     /// SwiftUI focus state so a reply submission can dismiss the keyboard reliably.
     var onTerminalFocusRequest: () -> Void = {}
@@ -152,13 +153,38 @@ struct LiveTerminalView: UIViewRepresentable {
             // this class of problem, so it failing in the PR's own headline flow is the worst place
             // for it.
             //
-            // `collapseRequested` distinguishes the two cases: an incidental pass still respects
-            // the selection, while a deliberate collapse resigns regardless and keeps the
-            // selection intact in the model. Resigning hides the system Copy menu, which is the
-            // honest consequence of asking for the keyboard to go away — and the selection is
-            // still there, so a double tap re-presents it without re-selecting.
-            if uiView.isFirstResponder, !isForeground || collapseRequested || !uiView.hasActiveSelection {
+            // `collapseToken` distinguishes the two cases: an incidental pass still respects the
+            // selection, while a deliberate collapse resigns regardless and keeps the selection
+            // intact in the model. Resigning hides the system Copy menu, which is the honest
+            // consequence of asking for the keyboard to go away — and the selection is still
+            // there, so a double tap re-presents it without re-selecting. Review endorsed that
+            // behaviour choice; what it rejected was my first MECHANISM for it.
+            //
+            // A MONOTONIC TOKEN, NOT A BOOL SET-AND-ASYNC-RESET, and this is the second defect
+            // review found in this one gate. My first fix set a `collapseRequested` flag and
+            // cleared it in `DispatchQueue.main.async`, intending "true for exactly the next body
+            // pass". That does not hold: the GCD main-queue drain runs BEFORE SwiftUI's deferred
+            // update flush, so this method would have observed the flag already false, refused the
+            // resign, and reproduced the very defect it was written to fix — an INERT fix that
+            // would have tested green as an unchanged bug.
+            //
+            // A token cannot be coalesced away. It carries no lifetime and no assumption about
+            // which pass reads it: whichever pass observes a value the Coordinator has not
+            // consumed is the collapse, and every later pass sees a consumed one. This is the
+            // pattern `performJumpToTail(ifTokenChanged:)` already uses two dozen lines up, so
+            // it is also the pattern this file had already settled on for exactly this problem.
+            //
+            // Consumed HERE rather than beside `performJumpToTail`, so a pass that re-requests
+            // focus cannot silently eat a collapse it was never going to act on.
+            let deliberateCollapse = context.coordinator.consumeCollapse(ifTokenChanged: collapseToken)
+            if uiView.isFirstResponder, !isForeground || deliberateCollapse || !uiView.hasActiveSelection {
                 uiView.resignFirstResponder()
+                // A READING FROM THE ONE PATH NO GESTURE HANDLER COVERS. Every other probe publish
+                // sits in a tap handler; this resign happens during a SwiftUI update, so without
+                // this call `fr` would only ever be sampled at gesture time and the collapse would
+                // stay unobservable — which is precisely how the inert first mechanism escaped.
+                // Compiled out in Release and inert without the mock env var.
+                context.coordinator.publishSelectionProbe(deliberateCollapse ? "collapseResign" : "passResign")
             }
         }
         context.coordinator.applyFont(size: fontSize)
@@ -688,6 +714,24 @@ struct LiveTerminalView: UIViewRepresentable {
             jumpToTail()
         }
 
+        /// The last collapse token this Coordinator has acted on. Starts at 0, matching the
+        /// host's initial `collapseToken`, so a freshly created pane does not read its own
+        /// initial state as a pending collapse request.
+        private var lastCollapseToken = 0
+
+        /// True for exactly ONE `updateUIView` pass per chevron tap — the pass that observes a
+        /// token the Coordinator has not consumed yet.
+        ///
+        /// Same shape as `performJumpToTail(ifTokenChanged:)` above and for the same reason: a
+        /// SwiftUI input cannot express "for the next pass only" as a bool the host resets,
+        /// because the host does not control when passes happen and any async reset races the
+        /// pass it was meant for. A monotonic counter needs no such timing assumption.
+        func consumeCollapse(ifTokenChanged token: Int) -> Bool {
+            guard token != lastCollapseToken else { return false }
+            lastCollapseToken = token
+            return true
+        }
+
         /// Publishes tail state to the host, and ONLY on a change, so scrolling cannot
         /// re-render SwiftUI on every frame.
         ///
@@ -696,7 +740,28 @@ struct LiveTerminalView: UIViewRepresentable {
         /// synchronous call would mutate SwiftUI `@State` during a view update, which
         /// SwiftUI warns about and can re-enter. The dedupe above stays synchronous, so
         /// deferring cannot publish a stale duplicate.
+        /// THE SINGLE PUBLISHER of tail state, and the single place the alternate screen is
+        /// judged — deliberately here rather than in each caller.
+        ///
+        /// Review found the alt-screen early return I had added to `scrolled(source:position:)`
+        /// was missing from `observeContentOffset`'s KVO hop, so a finger drag on an oversized
+        /// alt-screen grid could still publish `atTail: false` and fight the delegate path into
+        /// pill flicker. The narrow fix was to copy the guard into the KVO hop. That is a SITE
+        /// fix for what is plainly a CLASS defect: two publishers, one of them guarded, and
+        /// nothing stopping a third from being added unguarded.
+        ///
+        /// So the guard lives in the funnel every publisher already goes through, and each
+        /// caller now reports what it actually observed. A future publisher inherits the
+        /// alt-screen rule by construction instead of by whoever adds it remembering.
+        ///
+        /// WHY THE ALT SCREEN IS FORCED TO at-tail rather than left alone: a TUI pane keeps its
+        /// own viewport and is served by jumpToTail's Ctrl+End path, not by this pill, so the
+        /// honest report is "nothing to return to". `isCurrentBufferAlternate` is a synchronous
+        /// buffer-IDENTITY check, not a heuristic, so it cannot transiently lie on a normal
+        /// buffer — verified in the pinned SwiftTerm 1.15.0 by review.
         private func reportTailState(atTail: Bool) {
+            var atTail = atTail
+            if view?.getTerminal().isCurrentBufferAlternate == true { atTail = true }
             guard atTail != lastReportedAtTail else { return }
             lastReportedAtTail = atTail
             let publish = onTailStateChange
@@ -811,7 +876,7 @@ struct LiveTerminalView: UIViewRepresentable {
         /// What it publishes: sel, len, the selected TEXT, rows, cols, ydisp and a resize count.
         /// The text is deliberate and is what made the row-space defect findable; it is safe only
         /// because this cannot exist outside a DEBUG build fed by the canned mock transport.
-        private func publishSelectionProbe(_ publisher: String) {
+        fileprivate func publishSelectionProbe(_ publisher: String) {
             #if DEBUG
             guard ProcessInfo.processInfo.environment["HERDR_SCREENSHOT_MOCK"] != nil,
                   let view else { return }
@@ -872,10 +937,19 @@ struct LiveTerminalView: UIViewRepresentable {
             // spent a round on exactly that ambiguity: after a single tap the label still read
             // sel=1 text=<lazy>, which could have meant clearTap failed OR that the tap never
             // reached the terminal at all.
+            //
+            // `fr` IS THE RESPONDER STATE, added so the collapse chevron's contract is measurable
+            // at all. Review rejected this PR's first collapse mechanism as inert — a bool cleared
+            // in `DispatchQueue.main.async`, which drains before SwiftUI's update flush, so the
+            // resign would never have run. Nothing in the suite could have caught that, because
+            // "did the terminal give up the responder while keeping its selection" had no
+            // observable at all: an inert fix and a working one produced identical output. That is
+            // the worst shape a defect can have, so the observable comes with the fix.
             probePublishCount += 1
             probe.accessibilityLabel =
                 "sel=\(active ? 1 : 0) len=\(selected.count) text=<\(selected)> "
                 + "rows=\(term.rows) cols=\(term.cols) ydisp=\(term.buffer.yDisp) "
+                + "fr=\(view.isFirstResponder ? 1 : 0) "
                 + "resizes=\(resizeCount) pub=\(publisher)#\(probePublishCount)"
             #endif
         }
@@ -1487,26 +1561,22 @@ struct LiveTerminalView: UIViewRepresentable {
         /// reader needs it. Found by review, not by the receipt, because no test asserted the pill.
         ///
         /// `observeContentOffset()` covers the finger path. Both funnel through `reportTailState`,
-        /// which stays the single publisher and dedupes, so the two sources cannot double-publish.
+        /// which stays the single publisher, judges the alternate screen for both, and dedupes —
+        /// so the two sources cannot double-publish and neither can disagree with the other about
+        /// the alt buffer. The alt-screen guard that used to sit in this method has moved there;
+        /// see the note on `reportTailState` for why the caller is the wrong place for it.
+        ///
+        /// WHY THE ALT SCREEN NEEDED JUDGING AT ALL: AppleTerminalView.scrollPosition
+        /// short-circuits to 0 whenever the display buffer is the alternate one
+        /// (st_apple.swift:2012), while Terminal.scroll() notifies the delegate unconditionally
+        /// including on that buffer (Terminal.swift:5434). So on a Claude Code pane this callback
+        /// saw position 0 on EVERY output frame, and whenever the emulator grid exceeded the
+        /// laid-out view — the window before PTY-size negotiation settles, or a co-viewer
+        /// reclaiming the size — canScroll was true and atTail latched FALSE. The pill pinned
+        /// itself visible on a TUI pane where it cannot mean anything, and tapping it was undone
+        /// by the next frame.
         func scrolled(source: TerminalView, position: Double) {
             guard let view else { return }
-            // THE ALT SCREEN HAS NO MEANINGFUL POSITION, so do not publish one.
-            //
-            // AppleTerminalView.scrollPosition short-circuits to 0 whenever the display buffer is
-            // the alternate one (st_apple.swift:2012), while Terminal.scroll() notifies the delegate
-            // unconditionally including on that buffer (Terminal.swift:5434). So on a Claude Code
-            // pane this callback saw position 0 on EVERY output frame, and whenever the emulator
-            // grid exceeded the laid-out view — the window before PTY-size negotiation settles, or a
-            // co-viewer reclaiming the size — canScroll was true and atTail latched FALSE. The pill
-            // pinned itself visible on a TUI pane where it cannot mean anything, and tapping it was
-            // undone by the next frame. Reported by review as plausible; the short-circuit and the
-            // unconditional notify are both verified in the pinned source, so the guard is cheap
-            // insurance either way. A TUI pane keeps its own viewport and is served by
-            // jumpToTail's Ctrl+End path, not by this pill.
-            if view.getTerminal().isCurrentBufferAlternate {
-                reportTailState(atTail: true)
-                return
-            }
             let canScroll = view.contentSize.height > view.bounds.height + 1
             reportTailState(atTail: !canScroll || position >= 0.999)
         }

--- a/App/LiveTerminalView.swift
+++ b/App/LiveTerminalView.swift
@@ -696,6 +696,12 @@ struct LiveTerminalView: UIViewRepresentable {
         @objc private func handleFocusTap(_ gr: UITapGestureRecognizer) {
             guard !stopped, foreground, gr.state == .ended else { return }
             onTerminalFocusRequest?()
+            // Publishes because this recognizer has NO failure requirement, so it fires on tap 1
+            // of ANY tap that actually lands on the terminal. That makes it the discriminator for
+            // a tap that appears to do nothing: if the probe's publisher changes to focusTap, the
+            // touch reached the view and the fault is downstream in clearTap's require-to-fail
+            // chain; if it does not change at all, the tap missed the terminal entirely.
+            publishSelectionProbe("focusTap")
         }
 
         /// Clears an active selection on a GENUINE single tap. Guarded by
@@ -714,7 +720,7 @@ struct LiveTerminalView: UIViewRepresentable {
             view.clearSelection()
             // So a test can distinguish "the clear reached the view" from "the highlight
             // happened to stop being drawn". No-op outside UI-test builds.
-            publishSelectionProbe()
+            publishSelectionProbe("clearTap")
         }
 
         /// Re-present the Copy menu at the TAP POINT. Ordered AFTER SwiftTerm's own handler by
@@ -733,7 +739,7 @@ struct LiveTerminalView: UIViewRepresentable {
             let point = gr.location(in: view)
             DispatchQueue.main.async { [weak self] in
                 guard let self, !self.stopped, let view = self.view else { return }
-                self.publishSelectionProbe()   // records state even when the guards below refuse
+                self.publishSelectionProbe("menuTap")   // records state even when the guards below refuse
                 guard self.foreground, view.hasActiveSelection else { return }
                 view.showStandardContextMenu(at: point)
             }
@@ -767,7 +773,7 @@ struct LiveTerminalView: UIViewRepresentable {
         /// What it publishes: sel, len, the selected TEXT, rows, cols, ydisp and a resize count.
         /// The text is deliberate and is what made the row-space defect findable; it is safe only
         /// because this cannot exist outside a DEBUG build fed by the canned mock transport.
-        private func publishSelectionProbe() {
+        private func publishSelectionProbe(_ publisher: String) {
             #if DEBUG
             guard ProcessInfo.processInfo.environment["HERDR_SCREENSHOT_MOCK"] != nil,
                   let view else { return }
@@ -822,10 +828,17 @@ struct LiveTerminalView: UIViewRepresentable {
             // `yBase` is deliberately NOT published: it is internal to SwiftTerm (Buffer.swift:43
             // declares it without `public`, unlike yDisp at 58), so reading it would not compile.
             // Checked before pushing rather than after CI said so.
+            // `pub` names WHICH handler published this reading and counts publishes, so a test can
+            // tell "the handler ran and did nothing" from "the handler never ran". Without it, a
+            // stale reading from an earlier gesture is indistinguishable from a fresh one, and CI
+            // spent a round on exactly that ambiguity: after a single tap the label still read
+            // sel=1 text=<lazy>, which could have meant clearTap failed OR that the tap never
+            // reached the terminal at all.
+            probePublishCount += 1
             probe.accessibilityLabel =
                 "sel=\(active ? 1 : 0) len=\(selected.count) text=<\(selected)> "
                 + "rows=\(term.rows) cols=\(term.cols) ydisp=\(term.buffer.yDisp) "
-                + "resizes=\(resizeCount)"
+                + "resizes=\(resizeCount) pub=\(publisher)#\(probePublishCount)"
             #endif
         }
 
@@ -1502,6 +1515,8 @@ struct LiveTerminalView: UIViewRepresentable {
         /// outside a UI-test run. The property itself is left ungated because nothing assigns it
         /// outside that block; an unused optional costs a word and one `#if` less to get wrong.
         private var selectionProbe: UIView?
+        /// Monotonic publish counter for the probe, so a reading can be told apart from a stale one.
+        private var probePublishCount = 0
         /// How many times SwiftTerm has reported a grid change. Published by the probe because
         /// `processSizeChange` clears the selection on any rows/cols change, so a resize
         /// arriving late is one of the candidate explanations for a selection that vanishes —

--- a/App/LiveTerminalView.swift
+++ b/App/LiveTerminalView.swift
@@ -68,6 +68,11 @@ struct LiveTerminalView: UIViewRepresentable {
     /// Reports whether the pane is parked at its newest output. Invoked ONLY when
     /// the value changes, so it cannot re-render SwiftUI on every scroll frame.
     var onTailStateChange: (Bool) -> Void = { _ in }
+    /// The host's CURRENT belief about tail state, used to seed a fresh Coordinator on
+    /// a remount. Without it a `streamGen` remount resets the Coordinator's baseline to
+    /// `true` while the host still holds `false`, and the next jump's `atTail: true`
+    /// dedupes away as "no change", leaving the pill visible after a completed jump.
+    var isAtTail: Bool = true
     /// Terminal font size in points (the `terminal.fontSize` preference). Applied
     /// in-place via `Coordinator.applyFont` when it changes — re-lays-out the grid,
     /// no view recreation.
@@ -87,6 +92,11 @@ struct LiveTerminalView: UIViewRepresentable {
         context.coordinator.onNavigate = onNavigate
         context.coordinator.isFederated = isFederated
         context.coordinator.onTerminalFocusRequest = onTerminalFocusRequest
+        // SEED both baselines from the host before the first `updateUIView`. A remount
+        // (the header refresh bumps `streamGen`) builds a fresh Coordinator while the
+        // host's `@State` survives, so defaulting them replays the last jump as a second
+        // Ctrl+End and mis-dedupes the tail callback.
+        context.coordinator.seedBaselines(jumpToTailToken: jumpToTailToken, atTail: isAtTail)
         context.coordinator.attach(view)
         return view
     }
@@ -98,14 +108,22 @@ struct LiveTerminalView: UIViewRepresentable {
         context.coordinator.onTailStateChange = onTailStateChange
         context.coordinator.performJumpToTail(ifTokenChanged: jumpToTailToken)
         context.coordinator.setForeground(isForeground)
-        // Drive terminal key focus from SwiftUI intent. The resign is gated on
-        // `keyDriveEnabled` so it manages only writable-terminal focus, and on
-        // `hasActiveSelection` so a SwiftUI body pass cannot yank first responder
-        // out from under a live selection (resigning hides the Copy menu).
+        // Drive terminal key focus from SwiftUI intent.
+        //
+        // A BACKGROUNDED pane always resigns, and drops its selection with it: a hidden
+        // pane holding a writable responder could otherwise take keystrokes for an agent
+        // nobody is looking at, because panes stay mounted and the `send` delegate is not
+        // foreground-gated by itself. Only a FOREGROUND pane mid-selection keeps its
+        // responder, which is what stops a SwiftUI body pass from hiding the Copy menu.
         if wantsTerminalKeyFocus {
             if uiView.keyDriveEnabled && !uiView.isFirstResponder { _ = uiView.becomeFirstResponder() }
-        } else if uiView.keyDriveEnabled, uiView.isFirstResponder, !uiView.hasActiveSelection {
-            uiView.resignFirstResponder()
+        } else if uiView.keyDriveEnabled, uiView.isFirstResponder {
+            if !isForeground {
+                uiView.clearSelection()
+                uiView.resignFirstResponder()
+            } else if !uiView.hasActiveSelection {
+                uiView.resignFirstResponder()
+            }
         }
         context.coordinator.applyFont(size: fontSize)
     }
@@ -283,11 +301,21 @@ struct LiveTerminalView: UIViewRepresentable {
         /// Refreshed by `updateUIView`.
         var onTailStateChange: ((Bool) -> Void)?
         /// Last `jumpToTailToken` this Coordinator executed, so one increment performs
-        /// exactly one jump even though `updateUIView` runs on every body pass.
+        /// exactly one jump even though `updateUIView` runs on every body pass. SEEDED
+        /// from the host at `makeUIView`, because a remount builds a fresh Coordinator
+        /// while the host's token survives: defaulting to 0 would replay the last jump.
         private var lastJumpToTailToken = 0
-        /// Last value published through `onTailStateChange`. Starts true so a pane that
-        /// has never been scrolled publishes nothing.
+        /// Last value published through `onTailStateChange`. Also seeded from the host,
+        /// so a remount cannot dedupe away the next genuine transition.
         private var lastReportedAtTail = true
+
+        /// Adopt the host's current jump token and tail belief WITHOUT acting on either.
+        /// Called once per Coordinator, before `attach`, so a `streamGen` remount neither
+        /// re-sends a jump it already performed nor swallows the next tail callback.
+        func seedBaselines(jumpToTailToken: Int, atTail: Bool) {
+            lastJumpToTailToken = jumpToTailToken
+            lastReportedAtTail = atTail
+        }
 
         /// Per-pane geometry-ownership generation. Each `attach` for a pane id bumps this and
         /// records the value it claimed; the releasing `lock:false` — which can be DELAYED
@@ -446,18 +474,17 @@ struct LiveTerminalView: UIViewRepresentable {
             twoFingerTap.delegate = self
             twoFingerTap.cancelsTouchesInView = false
             view.addGestureRecognizer(twoFingerTap)
-            // Single tap clears a selection, else takes typing focus. It must defer to
-            // SwiftTerm's own double tap exactly as SwiftTerm's singleTap does, or tap 1
-            // of a word-select would fire it. SwiftTerm's doubleTap already requires its
-            // tripleTap, so requiring the 2-tap recognizer inherits the whole chain.
+            // Single tap clears a selection, else takes typing focus. It deliberately does
+            // NOT `require(toFail:)` SwiftTerm's double tap: SwiftTerm's `doubleTap`
+            // selects and presents its Copy menu WITHOUT calling `becomeFirstResponder`
+            // (only its long-press path does), and `canPerformAction` gates Copy on being
+            // first responder. Firing on tap 1 is what establishes the responder in time
+            // for tap 2's menu to offer Copy. Tap 1 is harmless otherwise: with nothing
+            // selected it only takes focus, and with something selected clearing it is
+            // exactly what a tap should do before a fresh word select.
             let singleTap = UITapGestureRecognizer(target: self, action: #selector(handleTerminalTap(_:)))
             singleTap.delegate = self
             singleTap.cancelsTouchesInView = false
-            for gr in view.gestureRecognizers ?? [] {
-                if let t = gr as? UITapGestureRecognizer, t.numberOfTapsRequired == 2 {
-                    singleTap.require(toFail: t)
-                }
-            }
             view.addGestureRecognizer(singleTap)
             // (Removed: the horizontal swipe-between-agents recognizers. A finger/mouse drag to
             // SELECT text was triggering them and paging to an unwanted agent; agent switching
@@ -481,9 +508,19 @@ struct LiveTerminalView: UIViewRepresentable {
             guard !stopped, let view else { return }
             let term = view.getTerminal()
             if term.isCurrentBufferAlternate || term.mouseMode != .off {
+                // Report the tail ONLY once the send has actually landed. Reporting up
+                // front cleared the pill while a rejected or dropped Ctrl+End left the
+                // agent's viewport exactly where it was, so the reader lost the affordance
+                // and the state lied at the same time.
                 Task { @MainActor [weak self] in
                     guard let self, !self.stopped else { return }
-                    _ = try? await self.client.sendText(pane: self.paneID, text: "\u{1b}[1;5F")
+                    do {
+                        _ = try await self.client.sendText(pane: self.paneID, text: "\u{1b}[1;5F")
+                        self.reportTailState(atTail: true)
+                    } catch {
+                        // Keep `lastReportedAtTail` untouched, so the pill stays up and the
+                        // reader can retry. A failed jump must not read as a completed one.
+                    }
                 }
             } else {
                 // animated:false — an animated jump is cancelled mid-flight on a streaming
@@ -492,8 +529,9 @@ struct LiveTerminalView: UIViewRepresentable {
                 // syncYDispFromContentOffset synchronously and re-engages auto-follow.
                 let maxY = max(0, view.contentSize.height - view.bounds.height)
                 view.setContentOffset(CGPoint(x: 0, y: maxY), animated: false)
+                // Synchronous and cannot fail, so the tail is true right now.
+                reportTailState(atTail: true)
             }
-            reportTailState(atTail: true)
         }
 
         /// Executes one jump per token increment. `updateUIView` runs on every SwiftUI
@@ -533,7 +571,7 @@ struct LiveTerminalView: UIViewRepresentable {
         /// which calls `setNeedsDisplay` and `disableSelectionPanGesture()`, so one call
         /// both redraws and removes the lazy extend pan.
         @objc private func handleTerminalTap(_ gr: UITapGestureRecognizer) {
-            guard !stopped, gr.state == .ended, let view else { return }
+            guard !stopped, foreground, gr.state == .ended, let view else { return }
             if view.hasActiveSelection {
                 view.clearSelection()
                 return   // a tap that dismisses a selection must not also raise the keyboard
@@ -1051,7 +1089,11 @@ struct LiveTerminalView: UIViewRepresentable {
         /// input and iPad hardware-keyboard input. Serialized through `enqueueInput` so
         /// a fast key burst becomes ordered batches rather than concurrent channels.
         func send(source: TerminalView, data: ArraySlice<UInt8>) {
-            guard !stopped, let v = view, v.keyDriveEnabled, v.isFirstResponder else { return }
+            // `foreground` is part of the guard, not just first-responder status. Panes stay
+            // MOUNTED when another is fronted, and a pane that held a selection keeps its
+            // responder for a moment, so first-responder alone would let a keystroke reach
+            // an agent nobody is looking at.
+            guard !stopped, foreground, let v = view, v.keyDriveEnabled, v.isFirstResponder else { return }
             enqueueInput(String(decoding: data, as: UTF8.self))
         }
 

--- a/App/LiveTerminalView.swift
+++ b/App/LiveTerminalView.swift
@@ -528,6 +528,37 @@ struct LiveTerminalView: UIViewRepresentable {
             focusTap.delegate = self
             focusTap.cancelsTouchesInView = false
             view.addGestureRecognizer(focusTap)
+            // MENU TAP: repositions the Copy menu SwiftTerm puts in the wrong place, and
+            // does nothing else. A review measured the menu overlapping the pane header —
+            // the back chevron, the title, the NEEDS YOU badge and the refresh icon.
+            //
+            // The cause is upstream and it is a coordinate-space bug:
+            // `makeContextMenuRegionForSelection()` builds its avoid-rect as
+            // `CGRect(y: CGFloat(selection.start.row) * cellDimension.height, ...)` from a
+            // BUFFER position, while the renderer correctly subtracts `yDisp` when it draws.
+            // With scrollback that y is thousands of points below the view, so UIMenuController
+            // clamps the menu to the top of the window. `makeContextMenuRegionForTap(point:)`
+            // is view-relative and correct, which is why long-press places the menu properly.
+            // This PR is what makes the double-tap menu reachable on iPhone, so it ships the
+            // defect and owns fixing it.
+            //
+            // A DEDICATED 2-TAP RECOGNIZER, not a branch inside `focusTap`. focusTap fires on
+            // tap 1 AND tap 2, so gating there would need to know whether SwiftTerm's handler
+            // had already run — the exact undocumented ordering this file's tap split exists to
+            // stop depending on. This one fires only on tap 2 by construction, and the async
+            // hop guarantees SwiftTerm's `doubleTap` has finished whichever order UIKit chose,
+            // because both handlers run in the same runloop turn and this block runs after it.
+            //
+            // It re-presents only; `showStandardContextMenu(at:)` computes a region and a hit
+            // and shows the menu, and does not re-select, so the word SwiftTerm just selected
+            // survives. It takes no responder and requires nothing to fail, so it cannot
+            // starve or reorder the existing chain. Declared BEFORE `clearTap` so that
+            // recognizer's "every 2-tap recognizer must fail" loop keeps meaning exactly that.
+            let menuTap = UITapGestureRecognizer(target: self, action: #selector(handleMenuRepositionTap(_:)))
+            menuTap.numberOfTapsRequired = 2
+            menuTap.delegate = self
+            menuTap.cancelsTouchesInView = false
+            view.addGestureRecognizer(menuTap)
             // CLEAR TAP: requires SwiftTerm's 2-tap recognizer to fail, exactly as
             // SwiftTerm guards its own `singleTap` (setupGestures does
             // `singleTap.require(toFail: doubleTap)` for this very reason). So it can only
@@ -657,6 +688,30 @@ struct LiveTerminalView: UIViewRepresentable {
             guard !stopped, foreground, gr.state == .ended, let view else { return }
             guard view.hasActiveSelection else { return }
             view.clearSelection()
+        }
+
+        /// Re-present the Copy menu at the TAP POINT, because SwiftTerm positions the
+        /// double-tap menu from a buffer-relative rect and UIMenuController then clamps it
+        /// over the pane header (see the `menuTap` comment in `attach`).
+        ///
+        /// The async hop is the whole reason this is order-independent: SwiftTerm's `doubleTap`
+        /// and this recognizer both fire in the same runloop turn in an order UIKit does not
+        /// document, and this block runs after that turn, so the selection and SwiftTerm's own
+        /// (mis-placed) presentation have both already happened.
+        ///
+        /// Guarded on a selection actually existing, so a double tap that selects nothing —
+        /// blank space past the end of a line yields an EMPTY range, which SwiftTerm still
+        /// marks active but paints nothing — does not get a menu moved onto it. `foreground`
+        /// is re-checked inside the hop: a pane can be backgrounded between the tap and the
+        /// hop, and a hidden pane must not present a menu.
+        @objc private func handleMenuRepositionTap(_ gr: UITapGestureRecognizer) {
+            guard !stopped, foreground, gr.state == .ended, let view else { return }
+            let point = gr.location(in: view)
+            DispatchQueue.main.async { [weak self] in
+                guard let self, !self.stopped, self.foreground, let view = self.view else { return }
+                guard view.hasActiveSelection else { return }
+                view.showStandardContextMenu(at: point)
+            }
         }
 
         func stop() {

--- a/App/LiveTerminalView.swift
+++ b/App/LiveTerminalView.swift
@@ -785,9 +785,26 @@ struct LiveTerminalView: UIViewRepresentable {
             let active = view.hasActiveSelection
             let selected = view.getSelection() ?? ""
             let term = view.getTerminal()
+            // yDisp IS THE LAST DISCRIMINATOR, and it is public (`Terminal.buffer` is
+            // `public private(set)`, `Buffer.yDisp` is `public`), so no internals are needed.
+            //
+            // The run at 001a092a reported a real three-character selection of "187" with ZERO
+            // painted pixels, deterministically in both passes. The fixture numbers its lines, so
+            // that text identifies the selection's line: "187" is 1-indexed, hence buffer row 186.
+            // Publishing yDisp lets the test decide, arithmetically rather than by inference,
+            // between the only two remaining explanations:
+            //   186 inside [yDisp, yDisp + rows - 1]  => the selection sits on a row being drawn,
+            //                                            so the PAINT is broken;
+            //   186 outside that window               => the selection sits on a row nobody draws,
+            //                                            so the tap's ROW SPACE is wrong after all.
+            // Both were reached by reading and neither survived; this settles it by measurement.
+            // `yBase` is deliberately NOT published: it is internal to SwiftTerm (Buffer.swift:43
+            // declares it without `public`, unlike yDisp at 58), so reading it would not compile.
+            // Checked before pushing rather than after CI said so.
             probe.accessibilityLabel =
                 "sel=\(active ? 1 : 0) len=\(selected.count) text=<\(selected)> "
-                + "rows=\(term.rows) cols=\(term.cols) resizes=\(resizeCount)"
+                + "rows=\(term.rows) cols=\(term.cols) ydisp=\(term.buffer.yDisp) "
+                + "resizes=\(resizeCount)"
         }
 
         func stop() {

--- a/HerdrUITests/TerminalSelectionTests.swift
+++ b/HerdrUITests/TerminalSelectionTests.swift
@@ -1,25 +1,32 @@
 import XCTest
+import UIKit
 
 /// THE REGRESSION RECEIPT for double-tap word selection.
 ///
 /// A review found the repaired behaviour unguarded: a compiling mutant that removes
 /// `clearTap.require(toFail: t)` restores the original defect, where the app's own tap
 /// recognizer clears the word SwiftTerm selected on the SAME touch-up, and nothing in the
-/// suite noticed. This file is the guard.
+/// suite noticed.
 ///
-/// It uses PIXEL DIFF rather than accessibility, for two reasons. SwiftTerm draws the
-/// selection highlight and its two handle ellipses with CoreGraphics, so there is no
-/// element to query; and the Copy affordance rides on `UIMenuController`, deprecated at
-/// iOS 16, so asserting on the menu would couple this receipt to an API whose survival is
-/// exactly what nobody can currently promise. Pixels are the thing a person sees.
+/// THE FIRST VERSION OF THIS FILE WAS PIXEL-BASED AND WAS WEAK, which its own CI run
+/// exposed. It asserted "the selection is still there" by diffing against the pre-selection
+/// baseline, and ANY difference satisfied that, including SwiftTerm's context menu simply
+/// being on screen. The final assertion then failed with a diff of exactly 0.0, which is the
+/// signature of a screen where nothing was left to change: the earlier step had passed for
+/// the wrong reason. Pixels cannot tell a selection from a popover.
 ///
-/// Structure mirrors ScrollTests: prove the terminal is STATIC first, so a later diff
-/// cannot be ambient animation.
+/// So this asserts on the CLIPBOARD instead, which cannot be satisfied by accident: a word
+/// only reaches the pasteboard if a selection existed AND Copy acted on it. That also
+/// settles, rather than assumes, the open question about `UIMenuController` being deprecated
+/// at iOS 16: if the menu never presents, this test says so directly.
 final class TerminalSelectionTests: XCTestCase {
 
-    override func setUp() { continueAfterFailure = false }
+    override func setUp() {
+        continueAfterFailure = false
+        UIPasteboard.general.string = ""   // a stale clipboard would fake a pass
+    }
 
-    func testDoubleTapSelectionSurvivesAndASingleTapClearsIt() {
+    func testDoubleTapSelectsAWordCopyWorksAndASingleTapDismisses() {
         let app = XCUIApplication()
         app.launchEnvironment["HERDR_SCREENSHOT_MOCK"] = "scroll"
         app.launch()
@@ -27,8 +34,8 @@ final class TerminalSelectionTests: XCTestCase {
         // The mock feeds 200 numbered lines into a real SwiftTerm view asynchronously.
         Thread.sleep(forTimeInterval: 3.0)
 
-        // (1) PREMISE: an untouched terminal is static. Without this, every diff below
-        // could be a cursor blink or a stream repaint rather than a selection.
+        // (1) PREMISE: an untouched terminal is static, so a later pixel change means the
+        // gesture did something rather than the stream repainting under us.
         let baseline = app.screenshot()
         Thread.sleep(forTimeInterval: 1.0)
         let idleDiff = pixelDiffFraction(baseline, app.screenshot())
@@ -36,40 +43,45 @@ final class TerminalSelectionTests: XCTestCase {
         XCTAssertLessThan(idleDiff, 0.02,
                           "terminal is not static when untouched (diff=\(idleDiff)); no later diff would mean anything")
 
-        // (2) DOUBLE TAP on terminal text. Mid-body: below the header, above the reply bar,
-        // matching the drag origin ScrollTests uses.
-        let word = app.coordinate(withNormalizedOffset: CGVector(dx: 0.35, dy: 0.45))
-        word.doubleTap()
+        // (2) DOUBLE TAP on terminal text: mid-body, below the header and above the reply
+        // bar, matching the drag origin ScrollTests uses.
+        app.coordinate(withNormalizedOffset: CGVector(dx: 0.35, dy: 0.45)).doubleTap()
         Thread.sleep(forTimeInterval: 1.0)
-
         let selected = app.screenshot()
         attach(selected, name: "02-after-double-tap")
-        let selectionDiff = pixelDiffFraction(baseline, selected)
-        XCTAssertGreaterThan(selectionDiff, 0.005,
-                             "double tap drew nothing (diff=\(selectionDiff)); word select is not reaching SwiftTerm")
+        XCTAssertGreaterThan(pixelDiffFraction(baseline, selected), 0.005,
+                             "double tap drew nothing at all; word select is not reaching SwiftTerm")
 
-        // (3) THE REGRESSION ITSELF: the selection must still be there a moment later.
-        // With one recognizer doing both jobs, the app's tap fired on tap 2 as well and
-        // cleared the selection on the same touch-up, so this is where that defect shows.
-        Thread.sleep(forTimeInterval: 1.5)
-        let held = app.screenshot()
-        attach(held, name: "03-selection-held")
-        let heldVsBaseline = pixelDiffFraction(baseline, held)
-        XCTAssertGreaterThan(heldVsBaseline, 0.005,
-                             "the selection vanished on its own (diff vs baseline=\(heldVsBaseline)); the clear tap is firing on tap 2")
+        // (3) THE COPY PATH. SwiftTerm presents Copy through UIMenuController, and
+        // canPerformAction only offers it while a selection is active, so the item existing
+        // IS the proof that a selection survived the same touch-up that created it. This is
+        // where the mutant shows: with the clear tap firing on tap 2, there is no selection
+        // by now and no Copy item.
+        let copy = app.menuItems["Copy"]
+        XCTAssertTrue(copy.waitForExistence(timeout: 4),
+                      "no Copy item after a double tap. Either the selection was cleared on the same touch-up (the regression this file guards) or UIMenuController no longer presents on this OS, which is a finding in its own right")
 
-        // (4) A GENUINE SINGLE TAP elsewhere must clear it, so the fix did not simply
-        // disable deselection. Tapped well away from the selected word.
+        copy.tap()
+        Thread.sleep(forTimeInterval: 1.0)
+
+        // (4) THE UNAMBIGUOUS ASSERTION: a word is on the clipboard. Nothing but a real
+        // selection plus a working Copy can produce this.
+        let pasted = UIPasteboard.general.string ?? ""
+        XCTAssertFalse(pasted.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+                       "Copy put nothing on the clipboard, so no selection was actually held")
+        // The mock seeds numbered lines, so whatever was selected should be printable text
+        // rather than control bytes.
+        XCTAssertNil(pasted.rangeOfCharacter(from: CharacterSet.controlCharacters.subtracting(.whitespacesAndNewlines)),
+                     "clipboard holds control bytes (\(pasted.debugDescription)); that is not selected screen text")
+
+        // (5) DESELECTION still works, so the fix did not simply disable it. A genuine
+        // single tap must leave no Copy item behind, which is a state assertion rather than
+        // a pixel guess.
         app.coordinate(withNormalizedOffset: CGVector(dx: 0.75, dy: 0.70)).tap()
-        Thread.sleep(forTimeInterval: 1.5)
-
-        let cleared = app.screenshot()
-        attach(cleared, name: "04-after-single-tap")
-        let clearedVsHeld = pixelDiffFraction(held, cleared)
-        XCTAssertGreaterThan(clearedVsHeld, 0.002,
-                             "a single tap changed nothing (diff=\(clearedVsHeld)); deselection is not reaching the view")
-        XCTAssertLessThan(pixelDiffFraction(baseline, cleared), heldVsBaseline,
-                          "after a single tap the terminal should be CLOSER to its unselected baseline than it was while selected")
+        Thread.sleep(forTimeInterval: 2.0)
+        attach(app.screenshot(), name: "03-after-single-tap")
+        XCTAssertFalse(app.menuItems["Copy"].exists,
+                       "a genuine single tap left the selection up; deselection is not reaching the view")
     }
 
     // MARK: - helpers (duplicated from ScrollTests, which keeps them private)
@@ -81,8 +93,8 @@ final class TerminalSelectionTests: XCTestCase {
         add(a)
     }
 
-    /// Fraction of pixels that differ beyond a small per-pixel threshold, compared at a
-    /// fixed small resolution so PNG jitter and antialiasing do not register as change.
+    /// Fraction of pixels differing beyond a small per-pixel threshold, compared at a fixed
+    /// small resolution so PNG jitter and antialiasing do not register as change.
     private func pixelDiffFraction(_ a: XCUIScreenshot, _ b: XCUIScreenshot) -> Double {
         let w = 90, h = 180
         guard let bufA = rgbaBuffer(a.image, w: w, h: h),

--- a/HerdrUITests/TerminalSelectionTests.swift
+++ b/HerdrUITests/TerminalSelectionTests.swift
@@ -3,12 +3,21 @@ import UIKit
 
 /// THE REGRESSION RECEIPT for double-tap word selection.
 ///
-/// A review found the repaired behaviour unguarded: a compiling mutant that removes
-/// `clearTap.require(toFail: t)` restores the original defect, where the app's own tap
-/// recognizer clears the word SwiftTerm selected on the SAME touch-up, and nothing in the
-/// suite noticed.
+/// WHAT IT DOES AND DOES NOT GUARD, stated first because the previous version of this comment
+/// claimed the wrong thing. A review found the repaired behaviour unguarded by a mutant that
+/// removes `clearTap.require(toFail: t)` — and a LATER review showed this receipt does not kill
+/// that mutant either, for a timing reason neither of us had accounted for: without the failure
+/// requirement `clearTap` recognizes at tap-2 touch-up, which is STRICTLY BEFORE SwiftTerm's
+/// tripleTap-delayed `doubleTap` selects the word. The clear lands on the pre-tap state, the
+/// selection is made ~0.3s later, the highlight paints, and this test passes.
 ///
-/// THIS FILE HAS BEEN WRONG THREE TIMES, always about its own instrument and never about the
+/// The same timing implies the mutant is largely BENIGN in production, so the original P1 was a
+/// reasoned coin-toss rather than a measured wipe. What this file does guard: no highlight at
+/// all, a selection that is active but EMPTY, a selection SwiftTerm holds but does not paint,
+/// and a deselection that never reaches the view. Those are real and it has caught three of
+/// them. It is not a guard on the require(toFail:) line, and saying so was overclaiming.
+///
+/// THIS FILE HAS NOW BEEN WRONG FOUR TIMES, always about its own instrument and never about the
 /// product code. Each lesson is kept because each was independently discoverable and I missed
 /// it:
 ///
@@ -22,25 +31,39 @@ import UIKit
 ///    HerdrApp.swift:685, both saying the app writes and never reads because that prompt
 ///    failed App Review under 2.1a.
 /// 3. A COPY MENU IS NOT A SELECTION. v3 asserted `menuItems["Copy"].exists`. A reviewer
-///    downloaded the CI artifacts and measured SwiftTerm's `selectedTextBackgroundColor`
-///    (0,166,178) at 0 of 3,162,132 pixels in every frame — while Copy WAS present. The cause
-///    is in SwiftTerm's own code: `selectedColumnsRange` yields an EMPTY range when
-///    `startCol == endCol`, so double-tapping blank space leaves `selection.active == true`
-///    with nothing selected and nothing painted, and `canPerformAction` offers Copy anyway.
-///    Both of v3's taps were also mis-aimed: dx=0.35 lands past the end of these short
-///    numbered lines, and dy=0.70 lands on the software keyboard, which occupies the bottom
-///    ~40% and would type into a live agent's PTY.
+///    measured SwiftTerm's `selectedTextBackgroundColor` at 0 of 3,162,132 pixels in every
+///    frame while Copy WAS present: `selectedColumnsRange` yields an EMPTY range when
+///    `startCol == endCol`, so a tap off the glyphs leaves `selection.active == true` with
+///    nothing selected and nothing painted, and `canPerformAction` offers Copy anyway.
+/// 4. A PIXEL COUNT CANNOT NAME A CAUSE. v4 measured the highlight and reported "teal px=0"
+///    twice, which is consistent with four different bugs. I diagnosed it twice from that one
+///    number and was wrong both times — first a keyboard-relayout race, then coordinates. So
+///    the app now publishes SwiftTerm's own selection state under the mock env var and this
+///    reads it, asserting STATE before PIXELS so a failure says which layer broke.
 ///
-/// So this version measures THE HIGHLIGHT ITSELF, with the same detector the reviewer used to
-/// falsify v3. A word painted in the selection colour cannot be produced by a popover, by an
-/// empty range, or by a stale clipboard, and it needs no pasteboard read. Copy's presence is
-/// kept only as a secondary signal, never as the proof.
+/// Two corrections to v4's own claims, both from review: my "these mock lines are short"
+/// remark was wrong (they are 68 of 80 columns, so the earlier dx values were over text after
+/// all, and the retroactive "past end of line" diagnosis was dubious), and the coordinates were
+/// sound throughout. The two-stage focus tap is kept anyway: it removes a real race in which a
+/// keyboard-driven resize can clear a just-made selection, which is a hazard on device even
+/// when CI happens to win it.
 final class TerminalSelectionTests: XCTestCase {
 
     /// SwiftTerm's default `selectedTextBackgroundColor` is (0, 166/255, 178/255) and the app's
-    /// `Coordinator.style` never overrides it (it sets only nativeBackground/Foreground,
-    /// backgroundColor, caretColor and installColors), so this teal is the selection and
-    /// nothing else in the palette is near it.
+    /// `Coordinator.style` never overrides it — verified: nothing in App/ or Sources/ assigns
+    /// `selectedTextBackgroundColor` or `selectedTextForegroundColor` at all, and `style(view)`
+    /// sets only font, nativeBackground/Foreground, backgroundColor, caretColor, isOpaque and
+    /// installColors. So a teal region in a frame IS SwiftTerm's selection.
+    ///
+    /// "NOTHING ELSE IN THE PALETTE IS NEAR IT" WAS FALSE, and a reviewer did the arithmetic:
+    /// `Palette.working` and `caretColor` are both 0x5B9BE8, which passes this detector
+    /// outright (g=155 > 91+40, b=232 > 131, g > 70), as do the ANSI cyan slots 0x4FB8C8 and
+    /// 0x74CEDC. None of them appears in THIS mock — the fixture's blocked agent draws an amber
+    /// dot, the cursor is hidden by ESC[?25l, and the seeded text is uncoloured — so the
+    /// detector is specific here. What makes that safe is not the constant but the
+    /// `baseTeal < 20` premise: a working-status dot would contribute roughly 28 downsampled
+    /// pixels, so any future collision fails the PREMISE loudly instead of quietly satisfying
+    /// the conclusion.
     ///
     /// The hue tests (`g > r + 40`, `b > r + 40`) are the reviewer's, unchanged. The
     /// BRIGHTNESS floor is 70 rather than their 90 because they measured full-resolution
@@ -130,9 +153,26 @@ final class TerminalSelectionTests: XCTestCase {
         let selected = app.screenshot()
         attach(selected, name: "03-selection-held")
 
-        // (4) THE ASSERTION THAT CANNOT PASS BY ACCIDENT: a word is painted in the selection
-        // colour. This is where the mutant shows — with the clear tap firing on tap 2, the
-        // selection is gone by now and there is no teal to find.
+        // (4) READ THE STATE, THEN THE PIXELS — in that order, because for four consecutive CI
+        // runs "no teal" was all this test could say, and it cannot distinguish: no selection
+        // was made; an EMPTY range was selected; a late resize wiped it (SwiftTerm clears the
+        // selection on any rows/cols change); or a selection exists and is painted a colour the
+        // detector does not match. Those are four different bugs and I guessed wrong twice.
+        // `terminal-selection-probe` is published by the app under the same mock env var and
+        // reports sel/len/rows/cols/resizes, so the diagnosis now comes from SwiftTerm.
+        let probe = app.descendants(matching: .any)["terminal-selection-probe"]
+        let reading = probe.waitForExistence(timeout: 5) ? (probe.label) : "PROBE ABSENT"
+
+        // The state assertion. `len > 0` is the part that matters: an active-but-EMPTY selection
+        // is exactly what a tap past end-of-line produces, and it offers Copy while painting
+        // nothing, which is how an earlier version of this file passed for the wrong reason.
+        XCTAssertTrue(reading.contains("sel=1"),
+                      "SwiftTerm reports no active selection after a double tap. probe[\(reading)]. If resizes climbed since the focus tap, a late relayout wiped it; if not, the double tap never reached SwiftTerm's recognizer")
+        XCTAssertFalse(reading.contains("len=0"),
+                       "the selection is active but EMPTY, so the tap landed off the glyphs. probe[\(reading)]")
+
+        // THE RENDER ASSERTION, which the state assertion cannot replace: the user sees pixels,
+        // and a selection that exists without being drawn is still broken for them.
         //
         // 60, three times the baseline ceiling of 20, so a marginal pass cannot straddle the
         // two limits: a run reading 19 before and 21 after would satisfy both a "nothing is
@@ -140,7 +180,7 @@ final class TerminalSelectionTests: XCTestCase {
         // word is ~3000 px at full resolution, ~170 here, so the gap is not tight.
         let heldTeal = tealPixelCount(selected)
         XCTAssertGreaterThan(heldTeal, 60,
-                             "no selection highlight after a double tap (teal px=\(heldTeal), baseline \(baseTeal)). Either the selection was cleared on the same touch-up — the regression this file guards — or the tap selected an empty range")
+                             "SwiftTerm holds a selection but nothing is painted in the selection colour (teal px=\(heldTeal), baseline \(baseTeal)). probe[\(reading)]")
 
         // Secondary only: Copy SHOULD be offered, but its presence alone proves nothing, since
         // an empty-but-active selection also offers it.

--- a/HerdrUITests/TerminalSelectionTests.swift
+++ b/HerdrUITests/TerminalSelectionTests.swift
@@ -308,9 +308,15 @@ final class TerminalSelectionTests: XCTestCase {
         //
         // Polling for the state this step is actually about lets a slow chain pass and still fails
         // a genuinely dead one, at the cost of up to 10s only when something is already wrong.
+        // The poll waits for a reading that is BOTH cleared and NEWER than the pre-tap one. Polling
+        // on `sel=0` alone would also accept a stale label from before the tap, which is the same
+        // class of error as the assertion above: a condition that can be satisfied without the
+        // event under test having happened. `pub=<handler>#<count>` is monotonic, so a changed
+        // label is proof of a fresh publish.
+        let beforeReading = probe.exists ? probe.label : ""
         let deselectDeadline = Date().addingTimeInterval(10)
         while Date() < deselectDeadline {
-            if probe.exists, probe.label.contains("sel=0") { break }
+            if probe.exists, probe.label.contains("sel=0"), probe.label != beforeReading { break }
             Thread.sleep(forTimeInterval: 0.25)
         }
         // One extra settle past the state change, so the screenshot cannot catch a half-drawn
@@ -333,10 +339,32 @@ final class TerminalSelectionTests: XCTestCase {
         // Without that field those two produce byte-identical readings, which is what cost the
         // previous round.
         let afterReading = probe.exists ? probe.label : "PROBE ABSENT"
+
+        // WHAT THIS STEP CAN AND CANNOT PROVE, corrected after a review showed the previous version
+        // passing while the app's own clear never executed.
+        //
+        // By this point the view IS first responder — focusTap took it on tap 1, and
+        // showStandardContextMenu takes it too (iOSTerminalView.swift:1392). SwiftTerm's OWN
+        // singleTap therefore runs its `if isFirstResponder` branch and calls selection.selectNone()
+        // (iOSTerminalView.swift:743-768), and it requires only its own doubleTap to fail — whereas
+        // the app's clearTap was made to require TWO 2-tap recognizers (SwiftTerm's doubleTap plus
+        // the app's menuTap, since the attach loop runs after menuTap is added). So on this path
+        // SWIFTTERM CLEARS FIRST, and the app's clearTap arrives later, publishes clearTapEntry
+        // reading sel=0, hits its `guard view.hasActiveSelection` and returns without clearing.
+        //
+        // The old assertion accepted `contains("pub=clearTap")`, which ALSO prefix-matches
+        // "pub=clearTapEntry" — so the receipt greened with view.clearSelection() never called. It
+        // was testing SwiftTerm and reporting it as testing the app.
+        //
+        // So this now asserts the USER-VISIBLE property — the selection is gone after a genuine
+        // single tap — and says plainly that it does not attribute the clear to either
+        // implementation. clearTap's own value is on an UNFOCUSED pane, where SwiftTerm's singleTap
+        // spends its tap taking the responder and does not clear; that path is not exercised here
+        // and is worth its own receipt.
         XCTAssertTrue(afterReading.contains("pub=focusTap") || afterReading.contains("pub=clearTap"),
                       "no terminal tap handler published after the single tap, so the touch never reached the terminal view — the coordinate missed it. Compare against the pre-tap reading probe[\(reading)]; after probe[\(afterReading)]")
         XCTAssertTrue(afterReading.contains("sel=0"),
-                      "the touch reached the terminal but SwiftTerm still reports an active selection, so clearTap did not run or its require(toFail:) chain had not resolved within the settle. probe[\(afterReading)]")
+                      "the touch reached the terminal but a selection is still active, so nothing cleared it — neither SwiftTerm's singleTap nor the app's clearTap. probe[\(afterReading)]")
 
         let clearedTeal = tealPixelCount(cleared)
         XCTAssertLessThan(clearedTeal, 20,

--- a/HerdrUITests/TerminalSelectionTests.swift
+++ b/HerdrUITests/TerminalSelectionTests.swift
@@ -1,0 +1,113 @@
+import XCTest
+
+/// THE REGRESSION RECEIPT for double-tap word selection.
+///
+/// A review found the repaired behaviour unguarded: a compiling mutant that removes
+/// `clearTap.require(toFail: t)` restores the original defect, where the app's own tap
+/// recognizer clears the word SwiftTerm selected on the SAME touch-up, and nothing in the
+/// suite noticed. This file is the guard.
+///
+/// It uses PIXEL DIFF rather than accessibility, for two reasons. SwiftTerm draws the
+/// selection highlight and its two handle ellipses with CoreGraphics, so there is no
+/// element to query; and the Copy affordance rides on `UIMenuController`, deprecated at
+/// iOS 16, so asserting on the menu would couple this receipt to an API whose survival is
+/// exactly what nobody can currently promise. Pixels are the thing a person sees.
+///
+/// Structure mirrors ScrollTests: prove the terminal is STATIC first, so a later diff
+/// cannot be ambient animation.
+final class TerminalSelectionTests: XCTestCase {
+
+    override func setUp() { continueAfterFailure = false }
+
+    func testDoubleTapSelectionSurvivesAndASingleTapClearsIt() {
+        let app = XCUIApplication()
+        app.launchEnvironment["HERDR_SCREENSHOT_MOCK"] = "scroll"
+        app.launch()
+
+        // The mock feeds 200 numbered lines into a real SwiftTerm view asynchronously.
+        Thread.sleep(forTimeInterval: 3.0)
+
+        // (1) PREMISE: an untouched terminal is static. Without this, every diff below
+        // could be a cursor blink or a stream repaint rather than a selection.
+        let baseline = app.screenshot()
+        Thread.sleep(forTimeInterval: 1.0)
+        let idleDiff = pixelDiffFraction(baseline, app.screenshot())
+        attach(baseline, name: "01-baseline")
+        XCTAssertLessThan(idleDiff, 0.02,
+                          "terminal is not static when untouched (diff=\(idleDiff)); no later diff would mean anything")
+
+        // (2) DOUBLE TAP on terminal text. Mid-body: below the header, above the reply bar,
+        // matching the drag origin ScrollTests uses.
+        let word = app.coordinate(withNormalizedOffset: CGVector(dx: 0.35, dy: 0.45))
+        word.doubleTap()
+        Thread.sleep(forTimeInterval: 1.0)
+
+        let selected = app.screenshot()
+        attach(selected, name: "02-after-double-tap")
+        let selectionDiff = pixelDiffFraction(baseline, selected)
+        XCTAssertGreaterThan(selectionDiff, 0.005,
+                             "double tap drew nothing (diff=\(selectionDiff)); word select is not reaching SwiftTerm")
+
+        // (3) THE REGRESSION ITSELF: the selection must still be there a moment later.
+        // With one recognizer doing both jobs, the app's tap fired on tap 2 as well and
+        // cleared the selection on the same touch-up, so this is where that defect shows.
+        Thread.sleep(forTimeInterval: 1.5)
+        let held = app.screenshot()
+        attach(held, name: "03-selection-held")
+        let heldVsBaseline = pixelDiffFraction(baseline, held)
+        XCTAssertGreaterThan(heldVsBaseline, 0.005,
+                             "the selection vanished on its own (diff vs baseline=\(heldVsBaseline)); the clear tap is firing on tap 2")
+
+        // (4) A GENUINE SINGLE TAP elsewhere must clear it, so the fix did not simply
+        // disable deselection. Tapped well away from the selected word.
+        app.coordinate(withNormalizedOffset: CGVector(dx: 0.75, dy: 0.70)).tap()
+        Thread.sleep(forTimeInterval: 1.5)
+
+        let cleared = app.screenshot()
+        attach(cleared, name: "04-after-single-tap")
+        let clearedVsHeld = pixelDiffFraction(held, cleared)
+        XCTAssertGreaterThan(clearedVsHeld, 0.002,
+                             "a single tap changed nothing (diff=\(clearedVsHeld)); deselection is not reaching the view")
+        XCTAssertLessThan(pixelDiffFraction(baseline, cleared), heldVsBaseline,
+                          "after a single tap the terminal should be CLOSER to its unselected baseline than it was while selected")
+    }
+
+    // MARK: - helpers (duplicated from ScrollTests, which keeps them private)
+
+    private func attach(_ shot: XCUIScreenshot, name: String) {
+        let a = XCTAttachment(screenshot: shot)
+        a.name = name
+        a.lifetime = .keepAlways
+        add(a)
+    }
+
+    /// Fraction of pixels that differ beyond a small per-pixel threshold, compared at a
+    /// fixed small resolution so PNG jitter and antialiasing do not register as change.
+    private func pixelDiffFraction(_ a: XCUIScreenshot, _ b: XCUIScreenshot) -> Double {
+        let w = 90, h = 180
+        guard let bufA = rgbaBuffer(a.image, w: w, h: h),
+              let bufB = rgbaBuffer(b.image, w: w, h: h) else { return 1.0 }
+        var differing = 0
+        var i = 0
+        while i < bufA.count {
+            let d = abs(Int(bufA[i]) - Int(bufB[i]))
+                  + abs(Int(bufA[i + 1]) - Int(bufB[i + 1]))
+                  + abs(Int(bufA[i + 2]) - Int(bufB[i + 2]))
+            if d > 30 { differing += 1 }
+            i += 4
+        }
+        return Double(differing) / Double(w * h)
+    }
+
+    private func rgbaBuffer(_ image: UIImage, w: Int, h: Int) -> [UInt8]? {
+        guard let cg = image.cgImage else { return nil }
+        var data = [UInt8](repeating: 0, count: w * h * 4)
+        let cs = CGColorSpaceCreateDeviceRGB()
+        guard let ctx = CGContext(data: &data, width: w, height: h,
+                                  bitsPerComponent: 8, bytesPerRow: w * 4, space: cs,
+                                  bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue) else { return nil }
+        ctx.interpolationQuality = .low
+        ctx.draw(cg, in: CGRect(x: 0, y: 0, width: w, height: h))
+        return data
+    }
+}

--- a/HerdrUITests/TerminalSelectionTests.swift
+++ b/HerdrUITests/TerminalSelectionTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import UIKit
 
 /// THE REGRESSION RECEIPT for double-tap word selection.
 ///
@@ -7,37 +8,67 @@ import XCTest
 /// recognizer clears the word SwiftTerm selected on the SAME touch-up, and nothing in the
 /// suite noticed.
 ///
-/// THIS FILE HAS FAILED CI TWICE, BOTH TIMES ON ITSELF RATHER THAN ON PRODUCT CODE, and
-/// both lessons are recorded here because each was already knowable.
+/// THIS FILE HAS BEEN WRONG THREE TIMES, always about its own instrument and never about the
+/// product code. Each lesson is kept because each was independently discoverable and I missed
+/// it:
 ///
-/// 1. PIXELS CANNOT TELL A SELECTION FROM A POPOVER. The first version proved persistence
-///    by diffing against the pre-selection baseline, so ANY on-screen difference satisfied
-///    it, including SwiftTerm's context menu merely being present. That step passed and the
-///    next failed with a diff of exactly 0.0, which is what revealed the earlier assertion
-///    had been satisfied for the wrong reason.
-/// 2. NEVER READ THE PASTEBOARD IN THIS REPO. The second version asserted on
-///    `UIPasteboard.general.string`. A pasteboard READ raises a system paste prompt, which
-///    nothing answers in CI, so the run hung until the 45 minute job timeout and was
-///    cancelled with no test results at all. This constraint was already written down twice
-///    in the app, at CopyForAgentButton.swift:9 and HerdrApp.swift:685, both saying the app
-///    writes and never reads precisely because that prompt failed App Review under 2.1a.
+/// 1. PIXELS AGAINST A BASELINE CANNOT TELL A SELECTION FROM A POPOVER. v1 proved persistence
+///    by diffing against the pre-selection frame, so ANY on-screen difference satisfied it —
+///    including SwiftTerm's context menu merely being present.
+/// 2. NEVER READ THE PASTEBOARD IN THIS REPO. v2 asserted on `UIPasteboard.general.string`. A
+///    pasteboard READ raises a system paste prompt, nothing answers it in CI, and the run hung
+///    to the 45-minute job timeout and was cancelled with no test results at all. The
+///    constraint was already written twice in the app, at CopyForAgentButton.swift:9 and
+///    HerdrApp.swift:685, both saying the app writes and never reads because that prompt
+///    failed App Review under 2.1a.
+/// 3. A COPY MENU IS NOT A SELECTION. v3 asserted `menuItems["Copy"].exists`. A reviewer
+///    downloaded the CI artifacts and measured SwiftTerm's `selectedTextBackgroundColor`
+///    (0,166,178) at 0 of 3,162,132 pixels in every frame — while Copy WAS present. The cause
+///    is in SwiftTerm's own code: `selectedColumnsRange` yields an EMPTY range when
+///    `startCol == endCol`, so double-tapping blank space leaves `selection.active == true`
+///    with nothing selected and nothing painted, and `canPerformAction` offers Copy anyway.
+///    Both of v3's taps were also mis-aimed: dx=0.35 lands past the end of these short
+///    numbered lines, and dy=0.70 lands on the software keyboard, which occupies the bottom
+///    ~40% and would type into a live agent's PTY.
 ///
-/// So this asserts on the MENU ITEM alone, which needs no clipboard and cannot pass by
-/// accident: `canPerformAction` returns Copy only while `selection.active`, so the item
-/// existing after a double tap IS proof that a selection survived the same touch-up that
-/// created it, and its absence after a single tap is proof deselection reached the view.
-///
-/// It also settles rather than assumes the standing question of whether `UIMenuController`,
-/// deprecated at iOS 16, still presents: if it does not, this fails and says which cause.
+/// So this version measures THE HIGHLIGHT ITSELF, with the same detector the reviewer used to
+/// falsify v3. A word painted in the selection colour cannot be produced by a popover, by an
+/// empty range, or by a stale clipboard, and it needs no pasteboard read. Copy's presence is
+/// kept only as a secondary signal, never as the proof.
 final class TerminalSelectionTests: XCTestCase {
+
+    /// SwiftTerm's default `selectedTextBackgroundColor` is (0, 166/255, 178/255) and the app's
+    /// `Coordinator.style` never overrides it (it sets only nativeBackground/Foreground,
+    /// backgroundColor, caretColor and installColors), so this teal is the selection and
+    /// nothing else in the palette is near it.
+    ///
+    /// The hue tests (`g > r + 40`, `b > r + 40`) are the reviewer's, unchanged. The
+    /// BRIGHTNESS floor is 70 rather than their 90 because they measured full-resolution
+    /// frames and this downsamples: a teal pixel averaged with the terminal's near-black
+    /// ground (#0B0D1C) at the edge of a glyph lands around g=89, which their threshold would
+    /// reject. Relaxing it can only admit more colours, which is why the test asserts the
+    /// BASELINE count is near zero before drawing any conclusion from a later count — that
+    /// premise, not this constant, is what makes the detector specific to the selection.
+    private func tealPixelCount(_ shot: XCUIScreenshot) -> Int {
+        let w = 300, h = 600
+        guard let buf = rgbaBuffer(shot.image, w: w, h: h) else { return 0 }
+        var n = 0
+        var i = 0
+        while i < buf.count {
+            let r = Int(buf[i]), g = Int(buf[i + 1]), b = Int(buf[i + 2])
+            if g > r + 40 && b > r + 40 && g > 70 { n += 1 }
+            i += 4
+        }
+        return n
+    }
 
     override func setUp() { continueAfterFailure = false }
 
-    func testDoubleTapHoldsASelectionAndASingleTapDismissesIt() {
+    func testDoubleTapSelectsAWordAndASingleTapDeselectsIt() {
         let app = XCUIApplication()
 
-        // Defence against the failure above generalising: if ANY system dialog appears, dismiss
-        // it rather than letting the run hang to the job timeout with no results.
+        // If ANY system dialog appears, dismiss it rather than letting the run hang to the job
+        // timeout with no results — the shape of lesson 2 above, guarded generally.
         addUIInterruptionMonitor(withDescription: "system dialog") { alert in
             let allow = alert.buttons.element(boundBy: alert.buttons.count - 1)
             if allow.exists { allow.tap(); return true }
@@ -50,39 +81,58 @@ final class TerminalSelectionTests: XCTestCase {
         // The mock feeds 200 numbered lines into a real SwiftTerm view asynchronously.
         Thread.sleep(forTimeInterval: 3.0)
 
-        // (1) PREMISE: the terminal is static when untouched, so a later pixel change means
-        // the gesture did something rather than the stream repainting under us.
+        // (1) PREMISES, both asserted before anything is concluded from them.
         let baseline = app.screenshot()
+        attach(baseline, name: "01-baseline")
+
+        // 1a. The terminal is static when untouched, so a later change means the gesture did
+        // something rather than the stream repainting under us.
         Thread.sleep(forTimeInterval: 1.0)
         let idleDiff = pixelDiffFraction(baseline, app.screenshot())
-        attach(baseline, name: "01-baseline")
         XCTAssertLessThan(idleDiff, 0.02,
-                          "terminal is not static when untouched (diff=\(idleDiff)); no later diff would mean anything")
+                          "terminal is not static when untouched (diff=\(idleDiff)); no later measurement would mean anything")
 
-        // (2) DOUBLE TAP on terminal text: mid-body, below the header and above the reply
-        // bar, matching the drag origin ScrollTests uses.
-        app.coordinate(withNormalizedOffset: CGVector(dx: 0.35, dy: 0.45)).doubleTap()
-        Thread.sleep(forTimeInterval: 1.0)
+        // 1b. NOTHING is already teal. Without this the selection assertion could be satisfied
+        // by any pre-existing colour in the palette, which is exactly how v1 passed.
+        let baseTeal = tealPixelCount(baseline)
+        XCTAssertLessThan(baseTeal, 20,
+                          "found \(baseTeal) selection-coloured pixels BEFORE selecting anything; the detector cannot distinguish a selection here")
+
+        // (2) DOUBLE TAP ON ACTUAL TEXT. dx is small because these mock lines are short and a
+        // tap past end-of-line selects an EMPTY range (lesson 3); dy sits in the terminal band,
+        // above the software keyboard and below the header.
+        app.coordinate(withNormalizedOffset: CGVector(dx: 0.10, dy: 0.32)).doubleTap()
+        Thread.sleep(forTimeInterval: 1.5)
         let selected = app.screenshot()
-        attach(selected, name: "02-after-double-tap")
-        XCTAssertGreaterThan(pixelDiffFraction(baseline, selected), 0.005,
-                             "double tap drew nothing at all; word select is not reaching SwiftTerm")
+        attach(selected, name: "02-selection-held")
 
-        // (3) THE ASSERTION THAT CANNOT PASS BY ACCIDENT. Copy is offered only while a
-        // selection is active, so this is where the mutant shows: with the clear tap firing
-        // on tap 2 there is no selection by now and no Copy item.
-        let copy = app.menuItems["Copy"]
-        XCTAssertTrue(copy.waitForExistence(timeout: 5),
-                      "no Copy item after a double tap. Either the selection was cleared on the same touch-up (the regression this file guards) or UIMenuController no longer presents on this OS, which is a finding in its own right")
+        // (3) THE ASSERTION THAT CANNOT PASS BY ACCIDENT: a word is painted in the selection
+        // colour. This is where the mutant shows — with the clear tap firing on tap 2, the
+        // selection is gone by now and there is no teal to find.
+        //
+        // 60, three times the baseline ceiling of 20, so a marginal pass cannot straddle the
+        // two limits: a run reading 19 before and 21 after would satisfy both a "nothing is
+        // teal" premise and a "something is teal" conclusion, and mean neither. A selected
+        // word is ~3000 px at full resolution, ~170 here, so the gap is not tight.
+        let heldTeal = tealPixelCount(selected)
+        XCTAssertGreaterThan(heldTeal, 60,
+                             "no selection highlight after a double tap (teal px=\(heldTeal), baseline \(baseTeal)). Either the selection was cleared on the same touch-up — the regression this file guards — or the tap selected an empty range")
 
-        // (4) DESELECTION still works, so the fix did not simply disable it. Deliberately NOT
-        // tapping Copy: that would put the reader's selection on the clipboard, and reading it
-        // back to verify is the pasteboard prompt that hung this test once already.
-        app.coordinate(withNormalizedOffset: CGVector(dx: 0.75, dy: 0.70)).tap()
-        Thread.sleep(forTimeInterval: 2.5)
-        attach(app.screenshot(), name: "03-after-single-tap")
-        XCTAssertFalse(app.menuItems["Copy"].exists,
-                       "a genuine single tap left the selection up; deselection is not reaching the view")
+        // Secondary only: Copy SHOULD be offered, but its presence alone proves nothing, since
+        // an empty-but-active selection also offers it.
+        XCTAssertTrue(app.menuItems["Copy"].waitForExistence(timeout: 5),
+                      "a word is highlighted but Copy is not offered, so the selection cannot be acted on")
+
+        // (4) DESELECTION still works, so the fix did not simply disable it. The tap stays in
+        // the terminal band and well away from the selected word — NOT on the keyboard, which
+        // on a live pane would type a character into the agent's shell.
+        app.coordinate(withNormalizedOffset: CGVector(dx: 0.70, dy: 0.22)).tap()
+        Thread.sleep(forTimeInterval: 2.0)
+        let cleared = app.screenshot()
+        attach(cleared, name: "03-after-single-tap")
+        let clearedTeal = tealPixelCount(cleared)
+        XCTAssertLessThan(clearedTeal, 20,
+                          "the selection highlight survived a genuine single tap (teal px=\(clearedTeal)); deselection is not reaching the view")
     }
 
     // MARK: - helpers (duplicated from ScrollTests, which keeps them private)

--- a/HerdrUITests/TerminalSelectionTests.swift
+++ b/HerdrUITests/TerminalSelectionTests.swift
@@ -298,7 +298,25 @@ final class TerminalSelectionTests: XCTestCase {
         // after that chain times out, about two multi-tap intervals, which under CI load is not
         // instant.
         app.coordinate(withNormalizedOffset: CGVector(dx: 0.60, dy: 0.30)).tap()
-        Thread.sleep(forTimeInterval: 3.0)
+        // A BOUNDED POLL, NOT A FIXED SLEEP, and this is the blocking finding from the review of
+        // 295df46f. The recognizer chain was verified SOUND against SwiftTerm 1.15.0
+        // (iOSTerminalView.swift:1077-1078), so the failure at 0544df88 — pub=focusTap#5, sel=1
+        // after three seconds — is consistent with a STALLED RUNLOOP rather than a dead chain:
+        // those failure timers run on the app's main runloop and are unbounded under CI load. A
+        // fixed sleep therefore encodes a guess about machine speed as if it were a property of
+        // the product, and fails a slow-but-healthy chain.
+        //
+        // Polling for the state this step is actually about lets a slow chain pass and still fails
+        // a genuinely dead one, at the cost of up to 10s only when something is already wrong.
+        let deselectDeadline = Date().addingTimeInterval(10)
+        while Date() < deselectDeadline {
+            if probe.exists, probe.label.contains("sel=0") { break }
+            Thread.sleep(forTimeInterval: 0.25)
+        }
+        // One extra settle past the state change, so the screenshot cannot catch a half-drawn
+        // repaint: the clear reaches the model synchronously but selectionChanged repaints on the
+        // next main-queue hop.
+        Thread.sleep(forTimeInterval: 0.75)
         let cleared = app.screenshot()
         attach(cleared, name: "04-after-single-tap")
 

--- a/HerdrUITests/TerminalSelectionTests.swift
+++ b/HerdrUITests/TerminalSelectionTests.swift
@@ -278,30 +278,47 @@ final class TerminalSelectionTests: XCTestCase {
         XCTAssertTrue(app.menuItems["Copy"].waitForExistence(timeout: 5),
                       "a word is highlighted but Copy is not offered, so the selection cannot be acted on")
 
-        // (5) DESELECTION still works, so the fix did not simply disable it. The tap stays in
-        // the terminal band and well away from the selected word — NOT on the keyboard, which
-        // on a live pane would type a character into the agent's shell. The keyboard is already
-        // up by now, so this tap cannot move the layout the way step 2's did.
+        // (5) DESELECTION still works, so the fix did not simply disable it.
         //
-        // THE SETTLE IS LONGER THAN IT LOOKS LIKE IT NEEDS TO BE, on purpose. `clearTap` requires
-        // SwiftTerm's 2-tap recognizer to fail, and `menuTap` — also in clearTap's require-to-fail
-        // set — requires the 3-tap one. So a genuine single tap clears only after that whole chain
-        // times out, roughly two multi-tap intervals, and under CI load that is not instant.
-        app.coordinate(withNormalizedOffset: CGVector(dx: 0.70, dy: 0.20)).tap()
+        // dy MATCHES THE TAPS THAT DEMONSTRABLY REACH THE TERMINAL. This was 0.20, and CI failed
+        // deterministically in both passes with the selection untouched — sel=1 len=4 text=<lazy>,
+        // republished by nobody. Since `handleClearSelectionTap` publishes AFTER clearing, sel=1
+        // means clearTap never ran; and dy 0.20 was a guess about where the terminal band starts,
+        // never a measured value, while 0.30 is proven twice over in this very test — the focus tap
+        // raises the keyboard from there and the double tap selects a word from there. So the most
+        // likely reading is that 0.20 was above the terminal, in the header or the TUI banner, and
+        // no terminal recognizer saw the touch at all.
+        //
+        // dx moves to 0.60 to stay clear of the selected word at column 7 while remaining inside
+        // the 50-column viewport.
+        //
+        // THE SETTLE IS LONGER THAN IT LOOKS, on purpose. `clearTap` requires SwiftTerm's 2-tap
+        // recognizer to fail, and `menuTap` — which joined clearTap's require-to-fail set when I
+        // declared it first — requires the 3-tap one. A genuine single tap therefore clears only
+        // after that chain times out, about two multi-tap intervals, which under CI load is not
+        // instant.
+        app.coordinate(withNormalizedOffset: CGVector(dx: 0.60, dy: 0.30)).tap()
         Thread.sleep(forTimeInterval: 3.0)
         let cleared = app.screenshot()
         attach(cleared, name: "04-after-single-tap")
 
-        // STATE BEFORE PIXELS HERE TOO, which this step was missing while step 4 had it. CI failed
-        // exactly here with teal px=384 and the message could only say "deselection is not reaching
-        // the view" — a conclusion it had no evidence for. `handleClearSelectionTap` republishes the
-        // probe after clearing, so the same reading that diagnoses step 4 can diagnose this one:
-        // sel=0 with teal remaining means the clear DID reach the view and the highlight is stale
-        // pixels; sel=1 means the clear never ran at all. Those are different bugs and the first
-        // version of this assertion could not tell them apart.
+        // STATE BEFORE PIXELS HERE TOO, which this step lacked while step 4 had it — so the one
+        // step that failed was the one that could not name its layer.
+        //
+        // AND `pub` SEPARATES THE TWO REMAINING CAUSES. The probe now reports which handler
+        // published it and a monotonic count, so:
+        //   pub=focusTap#N with N above the pre-tap value -> the touch REACHED the terminal
+        //     (focusTap has no failure requirement and fires on tap 1 of anything), so a still-
+        //     active selection means clearTap's require-to-fail chain is the fault;
+        //   pub unchanged from the double tap -> no terminal recognizer saw the touch, i.e. the
+        //     coordinate missed the view, which is a test-aim failure and not a product one.
+        // Without that field those two produce byte-identical readings, which is what cost the
+        // previous round.
         let afterReading = probe.exists ? probe.label : "PROBE ABSENT"
+        XCTAssertTrue(afterReading.contains("pub=focusTap") || afterReading.contains("pub=clearTap"),
+                      "no terminal tap handler published after the single tap, so the touch never reached the terminal view — the coordinate missed it. Compare against the pre-tap reading probe[\(reading)]; after probe[\(afterReading)]")
         XCTAssertTrue(afterReading.contains("sel=0"),
-                      "SwiftTerm still reports an active selection after a genuine single tap, so the clear never reached the view — clearTap did not fire, or its require(toFail:) chain had not resolved. probe[\(afterReading)]")
+                      "the touch reached the terminal but SwiftTerm still reports an active selection, so clearTap did not run or its require(toFail:) chain had not resolved within the settle. probe[\(afterReading)]")
 
         let clearedTeal = tealPixelCount(cleared)
         XCTAssertLessThan(clearedTeal, 20,

--- a/HerdrUITests/TerminalSelectionTests.swift
+++ b/HerdrUITests/TerminalSelectionTests.swift
@@ -143,25 +143,24 @@ final class TerminalSelectionTests: XCTestCase {
         XCTAssertLessThan(tealPixelCount(focused), 20,
                           "a single tap on an unselected pane produced selection colour; the premise for step 4 is broken")
 
-        // (3) DOUBLE TAP INSIDE THE WIDEST LETTER RUN AVAILABLE, because the previous
-        // coordinate was a coin toss and CI proved it.
+        // (3) DOUBLE TAP ON THE LINE NUMBER, and this coordinate is now MEASURED rather than
+        // computed — my arithmetic for it was wrong twice.
         //
-        // THE PROBE ANSWERED THE QUESTION THIS TEST EXISTED TO ASK. Aimed at the line number it
-        // reported `sel=1 len=1 text=< >` — a ONE-CHARACTER SPACE. `selectWordOrExpression` has
-        // a dedicated whitespace branch, so a tap that misses the glyphs selects the run of
-        // spaces instead of nothing, which is an active, non-empty, entirely invisible-ish
-        // selection: one cell paints roughly 26 downsampled pixels, under the 60 this test
-        // requires. The retry pass then SUCCEEDED, which settles the older mystery too — the
-        // selection does paint when the tap lands on a word, so the earlier zero-teal runs were
-        // about WHERE the tap landed and not about SwiftTerm's drawing.
+        // What the probe has established across two heads:
+        //   dx 0.22  -> selected "< >", a single space
+        //   dx 0.344 -> selected "187", the three-digit line number at columns 16-18
+        // I had predicted col 17.6 and col 27.5 respectively, assuming the 80-column line spans
+        // the screen width. It does not: solving from those two readings gives roughly 49 columns
+        // across the viewport, so the terminal's 80-column content is WIDER THAN THE SCREEN and
+        // the right-hand columns are simply off-view. That also retires my earlier claim that
+        // this fixture only offers five-character letter runs of slack — the visible portion is
+        // "SCROLLTEST line NNN  the quick…", and the widest thing in it is the number plus its
+        // surrounding spaces.
         //
-        // The mock line is "SCROLLTEST line 007  the quick brown fox jumps over the lazy dog" at
-        // 80 columns, and its longest letter runs are five characters. Columns: 0-9 SCROLLTEST,
-        // 10 space, 11-14 line, 15 space, 16-18 the digits, 19-20 two spaces, 21-23 the,
-        // 24 space, 25-29 quick, 30 space, 31-35 brown. Aiming at the MIDDLE of "quick" (col 27,
-        // dx = 27.5/80 ≈ 0.344) leaves two columns of slack on either side, which is the widest
-        // margin this fixture offers. The number at 16-18 offered one column, and dx 0.22 landed
-        // on a space at least once in two runs.
+        // KEEPING dx 0.344 DELIBERATELY, because landing on the NUMBER is better than landing on
+        // a word: the fixture numbers every line, so the selected text identifies WHICH LINE the
+        // selection is on, which is exactly the fact the render assertion below needs in order to
+        // name its own cause. A word would satisfy the length check and tell me nothing.
         //
         // dy=0.30 stays in the terminal band, which the keyboard has shrunk to roughly the top 58%.
         app.coordinate(withNormalizedOffset: CGVector(dx: 0.344, dy: 0.30)).doubleTap()
@@ -199,19 +198,41 @@ final class TerminalSelectionTests: XCTestCase {
         } ?? ""
         XCTAssertFalse(selectedText.trimmingCharacters(in: .whitespaces).isEmpty,
                        "the double tap selected WHITESPACE (\(selectedText.count) char(s)), so the coordinate missed the glyphs — this is a test-aim failure, not a drawing failure. probe[\(reading)]")
+        // Three characters, which is both the shortest word in the visible fixture text and the
+        // exact width of its line number — the intended target. Shorter means the tap clipped an
+        // edge, and the pixel threshold below would then be measuring a sliver.
         XCTAssertGreaterThanOrEqual(selectedText.count, 3,
-                                    "selected '\(selectedText)', shorter than any word in the fixture line, so the tap clipped a word edge and the pixel threshold below would be unreliable. probe[\(reading)]")
+                                    "selected '\(selectedText)', shorter than the fixture's line number or any of its words, so the tap clipped an edge and the pixel threshold below would be unreliable. probe[\(reading)]")
 
-        // THE RENDER ASSERTION, which the state assertion cannot replace: the user sees pixels,
+        // THE RENDER ASSERTION, which the state assertions cannot replace: the user sees pixels,
         // and a selection that exists without being drawn is still broken for them.
         //
         // 60, three times the baseline ceiling of 20, so a marginal pass cannot straddle the
         // two limits: a run reading 19 before and 21 after would satisfy both a "nothing is
-        // teal" premise and a "something is teal" conclusion, and mean neither. A selected
-        // word is ~3000 px at full resolution, ~170 here, so the gap is not tight.
+        // teal" premise and a "something is teal" conclusion, and mean neither. A three-cell
+        // selection is roughly 250 downsampled pixels here, so the gap is not tight.
+        //
+        // AND THE MESSAGE NAMES THE CAUSE ARITHMETICALLY. Two explanations survived the source
+        // reading and neither could be chosen from a pixel count: the selection sits on a row
+        // being drawn and the PAINT is broken, or it sits outside the drawn window and the tap's
+        // ROW SPACE is wrong. The fixture numbers its lines, so the selected text identifies the
+        // selection's line, and the probe now carries ydisp — which turns the choice into
+        // subtraction instead of another hypothesis.
         let heldTeal = tealPixelCount(selected)
+        let selRow = Int(selectedText).map { $0 - 1 }          // "187" is 1-indexed; buffer rows are 0-indexed
+        let yDisp = value(of: "ydisp", in: reading)
+        let rowCount = value(of: "rows", in: reading)
+        let placement: String = {
+            guard let selRow, let yDisp, let rowCount else {
+                return "could not derive placement (selected text is not a line number, or the probe lacked ydisp/rows)"
+            }
+            let visible = yDisp...(yDisp + rowCount - 1)
+            return visible.contains(selRow)
+                ? "the selection is on buffer row \(selRow), INSIDE the drawn window \(visible), so the ROW SPACE IS CORRECT and the PAINT is what fails"
+                : "the selection is on buffer row \(selRow), OUTSIDE the drawn window \(visible), so the TAP'S ROW SPACE is wrong and the paint never had a chance"
+        }()
         XCTAssertGreaterThan(heldTeal, 60,
-                             "SwiftTerm holds a selection but nothing is painted in the selection colour (teal px=\(heldTeal), baseline \(baseTeal)). probe[\(reading)]")
+                             "SwiftTerm holds a selection but nothing is painted in the selection colour (teal px=\(heldTeal), baseline \(baseTeal)). \(placement). probe[\(reading)]")
 
         // Secondary only: Copy SHOULD be offered, but its presence alone proves nothing, since
         // an empty-but-active selection also offers it.
@@ -231,6 +252,18 @@ final class TerminalSelectionTests: XCTestCase {
                           "the selection highlight survived a genuine single tap (teal px=\(clearedTeal)); deselection is not reaching the view")
     }
 
+    /// Pull an integer field out of the probe label, e.g. `ydisp=176` -> 176.
+    ///
+    /// Returns nil rather than a default when the field is absent, so a probe that stops
+    /// publishing something degrades into "could not derive" in the failure message instead of
+    /// silently asserting against a zero — a default here would be a plausible-looking number
+    /// with no measurement behind it, which is the shape of error this whole file exists because
+    /// of.
+    private func value(of key: String, in reading: String) -> Int? {
+        guard let start = reading.range(of: "\(key)=") else { return nil }
+        let digits = reading[start.upperBound...].prefix { $0.isNumber || $0 == "-" }
+        return Int(digits)
+    }
     // MARK: - helpers (duplicated from ScrollTests, which keeps them private)
 
     private func attach(_ shot: XCUIScreenshot, name: String) {

--- a/HerdrUITests/TerminalSelectionTests.swift
+++ b/HerdrUITests/TerminalSelectionTests.swift
@@ -282,13 +282,30 @@ final class TerminalSelectionTests: XCTestCase {
         // the terminal band and well away from the selected word — NOT on the keyboard, which
         // on a live pane would type a character into the agent's shell. The keyboard is already
         // up by now, so this tap cannot move the layout the way step 2's did.
+        //
+        // THE SETTLE IS LONGER THAN IT LOOKS LIKE IT NEEDS TO BE, on purpose. `clearTap` requires
+        // SwiftTerm's 2-tap recognizer to fail, and `menuTap` — also in clearTap's require-to-fail
+        // set — requires the 3-tap one. So a genuine single tap clears only after that whole chain
+        // times out, roughly two multi-tap intervals, and under CI load that is not instant.
         app.coordinate(withNormalizedOffset: CGVector(dx: 0.70, dy: 0.20)).tap()
-        Thread.sleep(forTimeInterval: 2.0)
+        Thread.sleep(forTimeInterval: 3.0)
         let cleared = app.screenshot()
         attach(cleared, name: "04-after-single-tap")
+
+        // STATE BEFORE PIXELS HERE TOO, which this step was missing while step 4 had it. CI failed
+        // exactly here with teal px=384 and the message could only say "deselection is not reaching
+        // the view" — a conclusion it had no evidence for. `handleClearSelectionTap` republishes the
+        // probe after clearing, so the same reading that diagnoses step 4 can diagnose this one:
+        // sel=0 with teal remaining means the clear DID reach the view and the highlight is stale
+        // pixels; sel=1 means the clear never ran at all. Those are different bugs and the first
+        // version of this assertion could not tell them apart.
+        let afterReading = probe.exists ? probe.label : "PROBE ABSENT"
+        XCTAssertTrue(afterReading.contains("sel=0"),
+                      "SwiftTerm still reports an active selection after a genuine single tap, so the clear never reached the view — clearTap did not fire, or its require(toFail:) chain had not resolved. probe[\(afterReading)]")
+
         let clearedTeal = tealPixelCount(cleared)
         XCTAssertLessThan(clearedTeal, 20,
-                          "the selection highlight survived a genuine single tap (teal px=\(clearedTeal)); deselection is not reaching the view")
+                          "SwiftTerm reports the selection cleared but the highlight is still painted (teal px=\(clearedTeal)), so the clear reached the model and not the screen. probe[\(afterReading)]")
     }
 
     /// Pull an integer field out of the probe label, e.g. `ydisp=176` -> 176.

--- a/HerdrUITests/TerminalSelectionTests.swift
+++ b/HerdrUITests/TerminalSelectionTests.swift
@@ -1,5 +1,4 @@
 import XCTest
-import UIKit
 
 /// THE REGRESSION RECEIPT for double-tap word selection.
 ///
@@ -8,34 +7,51 @@ import UIKit
 /// recognizer clears the word SwiftTerm selected on the SAME touch-up, and nothing in the
 /// suite noticed.
 ///
-/// THE FIRST VERSION OF THIS FILE WAS PIXEL-BASED AND WAS WEAK, which its own CI run
-/// exposed. It asserted "the selection is still there" by diffing against the pre-selection
-/// baseline, and ANY difference satisfied that, including SwiftTerm's context menu simply
-/// being on screen. The final assertion then failed with a diff of exactly 0.0, which is the
-/// signature of a screen where nothing was left to change: the earlier step had passed for
-/// the wrong reason. Pixels cannot tell a selection from a popover.
+/// THIS FILE HAS FAILED CI TWICE, BOTH TIMES ON ITSELF RATHER THAN ON PRODUCT CODE, and
+/// both lessons are recorded here because each was already knowable.
 ///
-/// So this asserts on the CLIPBOARD instead, which cannot be satisfied by accident: a word
-/// only reaches the pasteboard if a selection existed AND Copy acted on it. That also
-/// settles, rather than assumes, the open question about `UIMenuController` being deprecated
-/// at iOS 16: if the menu never presents, this test says so directly.
+/// 1. PIXELS CANNOT TELL A SELECTION FROM A POPOVER. The first version proved persistence
+///    by diffing against the pre-selection baseline, so ANY on-screen difference satisfied
+///    it, including SwiftTerm's context menu merely being present. That step passed and the
+///    next failed with a diff of exactly 0.0, which is what revealed the earlier assertion
+///    had been satisfied for the wrong reason.
+/// 2. NEVER READ THE PASTEBOARD IN THIS REPO. The second version asserted on
+///    `UIPasteboard.general.string`. A pasteboard READ raises a system paste prompt, which
+///    nothing answers in CI, so the run hung until the 45 minute job timeout and was
+///    cancelled with no test results at all. This constraint was already written down twice
+///    in the app, at CopyForAgentButton.swift:9 and HerdrApp.swift:685, both saying the app
+///    writes and never reads precisely because that prompt failed App Review under 2.1a.
+///
+/// So this asserts on the MENU ITEM alone, which needs no clipboard and cannot pass by
+/// accident: `canPerformAction` returns Copy only while `selection.active`, so the item
+/// existing after a double tap IS proof that a selection survived the same touch-up that
+/// created it, and its absence after a single tap is proof deselection reached the view.
+///
+/// It also settles rather than assumes the standing question of whether `UIMenuController`,
+/// deprecated at iOS 16, still presents: if it does not, this fails and says which cause.
 final class TerminalSelectionTests: XCTestCase {
 
-    override func setUp() {
-        continueAfterFailure = false
-        UIPasteboard.general.string = ""   // a stale clipboard would fake a pass
-    }
+    override func setUp() { continueAfterFailure = false }
 
-    func testDoubleTapSelectsAWordCopyWorksAndASingleTapDismisses() {
+    func testDoubleTapHoldsASelectionAndASingleTapDismissesIt() {
         let app = XCUIApplication()
+
+        // Defence against the failure above generalising: if ANY system dialog appears, dismiss
+        // it rather than letting the run hang to the job timeout with no results.
+        addUIInterruptionMonitor(withDescription: "system dialog") { alert in
+            let allow = alert.buttons.element(boundBy: alert.buttons.count - 1)
+            if allow.exists { allow.tap(); return true }
+            return false
+        }
+
         app.launchEnvironment["HERDR_SCREENSHOT_MOCK"] = "scroll"
         app.launch()
 
         // The mock feeds 200 numbered lines into a real SwiftTerm view asynchronously.
         Thread.sleep(forTimeInterval: 3.0)
 
-        // (1) PREMISE: an untouched terminal is static, so a later pixel change means the
-        // gesture did something rather than the stream repainting under us.
+        // (1) PREMISE: the terminal is static when untouched, so a later pixel change means
+        // the gesture did something rather than the stream repainting under us.
         let baseline = app.screenshot()
         Thread.sleep(forTimeInterval: 1.0)
         let idleDiff = pixelDiffFraction(baseline, app.screenshot())
@@ -52,33 +68,18 @@ final class TerminalSelectionTests: XCTestCase {
         XCTAssertGreaterThan(pixelDiffFraction(baseline, selected), 0.005,
                              "double tap drew nothing at all; word select is not reaching SwiftTerm")
 
-        // (3) THE COPY PATH. SwiftTerm presents Copy through UIMenuController, and
-        // canPerformAction only offers it while a selection is active, so the item existing
-        // IS the proof that a selection survived the same touch-up that created it. This is
-        // where the mutant shows: with the clear tap firing on tap 2, there is no selection
-        // by now and no Copy item.
+        // (3) THE ASSERTION THAT CANNOT PASS BY ACCIDENT. Copy is offered only while a
+        // selection is active, so this is where the mutant shows: with the clear tap firing
+        // on tap 2 there is no selection by now and no Copy item.
         let copy = app.menuItems["Copy"]
-        XCTAssertTrue(copy.waitForExistence(timeout: 4),
+        XCTAssertTrue(copy.waitForExistence(timeout: 5),
                       "no Copy item after a double tap. Either the selection was cleared on the same touch-up (the regression this file guards) or UIMenuController no longer presents on this OS, which is a finding in its own right")
 
-        copy.tap()
-        Thread.sleep(forTimeInterval: 1.0)
-
-        // (4) THE UNAMBIGUOUS ASSERTION: a word is on the clipboard. Nothing but a real
-        // selection plus a working Copy can produce this.
-        let pasted = UIPasteboard.general.string ?? ""
-        XCTAssertFalse(pasted.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
-                       "Copy put nothing on the clipboard, so no selection was actually held")
-        // The mock seeds numbered lines, so whatever was selected should be printable text
-        // rather than control bytes.
-        XCTAssertNil(pasted.rangeOfCharacter(from: CharacterSet.controlCharacters.subtracting(.whitespacesAndNewlines)),
-                     "clipboard holds control bytes (\(pasted.debugDescription)); that is not selected screen text")
-
-        // (5) DESELECTION still works, so the fix did not simply disable it. A genuine
-        // single tap must leave no Copy item behind, which is a state assertion rather than
-        // a pixel guess.
+        // (4) DESELECTION still works, so the fix did not simply disable it. Deliberately NOT
+        // tapping Copy: that would put the reader's selection on the clipboard, and reading it
+        // back to verify is the pasteboard prompt that hung this test once already.
         app.coordinate(withNormalizedOffset: CGVector(dx: 0.75, dy: 0.70)).tap()
-        Thread.sleep(forTimeInterval: 2.0)
+        Thread.sleep(forTimeInterval: 2.5)
         attach(app.screenshot(), name: "03-after-single-tap")
         XCTAssertFalse(app.menuItems["Copy"].exists,
                        "a genuine single tap left the selection up; deselection is not reaching the view")

--- a/HerdrUITests/TerminalSelectionTests.swift
+++ b/HerdrUITests/TerminalSelectionTests.swift
@@ -250,6 +250,13 @@ final class TerminalSelectionTests: XCTestCase {
         // One extra re-seed reaches roughly 781, so 600 separates one seed from two with room on
         // both sides. Computed from the fixture rather than guessed, and stated here so the next
         // change to the fixture's line length or column pinning knows what this number depends on.
+        // AND THE GUARD MUST FAIL WHEN IT CANNOT RUN. `if let yDisp` silently took the else path
+        // if the probe ever stopped publishing that field — rename it, reorder the label, or let a
+        // selection contain "ydisp=" earlier in the string, and a fixture re-seeding to 3598 would
+        // produce a GREEN test. That is precisely the shape this file's header warns about: an
+        // instrument that cannot report its own absence. Caught by review, not by me.
+        XCTAssertNotNil(yDisp, "probe stopped publishing ydisp, so the re-seed guard did not run. probe[\(reading)]")
+        XCTAssertNotNil(rowCount, "probe stopped publishing rows, so the placement arithmetic cannot be derived. probe[\(reading)]")
         if let yDisp {
             XCTAssertLessThan(yDisp, 600,
                               "ydisp=\(yDisp) is far beyond the ~381 a single 200-line seed produces when wrapped at 50 columns, so the mock stream is re-seeding on reconnect again. The paint assertion below would then fail for that reason and not for a rendering fault. probe[\(reading)]")

--- a/HerdrUITests/TerminalSelectionTests.swift
+++ b/HerdrUITests/TerminalSelectionTests.swift
@@ -222,6 +222,25 @@ final class TerminalSelectionTests: XCTestCase {
         let selRow = Int(selectedText).map { $0 - 1 }          // "187" is 1-indexed; buffer rows are 0-indexed
         let yDisp = value(of: "ydisp", in: reading)
         let rowCount = value(of: "rows", in: reading)
+
+        // THE FIXTURE MUST NOT HAVE RE-SEEDED, asserted before anything is concluded from ydisp.
+        //
+        // This is the guard for the defect that cost this PR four CI rounds. The mock's
+        // `pane.stream` used to FINISH after delivering its 200-line reset; the app correctly
+        // treats an ended stream as a drop and reconnects, so every reconnect appended another
+        // 200 lines. CI measured ydisp=3598 in one pass and 3777 in the next — a buffer of
+        // thousands of lines in a fixture that seeds 200 — and the scroll view's geometry tracked
+        // the original ~200 while yDisp ran away, so a tap resolved to a row nobody was drawing.
+        // The selection was real and off-screen, which is why no highlight ever appeared and why
+        // I spent four rounds looking at SwiftTerm's renderer, which was innocent throughout.
+        //
+        // 200 lines in a 24-row terminal parks yDisp at about 176. The ceiling is generous but far
+        // below a single extra seed, so a returning re-seed fails HERE, naming the fixture,
+        // instead of resurfacing as an unpaintable selection.
+        if let yDisp {
+            XCTAssertLessThan(yDisp, 400,
+                              "ydisp=\(yDisp) means the scrollback is far larger than the fixture's 200 seeded lines, so the mock stream is re-seeding on reconnect again. The paint assertion below would fail for that reason and not for a rendering fault. probe[\(reading)]")
+        }
         let placement: String = {
             guard let selRow, let yDisp, let rowCount else {
                 return "could not derive placement (selected text is not a line number, or the probe lacked ydisp/rows)"

--- a/HerdrUITests/TerminalSelectionTests.swift
+++ b/HerdrUITests/TerminalSelectionTests.swift
@@ -143,27 +143,33 @@ final class TerminalSelectionTests: XCTestCase {
         XCTAssertLessThan(tealPixelCount(focused), 20,
                           "a single tap on an unselected pane produced selection colour; the premise for step 4 is broken")
 
-        // (3) DOUBLE TAP ON THE LINE NUMBER, and this coordinate is now MEASURED rather than
-        // computed — my arithmetic for it was wrong twice.
+        // (3) DOUBLE TAP AT A COLUMN THAT IS WRITTEN ON BOTH ROW TYPES, because the terminal
+        // WRAPS and half the visible rows are continuations.
         //
-        // What the probe has established across two heads:
-        //   dx 0.22  -> selected "< >", a single space
-        //   dx 0.344 -> selected "187", the three-digit line number at columns 16-18
-        // I had predicted col 17.6 and col 27.5 respectively, assuming the 80-column line spans
-        // the screen width. It does not: solving from those two readings gives roughly 49 columns
-        // across the viewport, so the terminal's 80-column content is WIDER THAN THE SCREEN and
-        // the right-hand columns are simply off-view. That also retires my earlier claim that
-        // this fixture only offers five-character letter runs of slack — the visible portion is
-        // "SCROLLTEST line NNN  the quick…", and the widest thing in it is the number plus its
-        // surrounding spaces.
+        // The stream-lifecycle fix changed the geometry this test runs against, and the probe
+        // reported the new truth: rows=19 cols=50, not the 24x80 the fixture declares. The app
+        // pins the PTY to the phone's fit, so the fixture's 64-character line wraps:
+        //   row A (cols 0-49):  "SCROLLTEST line 187  the quick brown fox jumps ove"
+        //   row B (cols 0-13):  "r the lazy dog"   — and cols 14-49 are UNWRITTEN
+        // A tap on an unwritten cell hits selectWordOrExpression's NUL branch, which selects the
+        // run of nulls: active, and empty when read back. That is exactly what CI reported at the
+        // previous head — sel=1 len=0 text=<> — and dx 0.344 lands on col 17, which is inside the
+        // line number on row A and NUL on row B. Roughly half the rows are continuations, so that
+        // coordinate was a coin toss for the third time.
         //
-        // KEEPING dx 0.344 DELIBERATELY, because landing on the NUMBER is better than landing on
-        // a word: the fixture numbers every line, so the selected text identifies WHICH LINE the
-        // selection is on, which is exactly the fact the render assertion below needs in order to
-        // name its own cause. A word would satisfy the length check and tell me nothing.
+        // dx 0.150 is col 7, and it is chosen by enumerating every column written on BOTH row
+        // types with one column of slack either side, inside a word of at least three characters:
+        // columns 3, 7, 8 and 12 qualify. Col 7 is "SCROLLTEST" on a primary row and "lazy" on a
+        // continuation row, and cols 6 and 8 are inside the same two words, so a one-column drift
+        // still selects a real word.
+        //
+        // The cost is that the selected text no longer identifies the line, so the placement
+        // arithmetic below degrades to best-effort. That is an acceptable trade now: the row-space
+        // question it was built to answer has been ANSWERED — the fixture was re-seeding — and the
+        // ydisp guard is what protects against that returning.
         //
         // dy=0.30 stays in the terminal band, which the keyboard has shrunk to roughly the top 58%.
-        app.coordinate(withNormalizedOffset: CGVector(dx: 0.344, dy: 0.30)).doubleTap()
+        app.coordinate(withNormalizedOffset: CGVector(dx: 0.150, dy: 0.30)).doubleTap()
         Thread.sleep(forTimeInterval: 1.5)
         let selected = app.screenshot()
         attach(selected, name: "03-selection-held")
@@ -234,12 +240,19 @@ final class TerminalSelectionTests: XCTestCase {
         // The selection was real and off-screen, which is why no highlight ever appeared and why
         // I spent four rounds looking at SwiftTerm's renderer, which was innocent throughout.
         //
-        // 200 lines in a 24-row terminal parks yDisp at about 176. The ceiling is generous but far
-        // below a single extra seed, so a returning re-seed fails HERE, naming the fixture,
-        // instead of resurfacing as an unpaintable selection.
+        // THE CEILING IS 600, AND MY FIRST ATTEMPT AT 400 WAS ABOUT TO FALSE-FAIL. I sized it for
+        // an UNWRAPPED buffer — 200 lines in a 24-row terminal parks yDisp near 176 — but the app
+        // pins the PTY to the phone's fit of 50 columns, so each 64-character fixture line wraps
+        // to TWO rows: about 400 buffer rows, minus the 19 visible, giving yDisp ≈ 381. CI observed
+        // 382. A guard at 400 would have fired on correct behaviour within nineteen rows of slack,
+        // which is the sort of check that gets deleted for crying wolf rather than fixed.
+        //
+        // One extra re-seed reaches roughly 781, so 600 separates one seed from two with room on
+        // both sides. Computed from the fixture rather than guessed, and stated here so the next
+        // change to the fixture's line length or column pinning knows what this number depends on.
         if let yDisp {
-            XCTAssertLessThan(yDisp, 400,
-                              "ydisp=\(yDisp) means the scrollback is far larger than the fixture's 200 seeded lines, so the mock stream is re-seeding on reconnect again. The paint assertion below would fail for that reason and not for a rendering fault. probe[\(reading)]")
+            XCTAssertLessThan(yDisp, 600,
+                              "ydisp=\(yDisp) is far beyond the ~381 a single 200-line seed produces when wrapped at 50 columns, so the mock stream is re-seeding on reconnect again. The paint assertion below would then fail for that reason and not for a rendering fault. probe[\(reading)]")
         }
         let placement: String = {
             guard let selRow, let yDisp, let rowCount else {

--- a/HerdrUITests/TerminalSelectionTests.swift
+++ b/HerdrUITests/TerminalSelectionTests.swift
@@ -143,24 +143,28 @@ final class TerminalSelectionTests: XCTestCase {
         XCTAssertLessThan(tealPixelCount(focused), 20,
                           "a single tap on an unselected pane produced selection colour; the premise for step 4 is broken")
 
-        // (3) DOUBLE TAP ON THE LINE NUMBER, deliberately, because that is what makes the
-        // probe's reading diagnostic rather than merely present.
+        // (3) DOUBLE TAP INSIDE THE WIDEST LETTER RUN AVAILABLE, because the previous
+        // coordinate was a coin toss and CI proved it.
         //
-        // The mock seeds uniquely numbered lines, "SCROLLTEST line 007  the quick brown fox…"
-        // at 80 columns, and `selectWordOrExpression` treats digits as a selectable word. So
-        // aiming at the number makes the SELECTED TEXT identify which line the selection landed
-        // on: columns 0-10 are "SCROLLTEST ", 11-15 are "line ", and 16-18 are the digits, so
-        // col ~17 is dx ≈ 17.5/80 ≈ 0.22.
+        // THE PROBE ANSWERED THE QUESTION THIS TEST EXISTED TO ASK. Aimed at the line number it
+        // reported `sel=1 len=1 text=< >` — a ONE-CHARACTER SPACE. `selectWordOrExpression` has
+        // a dedicated whitespace branch, so a tap that misses the glyphs selects the run of
+        // spaces instead of nothing, which is an active, non-empty, entirely invisible-ish
+        // selection: one cell paints roughly 26 downsampled pixels, under the 60 this test
+        // requires. The retry pass then SUCCEEDED, which settles the older mystery too — the
+        // selection does paint when the tap lands on a word, so the earlier zero-teal runs were
+        // about WHERE the tap landed and not about SwiftTerm's drawing.
         //
-        // Why that matters here: every explanation for "SwiftTerm holds a selection and nothing
-        // is painted" has been eliminated by reading the SwiftTerm source, which means one of
-        // those readings is wrong. The line number is the one runtime fact that discriminates —
-        // a number from far outside the visible window means the tap's row space is wrong, and a
-        // visible number means the row space is fine and the defect is in the drawing.
+        // The mock line is "SCROLLTEST line 007  the quick brown fox jumps over the lazy dog" at
+        // 80 columns, and its longest letter runs are five characters. Columns: 0-9 SCROLLTEST,
+        // 10 space, 11-14 line, 15 space, 16-18 the digits, 19-20 two spaces, 21-23 the,
+        // 24 space, 25-29 quick, 30 space, 31-35 brown. Aiming at the MIDDLE of "quick" (col 27,
+        // dx = 27.5/80 ≈ 0.344) leaves two columns of slack on either side, which is the widest
+        // margin this fixture offers. The number at 16-18 offered one column, and dx 0.22 landed
+        // on a space at least once in two runs.
         //
-        // dy=0.30 stays in the terminal band, which the keyboard has shrunk to roughly the top
-        // 58%. The band shows the tail of a 200-line buffer, so a visible number is a high one.
-        app.coordinate(withNormalizedOffset: CGVector(dx: 0.22, dy: 0.30)).doubleTap()
+        // dy=0.30 stays in the terminal band, which the keyboard has shrunk to roughly the top 58%.
+        app.coordinate(withNormalizedOffset: CGVector(dx: 0.344, dy: 0.30)).doubleTap()
         Thread.sleep(forTimeInterval: 1.5)
         let selected = app.screenshot()
         attach(selected, name: "03-selection-held")
@@ -175,13 +179,28 @@ final class TerminalSelectionTests: XCTestCase {
         let probe = app.descendants(matching: .any)["terminal-selection-probe"]
         let reading = probe.waitForExistence(timeout: 5) ? (probe.label) : "PROBE ABSENT"
 
-        // The state assertion. `len > 0` is the part that matters: an active-but-EMPTY selection
-        // is exactly what a tap past end-of-line produces, and it offers Copy while painting
-        // nothing, which is how an earlier version of this file passed for the wrong reason.
+        // THE STATE ASSERTIONS, in order of how badly a failure would mislead.
         XCTAssertTrue(reading.contains("sel=1"),
                       "SwiftTerm reports no active selection after a double tap. probe[\(reading)]. If resizes climbed since the focus tap, a late relayout wiped it; if not, the double tap never reached SwiftTerm's recognizer")
         XCTAssertFalse(reading.contains("len=0"),
-                       "the selection is active but EMPTY, so the tap landed off the glyphs. probe[\(reading)]")
+                       "the selection is active but EMPTY, so the tap landed past the end of the line. probe[\(reading)]")
+
+        // A WHITESPACE SELECTION IS A COORDINATE MISS, NOT A RENDER BUG, and it must say so.
+        // `selectWordOrExpression` has a dedicated branch that selects a RUN OF SPACES, so a tap
+        // between words yields an active, non-empty selection that paints one or two cells —
+        // which then fails the pixel threshold below and reads exactly like a drawing failure.
+        // That cost a CI round: the probe reported `len=1 text=< >` while the message blamed the
+        // renderer. Extracting the text and checking it is a word turns the same run into a
+        // one-line diagnosis.
+        let selectedText = reading.range(of: "text=<").flatMap { start -> String? in
+            let rest = reading[start.upperBound...]
+            guard let end = rest.range(of: ">") else { return nil }
+            return String(rest[..<end.lowerBound])
+        } ?? ""
+        XCTAssertFalse(selectedText.trimmingCharacters(in: .whitespaces).isEmpty,
+                       "the double tap selected WHITESPACE (\(selectedText.count) char(s)), so the coordinate missed the glyphs — this is a test-aim failure, not a drawing failure. probe[\(reading)]")
+        XCTAssertGreaterThanOrEqual(selectedText.count, 3,
+                                    "selected '\(selectedText)', shorter than any word in the fixture line, so the tap clipped a word edge and the pixel threshold below would be unreliable. probe[\(reading)]")
 
         // THE RENDER ASSERTION, which the state assertion cannot replace: the user sees pixels,
         // and a selection that exists without being drawn is still broken for them.

--- a/HerdrUITests/TerminalSelectionTests.swift
+++ b/HerdrUITests/TerminalSelectionTests.swift
@@ -371,6 +371,89 @@ final class TerminalSelectionTests: XCTestCase {
                           "SwiftTerm reports the selection cleared but the highlight is still painted (teal px=\(clearedTeal)), so the clear reached the model and not the screen. probe[\(afterReading)]")
     }
 
+
+    /// THE COLLAPSE CHEVRON'S RECEIPT, and it exists because this PR's FIRST attempt at the
+    /// chevron fix was inert and nothing here could tell.
+    ///
+    /// The defect: on iPhone, with a word selected, the chevron cleared both focus flags — which
+    /// hides the chevron itself — while `updateUIView`'s resign stayed gated on
+    /// `!hasActiveSelection`. So the keyboard stayed up over ~40% of the pane with its only
+    /// dismiss affordance gone. The first fix set a bool and cleared it in
+    /// `DispatchQueue.main.async`; that queue drains BEFORE SwiftUI's update flush, so the pane
+    /// read the flag as already false and the resign never ran. Review caught it by reading,
+    /// because an inert fix and a working one produce identical screenshots — there was no
+    /// observable for "gave up the responder while keeping the selection". Hence `fr=` on the
+    /// probe and hence this test.
+    ///
+    /// WHAT IT PINS, which is the product contract and not the mechanism: a deliberate collapse
+    /// resigns the responder (keyboard down) AND the selection survives in the model (a double
+    /// tap re-presents Copy without re-selecting). Under the async-reset mechanism this fails at
+    /// the `fr=0` poll; under a mechanism that resigns by clearing the selection it fails at
+    /// `sel=1`. Both are real regressions and each has its own failure message.
+    func testTheCollapseChevronDismissesTheKeyboardWithAWordSelected() throws {
+        // iPHONE-ONLY BY CONSTRUCTION: the chevron's own visibility condition is
+        // `replyFocused || (terminalInputFocused && idiom == .phone)`, because on iPad the
+        // terminal's inputView is zero-frame so there is no keyboard to collapse. CI picks an
+        // iPhone destination (ci.yml greps `iPhone [0-9]+`), so this skips only on a local iPad run
+        // rather than silently passing there.
+        try XCTSkipUnless(UIDevice.current.userInterfaceIdiom == .phone,
+                          "the collapse chevron is iPhone-only; there is no keyboard to collapse on iPad")
+
+        let app = XCUIApplication()
+        addUIInterruptionMonitor(withDescription: "system dialog") { alert in
+            let allow = alert.buttons.element(boundBy: alert.buttons.count - 1)
+            if allow.exists { allow.tap(); return true }
+            return false
+        }
+        app.launchEnvironment["HERDR_SCREENSHOT_MOCK"] = "scroll"
+        app.launch()
+
+        let probe = app.descendants(matching: .any)["terminal-selection-probe"]
+        XCTAssertTrue(probe.waitForExistence(timeout: 20),
+                      "the terminal never came up, so nothing below is about the chevron")
+
+        // Two stages for the same reason the other test uses two: tap 1 raises the keyboard and
+        // relayouts the terminal band, so a double tap fired into that motion selects whatever
+        // slid under the finger. Settle first, then select.
+        app.coordinate(withNormalizedOffset: CGVector(dx: 0.50, dy: 0.30)).tap()
+        Thread.sleep(forTimeInterval: 2.5)
+        // dx 0.150 is col 7 — written on BOTH the primary and continuation row types with a
+        // column of slack either side. See the long note in the other test for the enumeration.
+        app.coordinate(withNormalizedOffset: CGVector(dx: 0.150, dy: 0.30)).doubleTap()
+        Thread.sleep(forTimeInterval: 1.5)
+
+        // PREMISES FIRST. Without a live selection AND a held responder this test would pass on a
+        // pane that simply never focused, which is the vacuity that cost this PR a round already.
+        let beforeReading = probe.exists ? probe.label : "PROBE ABSENT"
+        XCTAssertTrue(beforeReading.contains("sel=1"),
+                      "premise: no selection to preserve, so the gate under test is never reached. probe[\(beforeReading)]")
+        XCTAssertTrue(beforeReading.contains("fr=1"),
+                      "premise: the terminal does not hold the responder, so there is nothing for the chevron to resign. probe[\(beforeReading)]")
+
+        let chevron = app.buttons["Collapse keyboard"]
+        XCTAssertTrue(chevron.waitForExistence(timeout: 5),
+                      "the chevron is absent while the keyboard is up with a selection held — which IS the original defect: no affordance to dismiss with")
+        chevron.tap()
+
+        // A BOUNDED POLL FOR A READING THAT IS BOTH RESIGNED AND FRESH. `fr=0` alone would accept
+        // the label from before the keyboard ever came up; `pub=<handler>#<count>` is monotonic, so
+        // a changed label is proof of a new publish. The resign publishes `pub=collapseResign`,
+        // which is the one path no gesture handler covers.
+        let deadline = Date().addingTimeInterval(10)
+        while Date() < deadline {
+            if probe.exists, probe.label.contains("fr=0"), probe.label != beforeReading { break }
+            Thread.sleep(forTimeInterval: 0.25)
+        }
+        let afterReading = probe.exists ? probe.label : "PROBE ABSENT"
+
+        XCTAssertTrue(afterReading.contains("fr=0"),
+                      "the chevron did not resign the responder, so the keyboard is still up and the chevron has hidden itself — the exact defect this fix exists for. If pub= is unchanged from the pre-tap reading the update pass never observed the collapse token; if it changed and fr is still 1 the resign was refused by the selection guard. probe[\(afterReading)] before[\(beforeReading)]")
+        XCTAssertTrue(afterReading.contains("sel=1"),
+                      "the collapse also DROPPED the selection. Resigning is meant to hide the Copy menu while leaving the selection in the model, so a double tap re-presents it without re-selecting. probe[\(afterReading)]")
+        XCTAssertTrue(afterReading.contains("pub=collapseResign"),
+                      "the responder was resigned by some other path than the deliberate collapse (pub names the publisher), so this run did not exercise the chevron even though the end state looks right. probe[\(afterReading)]")
+    }
+
     /// Pull an integer field out of the probe label, e.g. `ydisp=176` -> 176.
     ///
     /// Returns nil rather than a default when the field is absent, so a probe that stops

--- a/HerdrUITests/TerminalSelectionTests.swift
+++ b/HerdrUITests/TerminalSelectionTests.swift
@@ -143,12 +143,24 @@ final class TerminalSelectionTests: XCTestCase {
         XCTAssertLessThan(tealPixelCount(focused), 20,
                           "a single tap on an unselected pane produced selection colour; the premise for step 4 is broken")
 
-        // (3) DOUBLE TAP ON ACTUAL TEXT, on the now-stable layout. The mock lines read
-        // "SCROLLTEST line 007  the quick brown fox…" at 80 columns, so dx=0.30 is comfortably
-        // inside the glyphs — a tap past end-of-line selects an EMPTY range, which is the third
-        // way this file has been fooled. dy=0.30 stays in the terminal band, which the keyboard
-        // has now shrunk to roughly the top 58%.
-        app.coordinate(withNormalizedOffset: CGVector(dx: 0.30, dy: 0.30)).doubleTap()
+        // (3) DOUBLE TAP ON THE LINE NUMBER, deliberately, because that is what makes the
+        // probe's reading diagnostic rather than merely present.
+        //
+        // The mock seeds uniquely numbered lines, "SCROLLTEST line 007  the quick brown fox…"
+        // at 80 columns, and `selectWordOrExpression` treats digits as a selectable word. So
+        // aiming at the number makes the SELECTED TEXT identify which line the selection landed
+        // on: columns 0-10 are "SCROLLTEST ", 11-15 are "line ", and 16-18 are the digits, so
+        // col ~17 is dx ≈ 17.5/80 ≈ 0.22.
+        //
+        // Why that matters here: every explanation for "SwiftTerm holds a selection and nothing
+        // is painted" has been eliminated by reading the SwiftTerm source, which means one of
+        // those readings is wrong. The line number is the one runtime fact that discriminates —
+        // a number from far outside the visible window means the tap's row space is wrong, and a
+        // visible number means the row space is fine and the defect is in the drawing.
+        //
+        // dy=0.30 stays in the terminal band, which the keyboard has shrunk to roughly the top
+        // 58%. The band shows the tail of a 200-line buffer, so a visible number is a high one.
+        app.coordinate(withNormalizedOffset: CGVector(dx: 0.22, dy: 0.30)).doubleTap()
         Thread.sleep(forTimeInterval: 1.5)
         let selected = app.screenshot()
         attach(selected, name: "03-selection-held")

--- a/HerdrUITests/TerminalSelectionTests.swift
+++ b/HerdrUITests/TerminalSelectionTests.swift
@@ -98,15 +98,39 @@ final class TerminalSelectionTests: XCTestCase {
         XCTAssertLessThan(baseTeal, 20,
                           "found \(baseTeal) selection-coloured pixels BEFORE selecting anything; the detector cannot distinguish a selection here")
 
-        // (2) DOUBLE TAP ON ACTUAL TEXT. dx is small because these mock lines are short and a
-        // tap past end-of-line selects an EMPTY range (lesson 3); dy sits in the terminal band,
-        // above the software keyboard and below the header.
-        app.coordinate(withNormalizedOffset: CGVector(dx: 0.10, dy: 0.32)).doubleTap()
+        // (2) RAISE THE KEYBOARD FIRST, AND ASSERT THAT IT HAPPENED. This step exists because
+        // of a measured failure, not for tidiness: the previous version double-tapped a COLD
+        // pane and got teal px=0 with a clean baseline. Tap 1 of that double tap fires
+        // `focusTap`, which requests terminal focus and so raises the iPhone software keyboard;
+        // the keyboard takes roughly the bottom 40%, the terminal band relaid out under the
+        // finger, and tap 2 therefore hit different content and word-selected an EMPTY range —
+        // active selection, Copy offered, nothing painted. Doing it in two stages means the
+        // layout is settled before the gesture under test runs.
+        //
+        // The assertion is what makes this a wait with a reason rather than a sleep: a large
+        // diff IS the keyboard arriving, so if it ever stops arriving this fails here, naming
+        // the cause, instead of failing later as a mysteriously absent selection.
+        app.coordinate(withNormalizedOffset: CGVector(dx: 0.50, dy: 0.30)).tap()
+        Thread.sleep(forTimeInterval: 2.5)
+        let focused = app.screenshot()
+        attach(focused, name: "02-keyboard-up")
+        let focusDiff = pixelDiffFraction(baseline, focused)
+        XCTAssertGreaterThan(focusDiff, 0.10,
+                             "the focus tap changed almost nothing (diff=\(focusDiff)); the keyboard did not come up, so the double tap below would run against a layout that is still about to move")
+        XCTAssertLessThan(tealPixelCount(focused), 20,
+                          "a single tap on an unselected pane produced selection colour; the premise for step 4 is broken")
+
+        // (3) DOUBLE TAP ON ACTUAL TEXT, on the now-stable layout. The mock lines read
+        // "SCROLLTEST line 007  the quick brown fox…" at 80 columns, so dx=0.30 is comfortably
+        // inside the glyphs — a tap past end-of-line selects an EMPTY range, which is the third
+        // way this file has been fooled. dy=0.30 stays in the terminal band, which the keyboard
+        // has now shrunk to roughly the top 58%.
+        app.coordinate(withNormalizedOffset: CGVector(dx: 0.30, dy: 0.30)).doubleTap()
         Thread.sleep(forTimeInterval: 1.5)
         let selected = app.screenshot()
-        attach(selected, name: "02-selection-held")
+        attach(selected, name: "03-selection-held")
 
-        // (3) THE ASSERTION THAT CANNOT PASS BY ACCIDENT: a word is painted in the selection
+        // (4) THE ASSERTION THAT CANNOT PASS BY ACCIDENT: a word is painted in the selection
         // colour. This is where the mutant shows — with the clear tap firing on tap 2, the
         // selection is gone by now and there is no teal to find.
         //
@@ -123,13 +147,14 @@ final class TerminalSelectionTests: XCTestCase {
         XCTAssertTrue(app.menuItems["Copy"].waitForExistence(timeout: 5),
                       "a word is highlighted but Copy is not offered, so the selection cannot be acted on")
 
-        // (4) DESELECTION still works, so the fix did not simply disable it. The tap stays in
+        // (5) DESELECTION still works, so the fix did not simply disable it. The tap stays in
         // the terminal band and well away from the selected word — NOT on the keyboard, which
-        // on a live pane would type a character into the agent's shell.
-        app.coordinate(withNormalizedOffset: CGVector(dx: 0.70, dy: 0.22)).tap()
+        // on a live pane would type a character into the agent's shell. The keyboard is already
+        // up by now, so this tap cannot move the layout the way step 2's did.
+        app.coordinate(withNormalizedOffset: CGVector(dx: 0.70, dy: 0.20)).tap()
         Thread.sleep(forTimeInterval: 2.0)
         let cleared = app.screenshot()
-        attach(cleared, name: "03-after-single-tap")
+        attach(cleared, name: "04-after-single-tap")
         let clearedTeal = tealPixelCount(cleared)
         XCTAssertLessThan(clearedTeal, 20,
                           "the selection highlight survived a genuine single tap (teal px=\(clearedTeal)); deselection is not reaching the view")


### PR DESCRIPTION
## Why

Text selection in an agent terminal pane was unreachable by dragging, on iPhone, iPad and Mac.

SwiftTerm installs its drag-to-extend pan lazily, only from `doubleTap`, `tripleTap`, `select(_:)` or `selectAll(_:)` (`iOSTerminalView.swift:1043`, called only from `:546`, `:554`, `:806`, `:830`). This app forced SwiftTerm's double tap to fail so it could use double tap for jump-to-tail, which removed word select and the only tap that installs the extend pan. Before any selection exists there is therefore no pan that can create one, so every drag could only scroll.

Mac is not a separate surface: `project.yml:208` sets `SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD: YES` with no Catalyst target, so Mac runs the unchanged iOS binary and inherited the same behaviour with a real mouse.

## What changed

- Give the single-finger double tap back to SwiftTerm. Drops the app's 2-tap recognizer and the loop that forced every 2-tap recognizer to `require(toFail:)` it. Restores word select, drag-to-extend and the Copy menu together.
- Jump-to-tail moves to three places: a two-finger tap (every SwiftTerm recognizer is single-finger, so it needs no failure requirement and costs the tap chain nothing), a "Latest" pill shown only while scrolled away from the tail, and the existing shortcut-row down arrow, which now routes through the pane instead of emitting a raw `ESC[1;5F` that was only correct on mouse-mode panes.
- A single tap clears an active selection via the public `hasActiveSelection` / `clearSelection()`. SwiftTerm only clears on single tap when the view is already first responder, so on an unfocused pane the tap was spent taking focus and the selection survived. Focus is taken only when nothing is selected.
- The agent-scroll pan no longer begins on a plain shell pane, where its handler returned early anyway, nor while a selection is active. The delegate previously returned `true` unconditionally, which per Apple's contract guarantees simultaneity, so an extend-drag both extended the selection and wheel-scrolled the agent underneath it.
- First responder is no longer resigned while a selection is active, which is what made the Copy menu vanish mid-selection.
- iPhone can type directly into the terminal: the system keyboard is retained and SwiftTerm key bytes route through the existing ordered PTY input path. Return in the reply field now dismisses the keyboard instead of handing focus back to the terminal. Added a one-tap `^P` cap for prompt history.
- Gestures help no longer teaches the swipe-between-agents gesture removed in August, and now teaches double tap, triple tap and two-finger tap.

Tail state is reported through `TerminalViewDelegate.scrolled`, which was a no-op stub. The scroll view delegate is deliberately NOT claimed: overriding SwiftTerm's scroll wiring dead-locked scrolling across roughly seven TestFlight builds previously.

## Verification

Not compiled or device-verified locally. The machine this was written on has no Swift toolchain for the app target, no Xcode and no simulator. CI builds this PR.

What was checked statically: brace, paren and bracket balance on all three files with two untouched files as controls and a negative control that correctly reported an injected imbalance; zero remaining references to the removed `handleDoubleTap`, the old `rawCap` down arrow, or the deleted help entry, with a positive control on the same instrument; and the memberwise init argument order against the property declaration order, since `LiveTerminalView` has no explicit init and exactly one call site.

Selection needs a device pass. CI cannot drive long press plus a context menu, which is recorded in #133.

## Known open question for the reviewer

All four SwiftTerm selection entry points present Copy through `UIMenuController`, deprecated at iOS 16 and still the only path through v1.20.0. If the menu does not present on current iOS, this restores the highlight but not the Copy affordance, and the follow-up is an app-owned Copy control calling `copy(nil)`. Worth attacking.

## Authorization

Owner instruction in the herdr-app pane, recorded as Gitmoot workflow note 101263.