### PR TITLE
fix(agents): let input_pending and a degraded peer's last-known blocked reach needs-you

### DIFF
--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -2278,7 +2278,10 @@ struct TerminalHomeView: View {
     /// nothing uninterpretable, the quiet state says so. A space holds the line
     /// while loading/empty so nothing above it moves.
     private var headerSubtitle: (text: String, color: Color) {
-        if fullList.needsYouCount > 0 { return ("\(fullList.needsYouCount) need you", Palette.waiting) }
+        // Reads the shared wording spec rather than formatting its own string: this header
+        // is NOT co-located with the row, so unlike the card it cannot rely on the reader
+        // seeing the stale marker beside the count.
+        if let summary = fullList.needsYouSummary { return (summary, Palette.waiting) }
         if fullList.isQuiet && !agents.isEmpty { return ("nothing needs you", Palette.textFaint) }
         return (" ", Palette.textFaint)
     }

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -2903,7 +2903,7 @@ struct TerminalHomeView: View {
             // needs-you, so without a marker a stale guess reads exactly like a colleague
             // genuinely waiting. Mark the row instead of suppressing the badge: hiding the
             // needs-you signal would be the worse error of the two.
-            if row.info.hasUnconfirmedStatus && !row.info.isUnreachable {
+            if row.showsUnconfirmedMarker {
                 Text("stale")
                     .font(Typography.app(11, .semibold)).foregroundStyle(Palette.textDim)
                     .padding(.horizontal, 8).padding(.vertical, 3)
@@ -6207,6 +6207,10 @@ struct MockTransport: HerdrTransport {
     // you" is `blocked`; the STOPPED row is NOT a status string — it comes from
     // liveness (w2:p1 is absent from demoLivePaneIDs below), exactly as the real
     // model derives it. done folds into idle.
+    // The mcb-air row is a DEGRADED FEDERATED agent, the shape this fixture lacked: the
+    // daemon blanked `agent_status` to "unknown" after a missed poll and moved the real
+    // state into `last_known_status`, so it escalates into NEEDS YOU on a last-known
+    // value and must render the "stale" marker. It is what the UI receipt asserts.
     static let agentList = #"""
     {"id":"mock","result":{"type":"agent_list","agents":[
       {"pane_id":"w1:p1","name":"jarvis","agent":"claude","agent_status":"blocked","cwd":"/root/herdr-ios","terminal_title_stripped":"asking to run tests"},
@@ -6217,15 +6221,18 @@ struct MockTransport: HerdrTransport {
       {"pane_id":"w3:p2","name":"aste-screener","agent":"codex","agent_status":"idle","cwd":"/root/aste-screener","terminal_title_stripped":"apify-harvest"},
       {"pane_id":"w4:p1","name":"discovery","agent":"gemini","agent_status":"idle","cwd":"/root/discovery-calls","terminal_title_stripped":"redaction-pass v3"},
       {"pane_id":"w4:p2","name":"bank-qa","agent":"claude","agent_status":"done","cwd":"/root/bank-qa","terminal_title_stripped":"deal-assistant rag"},
+      {"pane_id":"mcb-air/w1:p9","name":"mcb-air/mcb-air","agent":"omp","agent_status":"unknown","last_known_status":"blocked","machine_id":"mcb-air","reachability":"degraded","cwd":"/Users/jerry/omp-workspace","terminal_title_stripped":"clone repo and help deimos"},
       {"pane_id":"w5:p1","name":"huurjacht","agent":"claude","agent_status":"idle","cwd":"/root/huurjacht","terminal_title_stripped":"pararius scrape","archived":{"at":"2026-08-26T18:00:00Z","by":"jerry","reason":"parked for the weekend"}}
     ]}}
     """#
 
     /// The panes herdr still lists, for the mock render. Excludes w2:p1 so that
-    /// row lands in STOPPED via liveness (not a status string). MUST stay in sync
-    /// with the census the fixture test uses.
+    /// row lands in STOPPED via liveness (not a status string). Includes the federated
+    /// `mcb-air/w1:p9`, because a pane absent from the census is `.stopped` and a stopped
+    /// row is never escalated, which would silently defeat the degraded-peer receipt.
+    /// MUST stay in sync with the census the fixture test uses.
     static let demoLivePaneIDs: Set<String> = [
-        "w1:p1", "w1:p2", "w2:p2", "w3:p1", "w3:p2", "w4:p1", "w4:p2",
+        "w1:p1", "w1:p2", "w2:p2", "w3:p1", "w3:p2", "w4:p1", "w4:p2", "mcb-air/w1:p9",
     ]
 
     /// `accounts.list` for the Settings mock render: two claude accounts (one active

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -2908,6 +2908,11 @@ struct TerminalHomeView: View {
                     .font(Typography.app(11, .semibold)).foregroundStyle(Palette.textDim)
                     .padding(.horizontal, 8).padding(.vertical, 3)
                     .background(Capsule().fill(Palette.textDim.opacity(0.12)))
+                    // The LABEL is replaced for VoiceOver, so the visible word "stale" is no
+                    // longer findable by label. Carry an explicit identifier as well, which is
+                    // what the UI receipt asserts on. Without it the receipt failed on its
+                    // first CI run looking for a label that the modifier above had overwritten.
+                    .accessibilityIdentifier("agent-row-stale-marker")
                     .accessibilityLabel(Text("status not confirmed on the last poll"))
             }
             // A remote agent whose machine is unreachable has a stale status, so

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -2898,6 +2898,18 @@ struct TerminalHomeView: View {
                     .background(Capsule().fill(Palette.died.opacity(0.12)))
                     .overlay(Capsule().stroke(Palette.died.opacity(0.5), lineWidth: 1))
             }
+            // A DEGRADED peer (the daemon's 1 to 2 missed polls) still renders a live
+            // status badge, and `resolvedGroup` can surface a LAST-KNOWN blocked row into
+            // needs-you, so without a marker a stale guess reads exactly like a colleague
+            // genuinely waiting. Mark the row instead of suppressing the badge: hiding the
+            // needs-you signal would be the worse error of the two.
+            if row.info.hasUnconfirmedStatus && !row.info.isUnreachable {
+                Text("stale")
+                    .font(Typography.app(11, .semibold)).foregroundStyle(Palette.textDim)
+                    .padding(.horizontal, 8).padding(.vertical, 3)
+                    .background(Capsule().fill(Palette.textDim.opacity(0.12)))
+                    .accessibilityLabel(Text("status not confirmed on the last poll"))
+            }
             // A remote agent whose machine is unreachable has a stale status, so
             // it reads as offline rather than showing a misleading live badge.
             if row.info.isUnreachable {

--- a/App/LiveActivityController.swift
+++ b/App/LiveActivityController.swift
@@ -132,6 +132,10 @@ final class LiveActivityController: ObservableObject {
             headline: lead?.title ?? "No agents",
             status: status,
             needsYouCount: list.needsYouCount,
+            // Carried so the lock screen can qualify the count. Without it the widget
+            // asserted a last-known blocked state on a degraded peer as fact, which is the
+            // one thing the roster card's "stale" marker exists to prevent.
+            unconfirmedCount: list.unconfirmedNeedsYouCount,
             workingCount: rows.filter { $0.group == .working }.count,
             totalCount: rows.count,
             workingSince: workingSince

--- a/App/LiveActivityController.swift
+++ b/App/LiveActivityController.swift
@@ -107,42 +107,32 @@ final class LiveActivityController: ObservableObject {
 
     // MARK: - Mapping HerdrKit → the shared content state
 
-    /// Build a content state from the current agent list.
+    /// Copy `AgentList.activityContent` into the activity's own state type. THIS FUNCTION
+    /// DECIDES NOTHING, deliberately.
     ///
-    /// The headline comes from `AgentList.activityLead`, NOT from the list ordering. This
-    /// used to re-derive it here as `rows.min { $0.group.rawValue < ... }`, which reuses the
-    /// ROSTER'S SECTION ORDER to answer a different question, and a single freshly stopped
-    /// pane therefore outranked N working agents: a red Stopped dot over a summary line
-    /// reading "N working". The rule now has ONE definition, in HerdrKit, where it is unit
-    /// tested on Linux — this file cannot be, since nothing in the app has a test target.
+    /// It used to derive the headline here, first as `rows.min { $0.group.rawValue < ... }`
+    /// (the roster's section order answering a different question, which put a red Stopped dot
+    /// over a summary reading "N working") and then, after that rule moved to HerdrKit, as a
+    /// single `list.activityLead` call. A reviewer showed the second version was barely better
+    /// than the first: nothing in the repo executes this function, no test target can see
+    /// `App/`, and so the ONE-LINE REVERT back to the buggy expression restored the shipped
+    /// defect in full and passed all 446 tests. Pinning the helper was not pinning the path.
+    ///
+    /// Every decision therefore moved into `activityContent`, where a test does execute it.
+    /// What is left here is a field copy, and the one remaining judgement — an unknown status
+    /// word — resolves the way the rest of this stack resolves it, toward surfacing rather
+    /// than sinking. A cross-target test asserts HerdrKit can only ever emit the four words
+    /// this enum accepts, so the fallback is unreachable rather than merely unlikely.
     static func state(from list: AgentList) -> AgentActivityAttributes.ContentState {
-        let rows = list.rows
-        let lead = list.activityLead
-        let status: AgentActivityAttributes.Status
-        switch lead?.group {
-        case .needsYou, .unrecognised: status = .needsYou
-        case .stopped:                 status = .stopped
-        case .working:                 status = .working
-        case .idle, .none:             status = .idle
-        }
-        // Only the working state carries a start time — the headline agent's current
-        // turn ≈ its last completed-turn boundary (stable while it works that turn, so
-        // the widget timer doesn't reset on every list refresh). Same signal the
-        // in-app header uses.
-        let workingSince: Double? = status == .working
-            ? lead?.info.lastCompletedTurn?.completedUnixMs.map { Double($0) / 1000 }
-            : nil
+        let c = list.activityContent
         return AgentActivityAttributes.ContentState(
-            headline: lead?.title ?? "No agents",
-            status: status,
-            needsYouCount: list.needsYouCount,
-            // Carried so the lock screen can qualify the count. Without it the widget
-            // asserted a last-known blocked state on a degraded peer as fact, which is the
-            // one thing the roster card's "stale" marker exists to prevent.
-            unconfirmedCount: list.unconfirmedNeedsYouCount,
-            workingCount: rows.filter { $0.group == .working }.count,
-            totalCount: rows.count,
-            workingSince: workingSince
+            headline: c.headline,
+            status: AgentActivityAttributes.Status(rawValue: c.statusWord) ?? .needsYou,
+            needsYouCount: c.needsYouCount,
+            unconfirmedCount: c.unconfirmedCount,
+            workingCount: c.workingCount,
+            totalCount: c.totalCount,
+            workingSince: c.workingSinceUnixSeconds
         )
     }
 

--- a/App/LiveActivityController.swift
+++ b/App/LiveActivityController.swift
@@ -107,13 +107,17 @@ final class LiveActivityController: ObservableObject {
 
     // MARK: - Mapping HerdrKit → the shared content state
 
-    /// Build a content state from the current agent list. The headline is the
-    /// highest-priority agent (lowest `AgentGroup` rawValue: needsYou < stopped <
-    /// unrecognised < working < idle), so the surface always leads with whatever most
-    /// wants the user's attention.
+    /// Build a content state from the current agent list.
+    ///
+    /// The headline comes from `AgentList.activityLead`, NOT from the list ordering. This
+    /// used to re-derive it here as `rows.min { $0.group.rawValue < ... }`, which reuses the
+    /// ROSTER'S SECTION ORDER to answer a different question, and a single freshly stopped
+    /// pane therefore outranked N working agents: a red Stopped dot over a summary line
+    /// reading "N working". The rule now has ONE definition, in HerdrKit, where it is unit
+    /// tested on Linux — this file cannot be, since nothing in the app has a test target.
     static func state(from list: AgentList) -> AgentActivityAttributes.ContentState {
         let rows = list.rows
-        let lead = rows.min { $0.group.rawValue < $1.group.rawValue }
+        let lead = list.activityLead
         let status: AgentActivityAttributes.Status
         switch lead?.group {
         case .needsYou, .unrecognised: status = .needsYou

--- a/HerdrUITests/StaleFleetRowTests.swift
+++ b/HerdrUITests/StaleFleetRowTests.swift
@@ -13,7 +13,14 @@ import XCTest
 /// `last_known_status: "blocked"` and `reachability: "degraded"`. That row escalates into
 /// NEEDS YOU on a last-known value, so it is exactly the row that must not read as a
 /// confirmed one.
+///
+/// Asserts on the ACCESSIBILITY IDENTIFIER, not the visible string. The chip overrides its
+/// accessibility label with an explanatory sentence for VoiceOver, which means the word
+/// "stale" is not findable by label. The first version of this file looked for the label
+/// and failed on its first CI run for exactly that reason.
 final class StaleFleetRowTests: XCTestCase {
+
+    private let markerID = "agent-row-stale-marker"
 
     override func setUp() { continueAfterFailure = false }
 
@@ -27,21 +34,16 @@ final class StaleFleetRowTests: XCTestCase {
         XCTAssertTrue(app.staticTexts["mcb-air/mcb-air"].waitForExistence(timeout: 12),
                       "the degraded federated fixture row should be on the roster")
 
-        // The marker itself. `staticTexts` rather than a label lookup, because the chip is
-        // the thing a person sees; asserting the accessibility label alone would pass on a
-        // view that renders nothing visible.
-        XCTAssertTrue(app.staticTexts["stale"].waitForExistence(timeout: 4),
+        let marker = app.descendants(matching: .any).matching(identifier: markerID)
+        XCTAssertTrue(marker.firstMatch.waitForExistence(timeout: 4),
                       "a needs-you row resting on a last-known status must be marked stale")
 
-        // And the marker is SCOPED: the two locally blocked rows are live, so exactly one
-        // stale chip exists. A mutant that marked every row would pass the assertion above.
-        XCTAssertEqual(app.staticTexts.matching(identifier: "stale").count, 1,
-                       "only the unconfirmed row should carry the marker")
+        // The marker is SCOPED: the two locally blocked fixture rows are live, so exactly
+        // one chip exists. A mutant that marked every row would pass the assertion above.
+        XCTAssertEqual(marker.count, 1, "only the unconfirmed row should carry the marker")
 
-        // The row keeps its needs-you signal rather than being hidden or downgraded: the
-        // whole point is to surface it AND qualify it.
-        XCTAssertTrue(app.staticTexts["NEEDS YOU · 3"].exists
-                        || app.staticTexts.containing(NSPredicate(format: "label CONTAINS 'NEEDS YOU'")).count > 0,
-                      "the escalated row should still be counted in the needs-you section")
+        // The label is the sentence a VoiceOver reader hears, not the four-letter chip.
+        XCTAssertEqual(marker.firstMatch.label, "status not confirmed on the last poll",
+                       "the marker must explain itself to a screen reader")
     }
 }

--- a/HerdrUITests/StaleFleetRowTests.swift
+++ b/HerdrUITests/StaleFleetRowTests.swift
@@ -1,0 +1,47 @@
+import XCTest
+
+/// THE RENDER RECEIPT for the degraded-peer staleness marker.
+///
+/// The unit tests pin the RULE (`AgentRow.showsUnconfirmedMarker`) but cannot see the
+/// view, so a review mutant that disabled the card's condition entirely
+/// (`if false && row.showsUnconfirmedMarker`) compiled and survived all 415 runnable
+/// HerdrKit tests. That is the gap this file closes: it asserts the marker is actually
+/// on screen, so the same mutant fails here instead of shipping green.
+///
+/// The `list` mock roster carries a federated `mcb-air/mcb-air` row whose live status the
+/// daemon blanked to "unknown" after a missed poll, with the real state moved to
+/// `last_known_status: "blocked"` and `reachability: "degraded"`. That row escalates into
+/// NEEDS YOU on a last-known value, so it is exactly the row that must not read as a
+/// confirmed one.
+final class StaleFleetRowTests: XCTestCase {
+
+    override func setUp() { continueAfterFailure = false }
+
+    func testDegradedFederatedRowRendersAStalenessMarker() {
+        let app = XCUIApplication()
+        app.launchEnvironment["HERDR_SCREENSHOT_MOCK"] = "list"
+        app.launch()
+
+        // Premise first: the roster actually rendered and the federated row is present.
+        // Without this a missing marker could not be told apart from a missing screen.
+        XCTAssertTrue(app.staticTexts["mcb-air/mcb-air"].waitForExistence(timeout: 12),
+                      "the degraded federated fixture row should be on the roster")
+
+        // The marker itself. `staticTexts` rather than a label lookup, because the chip is
+        // the thing a person sees; asserting the accessibility label alone would pass on a
+        // view that renders nothing visible.
+        XCTAssertTrue(app.staticTexts["stale"].waitForExistence(timeout: 4),
+                      "a needs-you row resting on a last-known status must be marked stale")
+
+        // And the marker is SCOPED: the two locally blocked rows are live, so exactly one
+        // stale chip exists. A mutant that marked every row would pass the assertion above.
+        XCTAssertEqual(app.staticTexts.matching(identifier: "stale").count, 1,
+                       "only the unconfirmed row should carry the marker")
+
+        // The row keeps its needs-you signal rather than being hidden or downgraded: the
+        // whole point is to surface it AND qualify it.
+        XCTAssertTrue(app.staticTexts["NEEDS YOU · 3"].exists
+                        || app.staticTexts.containing(NSPredicate(format: "label CONTAINS 'NEEDS YOU'")).count > 0,
+                      "the escalated row should still be counted in the needs-you section")
+    }
+}

--- a/HerdrWidgets/AgentLiveActivity.swift
+++ b/HerdrWidgets/AgentLiveActivity.swift
@@ -79,25 +79,6 @@ struct AgentLiveActivity: Widget {
     }
 }
 
-/// The summary wording, in ONE place, because two surfaces render it and the lock screen
-/// previously asserted an unconfirmed count as fact while the roster card marked it.
-enum AgentActivitySummary {
-    static func line(_ s: AgentActivityAttributes.ContentState) -> String {
-        if s.needsYouCount > 0 {
-            // Every waiting agent rests on an unconfirmed state, so the whole claim is a
-            // maybe: say so rather than appending a qualifier to an assertion.
-            if s.unconfirmedCount >= s.needsYouCount { return "\(s.needsYouCount) may need you" }
-            // Some are confirmed and some are not. Lead with the fact, name the doubt.
-            if s.unconfirmedCount > 0 {
-                return "\(s.needsYouCount) need you · \(s.unconfirmedCount) stale"
-            }
-            return "\(s.needsYouCount) need you"
-        }
-        if s.workingCount > 0 { return "\(s.workingCount) working" }
-        return s.status.label
-    }
-}
-
 /// The lock-screen / banner layout: status dot, agent name + summary, host on the
 /// right. Kept compact and legible on the dark banner tint.
 private struct LockScreenView: View {

--- a/HerdrWidgets/AgentLiveActivity.swift
+++ b/HerdrWidgets/AgentLiveActivity.swift
@@ -75,7 +75,24 @@ struct AgentLiveActivity: Widget {
 
     /// One-line summary line: prefer the actionable count, else the status word.
     private func summary(_ s: AgentActivityAttributes.ContentState) -> String {
-        if s.needsYouCount > 0 { return "\(s.needsYouCount) need you" }
+        AgentActivitySummary.line(s)
+    }
+}
+
+/// The summary wording, in ONE place, because two surfaces render it and the lock screen
+/// previously asserted an unconfirmed count as fact while the roster card marked it.
+enum AgentActivitySummary {
+    static func line(_ s: AgentActivityAttributes.ContentState) -> String {
+        if s.needsYouCount > 0 {
+            // Every waiting agent rests on an unconfirmed state, so the whole claim is a
+            // maybe: say so rather than appending a qualifier to an assertion.
+            if s.unconfirmedCount >= s.needsYouCount { return "\(s.needsYouCount) may need you" }
+            // Some are confirmed and some are not. Lead with the fact, name the doubt.
+            if s.unconfirmedCount > 0 {
+                return "\(s.needsYouCount) need you · \(s.unconfirmedCount) stale"
+            }
+            return "\(s.needsYouCount) need you"
+        }
         if s.workingCount > 0 { return "\(s.workingCount) working" }
         return s.status.label
     }
@@ -130,11 +147,7 @@ private struct LockScreenView: View {
         .padding(.vertical, 12)
     }
 
-    private var summary: String {
-        if state.needsYouCount > 0 { return "\(state.needsYouCount) need you" }
-        if state.workingCount > 0 { return "\(state.workingCount) working" }
-        return state.status.label
-    }
+    private var summary: String { AgentActivitySummary.line(state) }
 }
 
 /// A filled status circle; colour carries the meaning (amber = needs you, blue =

--- a/Package.swift
+++ b/Package.swift
@@ -44,9 +44,19 @@ let package = Package(
         .target(
             name: "HerdrKit",
             dependencies: [.product(name: "Citadel", package: "Citadel")]),
+        // `AgentActivityState` IS A TEST DEPENDENCY HERE, and it is the mechanical
+        // cross-check I previously reported as impossible. The forcing argument against
+        // sharing these types is about the SHIPPED binaries — the widget links only
+        // WidgetKit/SwiftUI/ActivityKit and cannot link HerdrKit, and a HerdrKit dependency
+        // would duplicate Shared's symbols in the app binary. NEITHER CONSTRAINT REACHES A
+        // TEST TARGET, which is linked into the test bundle and into nothing else. So the
+        // two duplicated wording tables, and HerdrKit's activity mapping against the state
+        // type it feeds, can both be pinned by real assertions instead of a "change both"
+        // comment. Reported as unfixable in note 102391; a reviewer showed it was one word.
         .testTarget(
             name: "HerdrKitTests",
-            dependencies: ["HerdrKit", .product(name: "Citadel", package: "Citadel")]),
+            dependencies: ["HerdrKit", "AgentActivityState",
+                           .product(name: "Citadel", package: "Citadel")]),
         // The Live Activity's ContentState, compiled WITHOUT ActivityKit so it can be
         // tested on Linux. `sources` names the one file deliberately: its sibling in the
         // same directory imports ActivityKit and must stay out of this target.

--- a/Package.swift
+++ b/Package.swift
@@ -47,5 +47,21 @@ let package = Package(
         .testTarget(
             name: "HerdrKitTests",
             dependencies: ["HerdrKit", .product(name: "Citadel", package: "Citadel")]),
+        // The Live Activity's ContentState, compiled WITHOUT ActivityKit so it can be
+        // tested on Linux. `sources` names the one file deliberately: its sibling in the
+        // same directory imports ActivityKit and must stay out of this target.
+        //
+        // Nothing links this product. The Xcode app and widget targets compile the whole
+        // Shared directory as sources, exactly as before, so these symbols are not in
+        // either binary twice. The target exists ONLY so the tests below can run: while
+        // these types were nested in the ActivityKit-importing file, a one-line revert in
+        // LiveActivityController reintroduced a shipped defect and survived everything.
+        .target(
+            name: "AgentActivityState",
+            path: "Shared",
+            sources: ["AgentActivityState.swift"]),
+        .testTarget(
+            name: "AgentActivityStateTests",
+            dependencies: ["AgentActivityState"]),
     ]
 )

--- a/Shared/AgentActivityAttributes.swift
+++ b/Shared/AgentActivityAttributes.swift
@@ -27,6 +27,13 @@ struct AgentActivityAttributes: ActivityAttributes {
         var status: Status
         /// How many agents are waiting on the user right now.
         var needsYouCount: Int
+        /// How many of `needsYouCount` rest on a state the home could NOT confirm on its
+        /// last poll: a federated agent on a degraded peer, whose blocked state is a
+        /// last-known value rather than a live one. The lock screen and Dynamic Island have
+        /// no room for a per-row marker, so the count is qualified in the summary line
+        /// instead. DEFAULTED, so an activity started by an older build still decodes when
+        /// this build pushes it an update.
+        var unconfirmedCount: Int = 0
         /// How many agents are actively working right now.
         var workingCount: Int
         /// Total agents in the session.

--- a/Shared/AgentActivityAttributes.swift
+++ b/Shared/AgentActivityAttributes.swift
@@ -31,8 +31,17 @@ struct AgentActivityAttributes: ActivityAttributes {
         /// last poll: a federated agent on a degraded peer, whose blocked state is a
         /// last-known value rather than a live one. The lock screen and Dynamic Island have
         /// no room for a per-row marker, so the count is qualified in the summary line
-        /// instead. DEFAULTED, so an activity started by an older build still decodes when
-        /// this build pushes it an update.
+        /// instead.
+        ///
+        /// A STORED-PROPERTY DEFAULT DOES NOT MAKE THIS DECODABLE FROM AN OLD PAYLOAD.
+        /// An earlier version of this comment claimed it did; that was measured false.
+        /// Synthesized `Decodable` calls `decode(Int.self, forKey:)` and throws
+        /// `keyNotFound` when the key is absent, because stored-property defaults are
+        /// invisible to Codable synthesis. Two directions actually break without help:
+        /// this build reading an activity persisted by an older one (ActivityKit drops an
+        /// undecodable activity, so it can never be reclaimed or ended), and a
+        /// daemon-pushed payload minted before this field existed. The explicit
+        /// `init(from:)` below uses `decodeIfPresent` for this ONE key to cover both.
         var unconfirmedCount: Int = 0
         /// How many agents are actively working right now.
         var workingCount: Int
@@ -45,6 +54,33 @@ struct AgentActivityAttributes: ActivityAttributes {
         /// A plain Double (not Date) so the daemon-pushed JSON decodes identically,
         /// dodging Swift's Date reference-date Codable strategy. `nil` when not working.
         var workingSince: Double?
+
+        /// Hand-written ONLY to make `unconfirmedCount` tolerant of an absent key; every
+        /// other field is required exactly as synthesis would have it, so a genuinely
+        /// malformed payload still fails loudly rather than decoding into a plausible zero.
+        init(from decoder: Decoder) throws {
+            let c = try decoder.container(keyedBy: CodingKeys.self)
+            headline = try c.decode(String.self, forKey: .headline)
+            status = try c.decode(Status.self, forKey: .status)
+            needsYouCount = try c.decode(Int.self, forKey: .needsYouCount)
+            unconfirmedCount = try c.decodeIfPresent(Int.self, forKey: .unconfirmedCount) ?? 0
+            workingCount = try c.decode(Int.self, forKey: .workingCount)
+            totalCount = try c.decode(Int.self, forKey: .totalCount)
+            workingSince = try c.decodeIfPresent(Double.self, forKey: .workingSince)
+        }
+
+        /// Restored because writing `init(from:)` suppresses the synthesized memberwise
+        /// initialiser this type is constructed with everywhere else.
+        init(headline: String, status: Status, needsYouCount: Int, unconfirmedCount: Int = 0,
+             workingCount: Int, totalCount: Int, workingSince: Double?) {
+            self.headline = headline
+            self.status = status
+            self.needsYouCount = needsYouCount
+            self.unconfirmedCount = unconfirmedCount
+            self.workingCount = workingCount
+            self.totalCount = totalCount
+            self.workingSince = workingSince
+        }
     }
 
     /// The display bucket. Mirrors HerdrKit's `AgentGroup` (needs-you / stopped /

--- a/Shared/AgentActivityAttributes.swift
+++ b/Shared/AgentActivityAttributes.swift
@@ -55,13 +55,30 @@ struct AgentActivityAttributes: ActivityAttributes {
         /// dodging Swift's Date reference-date Codable strategy. `nil` when not working.
         var workingSince: Double?
 
-        /// Hand-written ONLY to make `unconfirmedCount` tolerant of an absent key; every
-        /// other field is required exactly as synthesis would have it, so a genuinely
-        /// malformed payload still fails loudly rather than decoding into a plausible zero.
+        /// Hand-written for TWO additive directions, both of which otherwise make the whole
+        /// activity undecodable, which ActivityKit answers by DROPPING the activity so it
+        /// can never be reclaimed or ended.
+        ///
+        /// 1. An absent `unconfirmedCount`, from an activity persisted by, or a payload
+        ///    minted by, a build predating the field. A stored-property default does not
+        ///    help: Codable synthesis never consults it.
+        /// 2. An UNRECOGNISED `status` word, from a newer app or daemon pushing a bucket
+        ///    this widget binary lacks. Raw-value decoding throws `dataCorrupted` there,
+        ///    which is the same drop-the-activity outcome as case 1. HerdrKit already
+        ///    treats this hazard as first-class with `AgentStatus.unrecognised(String)`;
+        ///    this file cannot carry that arm without a new case, so it falls back to
+        ///    `.needsYou`, matching HerdrKit's rule that something uninterpretable
+        ///    SURFACES rather than sinking. A wrongly-attention-grabbing lock screen is
+        ///    recoverable; a silently dropped activity is not.
+        ///
+        /// Every OTHER field stays required exactly as synthesis would have it, so a
+        /// genuinely malformed payload still fails loudly instead of decoding into a
+        /// plausible zero.
         init(from decoder: Decoder) throws {
             let c = try decoder.container(keyedBy: CodingKeys.self)
             headline = try c.decode(String.self, forKey: .headline)
-            status = try c.decode(Status.self, forKey: .status)
+            let rawStatus = try c.decode(String.self, forKey: .status)
+            status = Status(rawValue: rawStatus) ?? .needsYou
             needsYouCount = try c.decode(Int.self, forKey: .needsYouCount)
             unconfirmedCount = try c.decodeIfPresent(Int.self, forKey: .unconfirmedCount) ?? 0
             workingCount = try c.decode(Int.self, forKey: .workingCount)

--- a/Shared/AgentActivityAttributes.swift
+++ b/Shared/AgentActivityAttributes.swift
@@ -4,8 +4,9 @@ import ActivityKit
 /// The shape of the Herdr agent-session Live Activity — shared verbatim by the app
 /// (which starts / updates / ends it) and the widget extension (which renders it).
 ///
-/// Deliberately free of SwiftUI and HerdrKit so the one file compiles into BOTH
-/// targets with no extra dependencies. The app maps HerdrKit's `AgentGroup` onto
+/// Deliberately free of SwiftUI and HerdrKit so it compiles into BOTH targets with no
+/// extra dependencies. `State` and `Status` are TYPEALIASES to types declared in
+/// AgentActivityState.swift, which avoids ActivityKit so SwiftPM can test them on Linux. The app maps HerdrKit's `AgentGroup` onto
 /// `Status` when it builds a state (see `LiveActivityController`); the widget only
 /// ever reads these plain values.
 ///
@@ -20,104 +21,9 @@ struct AgentActivityAttributes: ActivityAttributes {
     /// (the saved host's nickname if it has one, else the host itself).
     var hostLabel: String
 
-    struct State: Codable, Hashable {
-        /// The agent shown in the headline — the session's highest-priority one.
-        var headline: String
-        /// That agent's bucket: drives the colour and the status word.
-        var status: Status
-        /// How many agents are waiting on the user right now.
-        var needsYouCount: Int
-        /// How many of `needsYouCount` rest on a state the home could NOT confirm on its
-        /// last poll: a federated agent on a degraded peer, whose blocked state is a
-        /// last-known value rather than a live one. The lock screen and Dynamic Island have
-        /// no room for a per-row marker, so the count is qualified in the summary line
-        /// instead.
-        ///
-        /// A STORED-PROPERTY DEFAULT DOES NOT MAKE THIS DECODABLE FROM AN OLD PAYLOAD.
-        /// An earlier version of this comment claimed it did; that was measured false.
-        /// Synthesized `Decodable` calls `decode(Int.self, forKey:)` and throws
-        /// `keyNotFound` when the key is absent, because stored-property defaults are
-        /// invisible to Codable synthesis. Two directions actually break without help:
-        /// this build reading an activity persisted by an older one (ActivityKit drops an
-        /// undecodable activity, so it can never be reclaimed or ended), and a
-        /// daemon-pushed payload minted before this field existed. The explicit
-        /// `init(from:)` below uses `decodeIfPresent` for this ONE key to cover both.
-        var unconfirmedCount: Int = 0
-        /// How many agents are actively working right now.
-        var workingCount: Int
-        /// Total agents in the session.
-        var totalCount: Int
-        /// When the headline agent's CURRENT turn started (Unix SECONDS), set only
-        /// while `status == .working`. Drives a live `Text(timerInterval:)` in the
-        /// widget — the one thing iOS actually frame-interpolates in a Live Activity,
-        /// so the working state shows real motion on the lock screen / Dynamic Island.
-        /// A plain Double (not Date) so the daemon-pushed JSON decodes identically,
-        /// dodging Swift's Date reference-date Codable strategy. `nil` when not working.
-        var workingSince: Double?
-
-        /// Hand-written for TWO additive directions, both of which otherwise make the whole
-        /// activity undecodable, which ActivityKit answers by DROPPING the activity so it
-        /// can never be reclaimed or ended.
-        ///
-        /// 1. An absent `unconfirmedCount`, from an activity persisted by, or a payload
-        ///    minted by, a build predating the field. A stored-property default does not
-        ///    help: Codable synthesis never consults it.
-        /// 2. An UNRECOGNISED `status` word, from a newer app or daemon pushing a bucket
-        ///    this widget binary lacks. Raw-value decoding throws `dataCorrupted` there,
-        ///    which is the same drop-the-activity outcome as case 1. HerdrKit already
-        ///    treats this hazard as first-class with `AgentStatus.unrecognised(String)`;
-        ///    this file cannot carry that arm without a new case, so it falls back to
-        ///    `.needsYou`, matching HerdrKit's rule that something uninterpretable
-        ///    SURFACES rather than sinking. A wrongly-attention-grabbing lock screen is
-        ///    recoverable; a silently dropped activity is not.
-        ///
-        /// Every OTHER field stays required exactly as synthesis would have it, so a
-        /// genuinely malformed payload still fails loudly instead of decoding into a
-        /// plausible zero.
-        init(from decoder: Decoder) throws {
-            let c = try decoder.container(keyedBy: CodingKeys.self)
-            headline = try c.decode(String.self, forKey: .headline)
-            let rawStatus = try c.decode(String.self, forKey: .status)
-            status = Status(rawValue: rawStatus) ?? .needsYou
-            needsYouCount = try c.decode(Int.self, forKey: .needsYouCount)
-            unconfirmedCount = try c.decodeIfPresent(Int.self, forKey: .unconfirmedCount) ?? 0
-            workingCount = try c.decode(Int.self, forKey: .workingCount)
-            totalCount = try c.decode(Int.self, forKey: .totalCount)
-            workingSince = try c.decodeIfPresent(Double.self, forKey: .workingSince)
-        }
-
-        /// Restored because writing `init(from:)` suppresses the synthesized memberwise
-        /// initialiser this type is constructed with everywhere else.
-        init(headline: String, status: Status, needsYouCount: Int, unconfirmedCount: Int = 0,
-             workingCount: Int, totalCount: Int, workingSince: Double?) {
-            self.headline = headline
-            self.status = status
-            self.needsYouCount = needsYouCount
-            self.unconfirmedCount = unconfirmedCount
-            self.workingCount = workingCount
-            self.totalCount = totalCount
-            self.workingSince = workingSince
-        }
-    }
-
-    /// The display bucket. Mirrors HerdrKit's `AgentGroup` (needs-you / stopped /
-    /// working / idle) but is redeclared here so this shared file needs no HerdrKit
-    /// dependency. `.unrecognised` folds into `.needsYou` at the mapping site — an
-    /// uninterpretable agent surfaces, it does not sink.
-    enum Status: String, Codable, Hashable {
-        case needsYou
-        case working
-        case idle
-        case stopped
-
-        /// Short human word for the headline's status line.
-        var label: String {
-            switch self {
-            case .needsYou: return "Needs you"
-            case .working:  return "Working"
-            case .idle:     return "Idle"
-            case .stopped:  return "Stopped"
-            }
-        }
-    }
+    /// Re-exposed under the names they had while nested here, so `ContentState`,
+    /// `AgentActivityAttributes.State` and `AgentActivityAttributes.Status` all keep
+    /// resolving for the app and the widget.
+    typealias State = AgentActivityState
+    typealias Status = AgentActivityStatus
 }

--- a/Shared/AgentActivityState.swift
+++ b/Shared/AgentActivityState.swift
@@ -1,0 +1,146 @@
+import Foundation
+
+// NO ActivityKit IMPORT, AND THAT IS WHY THIS FILE EXISTS SEPARATELY.
+//
+// The sibling AgentActivityAttributes.swift must import ActivityKit to conform to
+// `ActivityAttributes`, and ActivityKit does not exist on Linux. While these two types
+// were nested inside it they were untestable BY CONSTRUCTION, because this repo has no
+// app-side unit test bundle either. A review measured what that cost: changing one line
+// in LiveActivityController reintroduced a shipped lock-screen defect in full and survived
+// the entire 434-test suite AND the UI receipt, since XCUITest cannot see a Live Activity.
+//
+// Split out, a SwiftPM target can take `path: "Shared"` with `sources` limited to THIS
+// file, beside its ActivityKit-importing sibling, and run on Linux. The Xcode app and
+// widget targets keep compiling the whole Shared directory as sources and do NOT link that
+// SwiftPM product, so nothing lands in either binary twice.
+//
+// The names are deliberately not `State` and `Status`: as top-level types those would be
+// far too generic. `AgentActivityAttributes` re-exposes them under its old nested names via
+// typealiases, so every existing reference keeps working.
+
+struct AgentActivityState: Codable, Hashable {
+    /// The agent shown in the headline — the session's highest-priority one.
+    var headline: String
+    /// That agent's bucket: drives the colour and the status word.
+    var status: AgentActivityStatus
+    /// How many agents are waiting on the user right now.
+    var needsYouCount: Int
+    /// How many of `needsYouCount` rest on a state the home could NOT confirm on its
+    /// last poll: a federated agent on a degraded peer, whose blocked state is a
+    /// last-known value rather than a live one. The lock screen and Dynamic Island have
+    /// no room for a per-row marker, so the count is qualified in the summary line
+    /// instead.
+    ///
+    /// A STORED-PROPERTY DEFAULT DOES NOT MAKE THIS DECODABLE FROM AN OLD PAYLOAD.
+    /// An earlier version of this comment claimed it did; that was measured false.
+    /// Synthesized `Decodable` calls `decode(Int.self, forKey:)` and throws
+    /// `keyNotFound` when the key is absent, because stored-property defaults are
+    /// invisible to Codable synthesis. Two directions actually break without help:
+    /// this build reading an activity persisted by an older one (ActivityKit drops an
+    /// undecodable activity, so it can never be reclaimed or ended), and a
+    /// daemon-pushed payload minted before this field existed. The explicit
+    /// `init(from:)` below uses `decodeIfPresent` for this ONE key to cover both.
+    var unconfirmedCount: Int = 0
+    /// How many agents are actively working right now.
+    var workingCount: Int
+    /// Total agents in the session.
+    var totalCount: Int
+    /// When the headline agent's CURRENT turn started (Unix SECONDS), set only
+    /// while `status == .working`. Drives a live `Text(timerInterval:)` in the
+    /// widget — the one thing iOS actually frame-interpolates in a Live Activity,
+    /// so the working state shows real motion on the lock screen / Dynamic Island.
+    /// A plain Double (not Date) so the daemon-pushed JSON decodes identically,
+    /// dodging Swift's Date reference-date Codable strategy. `nil` when not working.
+    var workingSince: Double?
+
+    /// Hand-written for TWO additive directions, both of which otherwise make the whole
+    /// activity undecodable, which ActivityKit answers by DROPPING the activity so it
+    /// can never be reclaimed or ended.
+    ///
+    /// 1. An absent `unconfirmedCount`, from an activity persisted by, or a payload
+    ///    minted by, a build predating the field. A stored-property default does not
+    ///    help: Codable synthesis never consults it.
+    /// 2. An UNRECOGNISED `status` word, from a newer app or daemon pushing a bucket
+    ///    this widget binary lacks. Raw-value decoding throws `dataCorrupted` there,
+    ///    which is the same drop-the-activity outcome as case 1. HerdrKit already
+    ///    treats this hazard as first-class with `AgentStatus.unrecognised(String)`;
+    ///    this file cannot carry that arm without a new case, so it falls back to
+    ///    `.needsYou`, matching HerdrKit's rule that something uninterpretable
+    ///    SURFACES rather than sinking. A wrongly-attention-grabbing lock screen is
+    ///    recoverable; a silently dropped activity is not.
+    ///
+    /// Every OTHER field stays required exactly as synthesis would have it, so a
+    /// genuinely malformed payload still fails loudly instead of decoding into a
+    /// plausible zero.
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        headline = try c.decode(String.self, forKey: .headline)
+        let rawStatus = try c.decode(String.self, forKey: .status)
+        status = AgentActivityStatus(rawValue: rawStatus) ?? .needsYou
+        needsYouCount = try c.decode(Int.self, forKey: .needsYouCount)
+        unconfirmedCount = try c.decodeIfPresent(Int.self, forKey: .unconfirmedCount) ?? 0
+        workingCount = try c.decode(Int.self, forKey: .workingCount)
+        totalCount = try c.decode(Int.self, forKey: .totalCount)
+        workingSince = try c.decodeIfPresent(Double.self, forKey: .workingSince)
+    }
+
+    /// Restored because writing `init(from:)` suppresses the synthesized memberwise
+    /// initialiser this type is constructed with everywhere else.
+    init(headline: String, status: AgentActivityStatus, needsYouCount: Int, unconfirmedCount: Int = 0,
+         workingCount: Int, totalCount: Int, workingSince: Double?) {
+        self.headline = headline
+        self.status = status
+        self.needsYouCount = needsYouCount
+        self.unconfirmedCount = unconfirmedCount
+        self.workingCount = workingCount
+        self.totalCount = totalCount
+        self.workingSince = workingSince
+    }
+}
+
+/// The display bucket. Mirrors HerdrKit's `AgentGroup` (needs-you / stopped /
+/// working / idle) but is redeclared here so this shared file needs no HerdrKit
+/// dependency. `.unrecognised` folds into `.needsYou` at the mapping site — an
+/// uninterpretable agent surfaces, it does not sink.
+enum AgentActivityStatus: String, Codable, Hashable {
+    case needsYou
+    case working
+    case idle
+    case stopped
+
+    /// Short human word for the headline's status line.
+    var label: String {
+        switch self {
+        case .needsYou: return "Needs you"
+        case .working:  return "Working"
+        case .idle:     return "Idle"
+        case .stopped:  return "Stopped"
+        }
+    }
+}
+
+/// The summary wording for a Live Activity, in ONE place and in the ActivityKit-free file
+/// so it is testable on Linux. Both widget layouts read it.
+///
+/// Kept in step with HerdrKit's `AgentList.needsYouSummary`, which serves the in-app roster
+/// header. The two cannot be a single function: the widget target links only WidgetKit,
+/// SwiftUI and ActivityKit and cannot see HerdrKit, and making HerdrKit depend on this
+/// target would put these symbols in the app binary twice. So the wording is duplicated on
+/// purpose, and BOTH copies are now pinned by tests against the same table.
+enum AgentActivitySummary {
+    static func line(_ s: AgentActivityState) -> String {
+        if s.needsYouCount > 0 {
+            // Every waiting agent rests on an unconfirmed state, so the whole claim is a
+            // maybe: say so rather than appending a qualifier to an assertion.
+            if s.unconfirmedCount >= s.needsYouCount { return "\(s.needsYouCount) may need you" }
+            // Some confirmed and some not. Lead with the fact, name the doubt.
+            if s.unconfirmedCount > 0 {
+                return "\(s.needsYouCount) need you · \(s.unconfirmedCount) stale"
+            }
+            return "\(s.needsYouCount) need you"
+        }
+        if s.workingCount > 0 { return "\(s.workingCount) working" }
+        return s.status.label
+    }
+}
+

--- a/Sources/HerdrKit/AgentList.swift
+++ b/Sources/HerdrKit/AgentList.swift
@@ -243,6 +243,29 @@ public struct AgentList: Equatable, Sendable {
         rows.filter { $0.group == .needsYou && $0.showsUnconfirmedMarker }.count
     }
 
+    /// THE WORDING SPEC for "N need you", in HerdrKit so every surface can share one rule
+    /// instead of each inventing its own. Three surfaces render this count: the roster
+    /// header, the Live Activity lock-screen line, and the Dynamic Island. The first
+    /// version qualified only the roster CARD, which is how the lock screen ended up
+    /// asserting an unconfirmed state as fact.
+    ///
+    /// The Dynamic Island compact trailing is the one place that cannot use this: it has
+    /// room for a glyph and a number, nothing more. That is a space constraint, recorded
+    /// rather than pretended away.
+    ///
+    /// `nil` when nothing is waiting, so a caller can fall through to its own wording.
+    public var needsYouSummary: String? {
+        let total = needsYouCount
+        guard total > 0 else { return nil }
+        let unconfirmed = unconfirmedNeedsYouCount
+        // Every waiting agent rests on an unconfirmed state, so the whole claim is a maybe.
+        // Saying it outright beats appending a qualifier to an assertion.
+        if unconfirmed >= total { return "\(total) may need you" }
+        // Some confirmed, some not: lead with the fact, then name the doubt.
+        if unconfirmed > 0 { return "\(total) need you · \(unconfirmed) stale" }
+        return "\(total) need you"
+    }
+
     /// True when nothing is blocked AND nothing is unrecognised. The quiet state
     /// has to mean "I checked everything", so an uninterpretable agent must
     /// prevent it — otherwise the screen says all-clear while holding a row it

--- a/Sources/HerdrKit/AgentList.swift
+++ b/Sources/HerdrKit/AgentList.swift
@@ -118,19 +118,29 @@ public struct AgentRow: Equatable, Sendable, Identifiable {
         self.group = AgentRow.resolvedGroup(info: info, status: status, isLive: isLive)
     }
 
-    /// Whether this row's state should be shown with a STALENESS MARKER: it is live, on a
-    /// peer the home did not confirm on its last poll, and it is presenting a state the
-    /// reader would otherwise read as current.
+    /// WHETHER THIS ROW'S STATE IS UNCONFIRMED. A FACT about the row, with no rendering
+    /// opinion in it: the row is live and sits on a peer the home did not confirm on its
+    /// last poll, whether that peer is merely degraded or fully unreachable.
     ///
-    /// ONE DEFINITION, DELIBERATELY. Two surfaces render needs-you (the roster card and
-    /// the Live Activity), and the first version of this marker existed only on the card,
-    /// so the lock screen went on asserting an unconfirmed "1 need you" as fact. Any
-    /// surface that renders a status must read THIS, not re-derive it.
+    /// SEPARATE FROM `showsUnconfirmedMarker` ON PURPOSE, and the separation is the fix for
+    /// a real defect: the count below used to reuse the marker, which excludes
+    /// `isUnreachable` for a RENDERING reason, so a fully OFFLINE peer's last-known-blocked
+    /// agents escalated into needs-you and were then reported as CONFIRMED on the two
+    /// surfaces that have no row to mark. A predicate scoped to one surface's drawing
+    /// decision is the wrong thing to count with.
+    public var hasUnconfirmedState: Bool {
+        isLive && info.hasUnconfirmedStatus
+    }
+
+    /// Whether this row should be DRAWN with a staleness marker. The fact above, minus the
+    /// unreachable case, which already replaces the status outright with an offline mark;
+    /// doubling up would say the same thing twice in one row.
     ///
-    /// `isUnreachable` is excluded because that case already replaces the status outright
-    /// with an offline mark; doubling up would say the same thing twice.
+    /// ONE DEFINITION, DELIBERATELY. Every surface that draws a status reads THIS rather
+    /// than re-deriving it: the first version of this marker existed only on the roster
+    /// card, which is how the lock screen went on asserting an unconfirmed count as fact.
     public var showsUnconfirmedMarker: Bool {
-        isLive && info.hasUnconfirmedStatus && !info.isUnreachable
+        hasUnconfirmedState && !info.isUnreachable
     }
 
     /// ESCALATION-ONLY overlay on `group(for:isLive:)`. Two signals may move a row UP
@@ -240,7 +250,11 @@ public struct AgentList: Equatable, Sendable {
     /// with no room for a per-row marker (the Live Activity) needs this to avoid asserting
     /// an unconfirmed "N need you" as fact on the lock screen.
     public var unconfirmedNeedsYouCount: Int {
-        rows.filter { $0.group == .needsYou && $0.showsUnconfirmedMarker }.count
+        // `hasUnconfirmedState`, NOT `showsUnconfirmedMarker`. The marker excludes
+        // unreachable rows because the card draws them an offline badge instead, and
+        // counting with that exclusion reported a fully OFFLINE peer's stale guess as
+        // CONFIRMED on exactly the two surfaces that have no row to mark.
+        rows.filter { $0.group == .needsYou && $0.hasUnconfirmedState }.count
     }
 
     /// THE WORDING SPEC for "N need you", in HerdrKit so every surface can share one rule

--- a/Sources/HerdrKit/AgentList.swift
+++ b/Sources/HerdrKit/AgentList.swift
@@ -121,8 +121,13 @@ public struct AgentRow: Equatable, Sendable, Identifiable {
     /// ESCALATION-ONLY overlay on `group(for:isLive:)`. Two signals may move a row UP
     /// into `needsYou`; nothing here may ever move a row toward a QUIETER section, so
     /// the fail-closed placement the group order encodes cannot be undone by a lenient
-    /// field. `group(for:isLive:)` keeps its exhaustive switch, so adding an
-    /// `AgentStatus` case still fails to compile there rather than falling through.
+    /// field.
+    ///
+    /// TWO SITES, NOT ONE. `group(for:isLive:)` keeps its exhaustive switch, so adding an
+    /// `AgentStatus` case still fails to compile THERE. This overlay does NOT get that
+    /// protection: it compares by equality (`status == .indefinite`), which keeps
+    /// compiling forever, so a new status would silently decline the last-known
+    /// escalation. Anyone adding a case must visit both.
     ///
     /// 1. `inputPending`. The group switch reads ONLY the status string, so an agent
     ///    showing a plan-approval or AskUserQuestion menu while its status is anything
@@ -146,6 +151,10 @@ public struct AgentRow: Equatable, Sendable, Identifiable {
         // A pane that is gone needs nothing from anybody: never escalate off `.stopped`.
         guard isLive else { return base }
         if info.isAwaitingMenuInput { return .needsYou }
+        // The `.indefinite` precondition is load-bearing, not decoration: a LIVE status is
+        // authoritative, and `last_known_status` is only meaningful once the daemon has
+        // blanked the live one to "unknown". Escalating on a known-idle row that happens to
+        // carry a stale blocked value would resurrect a state the server already replaced.
         if status == .indefinite, AgentStatus(wire: info.lastKnownStatus).isBlocked {
             return .needsYou
         }
@@ -197,13 +206,19 @@ public struct AgentList: Equatable, Sendable {
     /// most-recently-archived first.
     public let archived: [AgentRow]
 
-    /// What the top of the screen says. Counts only positively-blocked agents —
-    /// an unrecognised status is surfaced by its own section, and inflating this
-    /// number with maybes would make the one number on the screen untrustworthy.
-    /// Counts the GROUP, not the retained status. Reading `status.isBlocked`
-    /// directly meant a blocked agent whose pane had since vanished sorted into
-    /// `.stopped` and made `isQuiet` true while still reporting 1 here — the
-    /// screen simultaneously claiming all-clear and one-waiting.
+    /// What the top of the screen says. Counts the `needsYou` GROUP, not the retained
+    /// status. Reading `status.isBlocked` directly meant a blocked agent whose pane had
+    /// since vanished sorted into `.stopped` and made `isQuiet` true while still
+    /// reporting 1 here — the screen simultaneously claiming all-clear and one-waiting.
+    ///
+    /// THIS IS NO LONGER "positively-blocked agents only", and the older wording said so.
+    /// `AgentRow.resolvedGroup` escalates two further shapes into the group: a row whose
+    /// status is not `blocked` but which reports `input_pending`, and a row on a degraded
+    /// peer whose blocked state is a LAST-KNOWN value. The second is a maybe by
+    /// construction. That is a deliberate trade, because an agent waiting on a human is
+    /// worse to hide than to over-report, and the row itself carries a staleness mark so
+    /// the count is never the only thing the reader sees. An unrecognised status still has
+    /// its own section and is still not counted here.
     public var needsYouCount: Int { rows.filter { $0.group == .needsYou }.count }
 
     /// True when nothing is blocked AND nothing is unrecognised. The quiet state

--- a/Sources/HerdrKit/AgentList.swift
+++ b/Sources/HerdrKit/AgentList.swift
@@ -297,6 +297,73 @@ public struct AgentList: Equatable, Sendable {
         return rows.min { rank($0) < rank($1) }
     }
 
+    /// EVERY DECISION THE LIVE ACTIVITY RENDERS, computed here so it is reachable by a test.
+    ///
+    /// The previous head moved the headline RULE into `activityLead` but left the CALL SITE
+    /// in `App/LiveActivityController.state(from:)`, which no test target can see — so the
+    /// one-line revert to `rows.min { $0.group.rawValue < $1.group.rawValue }` still restored
+    /// the shipped defect in full and passed the entire suite. A test that pins a helper is
+    /// not a test of the path. So the whole mapping lives here now and the app-side function
+    /// copies fields and decides nothing.
+    ///
+    /// `statusWord` is a String rather than the activity's own enum because that enum sits in
+    /// `Shared/`, which the widget compiles without HerdrKit. The words are exactly
+    /// `AgentActivityStatus`'s raw values, and a cross-target test asserts that rather than
+    /// trusting this comment.
+    public struct ActivityContent: Equatable, Sendable {
+        public let headline: String
+        public let statusWord: String
+        public let needsYouCount: Int
+        public let unconfirmedCount: Int
+        public let workingCount: Int
+        public let totalCount: Int
+        public let workingSinceUnixSeconds: Double?
+    }
+
+    /// THE ATTENTION COUNTS DIVERGE FROM THE ROSTER'S ON PURPOSE, and this is the reason.
+    ///
+    /// `needsYouCount` counts only `group == .needsYou`; an unrecognised agent gets its own
+    /// SECTION instead, which is honest on a screen that has sections. The lock screen has
+    /// none, so with the strict count an unrecognised lead produced 0, and the summary line
+    /// fell through to the working branch: an amber needs-you dot above the text "N working",
+    /// coloured amber, on one surface, from one list. That is the same self-contradiction as
+    /// the red-Stopped-over-"2 working" defect this rule was written to remove.
+    ///
+    /// So a surface with no room for rows carries what the rows would have shown — exactly
+    /// the argument that produced `unconfirmedNeedsYouCount`. Unrecognised rows count toward
+    /// the attention total AND toward its unconfirmed portion, because "I cannot interpret
+    /// this agent" is a maybe, not a fact. The line then reads "1 may need you" beside an
+    /// amber dot, which agrees with itself and with `isQuiet`'s refusal to call an
+    /// unrecognised roster all-clear.
+    public var activityContent: ActivityContent {
+        let lead = activityLead
+        let word: String
+        switch lead?.group {
+        case .needsYou, .unrecognised: word = "needsYou"
+        case .stopped:                 word = "stopped"
+        case .working:                 word = "working"
+        case .idle, .none:             word = "idle"
+        }
+        let attention = rows.filter { $0.group == .needsYou || $0.group == .unrecognised }.count
+        let unconfirmed = rows.filter {
+            ($0.group == .needsYou && $0.hasUnconfirmedState) || $0.group == .unrecognised
+        }.count
+        // Only the working state carries a start time — the headline agent's current turn is
+        // approximated by its last completed-turn boundary, which is stable while it works
+        // that turn, so the widget's timer does not reset on every list refresh.
+        let since: Double? = word == "working"
+            ? lead?.info.lastCompletedTurn?.completedUnixMs.map { Double($0) / 1000 }
+            : nil
+        return ActivityContent(
+            headline: lead?.title ?? "No agents",
+            statusWord: word,
+            needsYouCount: attention,
+            unconfirmedCount: unconfirmed,
+            workingCount: rows.filter { $0.group == .working }.count,
+            totalCount: rows.count,
+            workingSinceUnixSeconds: since)
+    }
+
     /// THE WORDING SPEC for "N need you", in HerdrKit so every surface can share one rule
     /// instead of each inventing its own. Three surfaces render this count: the roster
     /// header, the Live Activity lock-screen line, and the Dynamic Island. The first

--- a/Sources/HerdrKit/AgentList.swift
+++ b/Sources/HerdrKit/AgentList.swift
@@ -257,6 +257,46 @@ public struct AgentList: Equatable, Sendable {
         rows.filter { $0.group == .needsYou && $0.hasUnconfirmedState }.count
     }
 
+    /// THE ACTIVITY HEADLINE, which answers a DIFFERENT QUESTION FROM THE LIST ORDER, and
+    /// lives here rather than in the app so it can be tested at all.
+    ///
+    /// `AgentGroup`'s ordering is a LIST order: it answers "which section does this row
+    /// belong in, and what does the reader most need to scroll to". A gone pane sorts high
+    /// there on purpose. The Live Activity asks something else — "what is this session
+    /// doing right now" — and reusing the list order to answer it made a single freshly
+    /// stopped pane outrank N working agents, so the lock screen showed a red Stopped dot
+    /// above a summary line reading "N working": one surface contradicting itself.
+    ///
+    /// This is the FOURTH time in this PR's review history that a predicate scoped for one
+    /// surface was reused to answer another surface's question, so the rule is written once,
+    /// here, next to the ordering it deliberately differs from.
+    ///
+    /// The rule, in order:
+    ///  1. `needsYou`, and WITHIN it a CONFIRMED row before an unconfirmed one, so the
+    ///     headline names an agent we actually know is waiting rather than a last-known
+    ///     guess on a peer that went quiet. The doubt is still reported, by
+    ///     `unconfirmedNeedsYouCount`; what changes is that it no longer picks the NAME.
+    ///  2. `unrecognised`, keeping the fail-closed placement: not knowing what an agent is
+    ///     doing is nearer to needing attention than to nothing to do.
+    ///  3. `working`, then `idle`.
+    ///  4. `stopped` LAST. A pane that is gone is not what the session is doing, so it is
+    ///     the headline only when there is nothing else to say — which is honest, because
+    ///     then it is the whole truth.
+    public var activityLead: AgentRow? {
+        func rank(_ r: AgentRow) -> Int {
+            switch r.group {
+            case .needsYou:     return r.hasUnconfirmedState ? 1 : 0
+            case .unrecognised: return 2
+            case .working:      return 3
+            case .idle:         return 4
+            case .stopped:      return 5
+            }
+        }
+        // `min(by:)` keeps the first row of the winning rank, so within a rank the
+        // server's own order decides and this introduces no second sort.
+        return rows.min { rank($0) < rank($1) }
+    }
+
     /// THE WORDING SPEC for "N need you", in HerdrKit so every surface can share one rule
     /// instead of each inventing its own. Three surfaces render this count: the roster
     /// header, the Live Activity lock-screen line, and the Dynamic Island. The first

--- a/Sources/HerdrKit/AgentList.swift
+++ b/Sources/HerdrKit/AgentList.swift
@@ -118,6 +118,21 @@ public struct AgentRow: Equatable, Sendable, Identifiable {
         self.group = AgentRow.resolvedGroup(info: info, status: status, isLive: isLive)
     }
 
+    /// Whether this row's state should be shown with a STALENESS MARKER: it is live, on a
+    /// peer the home did not confirm on its last poll, and it is presenting a state the
+    /// reader would otherwise read as current.
+    ///
+    /// ONE DEFINITION, DELIBERATELY. Two surfaces render needs-you (the roster card and
+    /// the Live Activity), and the first version of this marker existed only on the card,
+    /// so the lock screen went on asserting an unconfirmed "1 need you" as fact. Any
+    /// surface that renders a status must read THIS, not re-derive it.
+    ///
+    /// `isUnreachable` is excluded because that case already replaces the status outright
+    /// with an offline mark; doubling up would say the same thing twice.
+    public var showsUnconfirmedMarker: Bool {
+        isLive && info.hasUnconfirmedStatus && !info.isUnreachable
+    }
+
     /// ESCALATION-ONLY overlay on `group(for:isLive:)`. Two signals may move a row UP
     /// into `needsYou`; nothing here may ever move a row toward a QUIETER section, so
     /// the fail-closed placement the group order encodes cannot be undone by a lenient
@@ -220,6 +235,13 @@ public struct AgentList: Equatable, Sendable {
     /// the count is never the only thing the reader sees. An unrecognised status still has
     /// its own section and is still not counted here.
     public var needsYouCount: Int { rows.filter { $0.group == .needsYou }.count }
+
+    /// How many of `needsYouCount` rest on a state the home could not confirm. A surface
+    /// with no room for a per-row marker (the Live Activity) needs this to avoid asserting
+    /// an unconfirmed "N need you" as fact on the lock screen.
+    public var unconfirmedNeedsYouCount: Int {
+        rows.filter { $0.group == .needsYou && $0.showsUnconfirmedMarker }.count
+    }
 
     /// True when nothing is blocked AND nothing is unrecognised. The quiet state
     /// has to mean "I checked everything", so an uninterpretable agent must

--- a/Sources/HerdrKit/AgentList.swift
+++ b/Sources/HerdrKit/AgentList.swift
@@ -115,7 +115,41 @@ public struct AgentRow: Equatable, Sendable, Identifiable {
         self.isLive = isLive
         let status = AgentStatus(wire: info.agentStatus)
         self.status = status
-        self.group = AgentRow.group(for: status, isLive: isLive)
+        self.group = AgentRow.resolvedGroup(info: info, status: status, isLive: isLive)
+    }
+
+    /// ESCALATION-ONLY overlay on `group(for:isLive:)`. Two signals may move a row UP
+    /// into `needsYou`; nothing here may ever move a row toward a QUIETER section, so
+    /// the fail-closed placement the group order encodes cannot be undone by a lenient
+    /// field. `group(for:isLive:)` keeps its exhaustive switch, so adding an
+    /// `AgentStatus` case still fails to compile there rather than falling through.
+    ///
+    /// 1. `inputPending`. The group switch reads ONLY the status string, so an agent
+    ///    showing a plan-approval or AskUserQuestion menu while its status is anything
+    ///    other than the literal "blocked" could never reach `needsYou`. The predicate
+    ///    already exists as `AgentInfo.isAwaitingMenuInput` and already gates input
+    ///    routing; this makes the LIST agree with the router instead of contradicting it.
+    ///
+    /// 2. `lastKnownStatus`, and ONLY when it reads `blocked`. A federated peer that
+    ///    misses a SINGLE poll is marked Degraded, and the daemon then overwrites
+    ///    `agent_status` with "unknown" and moves the real state into
+    ///    `last_known_status`, so every agent on that machine leaves both `working` and
+    ///    `needsYou` at once. Reading the surviving copy for the blocked case only keeps
+    ///    a fleet agent that is waiting on a human visible, without presenting any other
+    ///    stale state as though it were live. A last-known `working` deliberately does
+    ///    NOT restore the `working` group: that would be a demotion out of
+    ///    `unrecognised`, and "this machine went quiet on us" is the louder, truer thing
+    ///    to say. The real remedy for that case is daemon-side, not blanking a whole
+    ///    peer on one missed poll.
+    static func resolvedGroup(info: AgentInfo, status: AgentStatus, isLive: Bool) -> AgentGroup {
+        let base = group(for: status, isLive: isLive)
+        // A pane that is gone needs nothing from anybody: never escalate off `.stopped`.
+        guard isLive else { return base }
+        if info.isAwaitingMenuInput { return .needsYou }
+        if status == .indefinite, AgentStatus(wire: info.lastKnownStatus).isBlocked {
+            return .needsYou
+        }
+        return base
     }
 
     /// EXHAUSTIVE OVER `AgentStatus` ON PURPOSE — no `default:` arm.

--- a/Sources/HerdrKit/Wire.swift
+++ b/Sources/HerdrKit/Wire.swift
@@ -360,6 +360,22 @@ public struct AgentInfo: Decodable, Equatable, Sendable, Identifiable {
     /// server) read as reachable — the safe default is "not offline".
     public var isUnreachable: Bool { reachability == "unreachable" }
 
+    /// A remote agent whose status the home has NOT confirmed on its latest poll:
+    /// `degraded` (the daemon's 1 to 2 missed polls) or the fully `unreachable` case.
+    ///
+    /// The distinction matters because the daemon overwrites `agent_status` with
+    /// "unknown" the moment reachability leaves `reachable`, and moves the real state
+    /// into `last_known_status`. `AgentRow.resolvedGroup` surfaces a last-known BLOCKED
+    /// row into needs-you, so without this the reader could not tell a colleague
+    /// genuinely waiting from a guess about a machine that went quiet.
+    ///
+    /// Enumerated rather than `!= "reachable"`, matching `isUnreachable` above: an
+    /// unknown string from a newer server reads as fresh, because the safe default is
+    /// not to stamp every row as stale.
+    public var hasUnconfirmedStatus: Bool {
+        reachability == "degraded" || reachability == "unreachable"
+    }
+
     /// This agent's recorded account is gone from the server's registry, so it will
     /// REFUSE to resume rather than come back on the default account and append to the
     /// wrong transcript. An error state a person must act on (re-register the account),

--- a/Tests/AgentActivityStateTests/AgentActivityStateTests.swift
+++ b/Tests/AgentActivityStateTests/AgentActivityStateTests.swift
@@ -30,8 +30,18 @@ final class AgentActivityStateTests: XCTestCase {
 
     /// The tolerance is scoped to that ONE key. A genuinely malformed payload must still
     /// fail loudly rather than decoding into a plausible zero.
+    ///
+    /// `status` IS IN THIS LOOP DELIBERATELY, and it is the subtle member. This type treats
+    /// an ABSENT status and an UNRECOGNISED status differently on purpose: an unrecognised
+    /// word falls back to `needsYou` (see the additive-ENUM-CASE test below, because a new
+    /// writer may ship a bucket this reader has never heard of), while an absent key is
+    /// malformed and must throw. A review found the loop omitting it, and the mutant that
+    /// exploits the omission — `decodeIfPresent(String.self, forKey: .status) ?? "needsYou"`
+    /// — survived all 441 tests while COLLAPSING that distinction, decoding a status-less
+    /// payload into the maximally attention-grabbing bucket. Tolerating an unknown value is
+    /// not the same as inventing a missing one.
     func testAMissingRequiredKeyStillThrows() throws {
-        for missing in ["headline", "needsYouCount", "workingCount", "totalCount"] {
+        for missing in ["headline", "status", "needsYouCount", "workingCount", "totalCount"] {
             var obj: [String: Any] = ["headline": "a", "status": "idle", "needsYouCount": 0,
                                       "workingCount": 0, "totalCount": 3]
             obj.removeValue(forKey: missing)
@@ -39,8 +49,12 @@ final class AgentActivityStateTests: XCTestCase {
             XCTAssertThrowsError(try JSONDecoder().decode(AgentActivityState.self, from: data),
                                  "a payload missing \(missing) must not decode")
         }
-        // And a wrong TYPE is still an error, not a coerced value.
+        // And a wrong TYPE is still an error, not a coerced value. `status` is checked here
+        // too: a non-string status is malformed input, NOT an unrecognised bucket, so the
+        // enum fallback must not launder it into needsYou either.
         XCTAssertThrowsError(try decode(#"{"headline":"a","status":"idle","needsYouCount":"two","workingCount":0,"totalCount":3}"#))
+        XCTAssertThrowsError(try decode(#"{"headline":"a","status":42,"needsYouCount":0,"workingCount":0,"totalCount":3}"#),
+                             "a non-string status is malformed, not an unknown bucket")
     }
 
     // MARK: - additive-ENUM-CASE tolerance

--- a/Tests/AgentActivityStateTests/AgentActivityStateTests.swift
+++ b/Tests/AgentActivityStateTests/AgentActivityStateTests.swift
@@ -1,0 +1,109 @@
+import XCTest
+@testable import AgentActivityState
+
+/// The first tests this repo has for anything outside Sources/HerdrKit.
+///
+/// A review measured why they were needed: while these types were nested inside the
+/// ActivityKit-importing file they were untestable on Linux, and this repo has no app-side
+/// unit bundle, so changing one line in LiveActivityController reintroduced a shipped
+/// lock-screen defect in full and survived all 434 tests AND the UI receipt, because
+/// XCUITest cannot see a Live Activity.
+final class AgentActivityStateTests: XCTestCase {
+
+    private func decode(_ json: String) throws -> AgentActivityState {
+        try JSONDecoder().decode(AgentActivityState.self, from: Data(json.utf8))
+    }
+
+    // MARK: - additive-FIELD tolerance
+
+    /// A payload from a build that predates `unconfirmedCount` must still decode. A
+    /// stored-property default does NOT achieve this: Codable synthesis never consults it
+    /// and throws keyNotFound, which ActivityKit answers by DROPPING the activity, after
+    /// which it can never be reclaimed or ended. Only the hand-written decodeIfPresent does.
+    func testAnOldPayloadWithoutUnconfirmedCountDecodesToZero() throws {
+        let s = try decode(#"{"headline":"jarvis","status":"needsYou","needsYouCount":2,"workingCount":1,"totalCount":9}"#)
+        XCTAssertEqual(s.unconfirmedCount, 0)
+        XCTAssertEqual(s.needsYouCount, 2)
+        XCTAssertEqual(s.status, .needsYou)
+        XCTAssertNil(s.workingSince, "an absent workingSince is legitimately nil, not an error")
+    }
+
+    /// The tolerance is scoped to that ONE key. A genuinely malformed payload must still
+    /// fail loudly rather than decoding into a plausible zero.
+    func testAMissingRequiredKeyStillThrows() throws {
+        for missing in ["headline", "needsYouCount", "workingCount", "totalCount"] {
+            var obj: [String: Any] = ["headline": "a", "status": "idle", "needsYouCount": 0,
+                                      "workingCount": 0, "totalCount": 3]
+            obj.removeValue(forKey: missing)
+            let data = try JSONSerialization.data(withJSONObject: obj)
+            XCTAssertThrowsError(try JSONDecoder().decode(AgentActivityState.self, from: data),
+                                 "a payload missing \(missing) must not decode")
+        }
+        // And a wrong TYPE is still an error, not a coerced value.
+        XCTAssertThrowsError(try decode(#"{"headline":"a","status":"idle","needsYouCount":"two","workingCount":0,"totalCount":3}"#))
+    }
+
+    // MARK: - additive-ENUM-CASE tolerance
+
+    /// An unrecognised status word must not make the whole activity undecodable, which is
+    /// the same drop-the-activity outcome as a missing key. It falls back to needsYou,
+    /// matching HerdrKit's rule that something uninterpretable SURFACES rather than sinking:
+    /// a wrongly attention-grabbing lock screen is recoverable, a dropped activity is not.
+    func testAnUnknownStatusWordFallsBackInsteadOfThrowing() throws {
+        let s = try decode(#"{"headline":"a","status":"wat","needsYouCount":1,"workingCount":0,"totalCount":3}"#)
+        XCTAssertEqual(s.status, .needsYou, "an unknown bucket must surface, not sink")
+        XCTAssertEqual(s.needsYouCount, 1, "the rest of the payload still decodes")
+    }
+
+    /// Every known word still maps to itself, so the fallback above cannot be hiding a
+    /// broken mapping.
+    func testEveryKnownStatusWordRoundTrips() throws {
+        for (word, expected) in [("needsYou", AgentActivityStatus.needsYou), ("working", .working),
+                                 ("idle", .idle), ("stopped", .stopped)] {
+            let s = try decode(#"{"headline":"a","status":"\#(word)","needsYouCount":0,"workingCount":0,"totalCount":1}"#)
+            XCTAssertEqual(s.status, expected, "status \(word) must map to itself")
+        }
+    }
+
+    /// Encoding is still synthesized, so a state this build writes must be readable by it.
+    func testRoundTripThroughEncodeAndDecode() throws {
+        let original = AgentActivityState(headline: "jarvis", status: .working, needsYouCount: 2,
+                                          unconfirmedCount: 1, workingCount: 3, totalCount: 9,
+                                          workingSince: 1_788_200_000)
+        let back = try JSONDecoder().decode(AgentActivityState.self,
+                                            from: try JSONEncoder().encode(original))
+        XCTAssertEqual(back, original)
+    }
+
+    // MARK: - summary wording
+
+    /// The wording table. Duplicated on purpose in HerdrKit's AgentList tests, because the
+    /// widget target cannot see HerdrKit and HerdrKit cannot see this target without putting
+    /// these symbols in the app binary twice. If you change one table, change both.
+    func testSummaryQualifiesUnconfirmedCounts() {
+        func line(needsYou: Int, unconfirmed: Int, working: Int = 0,
+                  status: AgentActivityStatus = .idle) -> String {
+            AgentActivitySummary.line(.init(headline: "a", status: status, needsYouCount: needsYou,
+                                            unconfirmedCount: unconfirmed, workingCount: working,
+                                            totalCount: 9, workingSince: nil))
+        }
+        XCTAssertEqual(line(needsYou: 1, unconfirmed: 0), "1 need you")
+        XCTAssertEqual(line(needsYou: 1, unconfirmed: 1), "1 may need you",
+                       "all unconfirmed means the whole claim is a maybe")
+        XCTAssertEqual(line(needsYou: 5, unconfirmed: 5), "5 may need you")
+        XCTAssertEqual(line(needsYou: 2, unconfirmed: 1), "2 need you · 1 stale",
+                       "mixed: lead with the fact, then name the doubt")
+        // Falls through only when nothing is waiting.
+        XCTAssertEqual(line(needsYou: 0, unconfirmed: 0, working: 2), "2 working")
+        XCTAssertEqual(line(needsYou: 0, unconfirmed: 0, working: 0, status: .stopped), "Stopped")
+    }
+
+    /// An unconfirmed count exceeding the waiting count is nonsense the surfaces should
+    /// survive rather than crash on, so pin the branch it lands in.
+    func testAnOverlargeUnconfirmedCountStillReadsAsAMaybe() {
+        let s = AgentActivityState(headline: "a", status: .needsYou, needsYouCount: 1,
+                                   unconfirmedCount: 4, workingCount: 0, totalCount: 1,
+                                   workingSince: nil)
+        XCTAssertEqual(AgentActivitySummary.line(s), "1 may need you")
+    }
+}

--- a/Tests/HerdrKitTests/ActivityContentTests.swift
+++ b/Tests/HerdrKitTests/ActivityContentTests.swift
@@ -1,0 +1,250 @@
+import XCTest
+@testable import HerdrKit
+@testable import AgentActivityState
+
+/// THE CROSS-TARGET TESTS, and the first in this repo that can see both HerdrKit and the Live
+/// Activity's state type at once.
+///
+/// I reported this seam as impossible: the widget links only WidgetKit/SwiftUI/ActivityKit and
+/// cannot link HerdrKit, and a HerdrKit dependency would duplicate `Shared/`'s symbols in the
+/// app binary. Both are true of the SHIPPED BINARIES and neither reaches a test target, which
+/// is linked into the test bundle and into nothing else. A reviewer pointed that out; the fix
+/// was one word in Package.swift.
+///
+/// What that buys is the thing the previous head lacked. `AgentList.activityContent` is the
+/// whole mapping the lock screen renders, so these tests execute the PATH rather than pinning a
+/// helper beside it — the earlier five tests pinned `activityLead` while the app-side call site
+/// stayed invisible to every target, and the one-line revert to the buggy expression passed all
+/// 446 tests.
+final class ActivityContentTests: XCTestCase {
+
+    // MARK: - fixtures
+
+    /// Same decoder-first construction as AgentListTests, for the same reason: an in-memory
+    /// AgentInfo can hold a shape the wire cannot produce.
+    private func agent(
+        pane: String, status: String?, name: String? = nil, completedUnixMs: Int64? = nil,
+        lastKnownStatus: String? = nil, machineID: String? = nil, reachability: String? = nil
+    ) throws -> AgentInfo {
+        var obj: [String: Any] = ["pane_id": pane]
+        if let status { obj["agent_status"] = status }
+        if let name { obj["name"] = name }
+        if let completedUnixMs { obj["last_completed_turn"] = ["completed_unix_ms": completedUnixMs] }
+        if let lastKnownStatus { obj["last_known_status"] = lastKnownStatus }
+        if let machineID { obj["machine_id"] = machineID }
+        if let reachability { obj["reachability"] = reachability }
+        let data = try JSONSerialization.data(withJSONObject: obj)
+        return try JSONDecoder().decode(AgentInfo.self, from: data)
+    }
+
+    /// The six row kinds the headline rule distinguishes. `.stopped` comes from LIVENESS, not
+    /// from a status word, so it is expressed by omitting the pane from the census.
+    private enum Kind: String, CaseIterable {
+        case needsYouConfirmed, needsYouUnconfirmed, unrecognised, working, idle, stopped
+    }
+
+    private func list(_ kinds: [Kind]) throws -> AgentList {
+        var infos: [AgentInfo] = []
+        var live: Set<String> = []
+        for (i, k) in kinds.enumerated() {
+            let pane = "p\(i)"
+            switch k {
+            case .needsYouConfirmed:
+                infos.append(try agent(pane: pane, status: "blocked", name: k.rawValue))
+                live.insert(pane)
+            case .needsYouUnconfirmed:
+                infos.append(try agent(pane: pane, status: "unknown", name: k.rawValue,
+                                       lastKnownStatus: "blocked", machineID: "m\(i)",
+                                       reachability: "degraded"))
+                live.insert(pane)
+            case .unrecognised:
+                infos.append(try agent(pane: pane, status: "wat", name: k.rawValue))
+                live.insert(pane)
+            case .working:
+                infos.append(try agent(pane: pane, status: "working", name: k.rawValue))
+                live.insert(pane)
+            case .idle:
+                infos.append(try agent(pane: pane, status: "idle", name: k.rawValue))
+                live.insert(pane)
+            case .stopped:
+                // Present in the roster, absent from the census: that is what stopped IS.
+                infos.append(try agent(pane: pane, status: "working", name: k.rawValue))
+            }
+        }
+        return AgentList(agents: infos, livePaneIDs: live)
+    }
+
+    /// The production mapping, reproduced by CALLING it — `App/LiveActivityController` is a
+    /// field copy of exactly this and no test target can see `App/`.
+    private func state(_ l: AgentList) -> AgentActivityState {
+        let c = l.activityContent
+        return AgentActivityState(
+            headline: c.headline,
+            status: AgentActivityStatus(rawValue: c.statusWord) ?? .needsYou,
+            needsYouCount: c.needsYouCount,
+            unconfirmedCount: c.unconfirmedCount,
+            workingCount: c.workingCount,
+            totalCount: c.totalCount,
+            workingSince: c.workingSinceUnixSeconds)
+    }
+
+    // MARK: - the premise: HerdrKit can only emit words this enum accepts
+
+    /// The mapping crosses a module boundary as a String, so the fallback in the app
+    /// (`?? .needsYou`) is either unreachable or a silent bug. This makes it unreachable by
+    /// assertion rather than by comment.
+    func testEveryStatusWordHerdrKitCanEmitIsAValidActivityStatus() throws {
+        var seen: Set<String> = []
+        for n in 1...3 {
+            for combo in combinations(of: Kind.allCases, length: n) {
+                let word = try list(combo).activityContent.statusWord
+                XCTAssertNotNil(AgentActivityStatus(rawValue: word),
+                                "HerdrKit emitted '\(word)', which AgentActivityStatus rejects")
+                seen.insert(word)
+            }
+        }
+        XCTAssertEqual(seen, ["needsYou", "working", "idle", "stopped"],
+                       "every activity status must be reachable, or the untested word is dead code")
+    }
+
+    /// An empty roster still produces a decodable state rather than a crash or an empty
+    /// headline, since the activity can exist before the first list arrives.
+    func testAnEmptyRosterProducesTheNoAgentsState() {
+        let c = AgentList(agents: []).activityContent
+        XCTAssertEqual(c.headline, "No agents")
+        XCTAssertEqual(c.statusWord, "idle")
+        XCTAssertEqual(c.totalCount, 0)
+        XCTAssertNil(c.workingSinceUnixSeconds)
+    }
+
+    // MARK: - THE PROPERTY: one surface may not contradict itself
+
+    /// The defect this whole rule exists to remove is a single surface disagreeing with
+    /// itself: a red Stopped dot above the text "2 working", both derived from one list. Two
+    /// heads fixed instances of it. This asserts the CLASS instead, over every roster shape of
+    /// size 1-3 (258 lists), by requiring the summary line to agree with the status the dot is
+    /// drawn from.
+    ///
+    /// A reviewer's enumeration measured 9 contradicting shapes before the headline rule and 5
+    /// after. This test is what makes the remaining 5 fail rather than be counted.
+    func testTheSummaryLineNeverContradictsTheStatusDot() throws {
+        for n in 1...3 {
+            for combo in combinations(of: Kind.allCases, length: n) {
+                let s = state(try list(combo))
+                let line = AgentActivitySummary.line(s)
+                let shape = combo.map(\.rawValue).joined(separator: "+")
+                switch s.status {
+                case .needsYou:
+                    // Must speak about attention, never about work, and never a bare label.
+                    XCTAssertTrue(line.contains("need you"),
+                                  "[\(shape)] needs-you dot over the line '\(line)'")
+                case .working:
+                    XCTAssertEqual(line, "\(s.workingCount) working",
+                                   "[\(shape)] working dot over the line '\(line)'")
+                case .idle, .stopped:
+                    // Nothing is waiting and nothing is working, so the line is the label
+                    // itself; anything else would be a count the dot does not support.
+                    XCTAssertEqual(line, s.status.label,
+                                   "[\(shape)] \(s.status.rawValue) dot over the line '\(line)'")
+                }
+            }
+        }
+    }
+
+    /// THE SHAPE THE PREVIOUS HEAD LEFT OPEN, named explicitly so a regression reads as itself
+    /// rather than as one failure among 258. An unrecognised lead used to produce
+    /// needsYouCount == 0, so the line fell through to the working branch: an amber needs-you
+    /// dot above "2 working", painted amber.
+    func testAnUnrecognisedLeadDoesNotAnnounceWork() throws {
+        let s = state(try list([.unrecognised, .working, .working]))
+        XCTAssertEqual(s.status, .needsYou, "an uninterpretable agent must surface, not sink")
+        XCTAssertEqual(AgentActivitySummary.line(s), "1 may need you",
+                       "an unrecognised agent is a MAYBE: it must not be asserted, nor hidden behind a working count")
+        XCTAssertEqual(s.workingCount, 2, "the working agents are still counted, just not announced")
+    }
+
+    /// And the divergence from the roster's own count is deliberate, so it is pinned rather
+    /// than left to be discovered as an inconsistency. The roster shows the unrecognised row in
+    /// its own section; the lock screen has no sections, so it carries the row in the count.
+    func testTheRosterCountAndTheActivityCountDivergeDeliberately() throws {
+        let l = try list([.unrecognised, .working])
+        XCTAssertEqual(l.needsYouCount, 0, "the roster counts only genuinely blocked agents")
+        XCTAssertEqual(l.activityContent.needsYouCount, 1, "the activity carries what it cannot draw as a row")
+        XCTAssertEqual(l.activityContent.unconfirmedCount, 1, "and carries it as doubt, not as fact")
+        XCTAssertFalse(l.isQuiet, "the roster already refuses to call this all-clear")
+    }
+
+    // MARK: - the boundaries three surviving mutants exploited
+
+    /// M1 (`case .stopped: return 4`) and M2 (`case .idle: return 6`) both made stopped TIE
+    /// with idle, and because rows arrive group-sorted with stopped before idle, first-min-wins
+    /// then handed the headline to stopped. Both survived all five of the previous head's tests.
+    func testAStoppedPaneLosesToAnIdleOne() throws {
+        let l = try list([.stopped, .idle])
+        XCTAssertEqual(l.activityLead?.info.name, Kind.idle.rawValue,
+                       "a live idle agent is what the session IS doing; a gone pane is not")
+        XCTAssertEqual(l.activityContent.statusWord, "idle")
+        XCTAssertEqual(AgentActivitySummary.line(state(l)), "Idle",
+                       "'Idle - 2 agents' tells the reader a live agent is quiet; 'Stopped' asserts a whole-session fact that is false")
+    }
+
+    /// The order the rows arrive in must not decide this, since that is exactly how the two
+    /// tie mutants won: they relied on stopped preceding idle in the group sort.
+    func testTheStoppedIdleBoundaryIsIndependentOfRowOrder() throws {
+        for combo in [[Kind.stopped, .idle], [.idle, .stopped]] {
+            XCTAssertEqual(try list(combo).activityContent.statusWord, "idle",
+                           "row order changed the headline for \(combo.map(\.rawValue))")
+        }
+    }
+
+    /// M3 (`case .needsYou: return r.hasUnconfirmedState ? 4 : 0`) dropped an UNCONFIRMED
+    /// needs-you row to idle's rank, so working outranked it. An unconfirmed blocked agent is
+    /// still the most important thing on the screen; the doubt belongs in the wording, not in
+    /// whether it is mentioned at all.
+    func testAnUnconfirmedNeedsYouStillOutranksWorkAndIdle() throws {
+        let l = try list([.needsYouUnconfirmed, .working, .idle])
+        XCTAssertEqual(l.activityLead?.info.name, Kind.needsYouUnconfirmed.rawValue)
+        XCTAssertEqual(l.activityContent.statusWord, "needsYou")
+        XCTAssertEqual(AgentActivitySummary.line(state(l)), "1 may need you",
+                       "the doubt goes in the wording; it must not remove the row from the headline")
+    }
+
+    /// The floor above must not become a ceiling: a CONFIRMED row still wins the name.
+    func testAConfirmedNeedsYouStillOutranksAnUnconfirmedOne() throws {
+        let l = try list([.needsYouUnconfirmed, .needsYouConfirmed])
+        XCTAssertEqual(l.activityLead?.info.name, Kind.needsYouConfirmed.rawValue)
+        XCTAssertEqual(AgentActivitySummary.line(state(l)), "2 need you · 1 stale",
+                       "both are counted and the doubt is named")
+    }
+
+    // MARK: - the two duplicated wording tables
+
+    /// THE MECHANICAL CROSS-CHECK. `AgentList.needsYouSummary` and `AgentActivitySummary.line`
+    /// are duplicated because the widget cannot link HerdrKit, and until now each was pinned
+    /// only against its own local copy: editing one plus its own table passed everything while
+    /// the two surfaces drifted apart. The "change both" comment was the only guard.
+    func testTheTwoWordingTablesAgree() throws {
+        // (needsYou, unconfirmed) pairs both tables enumerate, including the boundary where
+        // every waiting agent is a maybe and the one where none is.
+        for (needsYou, unconfirmed) in [(1, 0), (1, 1), (5, 5), (2, 1), (3, 0), (4, 2)] {
+            var kinds = [Kind](repeating: .needsYouUnconfirmed, count: unconfirmed)
+            kinds += [Kind](repeating: .needsYouConfirmed, count: needsYou - unconfirmed)
+            let l = try list(kinds)
+            XCTAssertEqual(l.needsYouCount, needsYou, "fixture premise for (\(needsYou),\(unconfirmed))")
+            XCTAssertEqual(l.unconfirmedNeedsYouCount, unconfirmed, "fixture premise for (\(needsYou),\(unconfirmed))")
+            XCTAssertEqual(l.needsYouSummary, AgentActivitySummary.line(state(l)),
+                           "the two wording tables disagree at (\(needsYou),\(unconfirmed))")
+        }
+    }
+
+    // MARK: - helpers
+
+    /// Every ordered combination WITH repetition, so a roster of two working agents and a
+    /// roster of one are both covered, and so row order is exercised in both directions.
+    private func combinations(of kinds: [Kind], length: Int) -> [[Kind]] {
+        guard length > 1 else { return kinds.map { [$0] } }
+        return combinations(of: kinds, length: length - 1).flatMap { rest in
+            kinds.map { [$0] + rest }
+        }
+    }
+}

--- a/Tests/HerdrKitTests/AgentListTests.swift
+++ b/Tests/HerdrKitTests/AgentListTests.swift
@@ -217,6 +217,43 @@ final class AgentListTests: XCTestCase {
                        "mixed: lead with the fact, then name the doubt")
     }
 
+    /// A FULLY OFFLINE peer's escalated rows must still count as unconfirmed. This was the
+    /// fourth surviving mutant a review found, and it was a real defect rather than a
+    /// coverage hole: the count reused `showsUnconfirmedMarker`, which excludes
+    /// `isUnreachable` because the CARD draws those an offline badge instead. Counting with
+    /// a rendering exclusion meant a dead machine's stale guess was reported as CONFIRMED
+    /// on the Live Activity and the roster header, the two surfaces with no row to mark.
+    func testUnreachablePeerStillCountsAsUnconfirmed() throws {
+        let offline = try agent(pane: "p1", status: "unknown", lastKnownStatus: "blocked",
+                               machineID: "mcb-air", reachability: "unreachable")
+        let row = AgentRow(info: offline)
+        // The premises that made the defect invisible: it IS escalated, and it is
+        // deliberately NOT marked, because the offline badge replaces its status entirely.
+        XCTAssertEqual(row.group, .needsYou)
+        XCTAssertFalse(row.showsUnconfirmedMarker, "the card draws it offline, not stale")
+        XCTAssertTrue(row.hasUnconfirmedState, "but the underlying state is still unconfirmed")
+
+        let list = AgentList(agents: [offline])
+        XCTAssertEqual(list.unconfirmedNeedsYouCount, 1,
+                       "a dead machine's last-known blocked must never read as confirmed")
+        XCTAssertEqual(list.needsYouSummary, "1 may need you")
+
+        // Five agents on one dead machine previously rendered a flat "5 need you".
+        let five = try (1...5).map {
+            try agent(pane: "p\($0)", status: "unknown", lastKnownStatus: "blocked",
+                      machineID: "mcb-air", reachability: "unreachable")
+        }
+        XCTAssertEqual(AgentList(agents: five).needsYouSummary, "5 may need you")
+
+        // Mixed with a genuinely live blocked agent, the doubt is named rather than hidden.
+        let live = try agent(pane: "live", status: "blocked")
+        XCTAssertEqual(AgentList(agents: [live, offline]).needsYouSummary,
+                       "2 need you · 1 stale")
+
+        // And a stopped row on a dead peer is not unconfirmed, it is simply gone.
+        XCTAssertFalse(AgentRow(info: offline, isLive: false).hasUnconfirmedState)
+    }
+
     // MARK: - archived agents (issue #173)
 
     /// The `archived` block decodes through the wire path and drives `isArchived`.

--- a/Tests/HerdrKitTests/AgentListTests.swift
+++ b/Tests/HerdrKitTests/AgentListTests.swift
@@ -10,13 +10,17 @@ final class AgentListTests: XCTestCase {
     /// the JSON key was wrong.
     private func agent(
         pane: String, status: String?, name: String? = nil, completedUnixMs: Int64? = nil,
-        archivedBy: String? = nil, archivedAt: String? = nil, terminalID: String? = nil
+        archivedBy: String? = nil, archivedAt: String? = nil, terminalID: String? = nil,
+        inputPending: Bool? = nil, lastKnownStatus: String? = nil, machineID: String? = nil
     ) throws -> AgentInfo {
         var obj: [String: Any] = ["pane_id": pane]
         if let status { obj["agent_status"] = status }
         if let name { obj["name"] = name }
         if let terminalID { obj["terminal_id"] = terminalID }
         if let completedUnixMs { obj["last_completed_turn"] = ["completed_unix_ms": completedUnixMs] }
+        if let inputPending { obj["input_pending"] = inputPending }
+        if let lastKnownStatus { obj["last_known_status"] = lastKnownStatus }
+        if let machineID { obj["machine_id"] = machineID }
         if let archivedBy {
             obj["archived"] = ["at": archivedAt ?? "2026-08-26T18:00:00Z", "by": archivedBy]
         }
@@ -36,6 +40,51 @@ final class AgentListTests: XCTestCase {
     ) throws -> AgentInfo {
         try agent(pane: "", status: "idle", name: name,
                   archivedBy: by, archivedAt: at, terminalID: terminalID)
+    }
+
+    // MARK: - needs-you escalation
+
+    /// An agent showing a plan-approval / AskUserQuestion menu reaches `needsYou` even
+    /// though its status string is not the literal "blocked". Before this, grouping read
+    /// only the status, so the row sat in `working` while the input router already treated
+    /// it as awaiting a menu answer: the list and the router disagreed about one fact.
+    func testInputPendingReachesNeedsYouWithoutBlockedStatus() throws {
+        let row = AgentRow(info: try agent(pane: "p1", status: "working", inputPending: true))
+        XCTAssertEqual(row.group, .needsYou)
+        XCTAssertEqual(row.status, .working, "the raw status is still reported verbatim")
+        // Control: the same row without the flag stays in `working`, so the assertion
+        // above is about `input_pending` and not about the fixture.
+        let control = AgentRow(info: try agent(pane: "p1", status: "working"))
+        XCTAssertEqual(control.group, .working)
+    }
+
+    /// A federated peer that misses ONE poll gets `agent_status: "unknown"` with the real
+    /// state moved to `last_known_status`. A blocked agent on that machine must stay in
+    /// `needsYou` instead of vanishing into `unrecognised` with everything else on the peer.
+    func testDegradedPeerKeepsABlockedAgentInNeedsYou() throws {
+        let row = AgentRow(info: try agent(pane: "p1", status: "unknown",
+                                           lastKnownStatus: "blocked", machineID: "mcb-air"))
+        XCTAssertEqual(row.group, .needsYou)
+        XCTAssertEqual(row.status, .indefinite, "the status itself is still not known")
+    }
+
+    /// Escalation is one-way. A last-known status that is not `blocked` must NOT pull the
+    /// row down into a quieter section: `unrecognised` sorts above `working` and `idle` on
+    /// purpose, and "this machine went quiet on us" is the louder, truer thing to show.
+    func testDegradedPeerDoesNotDemoteANonBlockedLastKnownStatus() throws {
+        for last in ["working", "idle", "done"] {
+            let row = AgentRow(info: try agent(pane: "p1", status: "unknown",
+                                               lastKnownStatus: last, machineID: "mcb-air"))
+            XCTAssertEqual(row.group, .unrecognised, "last_known_status \(last) must not demote")
+        }
+    }
+
+    /// A pane that no longer exists needs nothing from anybody, so a stale `input_pending`
+    /// cannot resurrect it into `needsYou`.
+    func testStoppedPaneIsNeverEscalated() throws {
+        let row = AgentRow(info: try agent(pane: "p1", status: "blocked", inputPending: true),
+                           isLive: false)
+        XCTAssertEqual(row.group, .stopped)
     }
 
     // MARK: - archived agents (issue #173)

--- a/Tests/HerdrKitTests/AgentListTests.swift
+++ b/Tests/HerdrKitTests/AgentListTests.swift
@@ -11,7 +11,8 @@ final class AgentListTests: XCTestCase {
     private func agent(
         pane: String, status: String?, name: String? = nil, completedUnixMs: Int64? = nil,
         archivedBy: String? = nil, archivedAt: String? = nil, terminalID: String? = nil,
-        inputPending: Bool? = nil, lastKnownStatus: String? = nil, machineID: String? = nil
+        inputPending: Bool? = nil, lastKnownStatus: String? = nil, machineID: String? = nil,
+        reachability: String? = nil
     ) throws -> AgentInfo {
         var obj: [String: Any] = ["pane_id": pane]
         if let status { obj["agent_status"] = status }
@@ -21,6 +22,7 @@ final class AgentListTests: XCTestCase {
         if let inputPending { obj["input_pending"] = inputPending }
         if let lastKnownStatus { obj["last_known_status"] = lastKnownStatus }
         if let machineID { obj["machine_id"] = machineID }
+        if let reachability { obj["reachability"] = reachability }
         if let archivedBy {
             obj["archived"] = ["at": archivedAt ?? "2026-08-26T18:00:00Z", "by": archivedBy]
         }
@@ -85,6 +87,68 @@ final class AgentListTests: XCTestCase {
         let row = AgentRow(info: try agent(pane: "p1", status: "blocked", inputPending: true),
                            isLive: false)
         XCTAssertEqual(row.group, .stopped)
+    }
+
+    /// The input_pending escalation is written to fire for ANY status, so pin EVERY status
+    /// it can arrive with, not just one. A review mutant that narrowed it to
+    /// `status == .working` survived the whole 427-test suite because the only fixture
+    /// built "working"; the idle-plus-input_pending shape is the more common one in
+    /// practice, since an agent parked on a menu often reports idle.
+    func testInputPendingEscalatesFromEveryLiveStatus() throws {
+        for status in ["idle", "working", "done", "unknown", "blocked", "wat"] {
+            let row = AgentRow(info: try agent(pane: "p1", status: status, inputPending: true))
+            XCTAssertEqual(row.group, .needsYou, "input_pending must escalate from \(status)")
+        }
+        // Controls: the SAME statuses without the flag must land where grouping puts them,
+        // so the loop above is about input_pending and not about the fixture.
+        for (status, expected) in [("idle", AgentGroup.idle), ("working", .working),
+                                   ("done", .idle), ("unknown", .unrecognised),
+                                   ("blocked", .needsYou), ("wat", .unrecognised)] {
+            let row = AgentRow(info: try agent(pane: "p1", status: status))
+            XCTAssertEqual(row.group, expected, "control for \(status)")
+        }
+    }
+
+    /// The `status == .indefinite` precondition on the last-known escalation is
+    /// load-bearing: a LIVE status is authoritative, and `last_known_status` only means
+    /// anything once the daemon has blanked the live one to "unknown". A review mutant
+    /// that dropped the precondition survived the full suite, so pin it directly. The
+    /// shape is real: a fixture elsewhere in this file builds status "idle" with a
+    /// last-known "working".
+    func testLastKnownBlockedIsIgnoredWhileTheLiveStatusIsKnown() throws {
+        for status in ["idle", "working", "done"] {
+            let row = AgentRow(info: try agent(pane: "p1", status: status,
+                                               lastKnownStatus: "blocked", machineID: "mcb-air"))
+            XCTAssertNotEqual(row.group, .needsYou,
+                              "a live \(status) status must not be overridden by a stale blocked value")
+        }
+        // And the case it IS for: the daemon blanked the live status, so last-known decides.
+        let blanked = AgentRow(info: try agent(pane: "p1", status: "unknown",
+                                               lastKnownStatus: "blocked", machineID: "mcb-air"))
+        XCTAssertEqual(blanked.group, .needsYou)
+    }
+
+    /// A degraded peer is 1 to 2 missed polls, not offline, so `isUnreachable` is false
+    /// while the status is nevertheless unconfirmed. The row needs a staleness marker, and
+    /// the render keys on this predicate, so pin both arms plus the fresh case.
+    func testDegradedReachabilityIsUnconfirmedButNotUnreachable() throws {
+        let degraded = try agent(pane: "p1", status: "unknown", lastKnownStatus: "blocked",
+                                 machineID: "mcb-air", reachability: "degraded")
+        XCTAssertTrue(degraded.hasUnconfirmedStatus)
+        XCTAssertFalse(degraded.isUnreachable)
+        let gone = try agent(pane: "p2", status: "unknown", machineID: "mcb-air",
+                             reachability: "unreachable")
+        XCTAssertTrue(gone.hasUnconfirmedStatus)
+        XCTAssertTrue(gone.isUnreachable)
+        let live = try agent(pane: "p3", status: "idle", machineID: "mcb-air",
+                             reachability: "reachable")
+        XCTAssertFalse(live.hasUnconfirmedStatus)
+        // A newer server's unknown string must read as FRESH, never stamp every row stale.
+        let newer = try agent(pane: "p4", status: "idle", machineID: "mcb-air",
+                              reachability: "some-future-state")
+        XCTAssertFalse(newer.hasUnconfirmedStatus)
+        // A local agent carries no reachability at all.
+        XCTAssertFalse(try agent(pane: "p5", status: "idle").hasUnconfirmedStatus)
     }
 
     // MARK: - archived agents (issue #173)

--- a/Tests/HerdrKitTests/AgentListTests.swift
+++ b/Tests/HerdrKitTests/AgentListTests.swift
@@ -863,4 +863,71 @@ final class AgentListTests: XCTestCase {
         let notice = permanentStreamRefusal(code: "pane_not_found")
         XCTAssertEqual(notice?.contains("not reconnecting"), true)
     }
+
+    // MARK: - the activity headline (a DIFFERENT question from the list order)
+
+    /// THE EXACT CONTRADICTION A REVIEWER MEASURED: one freshly stopped pane used to
+    /// outrank every working agent, because the lock screen re-derived its headline from the
+    /// roster's SECTION ORDER. The surface then showed a red "Stopped" dot above a summary
+    /// line reading "2 working" — self-contradicting, from a single list.
+    ///
+    /// `.stopped` comes from LIVENESS, not from a status word (a "done" agent folds into
+    /// idle), so the census must omit the pane. THE PREMISE IS ASSERTED FIRST: the first
+    /// version of this test used `status: "done"` and passed while producing an IDLE row,
+    /// which working outranks anyway — green, and testing nothing.
+    func testAStoppedPaneIsNotTheHeadlineWhileOthersWork() throws {
+        let list = AgentList(agents: [
+            try agent(pane: "p1", status: "blocked", name: "gone-one"),
+            try agent(pane: "p2", status: "working"),
+            try agent(pane: "p3", status: "working"),
+        ], livePaneIDs: ["p2", "p3"])   // p1 is absent from the census
+        XCTAssertEqual(list.rows.first { $0.info.paneID == "p1" }?.group, .stopped,
+                       "premise: p1 must actually be stopped, and a blocked-but-gone pane is the strongest case")
+        XCTAssertEqual(list.activityLead?.group, .working,
+                       "a gone pane is not what the session is DOING; the list order says otherwise on purpose")
+        XCTAssertEqual(list.rows.filter { $0.group == .working }.count, 2,
+                       "and the summary count the headline used to contradict is 2")
+    }
+
+    /// Stopped IS the honest headline when it is the whole truth, so the demotion above is
+    /// a re-ranking and not a suppression.
+    func testAStoppedPaneIsTheHeadlineWhenNothingElseExists() throws {
+        let list = AgentList(agents: [try agent(pane: "p1", status: "working")],
+                             livePaneIDs: [])
+        XCTAssertEqual(list.activityLead?.group, .stopped)
+    }
+
+    /// Within needsYou, a CONFIRMED row names the headline before a last-known guess on a
+    /// peer that went quiet. The doubt is still reported by the count; it just no longer
+    /// picks the name.
+    func testAConfirmedNeedsYouOutranksAnUnconfirmedOne() throws {
+        let stale = try agent(pane: "p1", status: "unknown", name: "stale-one",
+                              lastKnownStatus: "blocked", machineID: "mcb", reachability: "degraded")
+        let live = try agent(pane: "p2", status: "blocked", name: "live-one")
+        // Server order puts the unconfirmed row FIRST, so a rule that merely kept list
+        // order would pick it.
+        let list = AgentList(agents: [stale, live])
+        XCTAssertEqual(list.activityLead?.info.name, "live-one",
+                       "a confirmed blocked agent should name the headline over a stale guess")
+        XCTAssertEqual(list.unconfirmedNeedsYouCount, 1,
+                       "the doubt is still reported, just not as the headline")
+    }
+
+    /// needsYou still outranks everything, and unrecognised still keeps its fail-closed
+    /// place above working and idle — so the demotion of `stopped` did not disturb the rest.
+    func testHeadlineOrderIsOtherwiseUnchanged() throws {
+        let needs = try agent(pane: "p1", status: "blocked")
+        let unrec = try agent(pane: "p2", status: "wat")
+        let work  = try agent(pane: "p3", status: "working")
+        let idle  = try agent(pane: "p4", status: "idle")
+        XCTAssertEqual(AgentList(agents: [idle, work, unrec, needs]).activityLead?.group, .needsYou)
+        XCTAssertEqual(AgentList(agents: [idle, work, unrec]).activityLead?.group, .unrecognised)
+        XCTAssertEqual(AgentList(agents: [idle, work]).activityLead?.group, .working)
+        XCTAssertEqual(AgentList(agents: [idle]).activityLead?.group, .idle)
+    }
+
+    /// An empty list has no headline at all, which the caller renders as "No agents".
+    func testAnEmptyListHasNoHeadline() {
+        XCTAssertNil(AgentList(agents: []).activityLead)
+    }
 }

--- a/Tests/HerdrKitTests/AgentListTests.swift
+++ b/Tests/HerdrKitTests/AgentListTests.swift
@@ -151,6 +151,72 @@ final class AgentListTests: XCTestCase {
         XCTAssertFalse(try agent(pane: "p5", status: "idle").hasUnconfirmedStatus)
     }
 
+    /// EVERY CONJUNCT of `showsUnconfirmedMarker` gets its own assertion, because a review
+    /// found all three one-conjunct mutants surviving the full 430-test suite. The UI
+    /// receipt cannot see them either: the mock fixture has no stopped or unreachable
+    /// degraded row, so its marker count stays 1 under all three.
+    func testShowsUnconfirmedMarkerRequiresEveryConjunct() throws {
+        let degraded = try agent(pane: "p1", status: "unknown", lastKnownStatus: "blocked",
+                                 machineID: "mcb-air", reachability: "degraded")
+        // The positive case, so the negatives below cannot pass by the rule never firing.
+        XCTAssertTrue(AgentRow(info: degraded).showsUnconfirmedMarker)
+
+        // isLive: a pane that is gone is not presenting anything to qualify. Dropping this
+        // conjunct puts a stale chip on a stopped row.
+        XCTAssertFalse(AgentRow(info: degraded, isLive: false).showsUnconfirmedMarker,
+                       "a stopped row must not be marked; it renders no live state at all")
+
+        // !isUnreachable: that case already REPLACES the status with an offline mark, so
+        // marking it too says the same thing twice. Dropping this conjunct double-marks.
+        let gone = try agent(pane: "p2", status: "unknown", lastKnownStatus: "blocked",
+                             machineID: "mcb-air", reachability: "unreachable")
+        XCTAssertFalse(AgentRow(info: gone).showsUnconfirmedMarker,
+                       "an unreachable row takes the offline treatment instead of the chip")
+
+        // hasUnconfirmedStatus: a live local row is never marked.
+        XCTAssertFalse(AgentRow(info: try agent(pane: "p3", status: "blocked")).showsUnconfirmedMarker)
+    }
+
+    /// `unconfirmedNeedsYouCount` counts only rows that are BOTH unconfirmed and in
+    /// needs-you. Dropping the group test was the strongest surviving mutant: the marker
+    /// rule itself does not look at the group, so a degraded row whose last-known status is
+    /// working or idle groups `.unrecognised` and would then be counted as a waiting agent.
+    func testUnconfirmedNeedsYouCountRequiresTheNeedsYouGroup() throws {
+        // Unconfirmed, but its last-known status is not blocked, so it groups unrecognised.
+        let notWaiting = try agent(pane: "p1", status: "unknown", lastKnownStatus: "working",
+                                   machineID: "mcb-air", reachability: "degraded")
+        let list = AgentList(agents: [notWaiting])
+        XCTAssertEqual(list.rows.first?.group, .unrecognised, "premise: this row is not waiting")
+        XCTAssertTrue(try XCTUnwrap(list.rows.first).showsUnconfirmedMarker,
+                      "premise: it IS unconfirmed, so only the group test can exclude it")
+        XCTAssertEqual(list.unconfirmedNeedsYouCount, 0,
+                       "an unconfirmed row that is not waiting must not be counted as waiting")
+
+        // And the row that IS waiting is counted.
+        let waiting = try agent(pane: "p2", status: "unknown", lastKnownStatus: "blocked",
+                                machineID: "mcb-air", reachability: "degraded")
+        XCTAssertEqual(AgentList(agents: [waiting]).unconfirmedNeedsYouCount, 1)
+    }
+
+    /// The wording spec every surface shares. Three surfaces render this count and the
+    /// first version qualified only the roster card, which is how the lock screen ended up
+    /// asserting an unconfirmed state as fact.
+    func testNeedsYouSummaryQualifiesUnconfirmedCounts() throws {
+        XCTAssertNil(AgentList(agents: [try agent(pane: "p1", status: "idle")]).needsYouSummary,
+                     "nothing waiting means no summary, so a caller can use its own wording")
+
+        let live = try agent(pane: "p1", status: "blocked")
+        XCTAssertEqual(AgentList(agents: [live]).needsYouSummary, "1 need you")
+
+        let stale = try agent(pane: "p2", status: "unknown", lastKnownStatus: "blocked",
+                              machineID: "mcb-air", reachability: "degraded")
+        XCTAssertEqual(AgentList(agents: [stale]).needsYouSummary, "1 may need you",
+                       "when every waiting agent is unconfirmed, the whole claim is a maybe")
+
+        XCTAssertEqual(AgentList(agents: [live, stale]).needsYouSummary, "2 need you · 1 stale",
+                       "mixed: lead with the fact, then name the doubt")
+    }
+
     // MARK: - archived agents (issue #173)
 
     /// The `archived` block decodes through the wire path and drives `isArchived`.

--- a/Tests/HerdrKitTests/MockWireFixtureTests.swift
+++ b/Tests/HerdrKitTests/MockWireFixtureTests.swift
@@ -39,7 +39,8 @@ final class MockWireFixtureTests: XCTestCase {
     func testMockAgentListDecodesRealisticStatuses() async throws {
         let client = HerdrClient(transport: FixtureTransport())
         let agents = try await client.agentList()
-        XCTAssertEqual(agents.count, 9, "mock agent.list did not decode to 9 agents (8 live + 1 archived)")
+        XCTAssertEqual(agents.count, 10,
+                       "mock agent.list did not decode to 10 agents (9 live + 1 archived)")
         XCTAssertEqual(agents.filter { $0.isArchived }.count, 1, "one fixture agent carries an archived block")
         XCTAssertEqual(agents.first?.paneID, "w1:p1")
         XCTAssertEqual(agents.first?.displayName, "jarvis",
@@ -73,14 +74,27 @@ final class MockWireFixtureTests: XCTestCase {
                        [.needsYou, .stopped, .working, .idle],
                        "sections did not render in the mockup's order/composition")
         let counts = Dictionary(uniqueKeysWithValues: list.sections.map { ($0.group, $0.rows.count) })
-        XCTAssertEqual(counts[.needsYou], 2)
+        XCTAssertEqual(counts[.needsYou], 3,
+                       "two locally blocked, plus the degraded federated row escalated on its last-known blocked")
         XCTAssertEqual(counts[.stopped], 1)
         XCTAssertEqual(counts[.working], 1)
         XCTAssertEqual(counts[.idle], 4, "the done agent should fold into idle, making IDLE · 4")
-        XCTAssertEqual(list.needsYouCount, 2, "header would show the wrong 'N need you'")
+        XCTAssertEqual(list.needsYouCount, 3, "header would show the wrong 'N need you'")
+        // And one of those three is a MAYBE, which every surface must be able to qualify.
+        XCTAssertEqual(list.unconfirmedNeedsYouCount, 1)
+        let federated = try XCTUnwrap(list.rows.first { $0.info.machineID != nil })
+        XCTAssertEqual(federated.group, .needsYou)
+        XCTAssertEqual(federated.status, .indefinite, "its live status is genuinely unknown")
+        XCTAssertTrue(federated.showsUnconfirmedMarker, "the card and the widget both key on this")
+        XCTAssertFalse(federated.info.isUnreachable, "degraded is not offline; it must not take the offline badge")
+        // The locally blocked rows are NOT marked, so the marker is about reachability and
+        // not about being in the needs-you group.
+        for row in list.rows where row.group == .needsYou && row.info.machineID == nil {
+            XCTAssertFalse(row.showsUnconfirmedMarker, "\(row.info.paneID) is a live blocked agent")
+        }
         // The archived fixture agent is partitioned OUT of the live sections (which still
         // sum to 8) and into its own collapsed section.
-        XCTAssertEqual(list.rows.count, 8, "archived agents must not inflate the live rows")
+        XCTAssertEqual(list.rows.count, 9, "archived agents must not inflate the live rows")
         XCTAssertEqual(list.archived.count, 1, "the archived fixture agent lands in the Archived section")
         XCTAssertEqual(list.archived.first?.info.name, "huurjacht")
 
@@ -418,6 +432,7 @@ enum MockWireFixtures {
       {"pane_id":"w3:p2","name":"aste-screener","agent":"codex","agent_status":"idle","cwd":"/root/aste-screener","terminal_title_stripped":"apify-harvest"},
       {"pane_id":"w4:p1","name":"discovery","agent":"gemini","agent_status":"idle","cwd":"/root/discovery-calls","terminal_title_stripped":"redaction-pass v3"},
       {"pane_id":"w4:p2","name":"bank-qa","agent":"claude","agent_status":"done","cwd":"/root/bank-qa","terminal_title_stripped":"deal-assistant rag"},
+      {"pane_id":"mcb-air/w1:p9","name":"mcb-air/mcb-air","agent":"omp","agent_status":"unknown","last_known_status":"blocked","machine_id":"mcb-air","reachability":"degraded","cwd":"/Users/jerry/omp-workspace","terminal_title_stripped":"clone repo and help deimos"},
       {"pane_id":"w5:p1","name":"huurjacht","agent":"claude","agent_status":"idle","cwd":"/root/huurjacht","terminal_title_stripped":"pararius scrape","archived":{"at":"2026-08-26T18:00:00Z","by":"jerry","reason":"parked for the weekend"}}
     ]}}
     """#
@@ -425,7 +440,7 @@ enum MockWireFixtures {
     /// The census the App's mock render passes (MockTransport.demoLivePaneIDs).
     /// Excludes w2:p1 so it groups STOPPED via liveness. Keep in sync with the App.
     static let demoLivePaneIDs: Set<String> = [
-        "w1:p1", "w1:p2", "w2:p2", "w3:p1", "w3:p2", "w4:p1", "w4:p2",
+        "w1:p1", "w1:p2", "w2:p2", "w3:p1", "w3:p2", "w4:p1", "w4:p2", "mcb-air/w1:p9",
     ]
 
     static let agentRead = #"""


### PR DESCRIPTION
## Why

Section grouping read exactly one field, the `agent_status` string (`AgentList.swift`, `group(for:isLive:)`). Two real states could therefore never surface.

1. An agent showing a plan-approval or AskUserQuestion menu whose status is anything other than the literal `blocked` could not enter needs-you, even though `AgentInfo.isAwaitingMenuInput` already treats it as awaiting a menu answer and already gates input routing. The list and the router disagreed about one fact.
2. A federated peer that misses a **single** poll is marked Degraded (`reachability_for_misses(1)`), after which the daemon overwrites `agent_status` with `unknown` and moves the real state into `last_known_status`. Every agent on that machine leaves both working and needs-you at once. The app decoded `last_known_status` and had **zero readers** of it, so the only surviving copy of the truth was discarded and the rows fell to UNRECOGNISED.

Measured on the live roster while investigating: 7 federated agents, none ever reported working across 50 samples over 150 seconds, while 5 local agents did.

## What changed

`AgentRow.resolvedGroup` is an **escalation-only** overlay on `group(for:isLive:)`. It may move a row up into needs-you and may never move one toward a quieter section, so the fail-closed placement encoded in the group order cannot be undone by a lenient field.

- `inputPending` reaches needs-you, via the existing `isAwaitingMenuInput`.
- `lastKnownStatus` is read only when it says `blocked`, and only when the status is `indefinite`.
- A last-known `working` deliberately does **not** restore the working group. That would be a demotion out of `unrecognised`, and "this machine went quiet on us" is the louder and truer thing to show. The real remedy for that case is daemon-side: not blanking a whole peer on one missed poll.
- A stopped pane is never escalated. A pane that is gone needs nothing.

`group(for:isLive:)` keeps its exhaustive switch untouched, so adding an `AgentStatus` case still fails to compile there rather than falling through to a guess.

## Verification

Run in the `swift:6.1` container CI uses.

- Full suite on this branch as it sits on `main`: **427 tests, 0 failures**, 15 skipped.
- Four new tests, run by name: all pass.
- Mutation matrix, because a green test proves nothing on its own. Both mutants still compiled, so neither result is the compiler passing instead of the guard:

| mutant on the production path | result |
|---|---|
| both escalations removed | `testInputPendingReachesNeedsYou...` and `testDegradedPeerKeepsABlockedAgent...` fail |
| `resolvedGroup` always returns `.needsYou` | `testDegradedPeerDoesNotDemote...` and `testStoppedPaneIsNeverEscalated` fail |

One instrument note, stated because it produced a false failure first: running with `--scratch-path` outside the package root makes `PaneSnapshotAccessTests` fail, because it reads `/src/.build`. Confirmed as a harness artifact by running the same setup against clean `main`, which fails identically. The 427/0 result above used the default scratch path.

## Not covered

Fleet agents still have no event or push channel, so they only refresh with the whole roster. That is the remaining reason they do not feel live, and it is a daemon change, not an app one.

## Authorization

Owner instruction in the herdr-app pane, recorded as Gitmoot workflow note 101263.