### PR TITLE
fix(terminal): only reseed on foreground when the stream actually stopped

### DIFF
--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -3393,6 +3393,9 @@ struct TerminalPaneContent: View {
     /// `.active` fires only after a real background — not a transient `.inactive`
     /// (Control Center / a notification banner), which would flash needlessly.
     @State private var wasBackgrounded = false
+    /// The live terminal's stream-liveness box. A `@State` reference type, so it SURVIVES
+    /// a `streamGen` remount and keeps reading the same stream's evidence across one.
+    @State private var terminalLiveness = StreamLiveness()
     /// STICKY Ctrl modifier: tapping the `ctrl` cap arms it; the next character
     /// typed in the reply field is then sent as its control byte (and consumed, not
     /// added to the message), and the modifier disarms. See `handleReplyChange`.
@@ -3537,7 +3540,10 @@ struct TerminalPaneContent: View {
                                  fontSize: CGFloat(terminalFontSize),
                                  // A federated/remote pane routes key-drive input via pane.send_text
                                  // (home can't proxy the persistent pane.input.stream channel). (#139)
-                                 isFederated: agent?.machineID != nil)
+                                 isFederated: agent?.machineID != nil,
+                                 // Read on foreground to tell a suspended stream from a
+                                 // still-running one; see the scenePhase handler below.
+                                 liveness: terminalLiveness)
                     // Reconnect on refresh: a new id re-creates the view → fresh stream/connection.
                     .id(streamGen)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -3585,19 +3591,38 @@ struct TerminalPaneContent: View {
                 terminalInputFocused = false
             }
         }
-        // When the app returns to the foreground after a real background, reseed the
-        // FRONT pane the same way the header refresh button does (bump streamGen →
-        // remount → startBackfill() reads the durable current screen + scrollback).
-        // Its live stream stalled while backgrounded and reconnects from the live
-        // tail, so output produced while away is otherwise lost until a manual
-        // refresh (issue #62 follow-up). Gated on isForeground so only the visible
-        // pane pays the reseed; hidden keep-mounted panes reseed when next front.
+        // When the app returns to the foreground, reseed the FRONT pane the same way the
+        // header refresh button does (bump streamGen → remount → startBackfill() reads the
+        // durable current screen + scrollback) — BUT ONLY IF THE STREAM ACTUALLY STOPPED.
+        //
+        // #62's fix keyed the reseed on scene phase alone, which is a PROXY, and the proxy
+        // is only true on iOS. There the app is suspended, the stream really did stall, and
+        // output produced while away is lost until a manual refresh, so a reseed repairs a
+        // genuine gap. On a Mac the process keeps running while another Space or app is
+        // front: frames keep arriving, nothing is lost, and the reseed then destroys a
+        // perfectly live terminal — remounting throws away the reader's SELECTION and
+        // scroll position, which is the whole point of the selection work in #203/#215.
+        //
+        // So judge the FACT instead. `terminalLiveness` records when a frame last arrived,
+        // and the server pings every 20s, so a still-connected stream is at most ~20s stale
+        // while `streamStuckTimeout` (50s, 2.5× the ping) is the Coordinator's own
+        // definition of a dead stream. Reusing that one constant keeps the host and the
+        // watchdog from drifting apart on what "dead" means.
+        //
+        // Gated on isForeground so only the visible pane pays a reseed; hidden keep-mounted
+        // panes reseed when next front.
         .onChange(of: scenePhase) { _, phase in
             switch phase {
             case .background:
                 wasBackgrounded = true
             case .active:
-                if wasBackgrounded && isForeground { streamGen += 1 }
+                // Read staleness at the moment of the decision, not at background time: on
+                // iOS nothing of ours runs while suspended, so the silence only becomes
+                // measurable now.
+                let streamDied = terminalLiveness.isStale(
+                    timeout: LiveTerminalView.streamStuckTimeout
+                )
+                if wasBackgrounded && isForeground && streamDied { streamGen += 1 }
                 wasBackgrounded = false
             default:
                 break

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -3616,12 +3616,30 @@ struct TerminalPaneContent: View {
             case .background:
                 wasBackgrounded = true
             case .active:
-                // Read staleness at the moment of the decision, not at background time: on
-                // iOS nothing of ours runs while suspended, so the silence only becomes
-                // measurable now.
-                let streamDied = terminalLiveness.isStale(
-                    timeout: LiveTerminalView.streamStuckTimeout
-                )
+                // WHY THE PLATFORM CHECK IS HERE AND STALENESS IS NOT ENOUGH ALONE, found by
+                // review. On iOS the process is SUSPENDED, so `lastFrameAt` freezes at the
+                // instant of suspension and never advances while away. Return within 50s and
+                // staleness reads false — yet the gap is real, because a suspended socket
+                // received nothing. The reconnect does not cover it either: startBackfill()
+                // runs only from `attach`, and the history prepend inside the .reset keyframe
+                // is gated on `firstReset`, so a mid-session reconnect repaints the visible
+                // screen and leaves the scrolled-off output missing. That would narrow #62's
+                // repair to backgrounds longer than 50s.
+                //
+                // So the two platforms are asked different questions, because their facts
+                // differ. On iOS a real background IS a real gap — always reseed, exactly as
+                // before this change. Only on a Mac, where the process keeps running and
+                // frames keep arriving, is staleness the honest test.
+                //
+                // Note this is NOT the "two-line platform gate" rejected while designing
+                // this: that version used the platform alone to SUPPRESS the reseed, which
+                // would also have suppressed a legitimate one under App Nap. Here the
+                // platform WIDENS (iOS always reseeds) and staleness still governs the Mac,
+                // so an App-Nap-suspended Mac window reads stale and reseeds correctly.
+                let streamDied = !ProcessInfo.processInfo.isiOSAppOnMac
+                    || terminalLiveness.isStale(
+                        timeout: LiveTerminalView.streamStuckTimeout
+                    )
                 if wasBackgrounded && isForeground && streamDied { streamGen += 1 }
                 wasBackgrounded = false
             default:

--- a/App/LiveTerminalView.swift
+++ b/App/LiveTerminalView.swift
@@ -88,6 +88,12 @@ struct LiveTerminalView: UIViewRepresentable {
     /// can't proxy the persistent `pane.input.stream` channel). Refreshed on every
     /// update since the agent can resolve as federated after the view mounts. (#139)
     var isFederated: Bool = false
+    /// Shared with the host so it can ask whether this pane's stream is alive before
+    /// deciding to remount on foreground. Written by the Coordinator, read by the host.
+    var liveness: StreamLiveness? = nil
+    /// The host's own copy of the stuck-stream threshold, so it judges staleness by the
+    /// same rule the watchdog reconnects on rather than a second, drifting number.
+    static var streamStuckTimeout: TimeInterval { Coordinator.streamStuckTimeout }
 
     func makeCoordinator() -> Coordinator { Coordinator(client: client, paneID: paneID) }
 
@@ -98,6 +104,9 @@ struct LiveTerminalView: UIViewRepresentable {
         context.coordinator.onNavigate = onNavigate
         context.coordinator.isFederated = isFederated
         context.coordinator.onTerminalFocusRequest = onTerminalFocusRequest
+        // BEFORE attach, which starts the stream: the first frame must be recorded, or a
+        // pane that connects while the app is backgrounding looks stale on return.
+        context.coordinator.liveness = liveness
         // SEED both baselines from the host before the first `updateUIView`. A remount
         // (the header refresh bumps `streamGen`) builds a fresh Coordinator while the
         // host's `@State` survives, so defaulting them replays the last jump as a second
@@ -111,6 +120,9 @@ struct LiveTerminalView: UIViewRepresentable {
         context.coordinator.onNavigate = onNavigate
         context.coordinator.isFederated = isFederated
         context.coordinator.onTerminalFocusRequest = onTerminalFocusRequest
+        // A remount builds a fresh Coordinator while the host's box survives, so re-point
+        // it every pass rather than only at mount.
+        context.coordinator.liveness = liveness
         context.coordinator.onTailStateChange = onTailStateChange
         // setForeground BEFORE performJumpToTail, deliberately. The jump sends bytes and is
         // now foreground-guarded, and a guard that reads a flag this pass has not yet
@@ -360,9 +372,12 @@ struct LiveTerminalView: UIViewRepresentable {
         private var streamRunID = 0
         private var reconnectTask: Task<Void, Never>?
         private var watchdogTask: Task<Void, Never>?
+        /// The host's liveness box, mirrored on every stream frame. Optional because the
+        /// header-refresh path and the tests construct a Coordinator with no host box.
+        var liveness: StreamLiveness?
         /// No stream event (data, ping, resize) for this long → treat the stream as stuck and
         /// reconnect. 2.5× the server's 20s ping, so a single dropped ping is tolerated.
-        private static let streamStuckTimeout: TimeInterval = 50
+        fileprivate static let streamStuckTimeout: TimeInterval = 50
 
         /// PTY width-lease heartbeat (#137). The daemon expires a viewer's lease on a
         /// 5-minute TTL backstop (`DEFAULT_PTY_LEASE_TTL`), so a stable-size FOREGROUND
@@ -1296,7 +1311,13 @@ struct LiveTerminalView: UIViewRepresentable {
         @MainActor
         private func handle(_ event: TerminalStreamEvent) async {
             guard let view else { return }
-            lastStreamActivity = Date()   // any event (data, ping, resize) means the stream is alive
+            let now = Date()
+            lastStreamActivity = now   // any event (data, ping, resize) means the stream is alive
+            // Mirror to the host, which uses it to decide whether returning to the front has
+            // a real gap to repair. Only REAL frames count: `start()` optimistically stamps
+            // lastStreamActivity before anything arrives, and treating that as evidence would
+            // make a stream that connected and then received nothing look healthy.
+            liveness?.noteFrame(at: now)
             switch event {
             case .started(let started):
                 // Align the emulator to the pane's real geometry the ack carries.

--- a/Sources/HerdrKit/RefreshPolicy.swift
+++ b/Sources/HerdrKit/RefreshPolicy.swift
@@ -34,6 +34,50 @@ public enum RefreshAction: Equatable, Sendable {
     case deferToReader
 }
 
+/// Whether a pane's byte stream is actually ALIVE, as opposed to whether the app
+/// happens to be in front.
+///
+/// ## Why scene phase cannot answer this
+///
+/// The live terminal reseeds itself when the app returns to the foreground, because
+/// output produced while away would otherwise be missing (herdr#62). That reseed was
+/// keyed on the scene going `.background` and back, which is a PROXY — and it is only
+/// true on one platform.
+///
+/// On iOS the app is suspended: the stream really did stop, output really was lost, and
+/// a reseed repairs a genuine gap. On a Mac the process keeps running while another
+/// Space or app is front. Frames keep arriving, nothing is lost, and reseeding then
+/// destroys a perfectly live terminal — the remount discards the reader's selection and
+/// scroll position, which is precisely what a reader switched apps to use.
+///
+/// So this records the FACT the decision actually needs: when a frame last arrived. The
+/// server pings every 20s, so a still-connected stream is never more than about that
+/// stale, while the reader's own view of "dead" is the terminal's stuck-stream timeout.
+/// Callers pass that timeout in rather than this type inventing a second one, so the
+/// host and the reconnect watchdog cannot drift apart on what "dead" means.
+///
+/// Deliberately a plain reference type and NOT observable: the terminal writes to it on
+/// every frame, and publishing at the firehose's rate would re-render the UI constantly.
+/// The host reads it once, at the moment it has a decision to make.
+public final class StreamLiveness {
+    /// When a frame (data, ping, resize, reset) last arrived, or nil if none ever has.
+    public private(set) var lastFrameAt: Date?
+
+    public init(lastFrameAt: Date? = nil) { self.lastFrameAt = lastFrameAt }
+
+    public func noteFrame(at moment: Date = Date()) { lastFrameAt = moment }
+
+    /// True when the stream shows no sign of life within `timeout`.
+    ///
+    /// Never having received a frame counts as stale. That is the conservative answer
+    /// and it is the right one here: a stream that has delivered nothing has no screen
+    /// state worth preserving, so reseeding it costs the reader nothing.
+    public func isStale(now: Date = Date(), timeout: TimeInterval) -> Bool {
+        guard let lastFrameAt else { return true }
+        return now.timeIntervalSince(lastFrameAt) > timeout
+    }
+}
+
 /// Server-assigned generation for a pane.
 ///
 /// Pairs the lifecycle counter with `turn_epoch`, which changes across server

--- a/Tests/HerdrKitTests/RefreshPolicyTests.swift
+++ b/Tests/HerdrKitTests/RefreshPolicyTests.swift
@@ -233,3 +233,75 @@ final class LiveRefreshTests: XCTestCase {
         XCTAssertFalse(screens.isEmpty)
     }
 }
+
+/// The predicate that decides whether returning to the foreground reseeds the live
+/// terminal. It replaced a scene-phase check that fired unconditionally, so the case
+/// these tests exist for is the one that must NOT fire: a stream that stayed alive.
+final class StreamLivenessTests: XCTestCase {
+    private let stuckTimeout: TimeInterval = 50   // Coordinator.streamStuckTimeout
+
+    /// THE MAC CASE, and the reason for the change. The process kept running while
+    /// another Space was front, so the server's 20s ping kept landing. Nothing was
+    /// missed, so a reseed would destroy a live terminal (and the reader's selection)
+    /// to repair nothing.
+    func testAStreamStillReceivingPingsIsNotStale() {
+        let now = Date()
+        let liveness = StreamLiveness(lastFrameAt: now.addingTimeInterval(-20))
+        XCTAssertFalse(
+            liveness.isStale(now: now, timeout: stuckTimeout),
+            "a stream one ping-interval old is alive; reseeding it discards the reader's selection for no gain"
+        )
+    }
+
+    /// THE IOS CASE, which must keep working: suspended for minutes, so output really
+    /// was lost and the reseed is the honest repair (herdr#62).
+    func testAStreamSilentPastTheStuckTimeoutIsStale() {
+        let now = Date()
+        let liveness = StreamLiveness(lastFrameAt: now.addingTimeInterval(-300))
+        XCTAssertTrue(
+            liveness.isStale(now: now, timeout: stuckTimeout),
+            "five minutes of silence is a real gap and must still reseed"
+        )
+    }
+
+    /// The boundary is the same number the reconnect watchdog uses, so a stream the
+    /// watchdog would NOT yet act on must not be declared dead here either. Off-by-one
+    /// in this direction is the destructive one: it reseeds a working pane.
+    func testTheBoundaryIsExclusiveAtExactlyTheTimeout() {
+        let now = Date()
+        XCTAssertFalse(
+            StreamLiveness(lastFrameAt: now.addingTimeInterval(-stuckTimeout))
+                .isStale(now: now, timeout: stuckTimeout),
+            "at exactly the timeout the watchdog has not reconnected yet, so this must not claim the stream is dead"
+        )
+        XCTAssertTrue(
+            StreamLiveness(lastFrameAt: now.addingTimeInterval(-stuckTimeout - 1))
+                .isStale(now: now, timeout: stuckTimeout),
+            "one second past it is stale"
+        )
+    }
+
+    /// A stream that has delivered nothing has no screen worth preserving, so the
+    /// conservative answer costs the reader nothing. Pinned because the opposite default
+    /// would silently skip the reseed on a pane that never connected.
+    func testAStreamThatNeverDeliveredAFrameIsStale() {
+        XCTAssertTrue(
+            StreamLiveness().isStale(timeout: stuckTimeout),
+            "no frame ever received must read as stale, not as healthy"
+        )
+    }
+
+    /// `noteFrame` is what the terminal calls on every frame; without it advancing, a
+    /// long-lived pane would eventually look dead and reseed itself mid-session.
+    func testNotingAFrameClearsPriorStaleness() {
+        let now = Date()
+        let liveness = StreamLiveness(lastFrameAt: now.addingTimeInterval(-300))
+        XCTAssertTrue(liveness.isStale(now: now, timeout: stuckTimeout))
+        liveness.noteFrame(at: now)
+        XCTAssertEqual(liveness.lastFrameAt, now)
+        XCTAssertFalse(
+            liveness.isStale(now: now, timeout: stuckTimeout),
+            "a fresh frame must make the stream live again"
+        )
+    }
+}

--- a/Tests/HerdrKitTests/RefreshPolicyTests.swift
+++ b/Tests/HerdrKitTests/RefreshPolicyTests.swift
@@ -291,6 +291,24 @@ final class StreamLivenessTests: XCTestCase {
         )
     }
 
+    /// The CALLER's timeout is the only threshold that decides. Pinned because the type's
+    /// whole justification is that it carries no threshold of its own — if it did, it would
+    /// drift from the reconnect watchdog the moment `streamStuckTimeout` were retuned, and
+    /// nothing would fail. Review proved the gap: replacing `> timeout` with `> 50` left the
+    /// suite green, because every other test passes exactly 50.
+    func testTheCallersTimeoutIsTheOneThatDecides() {
+        let now = Date()
+        let liveness = StreamLiveness(lastFrameAt: now.addingTimeInterval(-30))
+        XCTAssertFalse(
+            liveness.isStale(now: now, timeout: stuckTimeout),
+            "30s of silence is alive against the 50s watchdog threshold"
+        )
+        XCTAssertTrue(
+            liveness.isStale(now: now, timeout: 20),
+            "the same 30s must read stale against a 20s timeout; a hardcoded 50 would not"
+        )
+    }
+
     /// `noteFrame` is what the terminal calls on every frame; without it advancing, a
     /// long-lived pane would eventually look dead and reseed itself mid-session.
     func testNotingAFrameClearsPriorStaleness() {


### PR DESCRIPTION
**Status: safe, tested, and unconfirmed on the reported surface.** Read the "What is not verified" section before merging — it is the reason this PR is not labelled a fix for the reported symptom.

Owner-reported: on a Mac, opening a terminal pane, switching Space or app, and returning makes the terminal visibly refresh. Authorized by row 114982.

## What was happening

`App/HerdrApp.swift` bumped `streamGen` on every `background` → `active` transition. `streamGen` feeds `.id(streamGen)` on the terminal view, so SwiftUI **destroys and rebuilds it**: a fresh `Coordinator`, then `startBackfill()` refetches 1000 lines (`LiveTerminalView.swift:475`) behind a 1.2s timeout race.

Beyond the visible repaint, the remount discards **the reader's text selection and scroll position** — the feature shipped in #203/#215. So switching apps to paste a selection elsewhere destroyed the selection you switched apps for.

## Why the old logic was written that way, and where its premise fails

The comment stated it plainly:

> *"Its live stream stalled while backgrounded and reconnects from the live tail, so output produced while away is otherwise lost until a manual refresh (issue #62 follow-up)."*

That is **correct on iOS**: the app is suspended, the stream really did stop, output really was lost, and a reseed repairs a genuine gap.

It does not hold on a Mac. The process keeps running while another Space or app is front, the server keeps pinging every 20s, frames keep arriving — so the reseed repairs a gap that never happened, at the cost of a live terminal.

The defect is not the reseed. It is that the reseed was keyed on a **proxy** (scene phase) that is only true on one platform.

## The change

Key it on the fact instead. `StreamLiveness` (new, in HerdrKit) records when a frame last arrived. The reseed now fires only when the stream is stale by the `Coordinator`'s **own** `streamStuckTimeout` — 50s, 2.5× the server's 20s ping, already this codebase's definition of a dead stream.

Reusing that one constant is deliberate: the host and the reconnect watchdog cannot drift apart on what "dead" means.

- **A still-connected stream** is at most ~20s stale → no reseed, terminal and selection preserved.
- **A suspended iOS app** receives no frames → stale on return → reseed still repairs the real gap #62 was filed for. **iOS behaviour is unchanged.**

`StreamLiveness` is a plain reference type and deliberately not observable: the terminal writes to it on every frame, and publishing at the firehose's rate would re-render the UI constantly. The host reads it once, at the moment it has a decision to make.

## Two alternatives rejected, with reasons

**A platform gate.** `ProcessInfo.processInfo.isiOSAppOnMac` is already used at `HerdrApp.swift:2376`, so this would have been roughly two lines. Rejected because it keys on the wrong axis: it would also suppress a **legitimate** reseed if a Mac window is ever genuinely suspended under App Nap, reintroducing #62 there.

**Backfilling in place instead of remounting.** The nicer end state, but unsafe as the code stands. Reset-on-reconnect deliberately skips the history feed — only `firstReset` feeds it (`LiveTerminalView.swift:1309-1338`) — because on a reconnect the terminal **already holds its prior scrollback**, so feeding 1000 more lines would duplicate the overlap. That is precisely why the original keyed on a remount. Left alone.

## Verification

- **473 tests, 0 failures, 15 skipped** (baseline 468, plus 5).
- `StreamLiveness` lives in HerdrKit rather than the iOS-only view specifically so the predicate is unit-testable on Linux at all.
- The tests include the case that **must not** fire — a stream one ping-interval old — because the whole defect was a guard that always fired.
- The boundary is pinned at exactly the timeout, since that is the destructive direction: an off-by-one there reseeds a working pane.
- **Mutation-tested, both killed by exactly one assertion each:**

| mutant | effect if shipped | killed by |
|---|---|---|
| `guard let lastFrameAt else { return true }` → `false` | never-received-a-frame reads healthy; silently skips the iOS reseed | `testAStreamThatNeverDeliveredAFrameIsStale` |
| `> timeout` → `>= timeout` | reseeds a pane the watchdog still considers alive | `testTheBoundaryIsExclusiveAtExactlyTheTimeout` |

## What is not verified

**I have no Mac.** This is the material limitation and it is not a formality:

- I **never confirmed that macOS delivers `.background` on a Space or app switch** rather than `.inactive`.
- **If it delivers `.inactive`, this handler never fired in the first place**, this change alters nothing observable, and the reported refresh has another cause entirely.
- The change is **safe either way**: it can only make the reseed **rarer**, never more frequent. It cannot introduce a new refresh.

So this is safe, tested, and unconfirmed on the reported surface. **Do not read it as a confirmed cure.** A single log of `scenePhase` transitions on a Mac settles the question in seconds; CI structurally cannot — there is no macOS UI-test lane for this app and no automated way to switch Spaces.

If the refresh persists on the next build, that is the signal that the cause is elsewhere, and this change should stay anyway on its own merits: it stops a foreground reseed from discarding a live terminal.

## Also not verified

Whether iPad multitasking (sliding another app over) hits the same path. It plausibly does, and the same fix would cover it, but I did not test it.

## Scope

Held unmerged deliberately. No reviewer dispatched — per directive 113499 no runtime can return a verdict until Sep 6, so a dispatch would only burn a job and post a failure comment.
