### PR TITLE
fix(gram): keep the composer reachable when files are attached

### DIFF
--- a/App/GramView.swift
+++ b/App/GramView.swift
@@ -417,6 +417,14 @@ struct GramView: View {
             content
             bannerView
             composer
+                // The composer must ALWAYS fit: it holds the only way to send. Without a
+                // priority it is just another default-priority row, so when attachments add
+                // the chips strip and the progress block the stack's minimum can exceed the
+                // window - and a VStack overflows rather than clipping, putting the send
+                // button below the bottom edge. On Mac the split-view host anchors that
+                // overflow at the top (HerdrApp.swift:1885), so all of the excess is lost
+                // off-screen and, with no keyboard send, the composer becomes unreachable.
+                .layoutPriority(1)
         }
     }
 
@@ -435,6 +443,7 @@ struct GramView: View {
             content
             bannerView
             composer
+                .layoutPriority(1)   // see phoneBody: the composer must always fit
         }
     }
 
@@ -802,6 +811,10 @@ struct GramView: View {
                         ForEach(attachedFiles) { file in attachmentChip(file) }
                     }
                 }
+                // A ScrollView is greedy in BOTH axes by default, so the horizontal strip
+                // would also claim vertical slack and add to the height the composer
+                // demands. Pin it to the chips' own height.
+                .fixedSize(horizontal: false, vertical: true)
             }
             if let up = uploadBytes {
                 let frac = up.total > 0 ? min(1, Double(up.sent) / Double(up.total)) : 0
@@ -880,6 +893,12 @@ struct GramView: View {
                     .background(Circle().fill(canSend ? Palette.text : Palette.surface))
                 }
                 .disabled(!canSend)
+                // Keyboard send. The field is `axis: .vertical` so Return inserts a newline
+                // (a gram is often multi-line, and `onSubmit` does not fire for a vertical
+                // field anyway) - Command+Return sends, matching Mail and Messages.
+                // This is not a convenience: without it an unreachable send button is a total
+                // lockout, which is exactly what was reported on Mac.
+                .keyboardShortcut(.return, modifiers: .command)
             }
         }
         .padding(.horizontal, 16)


### PR DESCRIPTION
Reported on Mac: **after attaching files the input box and send button end up below the window**, unclickable, with no keyboard way to send.

## Three causes compound

1. **The composer has no layout priority.** It is a plain row of the page `VStack` (`phoneBody` :413, `iPadBody` :433). Attaching files adds the chips strip (:799) and the upload-progress block (:806), while its parts are incompressible — divider, To row, three 38pt buttons (`MicButton` is a fixed 38 at `VoiceInput.swift:300`), and a field growing to five lines. The stack's minimum exceeds the container, and **a VStack overflows rather than clipping**.
2. **The Mac host anchors the overflow at the top** — `ZStack(alignment: .topLeading)` at `HerdrApp.swift:1885` — so 100% of the excess spills off the *bottom*, taking the send button with it.
3. **The chips strip is a `ScrollView`, greedy in both axes**, so it also claimed vertical slack it never needed.

The feed cannot always give the space back: `centered` (:700-703) floors it at the empty/error art height in five states.

## Fix — 19 lines, all additive

- `.layoutPriority(1)` on `composer` in both bodies: it holds the only way to send, so it must always fit
- `.fixedSize(horizontal: false, vertical: true)` on the chips strip
- **`.keyboardShortcut(.return, modifiers: .command)` to send**

The last one is not a nicety. The field is `axis: .vertical`, so Return inserts a newline and `onSubmit` never fires — **that absence is what turned a layout glitch into a total lockout.** Command+Return matches Mail and Messages.

## Verification

`swiftc -parse` clean; the diff is **19 insertions, 0 deletions** (the send button is byte-identical — an earlier bad edit was fully reverted).

**Not verified: the visual result on Mac.** This Linux host has no simulator, so the layout claim rests on the code path, not a screenshot. The reporter can confirm on the next TestFlight build; if the composer still overflows in some state, the next step is `.safeAreaInset(edge: .bottom)` (precedent at `AgentSessionTransferSheet.swift:96`), which is a bigger change I did not make speculatively.