### PR TITLE
docs: the export-compliance deferral closed when 1.0.3 went public

### DIFF
--- a/docs/testflight-lane.md
+++ b/docs/testflight-lane.md
@@ -47,11 +47,20 @@ published encryption (AES/SSH via a standard library — no proprietary or custo
 which qualifies for the standard mass-market exemption (EAR Category 5 Part 2) — the
 declaration used by essentially every SSH client on the App Store. Owner-approved
 determination, 2026-08-05. The stricter `true` value was tried first but requires a full
-CCATS filing to upload (App Store Connect altool error 90592), disproportionate for a
-standard-encryption test build. A public App Store release should confirm the
-self-classification paperwork with a compliance specialist. The CI verifier still fails
-loudly on `MISSING_EXPORT_COMPLIANCE` as a backstop, but with `false` an internal build
-goes straight to testable. See Apple's [export-compliance guidance](https://developer.apple.com/documentation/security/complying-with-encryption-export-regulations).
+CCATS filing to upload (App Store Connect altool error 90592), disproportionate for
+standard encryption of this kind.
+
+**Confirmed for the public release.** This paragraph used to end by saying a public App
+Store release "should confirm the self-classification paperwork with a compliance
+specialist" — written when the app only shipped to TestFlight, and therefore stale from
+the moment 1.0.3 reached the App Store on 2026-09-03. The owner has since confirmed the
+self-classification for a public release (org directive 110552), which closes that
+deferral. Being exact about what the confirmation is: it is the owner's own determination
+as the responsible party. **No compliance specialist has reviewed it**, and nothing here
+should be read as a specialist opinion. The declaration value is unchanged.
+
+The CI verifier still fails loudly on `MISSING_EXPORT_COMPLIANCE` as a backstop. See
+Apple's [export-compliance guidance](https://developer.apple.com/documentation/security/complying-with-encryption-export-regulations).
 
 ## Fallback — run on a Mac by hand
 

--- a/project.yml
+++ b/project.yml
@@ -161,9 +161,16 @@ targets:
         # Store. Owner (the legal authority) approved this determination 2026-08-05,
         # after the stricter `true` value was found to REQUIRE A FULL CCATS FILING to
         # upload (App Store Connect altool error 90592: an empty ITSEncryptionExport
-        # ComplianceCode) — disproportionate for a standard-encryption test build.
-        # A public App Store release should confirm the self-classification paperwork
-        # with a compliance specialist; for TestFlight this uploads cleanly.
+        # ComplianceCode) — disproportionate for standard encryption of this kind.
+        # CONFIRMED FOR THE PUBLIC RELEASE: this comment used to say a public App
+        # Store release "should confirm the self-classification paperwork with a
+        # compliance specialist; for TestFlight this uploads cleanly" — written when
+        # the app only shipped to TestFlight, and stale from the moment 1.0.3 reached
+        # the App Store on 2026-09-03. The owner confirmed the self-classification for
+        # a public release (org directive 110552), closing that deferral. To be exact:
+        # that is the OWNER'S OWN determination as the responsible party. NO COMPLIANCE
+        # SPECIALIST HAS REVIEWED IT and nothing here is a specialist opinion. The
+        # value below is unchanged by that confirmation.
         ITSAppUsesNonExemptEncryption: false
         # Bundled design fonts (App/Fonts/, added as resources by xcodegen). Geist is
         # the APP voice, IBM Plex Mono the MACHINE voice — the two families the Claude


### PR DESCRIPTION
Documentation only. **The declaration value is untouched** — no diff line touches `ITSAppUsesNonExemptEncryption`; only the comments around it moved.

## What was stale

Two places justified `false` as proportionate *for a standard-encryption **test build***, and deferred the real check:

- `docs/testflight-lane.md` — "A public App Store release should confirm the self-classification paperwork with a compliance specialist."
- `project.yml` — the same sentence, plus "for TestFlight this uploads cleanly".

herdrup 1.0.3 reached the App Store on 2026-09-03, so that deferral **expired by its own stated trigger** rather than merely aging. That is what #217 recorded.

## What changed

The owner has confirmed the self-classification for a public release (**org directive 110552**), closing the deferral.

Both rewrites are explicit that **this is the owner's own determination as the responsible party, and that no compliance specialist has reviewed it.** #217 named two closing paths — owner or specialist — and this is the owner path. The old wording invited the wrong reading; the new wording forecloses it.

Also dropped "test build" from the CCATS-disproportionality sentence in both places: that reasoning holds for standard encryption of this kind regardless of distribution channel, and leaving it would have re-created the same staleness at the next release.

## Gate

Docs-only, so the path-filtered workflows produce **no CI checks** — as with #216, the exact-head review is the whole gate. Absent checks are not passing checks.

Closes #217 on merge.
