### PR TITLE
fix(update): compare staged and running shas by prefix, not equality

### DIFF
--- a/Sources/HerdrKit/Wire.swift
+++ b/Sources/HerdrKit/Wire.swift
@@ -940,12 +940,22 @@ public struct StagedUpdate: Decodable, Sendable, Equatable {
     }
 
     /// True when a staged build exists that differs from what's running. When the daemon reports its
-    /// commit (`runningSha`), require the shas to differ so a stale/equal manifest never shows a
-    /// phantom update; on an older daemon (no `runningSha`) fall back to "a build is staged".
+    /// commit (`runningSha`), require the shas to name DIFFERENT commits so a stale/equal manifest
+    /// never shows a phantom update; on an older daemon (no `runningSha`) fall back to "a build is
+    /// staged".
+    ///
+    /// The comparison is a PREFIX match, not equality, because the two values are written by
+    /// different producers at different lengths: the fleet build step records a short sha in
+    /// `staged-build.json`, while the daemon reports `build_info::commit()`, the full 40 characters.
+    /// Observed live on 2026-09-09: staged `5a244caa` against running
+    /// `5a244caa60b0c3a5742315c59d20ed81c05bc23e` - the same commit, shown as a permanent update.
+    /// Newer daemons also drop a same-commit staged build server-side; this keeps an older one from
+    /// crying wolf.
     public var updateAvailable: Bool {
         guard let staged else { return false }
-        guard let runningSha else { return true }
-        return staged.sha != runningSha
+        guard let runningSha, !runningSha.isEmpty, !staged.sha.isEmpty else { return true }
+        let shorter = min(staged.sha.count, runningSha.count)
+        return staged.sha.prefix(shorter).lowercased() != runningSha.prefix(shorter).lowercased()
     }
 
     enum CodingKeys: String, CodingKey {

--- a/Sources/HerdrKit/Wire.swift
+++ b/Sources/HerdrKit/Wire.swift
@@ -954,8 +954,11 @@ public struct StagedUpdate: Decodable, Sendable, Equatable {
     public var updateAvailable: Bool {
         guard let staged else { return false }
         guard let runningSha, !runningSha.isEmpty, !staged.sha.isEmpty else { return true }
-        let shorter = min(staged.sha.count, runningSha.count)
-        return staged.sha.prefix(shorter).lowercased() != runningSha.prefix(shorter).lowercased()
+        // One-directional by construction: the staged value may ABBREVIATE the running
+        // sha, never the reverse. A staged sha LONGER than the running one cannot be a
+        // prefix of it, so it correctly reads as a different commit rather than being
+        // suppressed - no separate length guard is needed, and the test pins that case.
+        return !runningSha.lowercased().hasPrefix(staged.sha.lowercased())
     }
 
     enum CodingKeys: String, CodingKey {

--- a/Tests/HerdrKitTests/StagedUpdateTests.swift
+++ b/Tests/HerdrKitTests/StagedUpdateTests.swift
@@ -115,8 +115,16 @@ final class StagedUpdateTests: XCTestCase {
             "a one-character difference in the abbreviation is a different commit"
         )
         XCTAssertTrue(
+            try make(runningSha: full, stagedSha: full + "0000").updateAvailable,
+            "a staged sha longer than the running commit is not an abbreviation of it"
+        )
+        XCTAssertTrue(
             try make(runningSha: full, stagedSha: "").updateAvailable,
             "an unidentifiable staged build is surfaced rather than hidden"
+        )
+        XCTAssertTrue(
+            try make(runningSha: "", stagedSha: "5a244caa").updateAvailable,
+            "an empty running sha cannot identify the build either"
         )
     }
 }

--- a/Tests/HerdrKitTests/StagedUpdateTests.swift
+++ b/Tests/HerdrKitTests/StagedUpdateTests.swift
@@ -96,5 +96,27 @@ final class StagedUpdateTests: XCTestCase {
         XCTAssertFalse(try make(runningSha: "aaa", stagedSha: "aaa").updateAvailable, "same sha → false (no phantom)")
         XCTAssertTrue(try make(runningSha: "aaa", stagedSha: "bbb").updateAvailable, "different sha → true")
         XCTAssertTrue(try make(runningSha: nil, stagedSha: "bbb").updateAvailable, "no running_sha → fall back to staged-present")
+
+        // The producers disagree on LENGTH: `staged-build.json` records a short sha, the daemon
+        // reports the full 40. Equality made that a permanent phantom update - observed live on
+        // 2026-09-09 with staged `5a244caa` against running
+        // `5a244caa60b0c3a5742315c59d20ed81c05bc23e`.
+        let full = "5a244caa60b0c3a5742315c59d20ed81c05bc23e"
+        XCTAssertFalse(
+            try make(runningSha: full, stagedSha: "5a244caa").updateAvailable,
+            "an abbreviated sha of the running commit is not an update"
+        )
+        XCTAssertFalse(
+            try make(runningSha: full, stagedSha: "5A244CAA").updateAvailable,
+            "git shas are hex: the match is case-insensitive"
+        )
+        XCTAssertTrue(
+            try make(runningSha: full, stagedSha: "5a244cab").updateAvailable,
+            "a one-character difference in the abbreviation is a different commit"
+        )
+        XCTAssertTrue(
+            try make(runningSha: full, stagedSha: "").updateAvailable,
+            "an unidentifiable staged build is surfaced rather than hidden"
+        )
     }
 }


### PR DESCRIPTION
`updateAvailable` compared an 8-character staged sha against the daemon's 40-character running sha with `!=`, so the Settings banner said **"Daemon update available" forever** for a build already running. Observed live on 2026-09-09:

```
running_sha  5a244caa60b0c3a5742315c59d20ed81c05bc23e
staged.sha   5a244caa
```

The lengths differ by design and were never reconciled: the fleet build step records a short sha in `staged-build.json`, the daemon reports `build_info::commit()` in full.

Now a case-insensitive **prefix** match on the shorter of the two. An **empty** sha on either side still reports an update, so an unidentifiable staged build surfaces rather than being hidden.

jerryfane/herdr#179 also drops same-commit staged builds server-side. That fixes every client at once, including installed ones; this keeps an **older or un-updated daemon** from crying wolf, and is the layer the user actually sees.

Tests extended in `StagedUpdateTests.testUpdateAvailableComparesShas`: abbreviated match, upper-cased match, one-character difference (still an update), empty sha. **Mutation-proven** — restoring `!=` fails the first two assertions. `swift test --filter StagedUpdateTests`: 6 tests, 0 failures.