### PR TITLE
feat(gram): search the messages, and a Read-all action

### DIFF
--- a/App/GramView.swift
+++ b/App/GramView.swift
@@ -47,6 +47,10 @@ struct GramView: View {
     /// async `load` directly — so it changes a token and `onChange` performs the load, the same
     /// one-shot-signal pattern the terminal uses for jump-to-tail and collapse.
     var refreshToken: Int = 0
+    /// Bumped by the host's sidebar Read-all button, same one-shot-signal reason as
+    /// `refreshToken`: a sibling column cannot call this view's async `markAllRead` directly.
+    /// Defaulted so the phone call site (which has its own header button) omits it.
+    var readAllToken: Int = 0
 
     /// The last server snapshot (newest first) and the owner's just-posted messages
     /// not yet reflected in a snapshot. `messages` composes them so a background poll
@@ -80,6 +84,11 @@ struct GramView: View {
     /// Messages with a mark-read in flight, so a re-`onAppear` (scroll) does not fire
     /// a duplicate `gram.mark_read`.
     @State private var markingRead: Set<String> = []
+    /// Free-text filter over the visible section. Local to the page: it is a transient view
+    /// concern, unlike `showingSaved`, which the sidebar owns (a sibling column drives that).
+    @State private var search = ""
+    /// True while a Read-all pass is running, so the button disables rather than stacking passes.
+    @State private var markingAllRead = false
 
     /// Files the owner picked to attach to the next post (read into memory at pick
     /// time), empty when none are staged. Several can be staged at once; each sends as
@@ -177,6 +186,34 @@ struct GramView: View {
             .filter { !deletedIDs.contains($0.id) }
     }
 
+    /// Inbox rows after the search filter. Matches message text, the sender, the recipient,
+    /// and an attachment's filename — a reader looking for "the key I sent keephair" searches
+    /// by any of those, and matching only `text` would miss the last two.
+    ///
+    /// DELIBERATELY SEPARATE from `messages`: the unfiltered set is what `unreadCount`,
+    /// `markReadIfNeeded` and `markAllRead` read, so an active search can never make the
+    /// badge lie or hide a message from a Read-all pass. Do not fold the filter into
+    /// `messages` itself.
+    private var visibleMessages: [GramMessage] {
+        guard !search.isEmpty else { return messages }
+        return messages.filter { message in
+            message.text.localizedCaseInsensitiveContains(search)
+                || message.from.localizedCaseInsensitiveContains(search)
+                || (message.to ?? "").localizedCaseInsensitiveContains(search)
+                || (message.file?.name ?? "").localizedCaseInsensitiveContains(search)
+        }
+    }
+
+    /// Saved rows after the same filter. `SavedGram` has no `to`, so sender + text + filename.
+    private var visibleSaved: [SavedGram] {
+        guard !search.isEmpty else { return savedGrams.saved }
+        return savedGrams.saved.filter { saved in
+            saved.text.localizedCaseInsensitiveContains(search)
+                || saved.from.localizedCaseInsensitiveContains(search)
+                || (saved.file?.name ?? "").localizedCaseInsensitiveContains(search)
+        }
+    }
+
     private enum LoadPhase: Equatable {
         case loading
         case loaded
@@ -237,6 +274,15 @@ struct GramView: View {
             guard new != old else { return }
             Task { await load(initial: false) }
         }
+        // The sidebar's Read-all button bumps `readAllToken` for the same reason refresh does.
+        .onChange(of: readAllToken) { old, new in
+            guard new != old else { return }
+            Task { await markAllRead() }
+        }
+        // A filter typed in Inbox has no meaning in Saved, and leaving it set would greet the
+        // just-selected section with "No matches", which reads as a bug. `showingSaved` is the
+        // host's binding, so this fires for both the phone toggle and the sidebar rows.
+        .onChange(of: showingSaved) { _, _ in search = "" }
         // Paperclip → a Telegram-style attach sheet picks the source, so we open the
         // RIGHT system picker. The picker is opened in the sheet's onDismiss (via
         // `pendingPicker`), not inline — presenting a sheet while another dismisses
@@ -338,6 +384,7 @@ struct GramView: View {
         VStack(spacing: 0) {
             header
             Divider().overlay(Palette.hairlineQuiet)
+            searchField
             content
             bannerView
             composer
@@ -355,10 +402,25 @@ struct GramView: View {
     /// every send/attach/poll behaviour is identical.
     private var iPadBody: some View {
         VStack(spacing: 0) {
+            searchField
             content
             bannerView
             composer
         }
+    }
+
+    /// The message filter, pinned ABOVE the scroll in both layouts (it must not scroll away),
+    /// copying the agents list's field verbatim except for the binding and placeholder so the
+    /// two search surfaces in the app look and behave identically.
+    private var searchField: some View {
+        TextField("Search messages", text: $search)
+            .font(Typography.app(15)).foregroundStyle(Palette.text)
+            .textInputAutocapitalization(.never).autocorrectionDisabled()
+            .padding(.horizontal, 16).padding(.vertical, 11)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(Palette.surface)
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+            .padding(.horizontal, 16).padding(.top, 4).padding(.bottom, 4)
     }
 
     /// A load error / send error, shown ABOVE the composer in every phase — the
@@ -400,6 +462,19 @@ struct GramView: View {
                     .font(.system(size: 15, weight: .semibold))
                     .foregroundStyle(showingSaved ? Palette.brand : Palette.textDim)
             }
+            // Read all — only while the Inbox is showing (Saved has no unread concept) and
+            // something is actually unread, so it never sits there as a no-op control.
+            if !showingSaved, unreadCount > 0 {
+                Button {
+                    Task { await markAllRead() }
+                } label: {
+                    Image(systemName: "envelope.open")
+                        .font(.system(size: 15, weight: .semibold))
+                        .foregroundStyle(Palette.textDim)
+                }
+                .disabled(markingAllRead)
+                .accessibilityLabel("Read all")
+            }
             if !showingSaved {
                 Button {
                     Task { await load(initial: false) }
@@ -435,6 +510,27 @@ struct GramView: View {
         .scrollDismissesKeyboard(.interactively)
     }
 
+    /// Shown when the list HAS rows but the active search matches none of them. A distinct
+    /// state from "nothing here yet": a blank scroll after typing reads as an empty inbox,
+    /// which is the bug the agents list already avoids the same way.
+    private var noMatches: some View {
+        centered {
+            VStack(spacing: 8) {
+                Image(systemName: "magnifyingglass")
+                    .font(.system(size: 28))
+                    .foregroundStyle(Palette.textFaint)
+                Text("No matches")
+                    .font(Typography.app(15, .medium))
+                    .foregroundStyle(Palette.textDim)
+                Text("Nothing in this list matches “\(search)”.")
+                    .font(Typography.app(13))
+                    .foregroundStyle(Palette.textFaint)
+                    .multilineTextAlignment(.center)
+            }
+            .padding(.horizontal, 32)
+        }
+    }
+
     /// The Saved section: locally-kept copies of bookmarked messages. Rendered from the local
     /// store (independent of the poll), so a saved message survives even after the original is
     /// deleted from the server.
@@ -456,10 +552,12 @@ struct GramView: View {
                 }
                 .padding(.horizontal, 32)
             }
+        } else if visibleSaved.isEmpty {
+            noMatches
         } else {
             ScrollView {
                 LazyVStack(spacing: 10) {
-                    ForEach(savedGrams.saved) { s in
+                    ForEach(visibleSaved) { s in
                         SavedGramRow(
                             saved: s,
                             isDownloadingFile: downloadingFileFor == s.id,
@@ -516,11 +614,15 @@ struct GramView: View {
                 }
                 .padding(.horizontal, 32)
             }
+        // Must sit ABOVE `case .loaded:` — Swift evaluates cases in order, so below it this
+        // is unreachable. The store-empty case above keeps its own "No messages yet" copy.
+        case .loaded where !search.isEmpty && visibleMessages.isEmpty:
+            noMatches
         case .loaded:
             ScrollView {
                 LazyVStack(spacing: 10) {
                     if shouldShowSetupCard { setupCard }
-                    ForEach(messages) { message in
+                    ForEach(visibleMessages) { message in
                         GramRow(
                             message: message,
                             isDownloadingFile: downloadingFileFor == message.id,
@@ -1320,6 +1422,41 @@ struct GramView: View {
                 // Leave it unread; the next poll re-surfaces it.
             }
         }
+    }
+
+    /// Marks EVERY unread message read, ignoring any active search — the button says "Read all"
+    /// and the badge must reach zero, so marking only the filtered matches would leave a
+    /// non-zero badge with no visible cause. Serial, not a TaskGroup: the daemon has no bulk
+    /// mark-read (`gram.mark_read` takes one id), so a serial loop is both the existing idiom
+    /// and the one that cannot flood a forwarded SSH connection.
+    private func markAllRead() async {
+        guard !markingAllRead else { return }
+        markingAllRead = true
+        defer { markingAllRead = false }
+        // Snapshot the ids first: `serverMessages` is mutated inside the loop and a poll may
+        // replace it mid-pass, so iterating the live array could skip or repeat a message.
+        let unreadIDs = serverMessages.filter { $0.isUnread }.map(\.id)
+        var failed = 0
+        for id in unreadIDs {
+            // A row's `onAppear` may already have this one in flight; reusing the same
+            // in-flight set is what stops a duplicate `gram.mark_read`.
+            guard !markingRead.contains(id) else { continue }
+            markingRead.insert(id)
+            do {
+                try await client.gramMarkRead(id: id)
+                if let index = serverMessages.firstIndex(where: { $0.id == id }) {
+                    serverMessages[index].readByOwner = true
+                }
+            } catch {
+                failed += 1
+            }
+            markingRead.remove(id)
+        }
+        // Recomputed from the array rather than decremented, so a racing poll cannot desync it.
+        unread?.count = serverMessages.filter { $0.isUnread }.count
+        // Partial failure is reported, not swallowed: the badge will still show a count and the
+        // reader needs to know why. `refreshNote` is the existing banner channel (bannerView).
+        refreshNote = failed == 0 ? nil : "\(failed) of \(unreadIDs.count) could not be marked read."
     }
 }
 

--- a/App/GramView.swift
+++ b/App/GramView.swift
@@ -89,6 +89,9 @@ struct GramView: View {
     @State private var search = ""
     /// True while a Read-all pass is running, so the button disables rather than stacking passes.
     @State private var markingAllRead = false
+    /// A partial-failure report from a Read-all pass. Its OWN slot rather than `refreshNote`,
+    /// which the 6-second poll clears on every success — same reasoning as `sendError`.
+    @State private var markAllNote: String?
 
     /// Files the owner picked to attach to the next post (read into memory at pick
     /// time), empty when none are staged. Several can be staged at once; each sends as
@@ -384,7 +387,7 @@ struct GramView: View {
         VStack(spacing: 0) {
             header
             Divider().overlay(Palette.hairlineQuiet)
-            searchField
+            searchFieldIfFilterable
             content
             bannerView
             composer
@@ -402,7 +405,7 @@ struct GramView: View {
     /// every send/attach/poll behaviour is identical.
     private var iPadBody: some View {
         VStack(spacing: 0) {
-            searchField
+            searchFieldIfFilterable
             content
             bannerView
             composer
@@ -423,12 +426,21 @@ struct GramView: View {
             .padding(.horizontal, 16).padding(.top, 4).padding(.bottom, 4)
     }
 
+    /// The field, but only where there is something to filter. `content` renders a spinner while
+    /// loading and an error card (with a Retry) when the daemon has no gram, and a search box
+    /// pinned above either of those is a live control over nothing. The agents list's field sits
+    /// above an EMPTY LIST, never above an error state.
+    @ViewBuilder
+    private var searchFieldIfFilterable: some View {
+        if showingSaved || phase == .loaded { searchField }
+    }
+
     /// A load error / send error, shown ABOVE the composer in every phase — the
     /// composer is enabled in all states, so a failure must be visible in all states
     /// (empty inbox, pre-deploy daemon, or a loaded list alike).
     @ViewBuilder
     private var bannerView: some View {
-        if let text = sendError ?? refreshNote {
+        if let text = sendError ?? markAllNote ?? refreshNote {
             Text(text)
                 .font(Typography.app(12))
                 .foregroundStyle(Palette.died)
@@ -615,8 +627,11 @@ struct GramView: View {
                 .padding(.horizontal, 32)
             }
         // Must sit ABOVE `case .loaded:` — Swift evaluates cases in order, so below it this
-        // is unreachable. The store-empty case above keeps its own "No messages yet" copy.
-        case .loaded where !search.isEmpty && visibleMessages.isEmpty:
+        // is unreachable. `!messages.isEmpty` is load-bearing: an EMPTY inbox showing the setup
+        // card falls through to `case .loaded:` (the case above needs `!shouldShowSetupCard`),
+        // and without it one keystroke would replace the only affordance telling the owner how
+        // to give their agents gram with "No matches" about a list that never had rows.
+        case .loaded where !search.isEmpty && !messages.isEmpty && visibleMessages.isEmpty:
             noMatches
         case .loaded:
             ScrollView {
@@ -1433,30 +1448,53 @@ struct GramView: View {
         guard !markingAllRead else { return }
         markingAllRead = true
         defer { markingAllRead = false }
+        markAllNote = nil
         // Snapshot the ids first: `serverMessages` is mutated inside the loop and a poll may
         // replace it mid-pass, so iterating the live array could skip or repeat a message.
-        let unreadIDs = serverMessages.filter { $0.isUnread }.map(\.id)
+        var pending = serverMessages.filter { $0.isUnread }.map(\.id)
+        // Ids this pass actually marked, re-applied after the loop: `load` REPLACES
+        // `serverMessages` wholesale, so a poll landing mid-pass reverts the flips written
+        // below and the badge would still show a count after a fully successful pass.
+        var marked: Set<String> = []
+        var attempted = 0
         var failed = 0
-        for id in unreadIDs {
-            // A row's `onAppear` may already have this one in flight; reusing the same
-            // in-flight set is what stops a duplicate `gram.mark_read`.
-            guard !markingRead.contains(id) else { continue }
-            markingRead.insert(id)
-            do {
-                try await client.gramMarkRead(id: id)
-                if let index = serverMessages.firstIndex(where: { $0.id == id }) {
-                    serverMessages[index].readByOwner = true
+        // Two passes: an id a row's own `onAppear` had in flight when we first reached it is
+        // retried once, by which time that Task has cleared its entry — otherwise "Read all"
+        // could silently leave it unread if that Task's own call failed (its catch is a no-op).
+        for _ in 0..<2 {
+            var stillInFlight: [String] = []
+            for id in pending {
+                // Reusing the existing in-flight set is what stops a duplicate `gram.mark_read`.
+                guard !markingRead.contains(id) else { stillInFlight.append(id); continue }
+                // Someone else's pass already read it; nothing left to do for this id.
+                guard serverMessages.first(where: { $0.id == id })?.isUnread ?? false else { continue }
+                markingRead.insert(id)
+                attempted += 1
+                do {
+                    try await client.gramMarkRead(id: id)
+                    marked.insert(id)
+                    if let index = serverMessages.firstIndex(where: { $0.id == id }) {
+                        serverMessages[index].readByOwner = true
+                    }
+                } catch {
+                    failed += 1
                 }
-            } catch {
-                failed += 1
+                markingRead.remove(id)
             }
-            markingRead.remove(id)
+            pending = stillInFlight
+            if pending.isEmpty { break }
         }
-        // Recomputed from the array rather than decremented, so a racing poll cannot desync it.
+        // Whatever array is current now, the ids we confirmed read are read. Ids still in flight
+        // elsewhere are left to their own Task, which flips them on success.
+        for index in serverMessages.indices where marked.contains(serverMessages[index].id) {
+            serverMessages[index].readByOwner = true
+        }
         unread?.count = serverMessages.filter { $0.isUnread }.count
         // Partial failure is reported, not swallowed: the badge will still show a count and the
-        // reader needs to know why. `refreshNote` is the existing banner channel (bannerView).
-        refreshNote = failed == 0 ? nil : "\(failed) of \(unreadIDs.count) could not be marked read."
+        // reader needs to know why. Its OWN slot, not `refreshNote` — the 6-second poll clears
+        // that one unconditionally on success, so the explanation would outlive the badge by
+        // seconds at most. `sendError` carries the same reasoning (see its declaration).
+        markAllNote = failed == 0 ? nil : "\(failed) of \(attempted) could not be marked read."
     }
 }
 

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -1904,9 +1904,11 @@ struct TerminalHomeView: View {
                         .frame(height: 15)
                 }
                 Spacer()
-                // Read all, beside refresh and only while something is unread — the count the
-                // ambient poll already keeps here, so the button needs nothing from the page.
-                if gramUnread.count > 0 {
+                // Read all, beside refresh. Gated exactly like the phone header's copy: only on
+                // the Inbox (Saved has no unread concept, so it would be a no-op control there)
+                // and only while something is unread. The count comes from the ambient poll this
+                // view already owns, so the button needs nothing from the page.
+                if !gramShowingSaved, gramUnread.count > 0 {
                     circleButton("envelope.open") { gramReadAllToken += 1 }
                         .accessibilityLabel("Read all")
                 }

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -1511,6 +1511,9 @@ struct TerminalHomeView: View {
     /// One-shot signal for the sidebar's refresh button. A sidebar button cannot call `GramView`'s
     /// async `load`, so it bumps this and the page's `onChange` performs the reload.
     @State private var gramRefreshToken = 0
+    /// One-shot signal for the sidebar's Read-all button, same reason as `gramRefreshToken`:
+    /// a sidebar button cannot call `GramView`'s async mark-read pass directly.
+    @State private var gramReadAllToken = 0
     /// Observed, not read statically: the Gram sidebar shows the Saved count as a badge, and
     /// `SavedGramStore.shared.saved.count` read directly would only refresh when some unrelated
     /// state re-rendered this view — so saving or removing a gram would leave a stale number.
@@ -1774,7 +1777,8 @@ struct TerminalHomeView: View {
                 case .gram:
                     GramView(client: client, agents: agents, unread: gramUnread,
                              showingSaved: $gramShowingSaved,
-                             refreshToken: gramRefreshToken)
+                             refreshToken: gramRefreshToken,
+                             readAllToken: gramReadAllToken)
                 case .settings:
                     SettingsView(
                         client: client,
@@ -1900,6 +1904,12 @@ struct TerminalHomeView: View {
                         .frame(height: 15)
                 }
                 Spacer()
+                // Read all, beside refresh and only while something is unread — the count the
+                // ambient poll already keeps here, so the button needs nothing from the page.
+                if gramUnread.count > 0 {
+                    circleButton("envelope.open") { gramReadAllToken += 1 }
+                        .accessibilityLabel("Read all")
+                }
                 circleButton("arrow.clockwise") { gramRefreshToken += 1 }
             }
             .padding(.horizontal, 16).padding(.top, 8).padding(.bottom, 10)

--- a/HerdrUITests/GramTests.swift
+++ b/HerdrUITests/GramTests.swift
@@ -32,4 +32,75 @@ final class GramTests: XCTestCase {
         attachment.lifetime = .keepAlways
         add(attachment)
     }
+
+    /// The search field filters the loaded inbox, and a filter that matches nothing says so
+    /// instead of leaving a blank scroll that reads as an empty inbox.
+    ///
+    /// Strings are picked from the `gram` fixture (MockTransport.gramList): "Digest" appears in
+    /// exactly one message (g1, from trend-scout), and "vetrina" is the sender label of a
+    /// DIFFERENT message (g5) — so one label surviving while the other disappears is a receipt
+    /// that rows were filtered, not merely re-laid-out.
+    func testGramSearchFiltersTheInbox() {
+        let app = XCUIApplication()
+        app.launchEnvironment["HERDR_SCREENSHOT_MOCK"] = "gram"
+        app.launch()
+
+        // Both senders are present before any filter: the pre-state the filter acts on. Without
+        // this the later disappearance would prove nothing (it could have never rendered).
+        XCTAssertTrue(app.staticTexts["trend-scout"].waitForExistence(timeout: 10),
+                      "the unread agent->owner message should render before filtering")
+        XCTAssertTrue(app.staticTexts["vetrina"].waitForExistence(timeout: 5),
+                      "the second agent->owner message should render before filtering")
+
+        let field = app.textFields["Search messages"]
+        XCTAssertTrue(field.waitForExistence(timeout: 5), "the search field should be pinned above the list")
+        field.tap()
+        field.typeText("Digest")
+        // Assert the FIELD took the text before asserting anything about the list: an unfocused
+        // field would otherwise fail as "filtering is broken" when the real fault is the keyboard.
+        XCTAssertEqual(field.value as? String, "Digest", "the search field did not take the typed text")
+
+        XCTAssertTrue(app.staticTexts["trend-scout"].waitForExistence(timeout: 3),
+                      "the matching message should survive the filter")
+        XCTAssertTrue(app.staticTexts["vetrina"].waitForNonExistence(timeout: 5),
+                      "a message matching nothing in the search should be filtered out")
+
+        // A filter that matches nothing: the "No matches" state, NOT a blank list.
+        field.typeText(String(repeating: XCUIKeyboardKey.delete.rawValue, count: 6))
+        field.typeText("zzzz")
+        XCTAssertTrue(app.staticTexts["No matches"].waitForExistence(timeout: 5),
+                      "a filter matching no message should say so")
+
+        // Clearing the field restores the full list.
+        field.typeText(String(repeating: XCUIKeyboardKey.delete.rawValue, count: 4))
+        XCTAssertTrue(app.staticTexts["vetrina"].waitForExistence(timeout: 5),
+                      "clearing the search should bring the filtered-out messages back")
+    }
+
+    /// Read all marks the unread messages read: the button is present while something is unread
+    /// and gone once the pass completes (it renders only for `unreadCount > 0`).
+    ///
+    /// Bounded retry, deliberately: the mock's `gram.list` is a CONSTANT that always reports g1
+    /// unread, so the page's 6-second poll re-introduces the unread message and the button
+    /// reappears. The receipt is that a tap drives it away at all — one attempt could sample the
+    /// instant a poll lands. A failure here means no tap ever cleared the unread count.
+    func testGramReadAllClearsTheUnreadCount() {
+        let app = XCUIApplication()
+        app.launchEnvironment["HERDR_SCREENSHOT_MOCK"] = "gram"
+        app.launch()
+
+        XCTAssertTrue(app.staticTexts["trend-scout"].waitForExistence(timeout: 10),
+                      "the Gram page should load the mock inbox")
+
+        let readAll = app.buttons["Read all"]
+        var cleared = false
+        for _ in 0..<3 {
+            // Up to two poll intervals: the row's own onAppear mark-read can clear the count
+            // first, and the next poll restores it.
+            guard readAll.waitForExistence(timeout: 14) else { continue }
+            readAll.tap()
+            if readAll.waitForNonExistence(timeout: 4) { cleared = true; break }
+        }
+        XCTAssertTrue(cleared, "tapping Read all should drive the unread count to zero")
+    }
 }

--- a/HerdrUITests/GramTests.swift
+++ b/HerdrUITests/GramTests.swift
@@ -80,10 +80,15 @@ final class GramTests: XCTestCase {
     /// Read all marks the unread messages read: the button is present while something is unread
     /// and gone once the pass completes (it renders only for `unreadCount > 0`).
     ///
-    /// Bounded retry, deliberately: the mock's `gram.list` is a CONSTANT that always reports g1
-    /// unread, so the page's 6-second poll re-introduces the unread message and the button
-    /// reappears. The receipt is that a tap drives it away at all — one attempt could sample the
-    /// instant a poll lands. A failure here means no tap ever cleared the unread count.
+    /// The button's presence is only STABLE after the first poll, and the test waits for that
+    /// deliberately: at launch the single unread message's own row marks itself read within a
+    /// moment (`markReadIfNeeded` from `onAppear`), which drives the count to zero and removes
+    /// the button — so a tap aimed at the launch-time button can miss. The mock's `gram.list` is
+    /// a CONSTANT that always reports g1 unread, so the 6-second poll restores it, and because
+    /// the row's identity is unchanged `onAppear` does not fire again: from then on the button
+    /// stays up. The retry exists because the same poll also re-creates it a few seconds after a
+    /// successful pass; each attempt guards `exists`/`isHittable` so a vanished button re-enters
+    /// the loop instead of failing the test on an unrecoverable `tap()`.
     func testGramReadAllClearsTheUnreadCount() {
         let app = XCUIApplication()
         app.launchEnvironment["HERDR_SCREENSHOT_MOCK"] = "gram"
@@ -94,10 +99,13 @@ final class GramTests: XCTestCase {
 
         let readAll = app.buttons["Read all"]
         var cleared = false
-        for _ in 0..<3 {
-            // Up to two poll intervals: the row's own onAppear mark-read can clear the count
-            // first, and the next poll restores it.
-            guard readAll.waitForExistence(timeout: 14) else { continue }
+        for _ in 0..<4 {
+            // One poll interval plus slack, so this waits out the launch-time flip described
+            // above rather than racing it.
+            guard readAll.waitForExistence(timeout: 14), readAll.isHittable else {
+                Thread.sleep(forTimeInterval: 1.0)
+                continue
+            }
             readAll.tap()
             if readAll.waitForNonExistence(timeout: 4) { cleared = true; break }
         }


### PR DESCRIPTION
## What

Two additions to the Gram page.

- **Search**, pinned above the list in both layouts (it must not scroll away), copying the agents list's field verbatim except the binding. Filters whichever section is showing — Inbox or Saved — over message **text, sender, recipient and an attachment's filename**: "the key I sent keephair" is looked for by any of those, and matching only `text` would miss the last two. Client-side over what is already loaded; `gram.list` takes only an `unreadOnly` flag, so there is no server-side search to call.
- **Read all**, which marks every unread message read in one pass. Before this the only way to clear unread was to scroll each message into view (a row's `onAppear` fires `markReadIfNeeded`).

## Load-bearing details

- `visibleMessages` / `visibleSaved` are **deliberately separate** from `messages`. `unreadCount`, `markReadIfNeeded` and `markAllRead` keep reading the unfiltered set, so an active search can never make the badge lie or hide a message from a Read-all pass. Both carry a comment saying so, because folding the filter into `messages` is the obvious "tidy-up" that would break it.
- A filtered-empty list shows **"No matches"**, not a blank scroll that reads as an empty inbox — the same distinction the agents list already draws. The case sits **above** `case .loaded:`; below it, Swift's in-order case evaluation would make it unreachable.
- **Read all ignores the active search.** The button says "Read all" and the badge must reach zero, so marking only the filtered matches would leave a non-zero badge with no visible cause.
- The pass is **serial** — no bulk mark-read exists (`gram.mark_read` takes one id) — and it: reuses the existing `markingRead` in-flight set so a row's `onAppear` and the pass cannot double-send the same id; **snapshots** the unread ids first, so a poll replacing `serverMessages` mid-pass can neither skip nor duplicate; recomputes the badge from the array rather than decrementing it; and reports partial failure through the existing banner instead of swallowing it.
- The button renders only while something is unread — phone header beside refresh, and the app's **real sidebar** on regular width through a one-shot token, exactly how the sidebar's refresh already reaches this page.
- Switching section clears the filter, so a just-selected section is never greeted with "No matches".

No API change: the daemon has no bulk mark-read, and no server-side gram search.

## Verification

- **HerdrKit (Linux), locally in `swift:6.1`:** `Executed 474 tests, with 15 tests skipped and 0 failures` — the same total as before this change, which is App-layer only.
- **New UI receipts in `HerdrUITests/GramTests.swift`**, both against `HERDR_SCREENSHOT_MOCK=gram`:
  - `testGramSearchFiltersTheInbox` — asserts **both** sender labels render first (so the later disappearance cannot be a row that never existed), types `Digest` (present in exactly one canned message, g1/trend-scout), asserts the field took the text *before* asserting anything about the list (an unfocused field would otherwise fail as "filtering is broken"), then asserts `trend-scout` survives and `vetrina` — a different message's sender label — does not. Then `zzzz` → `No matches`, and clearing → `vetrina` back.
  - `testGramReadAllClearsTheUnreadCount` — waits for the button, taps, asserts it disappears (it renders only for `unreadCount > 0`). **Bounded retry on purpose:** the mock's `gram.list` is a constant that always reports g1 unread, so the page's 6s poll re-introduces it and the button reappears; a single attempt could sample the instant a poll lands. A failure means no tap ever cleared the count.
- **`testGramPageRenders` is the regression guard** that the header edit did not break the phone layout.
- **Not verified here:** the iPad/Mac half. CI's UI suite runs on an **iPhone** simulator, where `hSizeClass` is compact, so the sidebar Read-all button and the regular-width field placement never render in CI. Those need one look on a Mac or iPad.
