### PR TITLE
docs: point Getting it at the App Store now that 1.0.3 is live

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ herdrup is an iOS client for [herdr](https://github.com/jerryfane/herdr) — a c
 board for the coding agents running on your machine, with a real terminal one tap behind each.
 When an agent needs you, you see it at a glance and can reply from anywhere.
 
-🌐 [herdrup.themartian.app](https://herdrup.themartian.app)
+[**⬇ Download on the App Store**](https://apps.apple.com/app/id6798087089) · 🌐 [herdrup.themartian.app](https://herdrup.themartian.app)
 
 The framing is *a herdr client that contains a terminal*, not a terminal app that happens to run
 herdr. A generic SSH terminal renders a character grid and cannot know what a pane or an agent is;
@@ -33,8 +33,11 @@ there is no system libssh2 to install, which is exactly what lets the protocol l
 
 ## Getting it
 
-The app ships to **TestFlight**. Join the beta from [herdrup.themartian.app](https://herdrup.themartian.app),
-or build it yourself below.
+**[Download on the App Store](https://apps.apple.com/app/id6798087089)** — herdrup is live, free, and
+iPhone + iPad (it also installs on Apple Silicon Macs as a Designed-for-iPad app).
+
+You can also [build it yourself](#building-from-source); it is Apache-2.0 and the whole client is in
+this repository.
 
 ## Building from source
 


### PR DESCRIPTION
herdrup is `READY_FOR_SALE` (1.0.3, build 119), so the README should send people to the App Store rather than invite them to a TestFlight beta.

**https://apps.apple.com/app/id6798087089**

Verified, and stating the method because my first attempt was wrong: a bare `curl` returned **429** (Apple rate-limiting), so a 200 was not observed on the first try. Re-checked with a browser UA -> **200**, and confirmed against the authoritative iTunes lookup API:

```
resultCount=1
trackName = 'herdrup: agents in your pocket'
version   = 1.0.3   price = 0.0   released = 2026-09-03
127 supported devices
```

The short `/app/id…` form is used deliberately over the slugged `trackViewUrl` — it is region-agnostic and survives a name change.

## Changes

- App Store link in the header, beside the existing site link
- `Getting it` section rewritten: App Store first, build-from-source second
- Mentions it installs on Apple Silicon Macs as a Designed-for-iPad app — `project.yml` has had that since #131 and the README never said so

## Deliberately NOT changed

The other eight TestFlight references in this repo are the release **lane**, not user-facing copy:

- `.github/workflows/testflight.yml`, `scripts/testflight.sh`, `ci/ExportOptions*.plist`, `project.yml`, `docs/testflight-lane.md`
- a comment in `LiveTerminalView.swift` recording that a scroll defect survived ~7 TestFlight builds — a measurement, not a mention

Stripping those would break shipping. "No more TestFlight mentions" means the install instructions, and that is what changed.

## Not in this PR

The website (`herdrup.themartian.app`) still says TestFlight and still needs the App Store buttons, the open-source line in the hero, and the `/fork` refresh.

**I could not find its source.** It is not in this repo, not in `jerryfane/themartian-web` (one passing mention, no `/fork`), and not in `jerryfane/herdr/website` (that is the herdr site). No Cloudflare Pages project in the visible account matches, and the CF token lacks DNS read permission so I could not trace the hostname. Asked the owner where it lives.
