### PR TITLE
fix(gram): put the Inbox/Saved selector in the app's real sidebar

### DIFF
--- a/App/GramView.swift
+++ b/App/GramView.swift
@@ -37,6 +37,16 @@ struct GramView: View {
     /// call sites (and the DEBUG harness) compile unchanged; written on load and
     /// mark-read so reading a message clears the badge without leaving the tab.
     var unread: GramUnreadTracker? = nil
+    /// Which "conversation" is shown — Inbox (false) or Saved (true). OWNED BY THE HOST, not
+    /// by this view, because on regular width the selector lives in the app's real
+    /// NavigationSplitView sidebar rather than inside this page. A sibling column cannot drive
+    /// a `@State` in here, so the state is hoisted and both layouts read the same binding.
+    @Binding var showingSaved: Bool
+    /// Bumped by the host to request a reload. The regular-width refresh affordance moved to
+    /// the sidebar with the rest of the selector, and a sidebar button cannot call this view's
+    /// async `load` directly — so it changes a token and `onChange` performs the load, the same
+    /// one-shot-signal pattern the terminal uses for jump-to-tail and collapse.
+    var refreshToken: Int = 0
 
     /// The last server snapshot (newest first) and the owner's just-posted messages
     /// not yet reflected in a snapshot. `messages` composes them so a background poll
@@ -60,11 +70,12 @@ struct GramView: View {
     /// A non-fatal refresh failure while messages are already shown.
     @State private var refreshNote: String?
     @State private var isLoading = false
-    /// Saved (bookmarked) Gram messages + whether the page is showing the Saved section.
+    /// Saved (bookmarked) Gram messages. Whether the Saved section is showing is the host's
+    /// `showingSaved` binding above, not local state.
     @ObservedObject private var savedGrams = SavedGramStore.shared
-    @State private var showingSaved = false
-    /// On iPad (regular width) Gram becomes a two-pane split — an Inbox/Saved rail beside the
-    /// message feed + composer — instead of the phone's header toggle. iPhone stays single-column.
+    /// On regular width this page renders the feed + composer only; the Inbox/Saved selector and
+    /// the refresh action live in the app's NavigationSplitView sidebar, so there is exactly ONE
+    /// sidebar on screen. iPhone keeps its single column with the header toggle.
     @Environment(\.horizontalSizeClass) private var hSizeClass
     /// Messages with a mark-read in flight, so a re-`onAppear` (scroll) does not fire
     /// a duplicate `gram.mark_read`.
@@ -218,6 +229,14 @@ struct GramView: View {
         // refresh (the gram store has no event stream); the loop ends when the view
         // goes away (task cancellation).
         .task { await pollLoop() }
+        // The sidebar's refresh button bumps `refreshToken`; consume the change here so a
+        // sibling column can drive this view's async reload without owning its state. Guarded on
+        // a real change (SwiftUI may re-run the body for unrelated reasons) and on `initial:
+        // false` so it refreshes in place instead of dropping back to the loading phase.
+        .onChange(of: refreshToken) { old, new in
+            guard new != old else { return }
+            Task { await load(initial: false) }
+        }
         // Paperclip → a Telegram-style attach sheet picks the source, so we open the
         // RIGHT system picker. The picker is opened in the sheet's onDismiss (via
         // `pendingPicker`), not inline — presenting a sheet while another dismisses
@@ -325,89 +344,21 @@ struct GramView: View {
         }
     }
 
-    /// iPad / regular width: a two-pane split — a fixed Inbox/Saved rail on the left (the phone's
-    /// header toggle, promoted to a persistent list) beside the message feed + composer on the
-    /// right. Reuses the SAME `content` / `bannerView` / `composer` as the phone; only the framing
-    /// differs, so every send/attach/poll behaviour is identical.
+    /// Regular width: the message feed + composer ONLY. The Inbox/Saved selector and the refresh
+    /// action are rendered by the host in the app's real `NavigationSplitView` sidebar, beside
+    /// the section picker, exactly like the agents list.
+    ///
+    /// This page used to draw its OWN 260pt rail here, which on iPad and Mac put a second
+    /// sidebar next to the split view's own column — and that column was rendering an empty
+    /// `Spacer()` for this section, so the screen showed one empty system sidebar and one
+    /// hand-rolled one. Reuses the SAME `content` / `bannerView` / `composer` as the phone, so
+    /// every send/attach/poll behaviour is identical.
     private var iPadBody: some View {
-        HStack(spacing: 0) {
-            gramRail
-                .frame(width: 260)
-            Divider().overlay(Palette.hairlineQuiet)
-            VStack(spacing: 0) {
-                content
-                bannerView
-                composer
-            }
+        VStack(spacing: 0) {
+            content
+            bannerView
+            composer
         }
-    }
-
-    /// The left rail of the iPad two-pane: the section title, a refresh action, and the two
-    /// "conversations" this channel has — Inbox (all messages, with an unread badge) and Saved
-    /// (bookmarked copies, with a count). Selecting one drives the same `showingSaved` state the
-    /// phone's header toggle does, so the right pane's `content` swaps in place.
-    private var gramRail: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            HStack(spacing: 8) {
-                Text("Gram")
-                    .font(Typography.app(20, .semibold))
-                    .foregroundStyle(Palette.text)
-                Spacer()
-                Button {
-                    Task { await load(initial: false) }
-                } label: {
-                    Image(systemName: "arrow.clockwise")
-                        .font(.system(size: 15, weight: .semibold))
-                        .foregroundStyle(Palette.textDim)
-                }
-            }
-            .padding(.horizontal, 16)
-            .padding(.vertical, 12)
-            Divider().overlay(Palette.hairlineQuiet)
-            VStack(spacing: 4) {
-                railRow(title: "Inbox", icon: "tray", selected: !showingSaved,
-                        badge: unreadCount) { showingSaved = false }
-                railRow(title: "Saved", icon: "bookmark", selected: showingSaved,
-                        badge: savedGrams.saved.count, badgeMuted: true) { showingSaved = true }
-            }
-            .padding(.horizontal, 10)
-            .padding(.top, 10)
-            Spacer(minLength: 0)
-        }
-        .frame(maxHeight: .infinity, alignment: .top)
-        .background(Palette.surface.ignoresSafeArea())
-    }
-
-    /// One selectable row in the Gram rail. `badgeMuted` renders the count as a quiet pill
-    /// (Saved) rather than the attention-coloured unread pill (Inbox).
-    private func railRow(title: String, icon: String, selected: Bool, badge: Int,
-                         badgeMuted: Bool = false, action: @escaping () -> Void) -> some View {
-        Button(action: action) {
-            HStack(spacing: 10) {
-                Image(systemName: selected && icon == "bookmark" ? "bookmark.fill" : icon)
-                    .font(.system(size: 14, weight: .medium))
-                    .foregroundStyle(selected ? Palette.brand : Palette.textDim)
-                    .frame(width: 20)
-                Text(title)
-                    .font(Typography.app(15, selected ? .semibold : .regular))
-                    .foregroundStyle(selected ? Palette.text : Palette.textDim)
-                Spacer(minLength: 0)
-                if badge > 0 {
-                    Text("\(badge)")
-                        .font(Typography.machine(11, .semibold))
-                        .foregroundStyle(badgeMuted ? Palette.textDim : Palette.ground)
-                        .padding(.horizontal, 6)
-                        .padding(.vertical, 2)
-                        .background(Capsule().fill(badgeMuted ? Palette.surfaceRaised : Palette.waiting))
-                }
-            }
-            .padding(.horizontal, 12)
-            .padding(.vertical, 10)
-            .background(selected ? Palette.surfaceRaised : Color.clear,
-                        in: RoundedRectangle(cornerRadius: 10))
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
     }
 
     /// A load error / send error, shown ABOVE the composer in every phase — the

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -397,11 +397,10 @@ struct RootView: View {
             // reresolveAgent leaves the seeded identity in place and the header stays stable.
             PagingTestHarness(client: mockClient)
         case .gram:
-            // The Gram page over a mock that answers gram.list with a canned owner
-            // view. Empty `agents` keeps the recipient picker to the shared queue;
-            // onClose nil hides the close X (there is nothing to dismiss to in the
-            // standalone screenshot render). The messages + claim states are the FYI.
-            GramView(client: mockClient, agents: [], onClose: nil)
+            // The Gram page over a mock that answers gram.list with a canned owner view. The
+            // harness owns the Inbox/Saved binding (see GramScreenshotHarness); the messages +
+            // claim states are the FYI.
+            GramScreenshotHarness(client: mockClient)
         }
     }
     #endif
@@ -1504,6 +1503,18 @@ struct TerminalHomeView: View {
     /// Unread agent→owner grams, badged on the Gram tab. Session-scoped; written
     /// by GramView while visible and by an ambient poll (below) while it isn't.
     @StateObject private var gramUnread = GramUnreadTracker()
+    /// Gram's Inbox/Saved selection, owned HERE rather than inside `GramView` because on regular
+    /// width the selector is rendered in the split view's sidebar — a sibling column of the page
+    /// it drives. Shared by both layouts, so the phone's header toggle and the sidebar rows read
+    /// and write the same value.
+    @State private var gramShowingSaved = false
+    /// One-shot signal for the sidebar's refresh button. A sidebar button cannot call `GramView`'s
+    /// async `load`, so it bumps this and the page's `onChange` performs the reload.
+    @State private var gramRefreshToken = 0
+    /// Observed, not read statically: the Gram sidebar shows the Saved count as a badge, and
+    /// `SavedGramStore.shared.saved.count` read directly would only refresh when some unrelated
+    /// state re-rendered this view — so saving or removing a gram would leave a stale number.
+    @ObservedObject private var savedGrams = SavedGramStore.shared
     /// First launch shows the gestures tutorial once; the "Gestures" tab reopens it.
     @AppStorage("hasSeenGesturesHelp") private var hasSeenGesturesHelp = false
 
@@ -1736,8 +1747,14 @@ struct TerminalHomeView: View {
                         }
                     case .settings:
                         settingsIndex   // the section index; each jumps the detail pane
+                    case .gram:
+                        // Gram's Inbox/Saved selector belongs in THIS column, beside the section
+                        // picker, the same way the agents list does. It used to render an empty
+                        // Spacer() here while GramView drew its own 260pt rail in the detail
+                        // pane, which put two sidebars on screen — one of them blank.
+                        gramSidebar
                     default:
-                        Spacer()   // Gram / Call live in the detail pane
+                        Spacer()   // Call lives in the detail pane
                     }
                 }
             }
@@ -1755,7 +1772,9 @@ struct TerminalHomeView: View {
                         detailPlaceholder("Select an agent", "square.grid.2x2")
                     }
                 case .gram:
-                    GramView(client: client, agents: agents, unread: gramUnread)
+                    GramView(client: client, agents: agents, unread: gramUnread,
+                             showingSaved: $gramShowingSaved,
+                             refreshToken: gramRefreshToken)
                 case .settings:
                     SettingsView(
                         client: client,
@@ -1858,6 +1877,81 @@ struct TerminalHomeView: View {
         Spacer(minLength: 0)
     }
 
+    /// Gram's sidebar column: a header matching the agents header's shape (title, one-number
+    /// subtitle, a trailing circle action) over the two "conversations" this channel has.
+    ///
+    /// This is the SAME column the agents list uses. Gram previously drew its own rail inside the
+    /// detail pane while this column rendered a blank `Spacer()`, so the reader saw two sidebars
+    /// and the left one was empty. Selecting a row writes `gramShowingSaved`, which the page
+    /// reads as a binding, so the detail pane's content swaps in place with no navigation.
+    private var gramSidebar: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack {
+                Spacer()
+                VStack(spacing: 2) {
+                    Text("Gram").font(Typography.app(20, .bold)).foregroundStyle(Palette.text)
+                    // Reserved height so the title never jumps as the count appears, matching
+                    // the agents header's `headerSubtitle` treatment.
+                    Text(gramUnread.count > 0
+                         ? "\(gramUnread.count) unread"
+                         : "nothing unread")
+                        .font(Typography.machine(12))
+                        .foregroundStyle(gramUnread.count > 0 ? Palette.waiting : Palette.textFaint)
+                        .frame(height: 15)
+                }
+                Spacer()
+                circleButton("arrow.clockwise") { gramRefreshToken += 1 }
+            }
+            .padding(.horizontal, 16).padding(.top, 8).padding(.bottom, 10)
+            Divider().overlay(Palette.hairlineQuiet)
+            VStack(spacing: 4) {
+                gramSidebarRow(title: "Inbox", icon: "tray", selected: !gramShowingSaved,
+                               badge: gramUnread.count) { gramShowingSaved = false }
+                gramSidebarRow(title: "Saved", icon: "bookmark", selected: gramShowingSaved,
+                               badge: savedGrams.saved.count,
+                               badgeMuted: true) { gramShowingSaved = true }
+            }
+            .padding(.horizontal, 10)
+            .padding(.top, 10)
+            Spacer(minLength: 0)
+        }
+        .frame(maxHeight: .infinity, alignment: .top)
+    }
+
+    /// One selectable row in the Gram sidebar. `badgeMuted` renders the count as a quiet pill
+    /// (Saved) rather than the attention-coloured unread pill (Inbox).
+    private func gramSidebarRow(title: String, icon: String, selected: Bool, badge: Int,
+                                badgeMuted: Bool = false,
+                                action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            HStack(spacing: 10) {
+                Image(systemName: selected && icon == "bookmark" ? "bookmark.fill" : icon)
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundStyle(selected ? Palette.brand : Palette.textDim)
+                    .frame(width: 20)
+                Text(title)
+                    .font(Typography.app(15, selected ? .semibold : .regular))
+                    .foregroundStyle(selected ? Palette.text : Palette.textDim)
+                Spacer(minLength: 0)
+                if badge > 0 {
+                    Text("\(badge)")
+                        .font(Typography.machine(11, .semibold))
+                        .foregroundStyle(badgeMuted ? Palette.textDim : Palette.ground)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(Capsule().fill(badgeMuted ? Palette.surfaceRaised : Palette.waiting))
+                }
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+            .background(selected ? Palette.surfaceRaised : Color.clear,
+                        in: RoundedRectangle(cornerRadius: 10))
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .hoverEffect(.highlight)
+    }
+
     /// The four top-level sections, a pill at the top of the iPad sidebar (the phone's tab bar,
     /// rotated up here — same sections, so the future Call tab already has its slot).
     private var sidebarSectionPicker: some View {
@@ -1919,7 +2013,8 @@ struct TerminalHomeView: View {
 
                 // Gram and Settings were modal covers; they are persistent tabs now.
                 // Both are nav-agnostic and take no onClose as tabs (no close button).
-                GramView(client: client, agents: agents, unread: gramUnread)
+                GramView(client: client, agents: agents, unread: gramUnread,
+                         showingSaved: $gramShowingSaved)
                     .tag(HomeTab.gram)
                     .tabItem { Label("Gram", systemImage: "bubble.left.and.bubble.right") }
                     .badge(gramUnread.count == 0 ? nil : Text("\(gramUnread.count)"))
@@ -6234,6 +6329,21 @@ private extension View {
 /// `HERDR_SCREENSHOT_MOCK=list` (default) or `=pane`, or the `-herdrScreenshotMock`
 /// launch argument.
 #if DEBUG
+/// Gram screenshot/UI-test harness (`HERDR_SCREENSHOT_MOCK=gram`). `GramView`'s Inbox/Saved
+/// selection is a binding owned by the host (on regular width the selector lives in the app's
+/// split-view sidebar), and `mockView` is a function that cannot hold `@State` — so this holds
+/// it, exactly as `PagingTestHarness` holds the pane slots for its harness.
+struct GramScreenshotHarness: View {
+    let client: HerdrClient
+    @State private var showingSaved = false
+
+    var body: some View {
+        // Empty `agents` keeps the recipient picker to the shared queue; `onClose` nil hides the
+        // close X (there is nothing to dismiss to in a standalone render).
+        GramView(client: client, agents: [], onClose: nil, showingSaved: $showingSaved)
+    }
+}
+
 /// Swipe-between-agents receipt harness (`HERDR_SCREENSHOT_MOCK=paging`). Holds three agents
 /// in the REAL `PaneKeepAliveContainer`, mirroring `TerminalHomeView`'s open/navigate, so an
 /// XCUITest swipe pages the front pane and the header heading changes. No LRU eviction here —


### PR DESCRIPTION
Owner-reported: *"the gram section has an additional sidebar, instead of using the same one agent section is using"*.

## What was on screen

In the iPad/Mac `NavigationSplitView`, the sidebar switch rendered `Spacer()` for `.gram` — an **empty column** — while `GramView.iPadBody` built its own 260pt `gramRail` inside the detail pane. Two sidebars, the left one blank.

`.agents` puts its list in the real sidebar; `.settings` puts its index there. Gram was the only section that did not.

## The change

The Inbox/Saved selector moves into that same column, under the existing section picker, with a header mirroring the agents header (title, one-number subtitle with reserved height so it cannot jump, trailing `circleButton`). Row styling is carried over unchanged so it reads as the same furniture.

A sidebar is a **sibling** of the page it drives, not a parent, so two things had to move with it:

- **`showingSaved` is hoisted** out of `GramView` into the host as a `@Binding`. Both layouts read one value, so the phone header toggle and the sidebar rows cannot disagree.
- **Refresh becomes a token** the host bumps and the page consumes in `onChange` — a sidebar button cannot call the page's async `load`. This is the same one-shot-signal pattern already used for `jumpToTailToken` and `collapseToken`, not a new idiom.

## One defect I introduced and then fixed

The first version read `SavedGramStore.shared.saved.count` directly in the sidebar. The host does not observe that store, so the Saved badge would only refresh when something unrelated re-rendered the view — saving or removing a gram would leave a stale number. The host now holds an `@ObservedObject`, the same way `GramView` does.

## Cutover

`gramRail` and `railRow` are **deleted**, not left unreachable, and the stale `"Gram / Call live in the detail pane"` comment is corrected. `mockView` is a function and cannot hold `@State`, so the gram screenshot harness gets a wrapper struct owning the binding — mirroring the existing `PagingTestHarness`.

## Verification

HerdrKit **474 tests, 0 failures**; both edited files parse. iPhone is untouched — it never had the rail, and its header toggle now writes the hoisted binding.

**Not verified, and it is the material gap:** CI's UI suite runs on an **iPhone** simulator, where `hSizeClass` is compact and this layout never renders. So `build-and-uitest` proves the app compiles and the phone path still works, and proves nothing about the sidebar itself. I have no Mac or iPad here. The layout needs one look on device before this is trusted.