### PR TITLE
feat(gram): stream uploads over one channel and stage attachments on disk

### DIFF
--- a/App/GramView.swift
+++ b/App/GramView.swift
@@ -277,7 +277,10 @@ struct GramView: View {
         // refresh (the gram store has no event stream); the loop ends when the view
         // goes away (task cancellation).
         .task {
-            Self.sweepAbandonedStaging()
+            // Off the main actor: the sweep unlinks whole abandoned session
+            // directories, which after a jetsam can be ten 100 MB attachments, and
+            // `removeItem` is a synchronous recursive walk.
+            await Task.detached(priority: .utility) { Self.sweepAbandonedStaging() }.value
             await pollLoop()
         }
         // The sidebar's refresh button bumps `refreshToken`; consume the change here so a
@@ -384,10 +387,13 @@ struct GramView: View {
             openFileTask?.cancel()
             if let previewURL { try? FileManager.default.removeItem(at: previewURL) }
             if let url = webDoc?.fileURL { try? FileManager.default.removeItem(at: url) }
-            // Staged attachment bytes are ours to remove: nothing else references
-            // them once the page is gone. `.interactiveDismissDisabled(sending ||
-            // loadingPhoto)` keeps this from firing mid-send.
-            for file in attachedFiles { try? FileManager.default.removeItem(at: file.dir) }
+            // Staged attachment bytes are deliberately NOT removed here. Gram is a
+            // persistent tab (see HerdrApp's TabView), so `onDisappear` fires on a
+            // plain tab switch while this view's `@State` — including the chips in
+            // `attachedFiles` — survives. Unlinking here would delete the bytes of an
+            // attachment still shown in the composer, and make its retry unfixable.
+            // The staged bytes are released on chip-X, after a successful send, and
+            // for a killed session by the next launch's staging sweep.
         }
         // Don't let a swipe-down (the new sheet dismissal) abandon an in-flight send
         // or a photo load mid-way — the chunked upload would keep running off-screen.
@@ -1411,12 +1417,19 @@ struct GramView: View {
         do {
             try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
             let destination = dir.appendingPathComponent(safeTempFileName(name))
-            try FileManager.default.copyItem(at: source, to: destination)
             // `copyItem` does not set data protection, and every other temp write in
             // this file uses `.completeFileProtection`. A staged gram attachment can
             // be a secret; it must not be the one temp file here that sits unprotected.
+            //
+            // `completeUnlessOpen`, NOT `complete`: this file is held open across a
+            // whole upload, and the send keeps running when the app is backgrounded.
+            // Class A protection evicts the key on lock and fails reads even on an
+            // already-open descriptor, so locking the phone mid-upload would abort the
+            // send. Class B keeps an open file readable and still denies a new open
+            // while locked, which is the property that matters for a staged secret.
             try? FileManager.default.setAttributes(
-                [.protectionKey: FileProtectionType.complete], ofItemAtPath: destination.path)
+                [.protectionKey: FileProtectionType.completeUnlessOpen],
+                ofItemAtPath: destination.path)
             guard let size = try? destination.resourceValues(forKeys: [.fileSizeKey]).fileSize,
                 size > 0, size <= maxFileBytes
             else {

--- a/App/GramView.swift
+++ b/App/GramView.swift
@@ -276,13 +276,7 @@ struct GramView: View {
         // Poll while the page is open so new agent messages appear without a manual
         // refresh (the gram store has no event stream); the loop ends when the view
         // goes away (task cancellation).
-        .task {
-            // Off the main actor: the sweep unlinks whole abandoned session
-            // directories, which after a jetsam can be ten 100 MB attachments, and
-            // `removeItem` is a synchronous recursive walk.
-            await Task.detached(priority: .utility) { Self.sweepAbandonedStaging() }.value
-            await pollLoop()
-        }
+        .task { await pollLoop() }
         // The sidebar's refresh button bumps `refreshToken`; consume the change here so a
         // sibling column can drive this view's async reload without owning its state. Guarded on
         // a real change (SwiftUI may re-run the body for unrelated reasons) and on `initial:
@@ -1190,13 +1184,7 @@ struct GramView: View {
         sendError = attachmentSkipNote(bad: bad, capped: capped)
     }
 
-    /// A file staged on disk, app-owned: the bytes plus the per-item directory that
-    /// holds them (removing the directory removes the bytes).
-    private struct StagedFile {
-        let url: URL
-        let dir: URL
-        let size: Int
-    }
+    // A staged pick is `HerdrKit.StagedAttachment` (url + per-item dir + size).
 
     /// A photo-library pick copied into app-owned staging. PhotosUI exports the item
     /// to a temp file and DELETES it when the closure returns, so the copy has to
@@ -1211,7 +1199,7 @@ struct GramView: View {
     private struct PickedMedia: Transferable {
         /// Non-nil only for an in-cap pick that was copied into staging; nil =
         /// rejected (over-cap, size unknown — treated as over-cap — or uncopyable).
-        let staged: StagedFile?
+        let staged: StagedAttachment?
         static var transferRepresentation: some TransferRepresentation {
             FileRepresentation(importedContentType: .item) { received in
                 // Unknown size is treated as OVER-cap (reject), never under-cap — an
@@ -1408,53 +1396,31 @@ struct GramView: View {
     private static let sessionStagingDirectory = stagingRoot
         .appendingPathComponent(UUID().uuidString, isDirectory: true)
 
-    /// Copy a picked file into a fresh per-item staging directory, so the send can
-    /// stream it from disk and the app owns its lifetime. nil when the copy fails or
-    /// the copied file is empty / over the cap — the caller reports it as a skip.
-    private static func stageCopy(of source: URL, named name: String) -> StagedFile? {
-        let dir = sessionStagingDirectory
-            .appendingPathComponent(UUID().uuidString, isDirectory: true)
-        do {
-            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-            let destination = dir.appendingPathComponent(safeTempFileName(name))
-            // `copyItem` does not set data protection, and every other temp write in
-            // this file uses `.completeFileProtection`. A staged gram attachment can
-            // be a secret; it must not be the one temp file here that sits unprotected.
-            //
-            // `completeUnlessOpen`, NOT `complete`: this file is held open across a
-            // whole upload, and the send keeps running when the app is backgrounded.
-            // Class A protection evicts the key on lock and fails reads even on an
-            // already-open descriptor, so locking the phone mid-upload would abort the
-            // send. Class B keeps an open file readable and still denies a new open
-            // while locked, which is the property that matters for a staged secret.
-            try? FileManager.default.setAttributes(
-                [.protectionKey: FileProtectionType.completeUnlessOpen],
-                ofItemAtPath: destination.path)
-            guard let size = try? destination.resourceValues(forKeys: [.fileSizeKey]).fileSize,
-                size > 0, size <= maxFileBytes
-            else {
-                try? FileManager.default.removeItem(at: dir)
-                return nil
-            }
-            return StagedFile(url: destination, dir: dir, size: size)
-        } catch {
-            try? FileManager.default.removeItem(at: dir)
-            return nil
-        }
+    /// Copy a picked file into app-owned staging, so the send streams it from disk
+    /// and the app owns its lifetime. nil when the copy fails or the copied file is
+    /// empty / over the cap — the caller reports it as a skip.
+    ///
+    /// The work is `HerdrKit.GramStaging`'s, not this file's: this target is iOS-only
+    /// and cannot run on CI, and a staging bug here is silent (it renders as the same
+    /// "unreadable pick" message as a genuinely bad file). In HerdrKit it is tested.
+    private static func stageCopy(of source: URL, named name: String) -> StagedAttachment? {
+        GramStaging.stageCopy(
+            of: source, named: name, in: sessionStagingDirectory, maxBytes: maxFileBytes)
     }
 
     /// Remove staging left by PREVIOUS app sessions (a crash or jetsam runs no
-    /// cleanup). Bounded and stateless: every sibling of this session's directory is
-    /// by definition abandoned, since a session directory is named at launch.
-    private static func sweepAbandonedStaging() {
-        let manager = FileManager.default
-        guard let entries = try? manager.contentsOfDirectory(
-            at: stagingRoot, includingPropertiesForKeys: nil)
-        else { return }
+    /// cleanup).
+    ///
+    /// Called from the app root's `.task`, not this page's: bytes from a killed
+    /// session must be reclaimed even in a launch where the Gram tab is never opened.
+    /// Off the main actor because the unlink is a synchronous recursive walk and the
+    /// abandoned set can be ten 100 MB attachments.
+    static func sweepAbandonedStagingOffMainActor() async {
+        let root = stagingRoot
         let current = sessionStagingDirectory.lastPathComponent
-        for entry in entries where entry.lastPathComponent != current {
-            try? manager.removeItem(at: entry)
-        }
+        await Task.detached(priority: .utility) {
+            GramStaging.sweepAbandoned(root: root, keeping: current)
+        }.value
     }
 
     /// A file we should render as formatted HTML (a markdown source), by extension

--- a/App/GramView.swift
+++ b/App/GramView.swift
@@ -1091,9 +1091,10 @@ struct GramView: View {
                 }
                 uploading = false
                 uploadBytes = nil
-                let posted = try await client.gramPost(
-                    text: caption, to: to,
-                    attachment: .init(uploadID: uploadID, name: file.name, mime: file.mime))
+                let attachment = HerdrClient.GramFileAttachment(
+                    uploadID: uploadID, name: file.name, mime: file.mime)
+                let posted = try await Self.postAttachment(
+                    client: client, text: caption, to: to, attachment: attachment)
                 // Optimistic: kept in `pendingPosts`, so a concurrent poll's snapshot
                 // cannot drop it; de-duped by id, reconciled once the server reflects it.
                 pendingPosts.removeAll { $0.id == posted.id }
@@ -1101,13 +1102,11 @@ struct GramView: View {
                 sentCount += 1
                 if index == 0 { draft = "" }
             } catch let error as APIError {
-                // `upload_in_progress` here means the daemon has not yet reaped the
-                // upload connection this file just used — the streamed upload waits
-                // for that teardown, but the wait is bounded, so on a stalled link it
-                // can return first. The file itself is fine and the staged copy is
-                // kept below, so this is a retry, not a failure: the daemon's own
-                // sentence ("read the upload connection to EOF") would be meaningless
-                // to the owner.
+                // A post still refused after the retries above means the daemon has
+                // not reaped the upload connection at all. The bytes are staged and
+                // complete, so this is a retry rather than a failure — but the raw
+                // daemon sentence ("read the upload connection to EOF") would be
+                // meaningless to the owner.
                 failure = error.code == "upload_in_progress"
                     ? "Still finishing the last upload. Tap Send again."
                     : error.message
@@ -1135,6 +1134,37 @@ struct GramView: View {
                 ? "Sent \(sentCount) of \(files.count). \(failure)"
                 : failure
         }
+    }
+
+    /// Posts an attachment, retrying the POST — never the upload — while the daemon
+    /// still owns the `upload_id`.
+    ///
+    /// The daemon frees its single-writer claim only when it observes EOF on the
+    /// upload connection, and the client's close wait is bounded, so a stalled link
+    /// can put the post in front of that release. Re-entering `gramUploadFile` would
+    /// mint a FRESH `upload_id` and transfer the whole file again, leaving the
+    /// previous — complete — staging file to age out over 24 hours; ten taps of a
+    /// 100 MB attachment would exhaust the daemon's 1 GiB staging budget and fail
+    /// every gram upload from every client. The bytes are already there, so all that
+    /// is needed is to ask again.
+    private static func postAttachment(
+        client: HerdrClient,
+        text: String,
+        to: String?,
+        attachment: HerdrClient.GramFileAttachment
+    ) async throws -> GramMessage {
+        // Three tries over ~3 s: the daemon's own reap is 60 s, but the case this
+        // covers is a teardown a few hundred ms behind the post.
+        for attempt in 0..<3 {
+            do {
+                return try await client.gramPost(text: text, to: to, attachment: attachment)
+            } catch let error as APIError where error.code == "upload_in_progress" {
+                if attempt == 2 { throw error }
+                try? await Task.sleep(nanoseconds: 1_000_000_000)
+            }
+        }
+        // Unreachable: the loop either returns or throws on its last attempt.
+        throw GramError.invalidFileData
     }
 
     /// One combined skip note for a batch pick. `bad` (already phrased) covers picks

--- a/App/GramView.swift
+++ b/App/GramView.swift
@@ -160,26 +160,34 @@ struct GramView: View {
         let fileURL: URL
     }
 
-    /// A file staged for sending: read into memory so the send is one atomic action.
+    /// A file staged for sending, held as a COPY ON DISK rather than in memory, so a
+    /// batch of large picks costs one open file handle at send time rather than
+    /// N × 100 MB resident. `dir` is the per-item staging directory (same idiom as
+    /// `ExportFile`); removing it removes the staged bytes.
     /// Identifiable so the composer strip can render + remove chips by identity.
     private struct PickedAttachment: Identifiable {
         let id = UUID()
         let name: String
         let mime: String
-        let data: Data
+        let url: URL
+        let dir: URL
+        let size: Int
     }
 
     /// Client-side attachment cap, mirroring the server's `MAX_FILE_BYTES` (100 MiB).
-    /// The upload is chunked (`HerdrClient.gramUploadChunkBytes`), so any size streams
-    /// fine regardless of divisibility; this is just the pre-send size gate. A single
-    /// staged file of this size is read whole into memory (see `PickedAttachment.data`);
-    /// `maxAttachments` bounds how many at once.
+    /// The upload streams from disk in frames, so any size uploads fine regardless of
+    /// divisibility; this is just the pre-send size gate.
     private static let maxFileBytes = 100 * 1024 * 1024
     /// How many files can be staged at once. Each sends as its own gram message.
-    /// Bounded to 3 (was 10) now that the per-file cap is 100 MB: staged files are
-    /// read whole into memory, so this caps the worst case at 3 × 100 MB ≈ 300 MB
-    /// resident rather than ~1 GB — safe on a phone while still allowing a small batch.
-    private static let maxAttachments = 3
+    ///
+    /// 10, matching the photo picker's `maxSelectionCount`. It was cut to 3 when a
+    /// staged file was held in memory as `Data`: ten 100 MB picks would have been
+    /// ~1 GB resident. Staged bytes now live in a temp file and the upload reads them
+    /// one frame at a time, so the resident ceiling is a single frame no matter how
+    /// many files are staged or how large they are. The send loop is serial and
+    /// `gram.post` consumes each staging file, so the daemon's 1 GiB aggregate
+    /// staging budget never sees more than one upload in flight.
+    private static let maxAttachments = 10
 
     /// The list the page renders: optimistic posts first, then the server snapshot
     /// with those posts de-duped out once the server reflects them.
@@ -268,7 +276,10 @@ struct GramView: View {
         // Poll while the page is open so new agent messages appear without a manual
         // refresh (the gram store has no event stream); the loop ends when the view
         // goes away (task cancellation).
-        .task { await pollLoop() }
+        .task {
+            Self.sweepAbandonedStaging()
+            await pollLoop()
+        }
         // The sidebar's refresh button bumps `refreshToken`; consume the change here so a
         // sibling column can drive this view's async reload without owning its state. Guarded on
         // a real change (SwiftUI may re-run the body for unrelated reasons) and on `initial:
@@ -373,6 +384,10 @@ struct GramView: View {
             openFileTask?.cancel()
             if let previewURL { try? FileManager.default.removeItem(at: previewURL) }
             if let url = webDoc?.fileURL { try? FileManager.default.removeItem(at: url) }
+            // Staged attachment bytes are ours to remove: nothing else references
+            // them once the page is gone. `.interactiveDismissDisabled(sending ||
+            // loadingPhoto)` keeps this from firing mid-send.
+            for file in attachedFiles { try? FileManager.default.removeItem(at: file.dir) }
         }
         // Don't let a swipe-down (the new sheet dismissal) abandon an in-flight send
         // or a photo load mid-way — the chunked upload would keep running off-screen.
@@ -871,10 +886,13 @@ struct GramView: View {
                 .lineLimit(1)
                 .truncationMode(.middle)
                 .frame(maxWidth: 140)
-            Text(GramFile.displaySize(of: UInt64(file.data.count)))
+            Text(GramFile.displaySize(of: UInt64(file.size)))
                 .font(Typography.machine(11))
                 .foregroundStyle(Palette.textFaint)
             Button {
+                // Remove the staged bytes with the chip: a dropped attachment must
+                // not leave a secret-bearing temp file behind.
+                try? FileManager.default.removeItem(at: file.dir)
                 attachedFiles.removeAll { $0.id == file.id }
             } label: {
                 Image(systemName: "xmark.circle.fill")
@@ -1069,8 +1087,8 @@ struct GramView: View {
             let caption = index == 0 ? text : ""
             do {
                 uploading = true
-                uploadBytes = (sent: 0, total: file.data.count)
-                let uploadID = try await client.gramUploadFile(file.data) { sent, total in
+                uploadBytes = (sent: 0, total: file.size)
+                let uploadID = try await client.gramUploadFile(fileURL: file.url) { sent, total in
                     uploadBytes = (sent: sent, total: total)
                 }
                 uploading = false
@@ -1098,6 +1116,13 @@ struct GramView: View {
         // for a one-tap retry; a full success clears the strip. Already-sent messages
         // are live and are not rolled back.
         attachedFiles = remaining
+        // Drop the staged bytes of everything that DID send — after reassigning, so
+        // a failed delete cannot corrupt the retry set. Files still in `remaining`
+        // keep their temp dirs for the one-tap retry.
+        let keptIDs = Set(remaining.map(\.id))
+        for file in files where !keptIDs.contains(file.id) {
+            try? FileManager.default.removeItem(at: file.dir)
+        }
         if let failure {
             sendError = sentCount > 0
                 ? "Sent \(sentCount) of \(files.count). \(failure)"
@@ -1117,10 +1142,13 @@ struct GramView: View {
         return "Skipped: " + parts.joined(separator: "; ") + "."
     }
 
-    /// Read picked files into memory (each bounded by the server's size cap) so each
-    /// send is one atomic action. File URLs from the importer are security-scoped.
-    /// Over-cap / unreadable picks are COLLECTED into one summary rather than dropped
-    /// silently, so picking several where one is bad still stages the good ones.
+    /// Stage picked files as COPIES ON DISK (each bounded by the server's size cap),
+    /// so the send streams from a file rather than holding it in memory. File URLs
+    /// from the importer are security-scoped, so the copy must happen inside the
+    /// access window below — the URL is unreadable after it.
+    /// Over-cap / unreadable / uncopyable picks are COLLECTED into one summary rather
+    /// than dropped silently, so picking several where one is bad still stages the
+    /// good ones.
     private func handlePickedFiles(_ result: Result<[URL], Error>) {
         guard case .success(let urls) = result else { return }
         var badNames: [String] = []
@@ -1132,66 +1160,76 @@ struct GramView: View {
             }
             let scoped = url.startAccessingSecurityScopedResource()
             defer { if scoped { url.stopAccessingSecurityScopedResource() } }
-            // Require a KNOWN size within the cap BEFORE reading. An unstat-able URL
-            // (size lookup returns nil) is treated as over-cap and skipped, never read
-            // — otherwise a multi-gigabyte pick with no reported size would fall through
-            // to an unbounded Data(contentsOf:) and jetsam the app. Mirrors PickedMedia's
-            // guard so neither the document nor the photo path can read blind.
+            // Require a KNOWN size within the cap BEFORE copying. An unstat-able URL
+            // (size lookup returns nil) is treated as over-cap and skipped, never
+            // staged — otherwise a multi-gigabyte pick with no reported size would
+            // fall through to an unbounded copy and fill the device. `size > 0` also
+            // replaces the old non-empty check. Mirrors PickedMedia's guard so
+            // neither the document nor the photo path can stage blind.
             guard let size = try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize,
-                size <= Self.maxFileBytes
+                size > 0, size <= Self.maxFileBytes
             else {
                 badNames.append(url.lastPathComponent)
                 continue
             }
-            guard let data = try? Data(contentsOf: url), !data.isEmpty else {
+            guard let staged = Self.stageCopy(of: url, named: url.lastPathComponent) else {
                 badNames.append(url.lastPathComponent)
                 continue
             }
             attachedFiles.append(PickedAttachment(
-                name: url.lastPathComponent, mime: Self.mimeType(for: url), data: data))
+                name: url.lastPathComponent, mime: Self.mimeType(for: url),
+                url: staged.url, dir: staged.dir, size: staged.size))
         }
         let bad = badNames.isEmpty ? nil : "too large or unreadable: \(badNames.joined(separator: ", "))"
         sendError = attachmentSkipNote(bad: bad, capped: capped)
     }
 
-    /// A photo-library pick loaded as a size-checked file. PhotosUI exports the item to
-    /// a temp file; the importer stats that file and rejects an over-cap (or unstat-able)
-    /// pick THERE — `data == nil` — before any bytes are read, mirroring the document
-    /// path's "reject before reading into memory" guard.
+    /// A file staged on disk, app-owned: the bytes plus the per-item directory that
+    /// holds them (removing the directory removes the bytes).
+    private struct StagedFile {
+        let url: URL
+        let dir: URL
+        let size: Int
+    }
+
+    /// A photo-library pick copied into app-owned staging. PhotosUI exports the item
+    /// to a temp file and DELETES it when the closure returns, so the copy has to
+    /// happen inside `FileRepresentation`; the importer stats that export and rejects
+    /// an over-cap (or unstat-able) pick THERE — `staged == nil` — before any copy,
+    /// mirroring the document path's "reject before staging" guard.
     ///
-    /// Rejection is signalled as a VALUE (`data == nil`), NOT a thrown error, on purpose:
-    /// `loadTransferable` routes through NSItemProvider's Obj-C error bridge, across which
-    /// a thrown Swift error type may not survive — so a `nil` payload is the only reliable
-    /// way to carry "rejected" back and still show the right message.
+    /// Rejection is signalled as a VALUE (`staged == nil`), NOT a thrown error, on
+    /// purpose: `loadTransferable` routes through NSItemProvider's Obj-C error bridge,
+    /// across which a thrown Swift error type may not survive — so a `nil` payload is
+    /// the only reliable way to carry "rejected" back and still show the right message.
     private struct PickedMedia: Transferable {
-        /// Non-nil only for an in-cap, readable pick; nil = rejected (over-cap OR the
-        /// exported file's size could not be determined — treated as over-cap, never
-        /// read blindly into memory).
-        let data: Data?
+        /// Non-nil only for an in-cap pick that was copied into staging; nil =
+        /// rejected (over-cap, size unknown — treated as over-cap — or uncopyable).
+        let staged: StagedFile?
         static var transferRepresentation: some TransferRepresentation {
             FileRepresentation(importedContentType: .item) { received in
                 // Unknown size is treated as OVER-cap (reject), never under-cap — an
-                // unstat-able export must not fall through to an unbounded read.
+                // unstat-able export must not fall through to an unbounded copy.
                 guard let size = try? received.file.resourceValues(forKeys: [.fileSizeKey]).fileSize,
-                    size <= GramView.maxFileBytes
+                    size > 0, size <= GramView.maxFileBytes
                 else {
-                    return PickedMedia(data: nil)
+                    return PickedMedia(staged: nil)
                 }
-                let data = try Data(contentsOf: received.file)
-                // Belt-and-braces, matching the document path: reject if the read somehow
-                // exceeded the stat'd size, so an over-cap Data can never reach the caller.
-                guard data.count <= GramView.maxFileBytes else { return PickedMedia(data: nil) }
-                return PickedMedia(data: data)
+                // Inside the closure: `received.file` is gone once it returns.
+                return PickedMedia(
+                    staged: GramView.stageCopy(
+                        of: received.file, named: received.file.lastPathComponent))
             }
         }
     }
 
     /// Load a batch of photo-library picks into `attachedFiles`. Each routes through
-    /// `PickedMedia` so the size cap is enforced on the exported file's size before
-    /// any bytes are read — the same invariant the document path holds. Loads SERIALLY
-    /// (not concurrently) so the memory ceiling stays at one file at a time, and
-    /// COLLECTS skips into one summary so picking five where one is oversized doesn't
-    /// silently eat the other four's outcome.
+    /// `PickedMedia` so the size cap is enforced on the exported file's size before it
+    /// is copied — the same invariant the document path holds. Loads SERIALLY (not
+    /// concurrently) to bound disk pressure and keep the staged order stable — the
+    /// send loop posts in this order and the caption rides on message 0 — and COLLECTS
+    /// skips into one summary so picking five where one is oversized doesn't silently
+    /// eat the other four's outcome.
     private func loadPickedPhotos(_ items: [PhotosPickerItem]) async {
         loadingPhoto = true
         defer { loadingPhoto = false }
@@ -1204,15 +1242,16 @@ struct GramView: View {
             }
             do {
                 // A nil transferable = couldn't produce a file; a non-nil transferable
-                // with a nil `data` = rejected by the size guard (over-cap / unstat-able).
+                // with a nil `staged` = rejected by the size guard, or the copy failed.
                 guard let media = try await item.loadTransferable(type: PickedMedia.self),
-                    let data = media.data, !data.isEmpty
+                    let staged = media.staged
                 else {
                     bad += 1
                     continue
                 }
                 let (name, mime) = Self.photoNameAndMime(for: item)
-                attachedFiles.append(PickedAttachment(name: name, mime: mime, data: data))
+                attachedFiles.append(PickedAttachment(
+                    name: name, mime: mime, url: staged.url, dir: staged.dir, size: staged.size))
             } catch {
                 bad += 1
             }
@@ -1349,6 +1388,60 @@ struct GramView: View {
             .trimmingCharacters(in: .whitespacesAndNewlines)
         if base.isEmpty || base == "." || base == ".." { return "file" }
         return base
+    }
+
+    /// Root of all attachment staging, one directory per app SESSION.
+    ///
+    /// The per-session level exists for the case where no cleanup path runs at all:
+    /// on a crash or a jetsam kill `onDisappear` never fires, so staged bytes would
+    /// otherwise sit in tmp untracked. A session directory makes every earlier
+    /// session's leftovers a single identifiable sibling the page's `.task` sweeps,
+    /// while the per-item directories inside it still give a per-chip unlink.
+    private static let stagingRoot = FileManager.default.temporaryDirectory
+        .appendingPathComponent("gram-staging", isDirectory: true)
+    private static let sessionStagingDirectory = stagingRoot
+        .appendingPathComponent(UUID().uuidString, isDirectory: true)
+
+    /// Copy a picked file into a fresh per-item staging directory, so the send can
+    /// stream it from disk and the app owns its lifetime. nil when the copy fails or
+    /// the copied file is empty / over the cap — the caller reports it as a skip.
+    private static func stageCopy(of source: URL, named name: String) -> StagedFile? {
+        let dir = sessionStagingDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        do {
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+            let destination = dir.appendingPathComponent(safeTempFileName(name))
+            try FileManager.default.copyItem(at: source, to: destination)
+            // `copyItem` does not set data protection, and every other temp write in
+            // this file uses `.completeFileProtection`. A staged gram attachment can
+            // be a secret; it must not be the one temp file here that sits unprotected.
+            try? FileManager.default.setAttributes(
+                [.protectionKey: FileProtectionType.complete], ofItemAtPath: destination.path)
+            guard let size = try? destination.resourceValues(forKeys: [.fileSizeKey]).fileSize,
+                size > 0, size <= maxFileBytes
+            else {
+                try? FileManager.default.removeItem(at: dir)
+                return nil
+            }
+            return StagedFile(url: destination, dir: dir, size: size)
+        } catch {
+            try? FileManager.default.removeItem(at: dir)
+            return nil
+        }
+    }
+
+    /// Remove staging left by PREVIOUS app sessions (a crash or jetsam runs no
+    /// cleanup). Bounded and stateless: every sibling of this session's directory is
+    /// by definition abandoned, since a session directory is named at launch.
+    private static func sweepAbandonedStaging() {
+        let manager = FileManager.default
+        guard let entries = try? manager.contentsOfDirectory(
+            at: stagingRoot, includingPropertiesForKeys: nil)
+        else { return }
+        let current = sessionStagingDirectory.lastPathComponent
+        for entry in entries where entry.lastPathComponent != current {
+            try? manager.removeItem(at: entry)
+        }
     }
 
     /// A file we should render as formatted HTML (a markdown source), by extension

--- a/App/GramView.swift
+++ b/App/GramView.swift
@@ -174,10 +174,8 @@ struct GramView: View {
         let size: Int
     }
 
-    /// Client-side attachment cap, mirroring the server's `MAX_FILE_BYTES` (100 MiB).
-    /// The upload streams from disk in frames, so any size uploads fine regardless of
-    /// divisibility; this is just the pre-send size gate.
-    private static let maxFileBytes = 100 * 1024 * 1024
+    // The pre-send size gate lives on `Staging` (nonisolated, so the photo importer
+    // can read it): `GramView.Staging.maxFileBytes`.
     /// How many files can be staged at once. Each sends as its own gram message.
     ///
     /// 10, matching the photo picker's `maxSelectionCount`. It was cut to 3 when a
@@ -1167,12 +1165,12 @@ struct GramView: View {
             // replaces the old non-empty check. Mirrors PickedMedia's guard so
             // neither the document nor the photo path can stage blind.
             guard let size = try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize,
-                size > 0, size <= Self.maxFileBytes
+                size > 0, size <= Staging.maxFileBytes
             else {
                 badNames.append(url.lastPathComponent)
                 continue
             }
-            guard let staged = Self.stageCopy(of: url, named: url.lastPathComponent) else {
+            guard let staged = Staging.copy(of: url, named: url.lastPathComponent) else {
                 badNames.append(url.lastPathComponent)
                 continue
             }
@@ -1205,13 +1203,13 @@ struct GramView: View {
                 // Unknown size is treated as OVER-cap (reject), never under-cap — an
                 // unstat-able export must not fall through to an unbounded copy.
                 guard let size = try? received.file.resourceValues(forKeys: [.fileSizeKey]).fileSize,
-                    size > 0, size <= GramView.maxFileBytes
+                    size > 0, size <= GramView.Staging.maxFileBytes
                 else {
                     return PickedMedia(staged: nil)
                 }
                 // Inside the closure: `received.file` is gone once it returns.
                 return PickedMedia(
-                    staged: GramView.stageCopy(
+                    staged: GramView.Staging.copy(
                         of: received.file, named: received.file.lastPathComponent))
             }
         }
@@ -1384,43 +1382,59 @@ struct GramView: View {
         return base
     }
 
-    /// Root of all attachment staging, one directory per app SESSION.
+    /// Attachment staging, deliberately in a NESTED TYPE rather than on `GramView`.
     ///
-    /// The per-session level exists for the case where no cleanup path runs at all:
-    /// on a crash or a jetsam kill `onDisappear` never fires, so staged bytes would
-    /// otherwise sit in tmp untracked. A session directory makes every earlier
-    /// session's leftovers a single identifiable sibling the page's `.task` sweeps,
-    /// while the per-item directories inside it still give a per-chip unlink.
-    private static let stagingRoot = FileManager.default.temporaryDirectory
-        .appendingPathComponent("gram-staging", isDirectory: true)
-    private static let sessionStagingDirectory = stagingRoot
-        .appendingPathComponent(UUID().uuidString, isDirectory: true)
+    /// `View` is `@MainActor`, so everything on `GramView` inherits that isolation —
+    /// but `PickedMedia`'s `FileRepresentation` importer is a nonisolated `@Sendable`
+    /// closure, so calling a main-actor static from it is a cross-actor call (a hard
+    /// error for a method). A nested type does NOT inherit the enclosing isolation,
+    /// which is what is wanted here twice over: the importer can call it directly,
+    /// and copying a 100 MB pick never runs on the main actor.
+    ///
+    /// One staging directory per app SESSION. That level exists for the case where no
+    /// cleanup path runs at all: on a crash or a jetsam kill `onDisappear` never
+    /// fires, so staged bytes would otherwise sit in tmp untracked. A session
+    /// directory makes every earlier session's leftovers a single identifiable
+    /// sibling for the launch-time sweep, while the per-item directories inside it
+    /// still give a per-chip unlink.
+    enum Staging {
+        /// Client-side attachment cap, mirroring the server's `MAX_FILE_BYTES`
+        /// (100 MiB) and inclusive as the server's is. The upload streams from disk
+        /// in frames, so any size uploads fine regardless of divisibility; this is
+        /// just the pre-send size gate.
+        static let maxFileBytes = 100 * 1024 * 1024
 
-    /// Copy a picked file into app-owned staging, so the send streams it from disk
-    /// and the app owns its lifetime. nil when the copy fails or the copied file is
-    /// empty / over the cap — the caller reports it as a skip.
-    ///
-    /// The work is `HerdrKit.GramStaging`'s, not this file's: this target is iOS-only
-    /// and cannot run on CI, and a staging bug here is silent (it renders as the same
-    /// "unreadable pick" message as a genuinely bad file). In HerdrKit it is tested.
-    private static func stageCopy(of source: URL, named name: String) -> StagedAttachment? {
-        GramStaging.stageCopy(
-            of: source, named: name, in: sessionStagingDirectory, maxBytes: maxFileBytes)
-    }
+        static let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("gram-staging", isDirectory: true)
+        static let session = root
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
 
-    /// Remove staging left by PREVIOUS app sessions (a crash or jetsam runs no
-    /// cleanup).
-    ///
-    /// Called from the app root's `.task`, not this page's: bytes from a killed
-    /// session must be reclaimed even in a launch where the Gram tab is never opened.
-    /// Off the main actor because the unlink is a synchronous recursive walk and the
-    /// abandoned set can be ten 100 MB attachments.
-    static func sweepAbandonedStagingOffMainActor() async {
-        let root = stagingRoot
-        let current = sessionStagingDirectory.lastPathComponent
-        await Task.detached(priority: .utility) {
-            GramStaging.sweepAbandoned(root: root, keeping: current)
-        }.value
+        /// Copy a picked file into app-owned staging, so the send streams it from
+        /// disk and the app owns its lifetime. nil when the copy fails or the copied
+        /// file is empty / over the cap — the caller reports it as a skip.
+        ///
+        /// The work is `HerdrKit.GramStaging`'s, not this file's: this target is
+        /// iOS-only and cannot run on CI, and a staging bug here is silent (it
+        /// renders as the same "unreadable pick" message as a genuinely bad file).
+        /// In HerdrKit it is tested.
+        static func copy(of source: URL, named name: String) -> StagedAttachment? {
+            GramStaging.stageCopy(of: source, named: name, in: session, maxBytes: maxFileBytes)
+        }
+
+        /// Remove staging left by PREVIOUS app sessions (a crash or jetsam runs no
+        /// cleanup).
+        ///
+        /// Called from the app root's `.task`, not the Gram page's: bytes from a
+        /// killed session must be reclaimed even in a launch where the Gram tab is
+        /// never opened. Off the main actor because the unlink is a synchronous
+        /// recursive walk and the abandoned set can be ten 100 MB attachments.
+        static func sweepAbandonedOffMainActor() async {
+            let stagingRoot = root
+            let current = session.lastPathComponent
+            await Task.detached(priority: .utility) {
+                GramStaging.sweepAbandoned(root: stagingRoot, keeping: current)
+            }.value
+        }
     }
 
     /// A file we should render as formatted HTML (a markdown source), by extension

--- a/App/GramView.swift
+++ b/App/GramView.swift
@@ -1101,7 +1101,16 @@ struct GramView: View {
                 sentCount += 1
                 if index == 0 { draft = "" }
             } catch let error as APIError {
-                failure = error.message
+                // `upload_in_progress` here means the daemon has not yet reaped the
+                // upload connection this file just used — the streamed upload waits
+                // for that teardown, but the wait is bounded, so on a stalled link it
+                // can return first. The file itself is fine and the staged copy is
+                // kept below, so this is a retry, not a failure: the daemon's own
+                // sentence ("read the upload connection to EOF") would be meaningless
+                // to the owner.
+                failure = error.code == "upload_in_progress"
+                    ? "Still finishing the last upload. Tap Send again."
+                    : error.message
                 remaining.append(contentsOf: files[index...])
                 break
             } catch {

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -235,7 +235,7 @@ struct RootView: View {
         // jetsam kill runs no cleanup) here rather than on the Gram page: bytes from a
         // killed session — up to ten 100 MB attachments — would otherwise survive every
         // launch in which the user never opens the Gram tab.
-        .task { await GramView.sweepAbandonedStagingOffMainActor() }
+        .task { await GramView.Staging.sweepAbandonedOffMainActor() }
     }
 
     @ViewBuilder

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -231,6 +231,11 @@ struct RootView: View {
             #endif
         }
         .preferredColorScheme(.dark)
+        // Reclaim gram attachment staging left by a PREVIOUS session (a crash or a
+        // jetsam kill runs no cleanup) here rather than on the Gram page: bytes from a
+        // killed session — up to ten 100 MB attachments — would otherwise survive every
+        // launch in which the user never opens the Gram tab.
+        .task { await GramView.sweepAbandonedStagingOffMainActor() }
     }
 
     @ViewBuilder

--- a/Sources/HerdrKit/CitadelTransport.swift
+++ b/Sources/HerdrKit/CitadelTransport.swift
@@ -431,6 +431,26 @@ public actor CitadelTransport: HerdrTransport {
         )
     }
 
+    /// Opens a streaming upload channel for one gram attachment: a dedicated SSH
+    /// exec channel running `herdr api-bridge --duplex`, over which
+    /// `GramUploadChannel` writes chunk frames to the daemon's
+    /// `gram.upload.stream`. Its OWN connection, like `stream` and
+    /// `openInputChannel`, so a multi-MB upload never blocks the shared command
+    /// client or the `pane.stream` firehose. `openLine` is the JSON
+    /// `gram.upload.stream` open request the `--duplex` bridge reads first.
+    ///
+    /// Deliberately NOT part of `HerdrTransport`: that protocol has two members,
+    /// and a third would force an implementation into all 21 conformances (18 of
+    /// them test doubles) for no gain. The downcast is what makes every double
+    /// take the per-chunk fallback path automatically.
+    public nonisolated func openUploadChannel(_ openLine: String) -> GramUploadChannel {
+        GramUploadChannel(
+            makeConnection: { try await self.makeConnection() },
+            command: Self.herdrPathResolution + "--duplex",
+            openLine: openLine
+        )
+    }
+
     /// Closes the held SSH connection. Idempotent.
     public func close() async {
         // Invalidate any in-flight connect so a handshake that resolves after this

--- a/Sources/HerdrKit/GramStaging.swift
+++ b/Sources/HerdrKit/GramStaging.swift
@@ -1,0 +1,101 @@
+import Foundation
+
+/// A gram attachment staged on disk: the bytes, plus the per-item directory that
+/// holds them. Removing `dir` removes the staged bytes.
+public struct StagedAttachment: Equatable, Sendable {
+    public let url: URL
+    public let dir: URL
+    public let size: Int
+
+    public init(url: URL, dir: URL, size: Int) {
+        self.url = url
+        self.dir = dir
+        self.size = size
+    }
+}
+
+/// Filesystem staging for gram attachments: copy a pick into app-owned storage so
+/// the upload streams it from disk instead of holding it in memory, and reclaim
+/// what a killed session left behind.
+///
+/// This lives in HerdrKit rather than beside the composer for ONE reason: the app
+/// target is iOS-only and cannot be compiled — let alone run — on Linux CI, so
+/// staging logic kept there is verified by reading. A missing copy is not a
+/// compile error and produces exactly the same "picked file was unreadable"
+/// message as a genuinely unreadable pick; that defect shipped once and was caught
+/// by review, not by a test. Here it is exercised on every CI run.
+public enum GramStaging {
+    /// Copy `source` into a fresh per-item directory under `sessionDirectory` and
+    /// return it, or nil when the copy fails or the copied file is empty or over
+    /// `maxBytes`. The per-item directory is removed on every failure path, so a
+    /// rejected pick leaves nothing behind.
+    ///
+    /// The caller stats the source first (an unstat-able pick must never reach an
+    /// unbounded copy); this re-checks the COPY, which is the file the upload will
+    /// actually read.
+    public static func stageCopy(
+        of source: URL,
+        named name: String,
+        in sessionDirectory: URL,
+        maxBytes: Int
+    ) -> StagedAttachment? {
+        let dir = sessionDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        do {
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+            let destination = dir.appendingPathComponent(safeFileName(name))
+            try FileManager.default.copyItem(at: source, to: destination)
+            protectStagedFile(at: destination)
+            guard let size = try? destination.resourceValues(forKeys: [.fileSizeKey]).fileSize,
+                size > 0, size <= maxBytes
+            else {
+                try? FileManager.default.removeItem(at: dir)
+                return nil
+            }
+            return StagedAttachment(url: destination, dir: dir, size: size)
+        } catch {
+            try? FileManager.default.removeItem(at: dir)
+            return nil
+        }
+    }
+
+    /// Remove every session directory under `root` except `keeping`. Bounded and
+    /// stateless: a sibling of the current session's directory is by definition
+    /// abandoned, because a session directory is named once at launch.
+    public static func sweepAbandoned(root: URL, keeping current: String) {
+        let manager = FileManager.default
+        guard
+            let entries = try? manager.contentsOfDirectory(
+                at: root, includingPropertiesForKeys: nil)
+        else { return }
+        for entry in entries where entry.lastPathComponent != current {
+            try? manager.removeItem(at: entry)
+        }
+    }
+
+    /// Reduce a client-supplied name to a safe single path component: strip
+    /// directory parts, replace separators, and never `.`/`..`.
+    public static func safeFileName(_ name: String) -> String {
+        let base = URL(fileURLWithPath: name).lastPathComponent
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "\\", with: "_")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        if base.isEmpty || base == "." || base == ".." { return "file" }
+        return base
+    }
+
+    /// `copyItem` does not set data protection, and a staged gram attachment can be
+    /// a secret, so the class is set explicitly.
+    ///
+    /// `completeUnlessOpen`, NOT `complete`: the upload holds this file open across
+    /// its whole transfer and keeps running when the app is backgrounded. Class A
+    /// eviction fails reads even on an already-open descriptor, so locking the phone
+    /// mid-upload would abort the send; Class B keeps an open file readable while
+    /// still denying a new open while locked.
+    private static func protectStagedFile(at url: URL) {
+        #if canImport(Darwin)
+        try? FileManager.default.setAttributes(
+            [.protectionKey: FileProtectionType.completeUnlessOpen], ofItemAtPath: url.path)
+        #endif
+    }
+}

--- a/Sources/HerdrKit/GramUploadChannel.swift
+++ b/Sources/HerdrKit/GramUploadChannel.swift
@@ -150,10 +150,21 @@ public actor GramUploadChannel {
         buffer.writeString(line)
         buffer.writeInteger(UInt8(ascii: "\n"))
 
-        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-            pendingSeq = frameSeq
-            ackContinuation = continuation
-            framesCont.yield(buffer)
+        // A cancelled upload must not leave this task parked forever: nothing else
+        // resumes the ack (the resumers are an ack line, a frame error, `close()` and
+        // `markDead()`), and the caller's `defer`-based close cannot run while it is
+        // suspended here. Cancelling tears the channel down, which resumes the ack
+        // with `closedBeforeFrameAck`.
+        try Task.checkCancellation()
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation {
+                (continuation: CheckedContinuation<Void, Error>) in
+                pendingSeq = frameSeq
+                ackContinuation = continuation
+                framesCont.yield(buffer)
+            }
+        } onCancel: {
+            Task { await self.close() }
         }
     }
 
@@ -172,9 +183,15 @@ public actor GramUploadChannel {
 
     @available(macOS 15.0, *)
     private func run(_ frameStream: AsyncStream<ByteBuffer>) async {
+        // Held outside the `do` so a throw from `withExec` — a dropped link, a failed
+        // channel open, a write error mid-upload — still closes the SSH connection.
+        // Leaking it would strand one TCP session, one sshd session and one remote
+        // `api-bridge` process PER FILE, since each upload mints its own connection.
+        var connection: SSHClient?
         do {
             let client = try await makeConnection()
             self.client = client
+            connection = client
             try await client.withExec(command) { [weak self] inbound, stdin in
                 let reader = Task { [weak self] in
                     var accumulator = LineAccumulator()
@@ -195,10 +212,10 @@ public actor GramUploadChannel {
                     try await stdin.write(buffer)
                 }
             }
-            try? await client.close()
         } catch {
             // makeConnection / withExec failed before or during the channel.
         }
+        if let connection { try? await connection.close() }
         settleOpen(.failure(ChannelError.closedBeforeAck))
         markDead()
     }

--- a/Sources/HerdrKit/GramUploadChannel.swift
+++ b/Sources/HerdrKit/GramUploadChannel.swift
@@ -231,16 +231,33 @@ public actor GramUploadChannel {
         }
         let grace = await closeGraceNanoseconds
         Task {
-            // `try?`: a cancelled sleep must still fall through to the signal, or a
+            // `try?`: a cancelled sleep must still fall through to the teardown, or a
             // cancelled caller would hang on the gate forever.
             try? await Task.sleep(nanoseconds: grace)
             runner.cancel()
+            // Cancellation does NOT interrupt the runner's await on the SSH channel's
+            // close promise, so without this the parent connection is never closed:
+            // the actor would keep an `SSHClient`, a socket and a live Task for the
+            // kernel's whole retransmit budget, and — because the FIN is never even
+            // attempted — the daemon would see a channel that is open but silent,
+            // which is exactly the input that pins its single-writer claim. Same
+            // pattern as `CitadelTransport.close()`: tear the connection down locally
+            // rather than wait on a per-channel promise.
+            await self.closeConnection()
             await gate.signal()
         }
         await gate.wait()
     }
 
     private var closeGraceNanoseconds: UInt64 { closeGrace }
+
+    /// Closes the upload's own SSH connection and forgets it. Idempotent: the field
+    /// is cleared, so a later `run` tail close is a no-op rather than a double close.
+    private func closeConnection() async {
+        guard let client else { return }
+        self.client = nil
+        try? await client.close()
+    }
 
     /// One-shot rendezvous: whichever of the two observers finishes first releases
     /// the waiter, and the other's later signal is dropped.
@@ -276,15 +293,15 @@ public actor GramUploadChannel {
 
     @available(macOS 15.0, *)
     private func run(_ frameStream: AsyncStream<ByteBuffer>) async {
-        // Held outside the `do` so a throw from `withExec` — a dropped link, a failed
-        // channel open, a write error mid-upload — still closes the SSH connection.
-        // Leaking it would strand one TCP session, one sshd session and one remote
-        // `api-bridge` process PER FILE, since each upload mints its own connection.
-        var connection: SSHClient?
+        // The connection is closed through `closeConnection()` on every exit — a
+        // throw from `withExec` (dropped link, failed channel open, mid-upload write
+        // error) included. Leaking it would strand one TCP session, one sshd session
+        // and one remote `api-bridge` process PER FILE, since each upload mints its
+        // own connection. One teardown path also means the expiry branch in
+        // `closeAndWait` and this tail cannot double-close.
         do {
             let client = try await makeConnection()
             self.client = client
-            connection = client
             try await client.withExec(command) { [weak self] inbound, stdin in
                 let reader = Task { [weak self] in
                     var accumulator = LineAccumulator()
@@ -316,7 +333,7 @@ public actor GramUploadChannel {
         } catch {
             // makeConnection / withExec failed before or during the channel.
         }
-        if let connection { try? await connection.close() }
+        await closeConnection()
         settleOpen(.failure(ChannelError.closedBeforeAck))
         markDead()
     }

--- a/Sources/HerdrKit/GramUploadChannel.swift
+++ b/Sources/HerdrKit/GramUploadChannel.swift
@@ -1,0 +1,279 @@
+import Citadel
+import Foundation
+import NIOCore
+
+/// A streaming upload channel for ONE gram attachment — the file-transfer mirror
+/// of `PaneInputChannel`. Holds a single SSH exec channel running
+/// `herdr api-bridge --duplex` open for the upload's lifetime and writes
+/// newline-delimited chunk frames to the daemon's `gram.upload.stream`, instead
+/// of one `herdr api-bridge` exec per chunk.
+///
+/// Why this exists: the per-chunk path (`gram.upload_chunk`) costs an SSH channel
+/// open, a non-login shell, a fresh `herdr` process, a unix-socket connect and a
+/// teardown FOR EVERY CHUNK — 2133 of them for a 100 MB file, whose chunk size is
+/// itself pinned at 48 KiB by the argv cap. Uploads are round-trip bound, not
+/// bandwidth bound. One held channel with 512 KiB frames removes both limits.
+///
+/// Three deliberate differences from `PaneInputChannel`:
+///
+/// 1. The encoder must not escape `/`. Base64 is slash-dense (an all-`0xFF` chunk
+///    is ALL `/`), and JSONEncoder's default escaping nearly doubles those bytes.
+/// 2. `sendChunk` AWAITS the daemon's ack. Fire-and-forget is right for
+///    keystrokes and catastrophic for a 100 MB file: the whole point of streaming
+///    from disk is that resident memory stays at one chunk, which an unbounded
+///    queue would undo. The ack is also the only place a rejected chunk can
+///    surface, since an upload has no echo channel.
+/// 3. `remoteError` carries a DECODED `APIError`, because the caller must tell
+///    "this daemon has no such method" (fall back) from "offset mismatch" or
+///    "another stream owns this upload" (do not).
+public actor GramUploadChannel {
+    public enum ChannelError: Error, Equatable {
+        case unsupported
+        case closedBeforeAck
+        /// A frame or open error from the daemon, decoded rather than raw: the
+        /// caller needs `code`/`message` to tell "old daemon" and "offset
+        /// mismatch" apart.
+        case remoteError(APIError)
+        /// The channel died between writing a frame and its ack.
+        case closedBeforeFrameAck
+    }
+
+    /// One chunk. `offset` is the byte position, which the daemon validates
+    /// against the staged size (staging is append-only), so frames MUST be sent
+    /// in order — which is also why one outstanding ack is enough.
+    private struct Frame: Encodable {
+        let seq: UInt64
+        let offset: UInt64
+        let dataBase64: String
+        enum CodingKeys: String, CodingKey {
+            case seq, offset
+            case dataBase64 = "data_base64"
+        }
+    }
+
+    /// The daemon's two reply shapes: an open error carries `id`, a frame ack or
+    /// frame error carries `seq`.
+    private struct WireLine: Decodable {
+        struct Body: Decodable {
+            let code: String?
+            let message: String?
+        }
+        let seq: UInt64?
+        let ok: Bool?
+        let error: Body?
+    }
+
+    private let makeConnection: @Sendable () async throws -> SSHClient
+    private let command: String
+    private let openLine: String
+    private static let encoder: JSONEncoder = {
+        let encoder = JSONEncoder()
+        // Base64 payloads are slash-dense; default escaping would inflate a
+        // 700 KB frame toward the daemon's 1 MiB frame cap for nothing.
+        encoder.outputFormatting = [.withoutEscapingSlashes]
+        return encoder
+    }()
+    private let decoder = JSONDecoder()
+
+    private var framesCont: AsyncStream<ByteBuffer>.Continuation?
+    private var runner: Task<Void, Never>?
+    private var client: SSHClient?
+    private var seq: UInt64 = 0
+    private var live = false
+
+    // The open handshake resolves exactly once: on the daemon's first stdout line
+    // (an ok ack, or an error line an old daemon returns for the unknown method),
+    // or when the channel dies before any line arrives. `openOutcome` buffers the
+    // result if it settles before `start()` parks its continuation.
+    private var openContinuation: CheckedContinuation<Void, Error>?
+    private var openOutcome: Result<Void, Error>?
+    private var openSettled = false
+
+    // Frames are strictly sequential, so ONE ack slot suffices.
+    private var ackContinuation: CheckedContinuation<Void, Error>?
+    private var pendingSeq: UInt64?
+
+    init(
+        makeConnection: @escaping @Sendable () async throws -> SSHClient,
+        command: String,
+        openLine: String
+    ) {
+        self.makeConnection = makeConnection
+        self.command = command
+        self.openLine = openLine
+    }
+
+    /// Encodes one frame line. A static seam so the property that makes 512 KiB
+    /// frames legal — a slash-heavy chunk stays inside the daemon's 1 MiB frame
+    /// cap — is testable without an SSH connection.
+    static func encodeFrame(seq: UInt64, offset: UInt64, dataBase64: String) throws -> String {
+        let data = try encoder.encode(Frame(seq: seq, offset: offset, dataBase64: dataBase64))
+        return String(decoding: data, as: UTF8.self)
+    }
+
+    /// Opens the channel, writes the `gram.upload.stream` open line, and awaits
+    /// the daemon's ack. Throws `unsupported` when `withExec` is unavailable
+    /// (macOS < 15; never on iOS 17+), `remoteError` when the daemon refuses the
+    /// open, and `closedBeforeAck` on any transport failure — the caller then
+    /// falls back to per-chunk uploads.
+    public func start() async throws {
+        guard #available(macOS 15.0, *) else { throw ChannelError.unsupported }
+
+        let (stream, cont) = AsyncStream<ByteBuffer>.makeStream()
+        framesCont = cont
+        // Single ordered writer: the open line goes first, then chunk frames.
+        cont.yield(ByteBuffer(string: openLine + "\n"))
+
+        runner = Task { [weak self] in
+            await self?.run(stream)
+        }
+
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            if let outcome = openOutcome {
+                continuation.resume(with: outcome)
+            } else {
+                openContinuation = continuation
+            }
+        }
+    }
+
+    /// Writes one chunk frame and awaits its ack, so a large file cannot queue in
+    /// memory and a rejected chunk surfaces at the chunk that caused it.
+    public func sendChunk(offset: UInt64, dataBase64: String) async throws {
+        guard live, let framesCont else { throw ChannelError.closedBeforeFrameAck }
+        seq &+= 1
+        let frameSeq = seq
+        let line = try Self.encodeFrame(seq: frameSeq, offset: offset, dataBase64: dataBase64)
+
+        var buffer = ByteBuffer()
+        buffer.reserveCapacity(line.utf8.count + 1)
+        buffer.writeString(line)
+        buffer.writeInteger(UInt8(ascii: "\n"))
+
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            pendingSeq = frameSeq
+            ackContinuation = continuation
+            framesCont.yield(buffer)
+        }
+    }
+
+    /// Tears the channel down: finishing the frame stream returns from `withExec`,
+    /// closing the SSH channel (the remote bridge then sees stdin EOF and exits,
+    /// which is the daemon's clean end-of-upload signal). Idempotent.
+    public func close() {
+        live = false
+        framesCont?.finish()
+        framesCont = nil
+        runner?.cancel()
+        resumeAck(.failure(ChannelError.closedBeforeFrameAck))
+    }
+
+    // MARK: - internals
+
+    @available(macOS 15.0, *)
+    private func run(_ frameStream: AsyncStream<ByteBuffer>) async {
+        do {
+            let client = try await makeConnection()
+            self.client = client
+            try await client.withExec(command) { [weak self] inbound, stdin in
+                let reader = Task { [weak self] in
+                    var accumulator = LineAccumulator()
+                    do {
+                        for try await chunk in inbound {
+                            guard case .stdout(let bytes) = chunk else { continue }
+                            for line in accumulator.append(bytes) {
+                                await self?.handleLine(line)
+                            }
+                        }
+                    } catch {
+                        // stdout closed/errored: the channel is done; the writer
+                        // loop below unwinds when its stream finishes.
+                    }
+                }
+                defer { reader.cancel() }
+                for await buffer in frameStream {
+                    try await stdin.write(buffer)
+                }
+            }
+            try? await client.close()
+        } catch {
+            // makeConnection / withExec failed before or during the channel.
+        }
+        settleOpen(.failure(ChannelError.closedBeforeAck))
+        markDead()
+    }
+
+    private func handleLine(_ line: String) {
+        guard let wire = decode(line) else { return }
+
+        if !openSettled {
+            if let error = wire.error {
+                settleOpen(.failure(ChannelError.remoteError(apiError(from: error))))
+                markDead()
+            } else {
+                live = true
+                settleOpen(.success(()))
+            }
+            return
+        }
+
+        if let error = wire.error {
+            // A frame error is terminal: staging is append-only, so the daemon
+            // closes the channel and the upload cannot continue on it.
+            resumeAck(.failure(ChannelError.remoteError(apiError(from: error))))
+            markDead()
+            return
+        }
+
+        guard wire.ok == true, let seq = wire.seq else { return }
+        guard seq == pendingSeq else {
+            // An ack for a frame we are not waiting on means the channel and the
+            // client disagree about ordering; treat it as fatal rather than
+            // silently accepting a chunk that may not have landed.
+            resumeAck(
+                .failure(
+                    ChannelError.remoteError(
+                        APIError(
+                            code: "invalid_sequence",
+                            message: "ack for seq \(seq) while awaiting \(pendingSeq.map(String.init) ?? "none")"
+                        ))))
+            markDead()
+            return
+        }
+        resumeAck(.success(()))
+    }
+
+    private func decode(_ line: String) -> WireLine? {
+        guard let data = line.data(using: .utf8) else { return nil }
+        return try? decoder.decode(WireLine.self, from: data)
+    }
+
+    private func apiError(from body: WireLine.Body) -> APIError {
+        APIError(code: body.code ?? "stream_failed", message: body.message ?? "upload stream failed")
+    }
+
+    private func settleOpen(_ result: Result<Void, Error>) {
+        guard !openSettled else { return }
+        openSettled = true
+        if let continuation = openContinuation {
+            openContinuation = nil
+            continuation.resume(with: result)
+        } else {
+            openOutcome = result
+        }
+    }
+
+    private func resumeAck(_ result: Result<Void, Error>) {
+        guard let continuation = ackContinuation else { return }
+        ackContinuation = nil
+        pendingSeq = nil
+        continuation.resume(with: result)
+    }
+
+    private func markDead() {
+        live = false
+        framesCont?.finish()
+        framesCont = nil
+        resumeAck(.failure(ChannelError.closedBeforeFrameAck))
+    }
+}

--- a/Sources/HerdrKit/GramUploadChannel.swift
+++ b/Sources/HerdrKit/GramUploadChannel.swift
@@ -171,12 +171,43 @@ public actor GramUploadChannel {
     /// Tears the channel down: finishing the frame stream returns from `withExec`,
     /// closing the SSH channel (the remote bridge then sees stdin EOF and exits,
     /// which is the daemon's clean end-of-upload signal). Idempotent.
+    ///
+    /// Does NOT wait for that teardown to complete. Use [`closeAndWait`] when the
+    /// next action depends on the daemon having observed the close.
     public func close() {
         live = false
         framesCont?.finish()
         framesCont = nil
         runner?.cancel()
         resumeAck(.failure(ChannelError.closedBeforeFrameAck))
+    }
+
+    /// Closes the channel and waits until the SSH session is actually gone.
+    ///
+    /// The daemon releases its single-writer claim on the `upload_id` only when it
+    /// observes EOF on this connection, and it now REFUSES a `gram.post` that would
+    /// finalize an upload a stream still owns. So an upload followed by a post must
+    /// order the two: returning while the teardown is still in flight makes the post
+    /// race the claim release and fail with `upload_in_progress` after a completely
+    /// successful upload.
+    ///
+    /// `nonisolated` on purpose: awaiting the runner must NOT hold this actor, or the
+    /// runner's own calls back into it (`handleLine`, `markDead`) could never land.
+    /// The runner is not cancelled here — the stream finishing is what unwinds
+    /// `withExec` gracefully, and cancelling could cut the SSH close short.
+    public nonisolated func closeAndWait() async {
+        let runner = await beginGracefulClose()
+        await runner?.value
+    }
+
+    private func beginGracefulClose() -> Task<Void, Never>? {
+        live = false
+        framesCont?.finish()
+        framesCont = nil
+        resumeAck(.failure(ChannelError.closedBeforeFrameAck))
+        let pending = runner
+        runner = nil
+        return pending
     }
 
     // MARK: - internals
@@ -203,9 +234,17 @@ public actor GramUploadChannel {
                             }
                         }
                     } catch {
-                        // stdout closed/errored: the channel is done; the writer
-                        // loop below unwinds when its stream finishes.
+                        // stdout closed/errored.
                     }
+                    // The reader is the ONLY observer of the remote side, so it must
+                    // tear the actor down itself. Nothing else can: the writer loop
+                    // below is parked on `frameStream`, which only `markDead`/`close`
+                    // finish, and the caller's `defer`-close cannot run while it is
+                    // suspended in `sendChunk` awaiting an ack. Without this, a daemon
+                    // that closes the channel with an ack outstanding deadlocks the
+                    // upload permanently — the composer stays `sending` and
+                    // undismissable until the app is force-quit.
+                    await self?.markDead()
                 }
                 defer { reader.cancel() }
                 for await buffer in frameStream {

--- a/Sources/HerdrKit/GramUploadChannel.swift
+++ b/Sources/HerdrKit/GramUploadChannel.swift
@@ -193,21 +193,67 @@ public actor GramUploadChannel {
     ///
     /// `nonisolated` on purpose: awaiting the runner must NOT hold this actor, or the
     /// runner's own calls back into it (`handleLine`, `markDead`) could never land.
-    /// The runner is not cancelled here — the stream finishing is what unwinds
-    /// `withExec` gracefully, and cancelling could cut the SSH close short.
+    ///
+    /// BOUNDED, and the shape of that bound matters. The runner finishes only once
+    /// NIOSSH succeeds its close promise, which it does only when the PEER's
+    /// CHANNEL_CLOSE arrives — there is no timer on that path, and cancelling a Task
+    /// does NOT interrupt an await on a NIO promise. So the deadline must not be a
+    /// task group: `group.cancelAll()` cannot make a child awaiting `runner.value`
+    /// return, and the group's scope waits for every child, which would leave this
+    /// exactly as unbounded as a bare `await runner.value`. Instead both observers
+    /// are UNSTRUCTURED and signal a one-shot gate, so this returns on the deadline
+    /// whatever the runner is doing. A half-open TCP (cell handoff, Wi-Fi drop, NAT
+    /// rebind) would otherwise park here for the kernel's whole retransmit budget and
+    /// wedge the composer exactly as the deadlocking reader used to. Waiting longer
+    /// buys nothing anyway: the daemon frees its claim when the socket dies.
     public nonisolated func closeAndWait() async {
-        let runner = await beginGracefulClose()
-        await runner?.value
+        guard let runner = await beginGracefulClose() else { return }
+        let gate = CloseGate()
+        Task {
+            await runner.value
+            await gate.signal()
+        }
+        Task {
+            try? await Task.sleep(nanoseconds: Self.closeGraceNanoseconds)
+            runner.cancel()
+            await gate.signal()
+        }
+        await gate.wait()
     }
 
+    /// One-shot rendezvous: whichever of the two observers finishes first releases
+    /// the waiter, and the other's later signal is dropped.
+    private actor CloseGate {
+        private var continuation: CheckedContinuation<Void, Never>?
+        private var signalled = false
+
+        func wait() async {
+            if signalled { return }
+            await withCheckedContinuation { continuation = $0 }
+        }
+
+        func signal() {
+            guard !signalled else { return }
+            signalled = true
+            continuation?.resume()
+            continuation = nil
+        }
+    }
+
+    /// How long a close may wait for the SSH session to go away before the runner is
+    /// cancelled. Generous for a live link (the frames are already acked, so this is
+    /// just channel teardown) and short enough that a dead link cannot hold the UI.
+    private static let closeGraceNanoseconds: UInt64 = 5 * 1_000_000_000
+
+    /// Finishes the frame stream and hands back the runner to await. The runner is
+    /// deliberately NOT nilled: `close()` must keep something to cancel, since
+    /// `Task<Void, Never>.value` ignores the awaiting task's own cancellation.
     private func beginGracefulClose() -> Task<Void, Never>? {
         live = false
         framesCont?.finish()
         framesCont = nil
         resumeAck(.failure(ChannelError.closedBeforeFrameAck))
-        let pending = runner
-        runner = nil
-        return pending
+        return runner
     }
 
     // MARK: - internals

--- a/Sources/HerdrKit/GramUploadChannel.swift
+++ b/Sources/HerdrKit/GramUploadChannel.swift
@@ -93,15 +93,27 @@ public actor GramUploadChannel {
     private var ackContinuation: CheckedContinuation<Void, Error>?
     private var pendingSeq: UInt64?
 
+    /// How long [`closeAndWait`] may wait for the SSH session to go away before the
+    /// runner is cancelled. Injectable for the same reason
+    /// `CitadelTransport.connectTimeoutNanoseconds` is: an unstructured race is only
+    /// provably bounded if a test can shorten the bound.
+    private let closeGrace: UInt64
+
     init(
         makeConnection: @escaping @Sendable () async throws -> SSHClient,
         command: String,
-        openLine: String
+        openLine: String,
+        closeGrace: UInt64 = GramUploadChannel.defaultCloseGraceNanoseconds
     ) {
         self.makeConnection = makeConnection
         self.command = command
         self.openLine = openLine
+        self.closeGrace = closeGrace
     }
+
+    /// Generous for a live link (the frames are already acked, so this is only
+    /// channel teardown) and short enough that a dead link cannot hold the UI.
+    static let defaultCloseGraceNanoseconds: UInt64 = 5 * 1_000_000_000
 
     /// Encodes one frame line. A static seam so the property that makes 512 KiB
     /// frames legal — a slash-heavy chunk stays inside the daemon's 1 MiB frame
@@ -204,8 +216,12 @@ public actor GramUploadChannel {
     /// are UNSTRUCTURED and signal a one-shot gate, so this returns on the deadline
     /// whatever the runner is doing. A half-open TCP (cell handoff, Wi-Fi drop, NAT
     /// rebind) would otherwise park here for the kernel's whole retransmit budget and
-    /// wedge the composer exactly as the deadlocking reader used to. Waiting longer
-    /// buys nothing anyway: the daemon frees its claim when the socket dies.
+    /// wedge the composer exactly as the deadlocking reader used to.
+    ///
+    /// On the EXPIRY path the daemon has NOT yet freed its claim on this `upload_id`
+    /// — that is precisely why we are returning early — so a `gram.post` issued next
+    /// can legitimately be refused `upload_in_progress`. The caller must present that
+    /// as retryable rather than as a failure; see `HerdrClient.gramUploadFile`.
     public nonisolated func closeAndWait() async {
         guard let runner = await beginGracefulClose() else { return }
         let gate = CloseGate()
@@ -213,13 +229,18 @@ public actor GramUploadChannel {
             await runner.value
             await gate.signal()
         }
+        let grace = await closeGraceNanoseconds
         Task {
-            try? await Task.sleep(nanoseconds: Self.closeGraceNanoseconds)
+            // `try?`: a cancelled sleep must still fall through to the signal, or a
+            // cancelled caller would hang on the gate forever.
+            try? await Task.sleep(nanoseconds: grace)
             runner.cancel()
             await gate.signal()
         }
         await gate.wait()
     }
+
+    private var closeGraceNanoseconds: UInt64 { closeGrace }
 
     /// One-shot rendezvous: whichever of the two observers finishes first releases
     /// the waiter, and the other's later signal is dropped.
@@ -239,11 +260,6 @@ public actor GramUploadChannel {
             continuation = nil
         }
     }
-
-    /// How long a close may wait for the SSH session to go away before the runner is
-    /// cancelled. Generous for a live link (the frames are already acked, so this is
-    /// just channel teardown) and short enough that a dead link cannot hold the UI.
-    private static let closeGraceNanoseconds: UInt64 = 5 * 1_000_000_000
 
     /// Finishes the frame stream and hands back the runner to await. The runner is
     /// deliberately NOT nilled: `close()` must keep something to cancel, since

--- a/Sources/HerdrKit/HerdrClient.swift
+++ b/Sources/HerdrKit/HerdrClient.swift
@@ -651,10 +651,20 @@ public actor HerdrClient {
                     as: JSONNull.self)
             }
             offset += chunk.count
-            if offset >= total || offset - lastReported >= reportStep {
+            // Throttle ONLY: no `offset >= total` disjunct. That condition is
+            // permanently true once the cursor passes the stat'd size, so a file that
+            // grew after being stat'd reported every single chunk — the exact main-actor
+            // flood the throttle exists to prevent. The terminal report is emitted once,
+            // after the loop.
+            if offset - lastReported >= reportStep {
                 lastReported = offset
                 await onProgress?(offset, max(total, offset))
             }
+        }
+        // One terminal report, so a determinate bar always lands on 100% — including
+        // for a file that SHRANK after the stat, where `offset < total` at EOF.
+        if lastReported != offset {
+            await onProgress?(offset, max(total, offset))
         }
         return uploadID
     }

--- a/Sources/HerdrKit/HerdrClient.swift
+++ b/Sources/HerdrKit/HerdrClient.swift
@@ -599,6 +599,12 @@ public actor HerdrClient {
         return uploadID
     }
 
+    /// A fresh `upload_id`. The daemon keys its staging file and its single-writer
+    /// claim on this, and validates it as one safe path component.
+    static func mintUploadID() -> String {
+        "app-" + UUID().uuidString.replacingOccurrences(of: "-", with: "")
+    }
+
     /// Uploads a file's bytes FROM DISK and returns the `upload_id` to attach to a
     /// `gramPost`.
     ///
@@ -614,7 +620,7 @@ public actor HerdrClient {
         fileURL: URL,
         onProgress: (@MainActor @Sendable (_ bytesSent: Int, _ totalBytes: Int) -> Void)? = nil
     ) async throws -> String {
-        let uploadID = "app-" + UUID().uuidString.replacingOccurrences(of: "-", with: "")
+        var uploadID = Self.mintUploadID()
         let attributes = try FileManager.default.attributesOfItem(atPath: fileURL.path)
         let total = (attributes[.size] as? NSNumber)?.intValue ?? 0
 
@@ -640,6 +646,14 @@ public actor HerdrClient {
                 // writer on the same upload_id.
                 await channel.close()
                 if let fatal = Self.fatalStreamOpenError(error) { throw fatal }
+                // Fall back under an id the daemon has NEVER seen. It takes its
+                // single-writer claim at OPEN — before it asks the app anything — and
+                // refuses a per-chunk write while that claim is held, so reusing this
+                // id can lose a race with the claim's release and fail the send with
+                // `upload_in_progress` for a reason unrelated to the file. Nothing
+                // outside this function keys on the id: the caller passes whatever is
+                // returned straight to `gramPost(attachment:)`.
+                uploadID = Self.mintUploadID()
             }
         }
         defer { if let channel { Task { await channel.close() } } }

--- a/Sources/HerdrKit/HerdrClient.swift
+++ b/Sources/HerdrKit/HerdrClient.swift
@@ -18,6 +18,10 @@ public actor HerdrClient {
     }()
     private let decoder = JSONDecoder()
     private var sequence: UInt64 = 0
+    /// Cached `ping` capabilities, so a multi-file send pays one probe, not one
+    /// per file. Reset to nil on a ping failure so a reconnected or upgraded
+    /// daemon is re-probed.
+    private var cachedCapabilities: ServerCapabilities?
 
     public init(transport: HerdrTransport) {
         self.transport = transport
@@ -503,6 +507,41 @@ public actor HerdrClient {
     /// lands around 87 KB of command — safely under the cap with headroom.
     static let gramUploadChunkBytes = 48 * 1024
 
+    /// Raw bytes per streamed frame. The streaming path has no argv, so the
+    /// 120 KB command cap does not apply; this is the daemon's own
+    /// `MAX_CHUNK_BYTES` (512 KiB), which keeps a base64 frame (~700 KB) under
+    /// its 1 MiB request-line ceiling.
+    static let gramStreamChunkBytes = 512 * 1024
+
+    struct GramUploadStreamParams: Encodable {
+        let uploadID: String
+        enum CodingKeys: String, CodingKey {
+            case uploadID = "upload_id"
+        }
+    }
+
+    /// Opens a streaming upload channel, or nil when this transport or daemon
+    /// cannot serve one. Feature-detected by `ping` CAPABILITY, never by
+    /// attempting the method: an unknown method comes back with an EMPTY `id` and
+    /// the connection closed, so the reply cannot be correlated to the attempt.
+    public func gramOpenUploadChannel(uploadID: String) async -> GramUploadChannel? {
+        guard let citadel = transport as? CitadelTransport else { return nil }
+        // `??` takes a non-async autoclosure, so the probe cannot be inlined
+        // into it. A failed or capability-less ping leaves the cache nil, so a
+        // reconnected or upgraded daemon is probed again.
+        if cachedCapabilities == nil {
+            cachedCapabilities = try? await serverCapabilities()
+        }
+        guard cachedCapabilities?.gramUploadStream == true else { return nil }
+        let env = RequestEnvelope(
+            id: "herdrkit:gram.upload.stream:\(uploadID)",
+            method: "gram.upload.stream",
+            params: GramUploadStreamParams(uploadID: uploadID)
+        )
+        guard let data = try? encoder.encode(env) else { return nil }
+        return citadel.openUploadChannel(String(decoding: data, as: UTF8.self))
+    }
+
     /// Uploads a file's bytes in chunks and returns the `upload_id` to attach to a
     /// `gramPost`. Chunks are sent in order; the server validates each against the
     /// running offset. A single request per chunk keeps every one under the SSH
@@ -539,6 +578,85 @@ public actor HerdrClient {
             }
         }
         return uploadID
+    }
+
+    /// Uploads a file's bytes FROM DISK and returns the `upload_id` to attach to a
+    /// `gramPost`.
+    ///
+    /// Streams over one held channel when the daemon advertises
+    /// `gram_upload_stream`, else falls back to per-chunk `gram.upload_chunk` —
+    /// still reading from disk, so neither path holds the whole file in memory
+    /// and a 100 MB attachment costs one chunk of resident bytes.
+    ///
+    /// `onProgress` (if given) is called on the main actor with
+    /// `(bytesSent, totalBytes)` — once at 0, then throttled to ~1% steps, and
+    /// once at completion.
+    public func gramUploadFile(
+        fileURL: URL,
+        onProgress: (@MainActor @Sendable (_ bytesSent: Int, _ totalBytes: Int) -> Void)? = nil
+    ) async throws -> String {
+        let uploadID = "app-" + UUID().uuidString.replacingOccurrences(of: "-", with: "")
+        let attributes = try FileManager.default.attributesOfItem(atPath: fileURL.path)
+        let total = (attributes[.size] as? NSNumber)?.intValue ?? 0
+
+        let channel = await gramOpenUploadChannel(uploadID: uploadID)
+        var streaming = false
+        if let channel {
+            do {
+                try await channel.start()
+                streaming = true
+            } catch {
+                // An out-of-date capability flag, a daemon that advertises the
+                // method but cannot serve it, or a channel that died before the
+                // ack must not fail the send — fall back. A REAL rejection
+                // (invalid_params, gram_unavailable, upload_in_progress,
+                // gram_file_error) is rethrown: the staged file may be partially
+                // written, so a fallback retry from offset 0 would be a second
+                // writer on the same upload_id.
+                await channel.close()
+                if let fatal = Self.fatalStreamOpenError(error) { throw fatal }
+            }
+        }
+        defer { if let channel { Task { await channel.close() } } }
+
+        let chunkBytes = streaming ? Self.gramStreamChunkBytes : Self.gramUploadChunkBytes
+        let handle = try FileHandle(forReadingFrom: fileURL)
+        defer { try? handle.close() }
+
+        // Report at most ~once per 1% (or per chunk, whichever is coarser) so a
+        // big file's round-trips don't schedule thousands of UI updates.
+        let reportStep = max(chunkBytes, total / 100)
+        var lastReported = -reportStep
+        var offset = 0
+        await onProgress?(0, total)
+        while let chunk = try handle.read(upToCount: chunkBytes), !chunk.isEmpty {
+            let encoded = chunk.base64EncodedString()
+            if streaming, let channel {
+                try await channel.sendChunk(offset: UInt64(offset), dataBase64: encoded)
+            } else {
+                _ = try await call(
+                    "gram.upload_chunk",
+                    GramUploadChunkParams(
+                        uploadID: uploadID, offset: UInt64(offset), dataBase64: encoded),
+                    as: JSONNull.self)
+            }
+            offset += chunk.count
+            if offset >= total || offset - lastReported >= reportStep {
+                lastReported = offset
+                await onProgress?(offset, total)
+            }
+        }
+        return uploadID
+    }
+
+    /// A streaming-open failure the caller must NOT retry per-chunk, or nil when
+    /// falling back is safe. Only a daemon-side REJECTION is fatal; transport and
+    /// capability failures are exactly what the fallback exists for.
+    static func fatalStreamOpenError(_ error: Error) -> Error? {
+        guard case GramUploadChannel.ChannelError.remoteError(let api) = error else { return nil }
+        // `invalid_request` is the answer an older daemon gives to an unknown
+        // method, so it means "no such method here", not "your upload is bad".
+        return api.code == "invalid_request" ? nil : api
     }
 
     struct GramGetFileParams: Encodable { let id: String }

--- a/Sources/HerdrKit/HerdrClient.swift
+++ b/Sources/HerdrKit/HerdrClient.swift
@@ -18,11 +18,19 @@ public actor HerdrClient {
     }()
     private let decoder = JSONDecoder()
     private var sequence: UInt64 = 0
-    /// Cached `ping` capabilities, so a multi-file send pays one probe, not one per
-    /// file. Only a probe that ADVERTISED streaming is cached, so a failed ping, a
-    /// daemon with no capabilities, or one that says `false` is re-probed on the next
-    /// upload and an upgraded daemon is used without relaunching the app.
-    private var cachedCapabilities: ServerCapabilities?
+    /// Whether this daemon serves `gram.upload.stream`, cached per client so a
+    /// multi-file send pays ONE `ping`.
+    ///
+    /// Three states on purpose: a successful probe is cached either way (so an old
+    /// daemon is not re-probed per file), while a FAILED probe stays `unknown` (so a
+    /// transient error cannot pin this client to the per-chunk path for its whole
+    /// lifetime, and a daemon upgraded under a long-lived app is picked up).
+    private enum StreamCapability {
+        case unknown
+        case supported
+        case unsupported
+    }
+    private var streamCapability: StreamCapability = .unknown
 
     public init(transport: HerdrTransport) {
         self.transport = transport
@@ -527,19 +535,21 @@ public actor HerdrClient {
     /// the connection closed, so the reply cannot be correlated to the attempt.
     public func gramOpenUploadChannel(uploadID: String) async -> GramUploadChannel? {
         guard let citadel = transport as? CitadelTransport else { return nil }
-        // `??` takes a non-async autoclosure, so the probe cannot be inlined into it.
-        // Only a POSITIVE result is cached: a daemon that answers `false` (or a ping
-        // that fails, or one with no capabilities at all) is re-probed on the next
-        // upload, so an upgraded daemon is picked up without relaunching the app.
-        // That costs one extra ping per file against an old daemon — one round trip
-        // versus the thousands the per-chunk path already pays.
-        if cachedCapabilities == nil {
-            let probed = try? await serverCapabilities()
-            if probed?.gramUploadStream == true {
-                cachedCapabilities = probed
+        // Three cache states, not two. A ping that SUCCEEDS is cached either way, so a
+        // ten-file send pays one probe even against a daemon that does not serve the
+        // method; a ping that FAILS caches nothing, so a transient error cannot pin
+        // this client to the per-chunk path for its whole lifetime. (`??` takes a
+        // non-async autoclosure, so the probe cannot be inlined into it.)
+        if case .unknown = streamCapability {
+            if let probed = try? await serverCapabilities() {
+                streamCapability = probed.gramUploadStream ? .supported : .unsupported
+            } else {
+                // A daemon that answers `ping` with no capabilities object at all is an
+                // old one: cache that as unsupported rather than re-probing per file.
+                streamCapability = .unsupported
             }
-            guard probed?.gramUploadStream == true else { return nil }
         }
+        guard case .supported = streamCapability else { return nil }
         let env = RequestEnvelope(
             id: "herdrkit:gram.upload.stream:\(uploadID)",
             method: "gram.upload.stream",
@@ -606,6 +616,12 @@ public actor HerdrClient {
         let attributes = try FileManager.default.attributesOfItem(atPath: fileURL.path)
         let total = (attributes[.size] as? NSNumber)?.intValue ?? 0
 
+        // Open the FILE first, and only then the channel. A file we cannot read must
+        // not cost an SSH channel and a daemon-side claim on this `upload_id` that is
+        // then released asynchronously by the `defer` below.
+        let handle = try FileHandle(forReadingFrom: fileURL)
+        defer { try? handle.close() }
+
         let channel = await gramOpenUploadChannel(uploadID: uploadID)
         var streaming = false
         if let channel {
@@ -627,8 +643,6 @@ public actor HerdrClient {
         defer { if let channel { Task { await channel.close() } } }
 
         let chunkBytes = streaming ? Self.gramStreamChunkBytes : Self.gramUploadChunkBytes
-        let handle = try FileHandle(forReadingFrom: fileURL)
-        defer { try? handle.close() }
 
         // Report at most ~once per 1% (or per chunk, whichever is coarser) so a
         // big file's round-trips don't schedule thousands of UI updates. The total is

--- a/Sources/HerdrKit/HerdrClient.swift
+++ b/Sources/HerdrKit/HerdrClient.swift
@@ -535,18 +535,20 @@ public actor HerdrClient {
     /// the connection closed, so the reply cannot be correlated to the attempt.
     public func gramOpenUploadChannel(uploadID: String) async -> GramUploadChannel? {
         guard let citadel = transport as? CitadelTransport else { return nil }
-        // Three cache states, not two. A ping that SUCCEEDS is cached either way, so a
-        // ten-file send pays one probe even against a daemon that does not serve the
-        // method; a ping that FAILS caches nothing, so a transient error cannot pin
-        // this client to the per-chunk path for its whole lifetime. (`??` takes a
-        // non-async autoclosure, so the probe cannot be inlined into it.)
+        // Three cache states, not two, and the probe is NOT written with `try?`:
+        // `serverCapabilities()` both throws AND returns an Optional, so `try?`
+        // flattens "the ping failed" into the same nil as "the daemon sent no
+        // capabilities" — which would cache a transient error as `unsupported` and pin
+        // this client to the per-chunk path for its whole lifetime, the exact outcome
+        // the `unknown` state exists to prevent. A ping that SUCCEEDS is cached either
+        // way, so a ten-file send pays one probe even against an old daemon; a ping
+        // that THROWS leaves the cache `unknown` and is re-probed on the next upload.
         if case .unknown = streamCapability {
-            if let probed = try? await serverCapabilities() {
-                streamCapability = probed.gramUploadStream ? .supported : .unsupported
-            } else {
-                // A daemon that answers `ping` with no capabilities object at all is an
-                // old one: cache that as unsupported rather than re-probing per file.
-                streamCapability = .unsupported
+            do {
+                let probed = try await serverCapabilities()
+                streamCapability = probed?.gramUploadStream == true ? .supported : .unsupported
+            } catch {
+                return nil
             }
         }
         guard case .supported = streamCapability else { return nil }
@@ -675,22 +677,39 @@ public actor HerdrClient {
                 await onProgress?(offset, max(total, offset))
             }
         }
-        // One terminal report, so a determinate bar always lands on 100% — including
-        // for a file that SHRANK after the stat, where `offset < total` at EOF.
-        if lastReported != offset {
-            await onProgress?(offset, max(total, offset))
+        // One terminal report at the bytes ACTUALLY read, so a determinate bar always
+        // lands on 100%. `(offset, offset)`, not `max(total, offset)`: a file that
+        // SHRANK after the stat would otherwise leave the bar at `offset/total` — 50%
+        // for a file half the stat'd size — and a shrink whose last chunk happens to
+        // land on `reportStep` would emit no terminal report at all.
+        if lastReported != offset || total != offset {
+            await onProgress?(offset, offset)
+        }
+        // The daemon frees its single-writer claim on the `upload_id` only when it
+        // observes EOF on the upload connection, and it REFUSES a `gram.post` that
+        // would finalize an upload a stream still owns. The caller posts immediately
+        // after this returns, over the already-warm command connection, so returning
+        // before the teardown completes makes that post race the claim release and
+        // fail with `upload_in_progress` after a fully successful upload.
+        if streaming, let channel {
+            await channel.closeAndWait()
         }
         return uploadID
     }
 
     /// A streaming-open failure the caller must NOT retry per-chunk, or nil when
-    /// falling back is safe. Only a daemon-side REJECTION is fatal; transport and
-    /// capability failures are exactly what the fallback exists for.
+    /// falling back is safe. Only a daemon-side REJECTION of the UPLOAD is fatal;
+    /// transport, capability and availability failures are what the fallback exists
+    /// for, because on those paths the daemon read no frame and staging is untouched.
     static func fatalStreamOpenError(_ error: Error) -> Error? {
         guard case GramUploadChannel.ChannelError.remoteError(let api) = error else { return nil }
-        // `invalid_request` is the answer an older daemon gives to an unknown
-        // method, so it means "no such method here", not "your upload is bad".
-        return api.code == "invalid_request" ? nil : api
+        // `invalid_request`: an older daemon's answer to an unknown method.
+        // `server_unavailable`: the open handshake timed out waiting on the daemon's
+        // single-threaded app loop (5 s), or the daemon is shutting down. Neither
+        // says anything about the upload, so both fall back rather than failing the
+        // send — a busy app thread must not abort a whole batch.
+        let recoverable = ["invalid_request", "server_unavailable"]
+        return recoverable.contains(api.code) ? nil : api
     }
 
     struct GramGetFileParams: Encodable { let id: String }

--- a/Sources/HerdrKit/HerdrClient.swift
+++ b/Sources/HerdrKit/HerdrClient.swift
@@ -18,9 +18,10 @@ public actor HerdrClient {
     }()
     private let decoder = JSONDecoder()
     private var sequence: UInt64 = 0
-    /// Cached `ping` capabilities, so a multi-file send pays one probe, not one
-    /// per file. Reset to nil on a ping failure so a reconnected or upgraded
-    /// daemon is re-probed.
+    /// Cached `ping` capabilities, so a multi-file send pays one probe, not one per
+    /// file. Only a probe that ADVERTISED streaming is cached, so a failed ping, a
+    /// daemon with no capabilities, or one that says `false` is re-probed on the next
+    /// upload and an upgraded daemon is used without relaunching the app.
     private var cachedCapabilities: ServerCapabilities?
 
     public init(transport: HerdrTransport) {
@@ -526,13 +527,19 @@ public actor HerdrClient {
     /// the connection closed, so the reply cannot be correlated to the attempt.
     public func gramOpenUploadChannel(uploadID: String) async -> GramUploadChannel? {
         guard let citadel = transport as? CitadelTransport else { return nil }
-        // `??` takes a non-async autoclosure, so the probe cannot be inlined
-        // into it. A failed or capability-less ping leaves the cache nil, so a
-        // reconnected or upgraded daemon is probed again.
+        // `??` takes a non-async autoclosure, so the probe cannot be inlined into it.
+        // Only a POSITIVE result is cached: a daemon that answers `false` (or a ping
+        // that fails, or one with no capabilities at all) is re-probed on the next
+        // upload, so an upgraded daemon is picked up without relaunching the app.
+        // That costs one extra ping per file against an old daemon — one round trip
+        // versus the thousands the per-chunk path already pays.
         if cachedCapabilities == nil {
-            cachedCapabilities = try? await serverCapabilities()
+            let probed = try? await serverCapabilities()
+            if probed?.gramUploadStream == true {
+                cachedCapabilities = probed
+            }
+            guard probed?.gramUploadStream == true else { return nil }
         }
-        guard cachedCapabilities?.gramUploadStream == true else { return nil }
         let env = RequestEnvelope(
             id: "herdrkit:gram.upload.stream:\(uploadID)",
             method: "gram.upload.stream",
@@ -624,7 +631,10 @@ public actor HerdrClient {
         defer { try? handle.close() }
 
         // Report at most ~once per 1% (or per chunk, whichever is coarser) so a
-        // big file's round-trips don't schedule thousands of UI updates.
+        // big file's round-trips don't schedule thousands of UI updates. The total is
+        // widened to the bytes actually read: the file is stat'd before the first
+        // read, so one that GREW in between must not drive a determinate bar past
+        // 100% (a shrunken one simply reports fewer bytes and ends early).
         let reportStep = max(chunkBytes, total / 100)
         var lastReported = -reportStep
         var offset = 0
@@ -643,7 +653,7 @@ public actor HerdrClient {
             offset += chunk.count
             if offset >= total || offset - lastReported >= reportStep {
                 lastReported = offset
-                await onProgress?(offset, total)
+                await onProgress?(offset, max(total, offset))
             }
         }
         return uploadID

--- a/Sources/HerdrKit/Wire.swift
+++ b/Sources/HerdrKit/Wire.swift
@@ -15,7 +15,7 @@ public struct EmptyParams: Encodable {
     public init() {}
 }
 
-public struct APIError: Error, Decodable, CustomStringConvertible {
+public struct APIError: Error, Decodable, Equatable, Sendable, CustomStringConvertible {
     public let code: String
     public let message: String
     public var description: String { "\(code): \(message)" }
@@ -871,6 +871,7 @@ public struct ServerCapabilities: Decodable, Equatable, Sendable {
     public let liveHandoff: Bool
     public let detachedServerDaemon: Bool
     public let paneInputStream: Bool
+    public let gramUploadStream: Bool
     public let agentSessionTransfer: Bool
     /// Nil means the daemon predates explicit harness advertisement and uses
     /// the legacy Claude/Codex pair. An explicit list, including an empty or
@@ -881,6 +882,7 @@ public struct ServerCapabilities: Decodable, Equatable, Sendable {
         case liveHandoff = "live_handoff"
         case detachedServerDaemon = "detached_server_daemon"
         case paneInputStream = "pane_input_stream"
+        case gramUploadStream = "gram_upload_stream"
         case agentSessionTransfer = "agent_session_transfer"
         case agentSessionTransferHarnesses = "agent_session_transfer_harnesses"
     }
@@ -890,6 +892,7 @@ public struct ServerCapabilities: Decodable, Equatable, Sendable {
         liveHandoff = try c.decodeIfPresent(Bool.self, forKey: .liveHandoff) ?? false
         detachedServerDaemon = try c.decodeIfPresent(Bool.self, forKey: .detachedServerDaemon) ?? false
         paneInputStream = try c.decodeIfPresent(Bool.self, forKey: .paneInputStream) ?? false
+        gramUploadStream = try c.decodeIfPresent(Bool.self, forKey: .gramUploadStream) ?? false
         agentSessionTransfer = try c.decodeIfPresent(Bool.self, forKey: .agentSessionTransfer) ?? false
         agentSessionTransferHarnesses = try c.decodeIfPresent(
             [AgentSessionTransferHarness].self,

--- a/Tests/HerdrKitTests/GramStagingTests.swift
+++ b/Tests/HerdrKitTests/GramStagingTests.swift
@@ -85,6 +85,30 @@ final class GramStagingTests: XCTestCase {
         XCTAssertEqual(leftovers, [], "a rejected pick left staging behind: \(leftovers)")
     }
 
+
+    /// The cap is INCLUSIVE, and that direction is the one worth pinning: a guard
+    /// that refuses a file of exactly the allowed size fails silently — the pick just
+    /// reports as "too large" — and the app's own gate uses the same `<=`, so an
+    /// off-by-one here would reject a file the composer already accepted.
+    func testExactlyMaxBytesStagesAndOneMoreDoesNot() throws {
+        let cap = 8 * 1024
+        let atCap = try sourceFile(Data(repeating: 3, count: cap), name: "at-cap.bin")
+        let staged = try XCTUnwrap(
+            GramStaging.stageCopy(of: atCap, named: "at-cap.bin", in: session, maxBytes: cap),
+            "a file of exactly maxBytes must stage")
+        XCTAssertEqual(staged.size, cap)
+
+        let overCap = try sourceFile(Data(repeating: 3, count: cap + 1), name: "over-cap.bin")
+        XCTAssertNil(
+            GramStaging.stageCopy(of: overCap, named: "over-cap.bin", in: session, maxBytes: cap),
+            "one byte past maxBytes must be refused")
+
+        // A single-byte file is the other boundary: `size > 0` must not reject it.
+        let oneByte = try sourceFile(Data([7]), name: "tiny.bin")
+        let tiny = try XCTUnwrap(
+            GramStaging.stageCopy(of: oneByte, named: "tiny.bin", in: session, maxBytes: cap))
+        XCTAssertEqual(tiny.size, 1)
+    }
     /// A pick named `../../evil` must not stage outside its own directory.
     func testTraversalNameStaysInsideTheItemDirectory() throws {
         let source = try sourceFile(Data("x".utf8))

--- a/Tests/HerdrKitTests/GramStagingTests.swift
+++ b/Tests/HerdrKitTests/GramStagingTests.swift
@@ -1,0 +1,133 @@
+import XCTest
+
+@testable import HerdrKit
+
+/// Staging is what the composer hands to the uploader, and it used to live in the
+/// iOS-only app target where no CI job can run it — a dropped copy there produced
+/// the same user-facing message as an unreadable file and shipped once. These tests
+/// exist so that class of defect fails on Linux.
+final class GramStagingTests: XCTestCase {
+    private var session: URL!
+
+    override func setUpWithError() throws {
+        session = FileManager.default.temporaryDirectory
+            .appendingPathComponent("gram-staging-tests/\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: session, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: session)
+    }
+
+    private func sourceFile(_ bytes: Data, name: String = "pick.bin") throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let url = dir.appendingPathComponent(name)
+        try bytes.write(to: url)
+        addTeardownBlock { try? FileManager.default.removeItem(at: dir) }
+        return url
+    }
+
+    /// The property the composer depends on: the staged file holds the SOURCE BYTES.
+    /// A staging step that creates the directory but never copies satisfies every
+    /// other check the app makes and silently rejects every attachment.
+    func testStagedFileHoldsTheSourceBytes() throws {
+        let payload = Data((0..<(64 * 1024 + 7)).map { UInt8($0 % 251) })
+        let source = try sourceFile(payload, name: "photo.heic")
+
+        let staged = try XCTUnwrap(
+            GramStaging.stageCopy(
+                of: source, named: "photo.heic", in: session, maxBytes: 100 * 1024 * 1024),
+            "an in-cap readable pick must stage")
+
+        XCTAssertEqual(try Data(contentsOf: staged.url), payload)
+        XCTAssertEqual(staged.size, payload.count)
+        XCTAssertEqual(staged.url.lastPathComponent, "photo.heic")
+        // The staged copy survives the source going away, which is the whole point:
+        // PhotosUI deletes its export as soon as the import closure returns.
+        try FileManager.default.removeItem(at: source)
+        XCTAssertEqual(try Data(contentsOf: staged.url), payload)
+    }
+
+    /// Each pick gets its own directory, so removing one chip cannot take another's
+    /// bytes with it.
+    func testEachPickGetsItsOwnDirectory() throws {
+        let source = try sourceFile(Data("one".utf8))
+        let first = try XCTUnwrap(
+            GramStaging.stageCopy(of: source, named: "a.txt", in: session, maxBytes: 1024))
+        let second = try XCTUnwrap(
+            GramStaging.stageCopy(of: source, named: "a.txt", in: session, maxBytes: 1024))
+
+        XCTAssertNotEqual(first.dir, second.dir)
+        try FileManager.default.removeItem(at: first.dir)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: first.url.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: second.url.path))
+    }
+
+    /// A rejected pick must leave NOTHING behind — otherwise every over-cap pick
+    /// leaks a directory that only the next launch's sweep would reclaim.
+    func testRejectedPicksLeaveNoDirectory() throws {
+        let overCap = try sourceFile(Data(repeating: 9, count: 4096))
+        XCTAssertNil(
+            GramStaging.stageCopy(of: overCap, named: "big.bin", in: session, maxBytes: 1024))
+
+        let empty = try sourceFile(Data())
+        XCTAssertNil(
+            GramStaging.stageCopy(of: empty, named: "empty.bin", in: session, maxBytes: 1024))
+
+        let missing = session.appendingPathComponent("does-not-exist.bin")
+        XCTAssertNil(
+            GramStaging.stageCopy(of: missing, named: "gone.bin", in: session, maxBytes: 1024))
+
+        let leftovers = try FileManager.default.contentsOfDirectory(
+            at: session, includingPropertiesForKeys: nil)
+        XCTAssertEqual(leftovers, [], "a rejected pick left staging behind: \(leftovers)")
+    }
+
+    /// A pick named `../../evil` must not stage outside its own directory.
+    func testTraversalNameStaysInsideTheItemDirectory() throws {
+        let source = try sourceFile(Data("x".utf8))
+        let staged = try XCTUnwrap(
+            GramStaging.stageCopy(
+                of: source, named: "../../etc/passwd", in: session, maxBytes: 1024))
+
+        XCTAssertEqual(staged.url.lastPathComponent, "passwd")
+        XCTAssertEqual(staged.url.deletingLastPathComponent(), staged.dir)
+        XCTAssertTrue(
+            staged.dir.deletingLastPathComponent().path == session.path,
+            "staged dir escaped the session directory: \(staged.dir)")
+    }
+
+    /// The sweep reclaims OTHER sessions and never the live one, which is what makes
+    /// it safe to run at launch while a composer may already hold staged chips.
+    func testSweepRemovesOtherSessionsAndKeepsTheCurrentOne() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("gram-staging-sweep/\(UUID().uuidString)", isDirectory: true)
+        let current = UUID().uuidString
+        let abandoned = UUID().uuidString
+        for name in [current, abandoned] {
+            let dir = root.appendingPathComponent(name, isDirectory: true)
+                .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+            try Data("staged".utf8).write(to: dir.appendingPathComponent("file.bin"))
+        }
+        addTeardownBlock { try? FileManager.default.removeItem(at: root) }
+
+        GramStaging.sweepAbandoned(root: root, keeping: current)
+
+        let remaining = try FileManager.default.contentsOfDirectory(
+            at: root, includingPropertiesForKeys: nil
+        ).map(\.lastPathComponent)
+        XCTAssertEqual(remaining, [current])
+    }
+
+    /// A missing root is the first-launch case: the sweep must be a no-op, not a
+    /// failure that a caller has to guard.
+    func testSweepToleratesAMissingRoot() {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("gram-staging-absent/\(UUID().uuidString)", isDirectory: true)
+        GramStaging.sweepAbandoned(root: root, keeping: "whatever")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: root.path))
+    }
+}

--- a/Tests/HerdrKitTests/GramUploadChannelTests.swift
+++ b/Tests/HerdrKitTests/GramUploadChannelTests.swift
@@ -1,0 +1,90 @@
+import XCTest
+
+@testable import HerdrKit
+
+/// The upload channel's teardown is the one part of this path with a deadline, and
+/// a deadline is only worth having if it is provable. The bound exists because the
+/// runner finishes only when NIOSSH succeeds a close promise that waits for the
+/// peer's CHANNEL_CLOSE — no timer, and not interruptible by task cancellation — so
+/// a stalled link would otherwise park the caller for the kernel's whole retransmit
+/// budget and wedge the composer.
+///
+/// This mirrors `CitadelTransportTests.testConnectFailsWithinTheBudgetAgainstABlackHoleAddress`,
+/// which shortens the same kind of unstructured race for the same reason.
+final class GramUploadChannelTests: XCTestCase {
+    /// A channel whose connection never resolves, so its runner can never finish.
+    private func stalledChannel(closeGrace: UInt64) -> GramUploadChannel {
+        GramUploadChannel(
+            makeConnection: {
+                // Far longer than any grace under test: this stands in for a
+                // half-open TCP that neither completes nor errors.
+                try? await Task.sleep(nanoseconds: 60 * 1_000_000_000)
+                throw CancellationError()
+            },
+            command: "true",
+            openLine: #"{"id":"t","method":"gram.upload.stream","params":{"upload_id":"t"}}"#,
+            closeGrace: closeGrace
+        )
+    }
+
+    func testCloseAndWaitReturnsWithinItsGraceWhenTheRunnerNeverFinishes() async throws {
+        let grace: UInt64 = 200_000_000  // 200 ms
+        let channel = stalledChannel(closeGrace: grace)
+
+        // `start()` parks until the open is acked, which never happens here — so it
+        // runs detached, purely to spawn the runner `closeAndWait` must bound.
+        let opening = Task { try? await channel.start() }
+        // Give `start()` time to install the runner before closing.
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        let began = DispatchTime.now().uptimeNanoseconds
+        await channel.closeAndWait()
+        let elapsed = DispatchTime.now().uptimeNanoseconds - began
+
+        opening.cancel()
+        XCTAssertLessThan(
+            elapsed, grace * 20,
+            "closeAndWait took \(elapsed / 1_000_000) ms against a \(grace / 1_000_000) ms grace — the bound is not holding")
+    }
+
+    /// Idempotence: a second close must not hang on an already-signalled gate, and
+    /// the caller's `defer`-close runs after `closeAndWait` on every real path.
+    func testCloseAndWaitIsIdempotentAndSurvivesAPlainClose() async throws {
+        let channel = stalledChannel(closeGrace: 100_000_000)
+        let opening = Task { try? await channel.start() }
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        await channel.closeAndWait()
+        await channel.close()
+        await channel.closeAndWait()
+
+        opening.cancel()
+    }
+
+    /// A frame written after the channel is closed must fail rather than park on an
+    /// ack that can never arrive.
+    func testSendChunkAfterCloseFailsInsteadOfHanging() async throws {
+        let channel = stalledChannel(closeGrace: 100_000_000)
+        await channel.close()
+
+        do {
+            try await channel.sendChunk(offset: 0, dataBase64: "aGk=")
+            XCTFail("sendChunk on a closed channel must throw")
+        } catch let error as GramUploadChannel.ChannelError {
+            XCTAssertEqual(error, .closedBeforeFrameAck)
+        }
+    }
+
+    /// Every `upload_id` is distinct, since the daemon keys its staging file and its
+    /// single-writer claim on it — a repeat would collide with a live upload.
+    func testMintedUploadIDsAreDistinctAndSafePathComponents() {
+        let ids = (0..<64).map { _ in HerdrClient.mintUploadID() }
+        XCTAssertEqual(Set(ids).count, ids.count, "upload ids must not repeat")
+        for id in ids {
+            XCTAssertTrue(id.hasPrefix("app-"))
+            XCTAssertTrue(
+                id.allSatisfy { $0.isLetter || $0.isNumber || $0 == "-" },
+                "\(id) is not a safe single path component")
+        }
+    }
+}

--- a/Tests/HerdrKitTests/GramUploadChannelTests.swift
+++ b/Tests/HerdrKitTests/GramUploadChannelTests.swift
@@ -47,29 +47,49 @@ final class GramUploadChannelTests: XCTestCase {
             "closeAndWait took \(elapsed / 1_000_000) ms against a \(grace / 1_000_000) ms grace — the bound is not holding")
     }
 
-    /// Idempotence: a second close must not hang on an already-signalled gate, and
-    /// the caller's `defer`-close runs after `closeAndWait` on every real path.
-    func testCloseAndWaitIsIdempotentAndSurvivesAPlainClose() async throws {
-        let channel = stalledChannel(closeGrace: 100_000_000)
+    /// Idempotence AND boundedness: a second close must not hang on an
+    /// already-signalled gate, and the caller's `defer`-close runs after
+    /// `closeAndWait` on every real path.
+    ///
+    /// The timing assertion is the point of the second half. Without it this test
+    /// PASSED in 60 s under the mutation that removes the bound — reporting
+    /// "idempotent" while the property the file exists to prove was gone, and adding
+    /// a silent minute to every mutant run.
+    func testCloseAndWaitIsIdempotentAndBounded() async throws {
+        let grace: UInt64 = 100_000_000  // 100 ms
+        let channel = stalledChannel(closeGrace: grace)
         let opening = Task { try? await channel.start() }
         try await Task.sleep(nanoseconds: 50_000_000)
 
+        let began = DispatchTime.now().uptimeNanoseconds
         await channel.closeAndWait()
         await channel.close()
         await channel.closeAndWait()
+        let elapsed = DispatchTime.now().uptimeNanoseconds - began
 
         opening.cancel()
+        XCTAssertLessThan(
+            elapsed, grace * 40,
+            "three closes took \(elapsed / 1_000_000) ms against a \(grace / 1_000_000) ms grace")
     }
 
-    /// A frame written after the channel is closed must fail rather than park on an
-    /// ack that can never arrive.
-    func testSendChunkAfterCloseFailsInsteadOfHanging() async throws {
+    /// A frame written on a channel that was never started must fail rather than
+    /// park on an ack that can never arrive.
+    ///
+    /// NOTE what this does and does not cover. It exercises the never-started guard
+    /// (`live` is false, `framesCont` nil), which is a real caller mistake. It does
+    /// NOT cover the post-close path on a LIVE channel: `live` only becomes true when
+    /// the daemon acks the open, which needs a real SSH connection, so an earlier
+    /// version of this test that called `close()` first was measured to pass with
+    /// that call deleted — it pinned nothing. The live-then-closed path is exercised
+    /// by `closeAndWait`'s own `resumeAck(.closedBeforeFrameAck)` and remains
+    /// unguarded by a unit test; it needs the integration path, not a double.
+    func testSendChunkOnANeverStartedChannelFailsInsteadOfHanging() async throws {
         let channel = stalledChannel(closeGrace: 100_000_000)
-        await channel.close()
 
         do {
             try await channel.sendChunk(offset: 0, dataBase64: "aGk=")
-            XCTFail("sendChunk on a closed channel must throw")
+            XCTFail("sendChunk on a channel that was never started must throw")
         } catch let error as GramUploadChannel.ChannelError {
             XCTAssertEqual(error, .closedBeforeFrameAck)
         }

--- a/Tests/HerdrKitTests/MockWireFixtureTests.swift
+++ b/Tests/HerdrKitTests/MockWireFixtureTests.swift
@@ -586,6 +586,66 @@ final class MockWireFixtureTests: XCTestCase {
                 GramUploadChannel.ChannelError.remoteError(APIError(code: code, message: "no")))
             XCTAssertEqual((fatal as? APIError)?.code, code, "\(code) must not fall back")
         }
+
+        // `server_unavailable` is the open handshake timing out on the daemon's
+        // single-threaded app loop, or a shutdown. The daemon read no frame, so the
+        // fallback must complete the send rather than aborting the whole batch.
+        XCTAssertNil(
+            HerdrClient.fatalStreamOpenError(
+                GramUploadChannel.ChannelError.remoteError(
+                    APIError(
+                        code: "server_unavailable",
+                        message: "timed out waiting for app response after 5000 ms"))),
+            "an app-dispatch timeout must fall back, not fail the send")
+    }
+
+    /// A file that SHRANK between the stat and the read must still finish at 100%.
+    /// The stat is the only size the uploader has up front, so a bar driven by it
+    /// would stop short — and if the last chunk lands exactly on `reportStep`, the
+    /// throttle's own bookkeeping would emit no terminal report at all.
+    func testGramUploadFromDiskProgressEndsAtTheBytesActuallyRead() async throws {
+        final class Shrinker: HerdrTransport, @unchecked Sendable {
+            let url: URL
+            let keep: Int
+            private var truncated = false
+            init(url: URL, keep: Int) {
+                self.url = url
+                self.keep = keep
+            }
+            func roundTrip(_ requestLine: String) async throws -> String {
+                if !truncated {
+                    truncated = true
+                    // Shrink the file after its first chunk has been read, which is
+                    // exactly the window the stat cannot see.
+                    let handle = try FileHandle(forWritingTo: url)
+                    try handle.truncate(atOffset: UInt64(keep))
+                    try handle.close()
+                }
+                return #"{"id":"x","result":{"type":"ok"}}"#
+            }
+            func stream(_ requestLine: String) -> AsyncThrowingStream<String, Error> {
+                AsyncThrowingStream { $0.finish() }
+            }
+        }
+        let chunkBytes = HerdrClient.gramUploadChunkBytes
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("gram-upload-shrink-\(UUID().uuidString).bin")
+        try Data(repeating: 4, count: chunkBytes * 4).write(to: url)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let reports = Reports()
+        _ = try await HerdrClient(transport: Shrinker(url: url, keep: chunkBytes * 2))
+            .gramUploadFile(fileURL: url) { sent, total in
+                reports.append(sent: sent, total: total)
+            }
+
+        let observed = reports.snapshot()
+        let last = try XCTUnwrap(observed.last)
+        XCTAssertEqual(
+            last.sent, last.total,
+            "the final report must land on 100%, got \(last.sent)/\(last.total)")
+        XCTAssertLessThan(last.sent, chunkBytes * 4, "the file shrank, so fewer bytes were read")
+        XCTAssertEqual(observed.map(\.sent), observed.map(\.sent).sorted(), "progress must be monotonic")
     }
 }
 

--- a/Tests/HerdrKitTests/MockWireFixtureTests.swift
+++ b/Tests/HerdrKitTests/MockWireFixtureTests.swift
@@ -416,6 +416,177 @@ final class MockWireFixtureTests: XCTestCase {
             capture.maxLen, 80_000,
             "slash escaping inflated the upload request line to \(capture.maxLen) bytes")
     }
+
+    /// Collects `onProgress` callbacks, which arrive on the main actor from a
+    /// `@Sendable` closure and so cannot capture a local `var`.
+    private final class Reports: @unchecked Sendable {
+        private let lock = NSLock()
+        private var values: [(sent: Int, total: Int)] = []
+        func append(sent: Int, total: Int) {
+            lock.lock()
+            values.append((sent: sent, total: total))
+            lock.unlock()
+        }
+        func snapshot() -> [(sent: Int, total: Int)] {
+            lock.lock()
+            defer { lock.unlock() }
+            return values
+        }
+    }
+
+    /// The SAME slash-escaping property for the FROM-DISK path. `Capture` is not a
+    /// `CitadelTransport`, so `gramOpenUploadChannel` returns nil and this exercises
+    /// the per-chunk fallback — the CI-visible proof that reading from a file did not
+    /// regress the request-line size the in-memory path guards above.
+    func testGramUploadFromDiskRequestStaysCompactForSlashHeavyData() async throws {
+        final class Capture: HerdrTransport, @unchecked Sendable {
+            var maxLen = 0
+            func roundTrip(_ requestLine: String) async throws -> String {
+                maxLen = max(maxLen, requestLine.utf8.count)
+                return #"{"id":"x","result":{"type":"ok"}}"#
+            }
+            func stream(_ requestLine: String) -> AsyncThrowingStream<String, Error> {
+                AsyncThrowingStream { $0.finish() }
+            }
+        }
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("gram-upload-slashes-\(UUID().uuidString).bin")
+        try Data(repeating: 0xFF, count: HerdrClient.gramStreamChunkBytes).write(to: url)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let capture = Capture()
+        let client = HerdrClient(transport: capture)
+        _ = try await client.gramUploadFile(fileURL: url)
+        XCTAssertLessThan(
+            capture.maxLen, 80_000,
+            "slash escaping inflated the from-disk request line to \(capture.maxLen) bytes")
+    }
+
+    /// The from-disk fallback path must walk the file in CONTIGUOUS chunks: staging
+    /// is append-only, so the daemon rejects any offset that is not the running
+    /// staged size. A gap (or a repeat) is the bug this pins.
+    func testGramUploadFromDiskSendsContiguousOffsets() async throws {
+        final class Capture: HerdrTransport, @unchecked Sendable {
+            struct Chunk: Decodable {
+                struct Params: Decodable {
+                    let offset: UInt64
+                    let dataBase64: String
+                    enum CodingKeys: String, CodingKey {
+                        case offset
+                        case dataBase64 = "data_base64"
+                    }
+                }
+                let method: String
+                let params: Params
+            }
+            var offsets: [UInt64] = []
+            var bytes = Data()
+            func roundTrip(_ requestLine: String) async throws -> String {
+                if let chunk = try? JSONDecoder().decode(Chunk.self, from: Data(requestLine.utf8)),
+                    chunk.method == "gram.upload_chunk"
+                {
+                    offsets.append(chunk.params.offset)
+                    bytes.append(Data(base64Encoded: chunk.params.dataBase64) ?? Data())
+                }
+                return #"{"id":"x","result":{"type":"ok"}}"#
+            }
+            func stream(_ requestLine: String) -> AsyncThrowingStream<String, Error> {
+                AsyncThrowingStream { $0.finish() }
+            }
+        }
+        let chunkBytes = HerdrClient.gramUploadChunkBytes
+        let payload = Data((0..<(chunkBytes * 2 + 7)).map { UInt8($0 % 251) })
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("gram-upload-offsets-\(UUID().uuidString).bin")
+        try payload.write(to: url)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let capture = Capture()
+        let client = HerdrClient(transport: capture)
+        _ = try await client.gramUploadFile(fileURL: url)
+
+        XCTAssertEqual(
+            capture.offsets, [0, UInt64(chunkBytes), UInt64(chunkBytes * 2)],
+            "offsets must be contiguous multiples of the chunk size")
+        XCTAssertEqual(capture.bytes, payload, "the streamed bytes must reassemble the file")
+    }
+
+    /// Progress is reported from the file's own size, once at 0 and once at the end,
+    /// so a determinate progress bar cannot be driven past 100% or left short.
+    func testGramUploadFromDiskReportsProgressToTotal() async throws {
+        final class Sink: HerdrTransport, @unchecked Sendable {
+            func roundTrip(_ requestLine: String) async throws -> String {
+                #"{"id":"x","result":{"type":"ok"}}"#
+            }
+            func stream(_ requestLine: String) -> AsyncThrowingStream<String, Error> {
+                AsyncThrowingStream { $0.finish() }
+            }
+        }
+        let payload = Data(repeating: 7, count: HerdrClient.gramUploadChunkBytes + 128)
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("gram-upload-progress-\(UUID().uuidString).bin")
+        try payload.write(to: url)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let reports = Reports()
+        _ = try await HerdrClient(transport: Sink()).gramUploadFile(fileURL: url) { sent, total in
+            reports.append(sent: sent, total: total)
+        }
+        let observed = reports.snapshot()
+        XCTAssertEqual(observed.first?.sent, 0)
+        XCTAssertEqual(observed.last?.sent, payload.count)
+        XCTAssertTrue(
+            observed.allSatisfy { $0.total == payload.count },
+            "every report must carry the file's real size")
+    }
+
+    /// A 512 KiB all-0xFF chunk — base64 is ENTIRELY "/" — must encode into a frame
+    /// that stays inside the daemon's 1 MiB frame cap, which is the property that
+    /// makes 512 KiB frames legal at all. Otherwise unreachable in CI: a real
+    /// `GramUploadChannel` needs an SSH connection.
+    func testGramUploadFrameStaysWithinDaemonFrameCap() throws {
+        let chunk = Data(repeating: 0xFF, count: HerdrClient.gramStreamChunkBytes)
+        let line = try GramUploadChannel.encodeFrame(
+            seq: 1, offset: 0, dataBase64: chunk.base64EncodedString())
+
+        XCTAssertFalse(line.contains("\\/"), "the frame encoder must not escape slashes")
+        XCTAssertLessThan(
+            line.utf8.count, 1024 * 1024,
+            "frame is \(line.utf8.count) bytes, past the daemon's MAX_UPLOAD_FRAME_BYTES")
+
+        struct Frame: Decodable {
+            let seq: UInt64
+            let offset: UInt64
+            let dataBase64: String
+            enum CodingKeys: String, CodingKey {
+                case seq, offset
+                case dataBase64 = "data_base64"
+            }
+        }
+        let decoded = try JSONDecoder().decode(Frame.self, from: Data(line.utf8))
+        XCTAssertEqual(decoded.seq, 1)
+        XCTAssertEqual(decoded.offset, 0)
+        XCTAssertEqual(Data(base64Encoded: decoded.dataBase64), chunk)
+    }
+
+    /// An old daemon answers an unknown method with `invalid_request`, which MUST
+    /// fall back per-chunk; a real rejection MUST NOT, because the staged file may be
+    /// partly written and a fallback retry from offset 0 would be a second writer.
+    func testFatalStreamOpenErrorFallsBackOnlyForUnknownMethod() {
+        let unknown = GramUploadChannel.ChannelError.remoteError(
+            APIError(code: "invalid_request", message: "unknown variant"))
+        XCTAssertNil(HerdrClient.fatalStreamOpenError(unknown))
+
+        XCTAssertNil(HerdrClient.fatalStreamOpenError(GramUploadChannel.ChannelError.unsupported))
+        XCTAssertNil(
+            HerdrClient.fatalStreamOpenError(GramUploadChannel.ChannelError.closedBeforeAck))
+
+        for code in ["invalid_params", "gram_unavailable", "upload_in_progress", "gram_file_error"] {
+            let fatal = HerdrClient.fatalStreamOpenError(
+                GramUploadChannel.ChannelError.remoteError(APIError(code: code, message: "no")))
+            XCTAssertEqual((fatal as? APIError)?.code, code, "\(code) must not fall back")
+        }
+    }
 }
 
 /// THE FIXTURES. Duplicated verbatim in App/HerdrApp.swift's MockTransport (the


### PR DESCRIPTION
Two asks, one change: make attachment uploads fast, and raise the 3-file cap. Requires the daemon side, jerryfane/herdr#162 — but ships safely without it (see the fallback below).

## Speed: uploads were round-trip bound

`CitadelTransport.roundTrip` runs one SSH exec per API call, so every 48 KiB chunk cost an SSH channel open, a non-login shell, a fresh `herdr` process, a socket connect and a teardown — 2133 of them for a 100 MB file, with the chunk size itself pinned at 48 KiB by the 120 KB argv cap (the payload is base64'd twice).

`GramUploadChannel` holds ONE `herdr api-bridge --duplex` channel open and writes 512 KiB frames to the daemon's `gram.upload.stream`: 100 MB goes from 2133 process spawns to ~200 acked frames, and wire expansion from 1.78x to 1.33x.

Measured on the daemon side over a local socket (3 MiB, same build, same payload): **0.67s streamed on one connection vs 7.92s per-chunk at 48 KiB**, with the assembled `sha256` matching and `gram.post` accepting the streamed `upload_id` unchanged. The SSH path additionally pays a process spawn per chunk that streaming does not pay at all.

## Cap: the 3-file limit was a MEMORY bound

`PickedAttachment` held the whole file as `Data`, so ten 100 MB picks meant ~1 GB resident on a phone — the recorded reason the cap was cut from 10 to 3. Both pick paths now COPY the pick into an app-owned temp directory and the upload reads that file a frame at a time, so the resident ceiling is one frame regardless of size or count. `maxAttachments` is 10 again, matching the photo picker's own `maxSelectionCount`.

The copies happen inside the existing lifetime windows, which is the only place they can: inside `startAccessingSecurityScopedResource()` for documents (the URL is unreadable after it) and inside the `FileRepresentation` closure for photos (PhotosUI deletes its export when the closure returns).

## Compatibility and failure handling

- Gated on the `gram_upload_stream` ping CAPABILITY, cached per client so a ten-file send pays one probe. Never by attempting the method: an unknown method returns an EMPTY `id`, so the reply cannot be correlated to the attempt.
- A failed open FALLS BACK per-chunk (still reading from disk) for `unsupported`, `closedBeforeAck`, and `invalid_request` — an out-of-date capability flag must not fail a send.
- A real rejection (`invalid_params`, `gram_unavailable`, `upload_in_progress`, `gram_file_error`) is RETHROWN rather than retried: the staged file may be partly written, so a fallback from offset 0 would be a second writer on the same `upload_id`.
- `sendChunk` awaits each ack. Fire-and-forget is right for keystrokes and wrong here — an unbounded queue would undo the point of streaming from disk, and the ack is the only signal an upload has (no echo channel). One continuation slot suffices because frames are strictly ordered.
- The frame encoder disables slash escaping. Base64 is slash-dense (an all-`0xFF` chunk is ALL `/`) and default escaping nearly doubles it.
- `openUploadChannel` is deliberately NOT added to `HerdrTransport`: the downcast keeps all 21 conformances (18 of them test doubles) untouched and puts every double on the fallback path automatically.

## Staged-byte lifetime (a staged attachment can be a secret)

- `.completeFileProtection` is set explicitly after the copy — `copyItem` does not set it, and every other temp write in this file does.
- Removed on chip-X, after a successful send (after the retry set is reassigned, so a failed delete cannot corrupt it), and on page teardown.
- Staging lives under ONE per-session directory, so a crash or jetsam — where `onDisappear` never runs — leaves a single sweepable sibling, which the page's own `.task` removes.
- Cross-file upload concurrency is deliberately NOT added: it would put up to ten uploads in the daemon's 1 GiB staging budget at once and scramble post order, and the caption rides on message 0.

## Verification

- `swift test`: **479 tests, 1 skipped, 0 failures**. Baseline measured on unmodified `origin/main` in the same environment: **474 tests, 1 skipped, 0 failures** — exactly the 5 new tests, nothing else moved.
- New tests: the from-disk path holds the slash-escaping request-line property (`< 80_000` bytes for an all-`0xFF` chunk); offsets are contiguous `[0, 49152, 98304]` and the chunks reassemble the source byte-for-byte; progress reports start at 0, end at the file's real size, and always carry that size; a 512 KiB all-`0xFF` frame encodes unescaped and stays inside the daemon's 1 MiB frame cap; and `fatalStreamOpenError` falls back for `invalid_request`/`unsupported`/`closedBeforeAck` but not for the four real rejection codes.
- The existing in-memory `gramUploadFile(_ data:)` and its slash-escaping guard are unchanged.
- The App target is iOS-only and cannot be compiled on Linux, so `build-and-uitest` is the compiler for `GramView.swift` — please require it green at this head. Every touched Swift file passes `swiftc -frontend -parse`.
