### PR TITLE
fix(release): bump the marketing version to 1.0.4

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -202,7 +202,7 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.jerryfane.herdr
-        MARKETING_VERSION: "1.0.3"
+        MARKETING_VERSION: "1.0.4"
         CURRENT_PROJECT_VERSION: "1"
         SWIFT_VERSION: "5.9"
         GENERATE_INFOPLIST_FILE: NO
@@ -307,7 +307,7 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.jerryfane.herdr.widgets
-        MARKETING_VERSION: "1.0.3"
+        MARKETING_VERSION: "1.0.4"
         CURRENT_PROJECT_VERSION: "1"
         SWIFT_VERSION: "5.9"
         GENERATE_INFOPLIST_FILE: NO


### PR DESCRIPTION
Unblocks the TestFlight ship of the Mac foreground-reseed fix (#221). Authorized by directive 115852.

## Why

Run 33870210544 reached `altool` and Apple rejected the upload **twice over**:

| code | message |
|---|---|
| 90062 | `CFBundleShortVersionString [1.0.3]` must contain a higher version than the previously approved version `[1.0.3]` |
| 90186 | Invalid Pre-Release Train: the train version `1.0.3` is closed for new build submissions |

1.0.3 is `READY_FOR_SALE`. A released version's pre-release train cannot be reopened, so **no** build ships under it regardless of build number. Nothing reached Apple: `/v1/builds` still tops out at 119 (uploaded Sep 2).

This was always going to fail, independently of the credential rotation — the previous run died at step 12 before `altool` ever ran, so one blocker was hiding the next.

## The change

`project.yml` only, +2/-2, same shape as #214. **Both targets move together** — `Herdr` (line 205) and `HerdrWidgets` (line 310) — because a widget whose short version differs from its host app is rejected on mismatch. Verified 0 remaining `1.0.3` occurrences.

## The credential class is closed

Steps 1–16 of that run all passed, including step 12 (the App Store Connect query that returned HTTP 401 on the prior run) and Archive/Export/version-check. `altool` authenticated far enough to receive an application-level rejection rather than an auth error, which is the proof.

## One consequence worth stating

Uploading under a new train **creates** an App Store version record `1.0.4` in `PREPARE_FOR_SUBMISSION`. That is not a submission: nothing goes to review or to users without a deliberate submit. The alternative is no TestFlight build at all.

Merged without a review verdict under the owner grant for `jerryfane/herdrup` (115325, reaffirmed behind 115784, and the standing policy in 115499).