### PR TITLE
fix(release): bump the marketing version to 1.0.3

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -195,7 +195,7 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.jerryfane.herdr
-        MARKETING_VERSION: "1.0.2"
+        MARKETING_VERSION: "1.0.3"
         CURRENT_PROJECT_VERSION: "1"
         SWIFT_VERSION: "5.9"
         GENERATE_INFOPLIST_FILE: NO
@@ -300,7 +300,7 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.jerryfane.herdr.widgets
-        MARKETING_VERSION: "1.0.2"
+        MARKETING_VERSION: "1.0.3"
         CURRENT_PROJECT_VERSION: "1"
         SWIFT_VERSION: "5.9"
         GENERATE_INFOPLIST_FILE: NO


### PR DESCRIPTION
The **1.0.2 train is closed for new build submissions**, so TestFlight uploads under it are rejected outright.

## Measured, not inferred

Run [33558708739](https://github.com/jerryfane/herdrup/actions/runs/33558708739) (`workflow_dispatch` on `main` at `e9c3d211`) **archived and exported cleanly** and failed at step 17:

```
ERROR: [altool] Invalid Pre-Release Train. The train version '1.0.2'
is closed for new build submissions (90186)
```

1.0.2 was set in #202 on 2026-08-30 and the last successful upload was 2026-08-31T13:46Z under it — so the train closed in the window since, i.e. **1.0.2 reached the App Store**. Nothing about the build is wrong; the version it would land under no longer accepts builds.

## Both targets move together

`MARKETING_VERSION` appears **twice** in `project.yml` (app `:198`, widget `:303`). A half-bump ships an app and a widget that disagree about their version, and the lane's archive-version check would catch that only for the app. The edit **asserts a match count of exactly 2 before writing** and refuses otherwise.

Nothing else hardcodes a version — grepping `*.swift`/`*.yml`/`*.plist`/`*.json` for `1.0.2` outside build dirs returns nothing, and the in-app footer reads `CFBundleShortVersionString` from the bundle at runtime (`HerdrApp.swift:5912`, `:6013`).

## What this unblocks

Four merges have been sitting unbuilt since 2026-08-31T13:46Z: #204, #207, #208, and **#203** — terminal double-tap word selection, jump-to-tail gestures and iPhone typing, the user-visible one. The owner's physical-device pass on selection depends on a build reaching TestFlight.

Dispatched under owner authorization note 105031 / directive 105035.

**Not verified:** no simulator or device on this box. This changes only a version string; the lane itself is the verification, and it re-runs on merge.