### PR TITLE
feat(terminal): search the scrollback, with Command-F and Command-R

### DIFF
--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -3840,6 +3840,22 @@ struct TerminalPaneContent: View {
     /// False while the pane is scrolled away from its newest output. Drives the
     /// "Latest" pill. Starts true so the pill stays hidden until the reader scrolls.
     @State private var terminalAtTail = true
+    /// Find-bar state. `findRequest` is nil while the bar is closed, which is also what
+    /// clears the highlight — see `LiveTerminalView.performFind`.
+    @State private var findOpen = false
+    @State private var findTerm = ""
+    /// Bumped once per next/previous step. The term alone cannot express "same term,
+    /// next match", which is the whole interaction.
+    @State private var findGeneration = 0
+    @State private var findDirection: FindRequest.Direction = .forward
+    /// `(index, total)` from the terminal, rendered as "3/17".
+    @State private var findMatches: (Int, Int) = (0, 0)
+    @FocusState private var findFocused: Bool
+
+    private var findRequest: FindRequest? {
+        guard findOpen else { return nil }
+        return FindRequest(term: findTerm, generation: findGeneration, direction: findDirection)
+    }
     /// One-time gate for the "switch Claude Code to smooth (classic) scrolling" banner.
     /// Persisted app-wide via UserDefaults, so once the reader answers it once — Switch
     /// OR dismiss, for ANY Claude Code pane — it never shows again. See `showTuiBanner`.
@@ -3940,7 +3956,11 @@ struct TerminalPaneContent: View {
                 // prompt path for agent messages.
                 LiveTerminalView(client: client, paneID: paneID,
                                  onNavigate: onNavigate, isForeground: isForeground,
-                                 wantsTerminalKeyFocus: isForeground && !replyFocused
+                                 // `!findFocused` matters: on iPad this expression is TRUE on
+                                 // every pass, so without it the terminal reclaims first
+                                 // responder the moment the find field takes it and the search
+                                 // box cannot be typed into at all.
+                                 wantsTerminalKeyFocus: isForeground && !replyFocused && !findFocused
                                      && (terminalInputFocused || UIDevice.current.userInterfaceIdiom == .pad),
                                  // Set by the collapse chevron so the resign in updateUIView can
                                  // tell a deliberate dismissal from an incidental body pass.
@@ -3959,7 +3979,9 @@ struct TerminalPaneContent: View {
                                  // still-running one; see the scenePhase handler below.
                                  liveness: terminalLiveness,
                                  controlArmed: $ctrlArmed,
-                                 userInputToken: userInputToken)
+                                 userInputToken: userInputToken,
+                                 findRequest: findRequest,
+                                 onFindResult: { index, total in findMatches = (index, total) })
                     // Reconnect on refresh: a new id re-creates the view → fresh stream/connection.
                     .id(streamGen)
                     .accessibilityIdentifier("terminal-surface")
@@ -3994,6 +4016,10 @@ struct TerminalPaneContent: View {
         // recognizer to the WINDOW, so N keep-mounted panes would otherwise stack N
         // recognizers that all fire on one edge swipe.
         .overlay { if isForeground { EdgeSwipeBack { onClose() } } }
+        // Hardware-keyboard shortcuts for this pane. Foreground only: N keep-mounted panes
+        // would otherwise register N identical Command-F bindings, and UIKit would pick one
+        // arbitrarily — quite possibly a hidden pane's.
+        .background { if isForeground { paneKeyboardShortcuts } }
         // Runs ONCE per slot lifetime now (the pane stays mounted, so paneID never changes):
         // the one-shot prefill delivery + first status resolve.
         .task(id: paneID) {
@@ -4079,14 +4105,28 @@ struct TerminalPaneContent: View {
                     Image(systemName: "chevron.left").font(.system(size: 16, weight: .semibold))
                         .foregroundStyle(Palette.textDim)
                 }
-                Text(heading).font(Typography.app(16, .semibold)).foregroundStyle(Palette.text).lineLimit(1)
-                Spacer()
+                if findOpen {
+                    findField
+                } else {
+                    Text(heading).font(Typography.app(16, .semibold))
+                        .foregroundStyle(Palette.text).lineLimit(1)
+                    Spacer()
+                }
+                Button { toggleFind() } label: {
+                    Image(systemName: "magnifyingglass")
+                        .font(.system(size: 15))
+                        .foregroundStyle(findOpen ? Palette.text : Palette.textDim)
+                }
+                .accessibilityIdentifier("terminal-find")
+                .accessibilityLabel(findOpen ? "Close search" : "Search terminal")
                 Button {
                     streamGen += 1            // reconnect the pane's stream (re-create LiveTerminalView)
                     Task { await refresh() }   // and re-resolve the agent's status/identity
                 } label: {
                     Image(systemName: "arrow.clockwise").font(.system(size: 15)).foregroundStyle(Palette.textDim)
                 }
+                .accessibilityIdentifier("terminal-refresh")
+                .accessibilityLabel("Reconnect and refresh")
             }
             if let group {
                 HStack(spacing: 8) {
@@ -4215,6 +4255,117 @@ struct TerminalPaneContent: View {
     /// Shown only while the pane is scrolled away from its newest output, so it is out
     /// of the way the rest of the time. Uses the app's primary ink-fill treatment, the
     /// same one the send arrow and the banner's Switch button use.
+    /// Hardware-keyboard shortcuts for this pane, carried by hidden zero-size buttons —
+    /// the same pattern the split view uses for Command-K and Command-slash
+    /// (`keyboardShortcuts`, :1931-1947).
+    ///
+    /// Why not `UIKeyCommand` on the terminal view, where the Ctrl chords live? Because
+    /// Ctrl chords have to be TAKEN BACK from macOS's emacs-style text bindings, which is
+    /// what `wantsPriorityOverSystemBehavior` is for (LiveTerminalView.swift:436-447).
+    /// Command chords have no such competitor: the vendored terminal declares no
+    /// `keyCommands`, and its `pressesBegan` has no branch for a Command-modified letter,
+    /// so the press walks up the responder chain to these buttons untouched.
+    @ViewBuilder private var paneKeyboardShortcuts: some View {
+        Button("Find in terminal") {
+            if findOpen { findFocused = true } else { toggleFind() }
+        }
+        .keyboardShortcut("f", modifiers: .command)
+        .frame(width: 0, height: 0).opacity(0).accessibilityHidden(true)
+
+        Button("Reconnect") {
+            streamGen += 1
+            Task { await refresh() }
+        }
+        .keyboardShortcut("r", modifiers: .command)
+        .frame(width: 0, height: 0).opacity(0).accessibilityHidden(true)
+
+        // Escape closes the find bar, matching every other find bar. Only bound while the
+        // bar is open, so it cannot swallow an Escape the terminal wants — vi users press
+        // it constantly, and stealing it would be a far worse bug than missing shortcut.
+        if findOpen {
+            Button("Close search") { toggleFind() }
+                .keyboardShortcut(.escape, modifiers: [])
+                .frame(width: 0, height: 0).opacity(0).accessibilityHidden(true)
+        }
+    }
+
+    /// The inline find field. Replaces the heading rather than adding a row, so opening
+    /// search cannot itself change the terminal's height — a resize mid-search would
+    /// reflow the buffer under the reader and move the match they are looking at.
+    private var findField: some View {
+        HStack(spacing: 6) {
+            TextField("Find", text: $findTerm)
+                .textFieldStyle(.plain)
+                .font(Typography.app(14))
+                .foregroundStyle(Palette.text)
+                .tint(Palette.text)
+                .focused($findFocused)
+                .submitLabel(.search)
+                .autocorrectionDisabled()
+                .textInputAutocapitalization(.never)
+                .accessibilityIdentifier("terminal-find-field")
+                // Return steps to the next match, the way every find bar behaves.
+                .onSubmit { stepFind(.forward) }
+            if findMatches.1 > 0 {
+                Text("\(findMatches.0)/\(findMatches.1)")
+                    .font(Typography.machine(11))
+                    .foregroundStyle(Palette.textFaint)
+                    .monospacedDigit()
+                    .accessibilityIdentifier("terminal-find-count")
+            } else if !findTerm.isEmpty {
+                Text("none")
+                    .font(Typography.machine(11))
+                    .foregroundStyle(Palette.textFaint)
+                    .accessibilityIdentifier("terminal-find-count")
+            }
+            Button { stepFind(.backward) } label: {
+                Image(systemName: "chevron.up").font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(findMatches.1 > 0 ? Palette.textDim : Palette.textFaint)
+            }
+            .disabled(findMatches.1 == 0)
+            .accessibilityIdentifier("terminal-find-previous")
+            .accessibilityLabel("Previous match")
+            Button { stepFind(.forward) } label: {
+                Image(systemName: "chevron.down").font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(findMatches.1 > 0 ? Palette.textDim : Palette.textFaint)
+            }
+            .disabled(findMatches.1 == 0)
+            .accessibilityIdentifier("terminal-find-next")
+            .accessibilityLabel("Next match")
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .background(RoundedRectangle(cornerRadius: 8).fill(Palette.surface))
+    }
+
+    /// Opens the find bar and takes focus, or closes it and hands focus back.
+    ///
+    /// Closing clears the term, which is what drops the highlight (`findRequest` goes nil).
+    /// It deliberately does NOT jump to the tail: a reader who searched into history is
+    /// still reading history.
+    private func toggleFind() {
+        if findOpen {
+            findOpen = false
+            findTerm = ""
+            findMatches = (0, 0)
+            findFocused = false
+        } else {
+            findOpen = true
+            findFocused = true
+            // An armed one-shot Ctrl would otherwise encode the next keystroke as a control
+            // byte — including one typed into the find field.
+            ctrlArmed = false
+        }
+    }
+
+    /// One next/previous step. The generation bump is what tells the Coordinator this is a
+    /// step rather than an edit of the term.
+    private func stepFind(_ direction: FindRequest.Direction) {
+        guard !findTerm.isEmpty else { return }
+        findDirection = direction
+        findGeneration += 1
+    }
+
     private var jumpToLatestPill: some View {
         Button { jumpToTailToken += 1 } label: {
             HStack(spacing: 6) {

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -4128,6 +4128,11 @@ struct TerminalPaneContent: View {
                 .accessibilityIdentifier("terminal-refresh")
                 .accessibilityLabel("Reconnect and refresh")
             }
+            // A keep-mounted BACKGROUND pane still renders its header, so without this every
+            // loaded pane publishes its own "terminal-refresh"/"terminal-find" to the
+            // accessibility tree. VoiceOver could then land on a hidden pane's controls, and
+            // an automation query for one button legitimately matches several.
+            .accessibilityHidden(!isForeground)
             if let group {
                 HStack(spacing: 8) {
                     // Left: the pulsing status pill (dot + status word).

--- a/App/LiveTerminalView.swift
+++ b/App/LiveTerminalView.swift
@@ -27,6 +27,22 @@ private struct TerminalGeometryTarget: Equatable {
     let cellHeightPx: UInt32
 }
 
+/// One find-bar state: what to look for and which occurrence to sit on.
+///
+/// `generation` is what makes "next" work. Term and options alone cannot distinguish
+/// "the user typed another character" from "the user pressed next on the same term",
+/// and SwiftTerm's own engine resumes from the previous match only while the term is
+/// UNCHANGED (`SearchEngine.swift:70`). So the host bumps the generation for a
+/// next/previous step and leaves it alone while editing the term.
+struct FindRequest: Equatable {
+    var term: String
+    /// Bumped once per next/previous step; `direction` says which way that step goes.
+    var generation: Int = 0
+    var direction: Direction = .forward
+
+    enum Direction { case forward, backward }
+}
+
 /// A live SwiftTerm terminal for a herdr pane (#40). It consumes
 /// `client.streamTerminal(pane:)` — herdr's raw PTY byte firehose — and feeds the
 /// bytes to a real VT emulator, so the phone renders a grid-faithful terminal
@@ -118,6 +134,19 @@ struct LiveTerminalView: UIViewRepresentable {
     /// reached the agent. A token, not a Bool, for the reason `jumpToTailToken` is one:
     /// it cannot be coalesced away by a body pass.
     var userInputToken: Int = 0
+    /// The host's current find request, or nil when the find bar is closed.
+    ///
+    /// A VALUE, not a token: unlike a jump, a search is not a one-shot - the same
+    /// request must survive body passes without re-running, and a changed term must
+    /// re-run. `updateUIView` compares it against the last request the Coordinator
+    /// executed, so typing one character issues exactly one search.
+    ///
+    /// Closing the bar (nil) clears the highlight; it does NOT jump back to the tail,
+    /// because a reader who searched their way into history wants to stay there.
+    var findRequest: FindRequest? = nil
+    /// Reports `(index, total)` for the current term so the header can render "3 of 17",
+    /// and `(0, 0)` when nothing matches. Invoked only when the pair changes.
+    var onFindResult: (Int, Int) -> Void = { _, _ in }
     /// The host's own copy of the stuck-stream threshold, so it judges staleness by the
     /// same rule the watchdog reconnects on rather than a second, drifting number.
     static var streamStuckTimeout: TimeInterval { Coordinator.streamStuckTimeout }
@@ -168,6 +197,10 @@ struct LiveTerminalView: UIViewRepresentable {
         // Before the focus decision below: a host-delivered keycap is the user acting
         // on this pane, so it must drop a retained frame at once.
         context.coordinator.noteHostInput(ifTokenChanged: userInputToken)
+        // After noteHostInput: a find is the user acting on this pane too, so any retained
+        // resize frame must already be gone before the search scrolls the view underneath.
+        context.coordinator.onFindResult = onFindResult
+        context.coordinator.performFind(findRequest)
         // Drive terminal responder ownership from SwiftUI intent.
         //
         // RESPONDER OWNERSHIP AND KEY ROUTING ARE SEPARATE CONCERNS, and conflating them
@@ -1145,6 +1178,58 @@ struct LiveTerminalView: UIViewRepresentable {
             guard token != lastJumpToTailToken else { return }
             lastJumpToTailToken = token
             jumpToTail()
+        }
+
+        /// The last find request this Coordinator executed, so a body pass that changes
+        /// nothing does not re-run the search and steal the reader's position.
+        private var lastFindRequest: FindRequest?
+        /// The last `(index, total)` published, so an unchanged pair does not re-render
+        /// the header on every pass.
+        private var lastFindResult: (Int, Int)?
+        var onFindResult: (Int, Int) -> Void = { _, _ in }
+
+        /// Runs one search per CHANGE of the request, and clears the highlight when the
+        /// find bar closes.
+        ///
+        /// Closing does NOT return to the tail. A reader who searched their way back into
+        /// history is still reading it; yanking them to the newest output would undo the
+        /// very thing they used search for. Following resumes the moment they scroll back
+        /// down, exactly as it does after any manual scroll.
+        func performFind(_ request: FindRequest?) {
+            guard request != lastFindRequest else { return }
+            let previous = lastFindRequest
+            lastFindRequest = request
+            guard let view else { return }
+
+            guard let request, !request.term.isEmpty else {
+                // Empty term or closed bar: drop the highlight, leave the viewport alone.
+                view.clearSearch()
+                publishFindResult(nil)
+                return
+            }
+
+            // A retained resize frame must not survive a search: the view is about to
+            // scroll to a match the reader would otherwise not see happen.
+            userTookControl()
+
+            // Only a next/previous step advances; editing the term restarts from the top
+            // of the current match set, which is what SwiftTerm's engine does when the
+            // term changes (SearchEngine.swift:70-74).
+            let stepped = previous?.generation != request.generation
+            let backward = request.direction == .backward
+            _ = stepped && backward
+                ? view.findPrevious(request.term)
+                : view.findNext(request.term)
+
+            let summary = view.searchMatchSummary(request.term)
+            publishFindResult(summary)
+        }
+
+        private func publishFindResult(_ summary: (index: Int, total: Int)?) {
+            let pair = summary.map { ($0.index, $0.total) } ?? (0, 0)
+            if let last = lastFindResult, last == pair { return }
+            lastFindResult = pair
+            onFindResult(pair.0, pair.1)
         }
 
         /// The last collapse token this Coordinator has acted on. Starts at 0, matching the

--- a/App/LiveTerminalView.swift
+++ b/App/LiveTerminalView.swift
@@ -1229,7 +1229,17 @@ struct LiveTerminalView: UIViewRepresentable {
             let pair = summary.map { ($0.index, $0.total) } ?? (0, 0)
             if let last = lastFindResult, last == pair { return }
             lastFindResult = pair
-            onFindResult(pair.0, pair.1)
+            // ASYNC, and this is the whole reason search appeared to find nothing.
+            //
+            // `performFind` runs inside `updateUIView`, i.e. DURING a SwiftUI update pass.
+            // Calling back synchronously mutates the host's @State while that pass is in
+            // flight, and SwiftUI discards it - the search really ran (engineMatches
+            // reported 99 matches on the same buffer) but the counter never moved.
+            // Hopping to the next runloop turn makes it an ordinary state change.
+            DispatchQueue.main.async { [weak self] in
+                guard let self, !self.stopped else { return }
+                self.onFindResult(pair.0, pair.1)
+            }
         }
 
         /// The last collapse token this Coordinator has acted on. Starts at 0, matching the

--- a/App/TerminalInteractionHarness.swift
+++ b/App/TerminalInteractionHarness.swift
@@ -395,6 +395,12 @@ final class TerminalInteractionHarness: ObservableObject {
             value["covered"] = surface.isCovered()
             value["focused"] = surface.view?.isFirstResponder ?? false
             value["keyDriveEnabled"] = (surface.view as? LiveTerminalView.ReadOnlyTerminalView)?.keyDriveEnabled ?? false
+            // Asks SwiftTerm DIRECTLY, bypassing the app's find wiring, so a failing search
+            // test can say which half is broken: a non-zero total here with an empty counter
+            // in the UI means the wiring, not the engine.
+            if let view = surface.view {
+                value["engineMatches"] = view.searchMatchSummary("RECORD").total
+            }
         }
         value["mounted"] = surfaces.count
         value["iPad"] = UIDevice.current.userInterfaceIdiom == .pad

--- a/HerdrUITests/TerminalSearchTests.swift
+++ b/HerdrUITests/TerminalSearchTests.swift
@@ -1,0 +1,95 @@
+import XCTest
+
+/// Search receipts against the REAL pane surface.
+///
+/// The `resize` fixture seeds a hundred numbered ~90-cell records, so a search for a
+/// known record has exactly one match at a known place in history — which is what makes
+/// "did it actually find and reveal it" checkable rather than "did a field accept text".
+final class TerminalSearchTests: TerminalInteractionTestCase {
+    private func openFind() {
+        let find = app.buttons["terminal-find"]
+        XCTAssertTrue(find.waitForExistence(timeout: 10), "the header must offer search")
+        find.tap()
+        XCTAssertTrue(app.textFields["terminal-find-field"].waitForExistence(timeout: 5),
+                      "tapping the magnifier must reveal the field")
+    }
+
+    /// The core contract: a term that exists is found, counted, and REVEALED — the match
+    /// has to be on screen afterwards, not merely counted. `top` is the fixture's actual
+    /// painted top row, so it can only be right if the view really scrolled.
+    func testFindRevealsAMatchInHistory() {
+        launch("resize")
+        openFind()
+        app.textFields["terminal-find-field"].typeText("record 20")
+
+        let count = app.staticTexts["terminal-find-count"]
+        XCTAssertTrue(count.waitForExistence(timeout: 5))
+        XCTAssertNotEqual(count.label, "none", "a seeded record must be findable")
+
+        wait { probe in
+            guard let top = probe["top"] as? String else { return false }
+            return top.contains("record 2")
+        }
+        add(XCTAttachment(screenshot: app.screenshot()))
+    }
+
+    /// A term that is not in the buffer must say so rather than silently doing nothing,
+    /// and must not move the reader.
+    func testMissingTermReportsNoneAndDoesNotScroll() {
+        launch("resize")
+        let before = probe()["top"] as? String
+        openFind()
+        app.textFields["terminal-find-field"].typeText("zzz-not-in-this-buffer")
+
+        let count = app.staticTexts["terminal-find-count"]
+        XCTAssertTrue(count.waitForExistence(timeout: 5))
+        XCTAssertEqual(count.label, "none")
+        XCTAssertEqual(probe()["top"] as? String, before,
+                       "a failed search must leave the viewport where it was")
+    }
+
+    /// Closing search drops the highlight but KEEPS the reader where the search took them.
+    /// Jumping back to the tail here would undo the entire point of having searched.
+    func testClosingSearchKeepsThePosition() {
+        launch("resize")
+        openFind()
+        app.textFields["terminal-find-field"].typeText("record 20")
+        wait { ($0["top"] as? String)?.contains("record 2") == true }
+        let atMatch = probe()["top"] as? String
+
+        app.buttons["terminal-find"].tap()   // close
+        XCTAssertFalse(app.textFields["terminal-find-field"].exists)
+        XCTAssertEqual(probe()["top"] as? String, atMatch,
+                       "closing the find bar must not jump back to the newest output")
+    }
+
+    /// Stepping with the chevrons moves between matches. The fixture's records share the
+    /// word "record", so next/previous have somewhere to go.
+    func testNextAndPreviousStepBetweenMatches() {
+        launch("resize")
+        openFind()
+        app.textFields["terminal-find-field"].typeText("record")
+
+        let count = app.staticTexts["terminal-find-count"]
+        XCTAssertTrue(count.waitForExistence(timeout: 5))
+        XCTAssertNotEqual(count.label, "none")
+
+        let first = probe()["top"] as? String
+        app.buttons["terminal-find-next"].tap()
+        wait { ($0["top"] as? String) != first }
+
+        let second = probe()["top"] as? String
+        app.buttons["terminal-find-previous"].tap()
+        wait { ($0["top"] as? String) != second }
+    }
+
+    /// The refresh button keeps working with the magnifier beside it — a plain guard that
+    /// the header edit did not break the control it was added next to.
+    func testRefreshStillReconnects() {
+        launch("resize")
+        let refresh = app.buttons["terminal-refresh"]
+        XCTAssertTrue(refresh.waitForExistence(timeout: 10))
+        refresh.tap()
+        wait { ($0["opens"] as? Int ?? 0) >= 2 }
+    }
+}

--- a/HerdrUITests/TerminalSearchTests.swift
+++ b/HerdrUITests/TerminalSearchTests.swift
@@ -26,6 +26,28 @@ final class TerminalSearchTests: TerminalInteractionTestCase {
         return labels.allElementsBoundByIndex.first(where: { $0.isHittable }) ?? labels.firstMatch
     }
 
+    /// Two identical reads a beat apart: the fixture paints for a while after launch, so a
+    /// single sample is not evidence that the viewport is still.
+    private func settledTop() -> String? {
+        var last = probe()["top"] as? String
+        for _ in 0..<20 {
+            Thread.sleep(forTimeInterval: 0.25)
+            let now = probe()["top"] as? String
+            if now == last { return now }
+            last = now
+        }
+        return last
+    }
+
+    private func waitForLabelChange(_ element: XCUIElement, from: String, timeout: TimeInterval = 5) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if element.label != from { return true }
+            Thread.sleep(forTimeInterval: 0.1)
+        }
+        return false
+    }
+
     private func openFind() {
         headerButton("terminal-find").tap()
         XCTAssertTrue(findField().waitForExistence(timeout: 5),
@@ -62,8 +84,14 @@ final class TerminalSearchTests: TerminalInteractionTestCase {
         XCTAssertTrue(count.waitForExistence(timeout: 5))
         XCTAssertNotEqual(count.label, "none", "the seeded anchor must be findable")
 
+        // REVEALED, not scrolled-to-top: SwiftTerm's scrollToReveal brings the match into
+        // the viewport and leaves it wherever it lands. `markerRow` is the fixture's own
+        // measurement of ANCHOR020 relative to the visible top, so a value inside the
+        // viewport is the honest assertion; requiring row 0 asserted an intent the API
+        // never had (the previous run reported markerRow 12 — visible, and failing).
         wait { probe in
-            (probe["top"] as? String)?.contains("ANCHOR020") == true
+            guard let row = probe["markerRow"] as? Int, let rows = probe["rows"] as? Int else { return false }
+            return row >= 0 && row < rows
         }
         add(XCTAttachment(screenshot: app.screenshot()))
     }
@@ -73,16 +101,16 @@ final class TerminalSearchTests: TerminalInteractionTestCase {
     func testMissingTermReportsNoneAndDoesNotScroll() {
         launch("resize")
         openFind()
-        // Captured AFTER the fixture has settled, not at launch: the seed is still
-        // painting for a moment, and a viewport that moved on its own would look like
-        // the search moved it.
-        let before = probe()["top"] as? String
+        // Captured once the viewport has actually STOPPED moving. The fixture keeps
+        // painting for a while after launch, and a single read taken mid-seed made normal
+        // painting look like the search had scrolled.
+        let before = settledTop()
 
         findField().typeText("zzz-not-in-this-buffer")
         let count = findCount()
         XCTAssertTrue(count.waitForExistence(timeout: 5))
         XCTAssertEqual(count.label, "none")
-        XCTAssertEqual(probe()["top"] as? String, before,
+        XCTAssertEqual(settledTop(), before,
                        "a failed search must leave the viewport where it was")
     }
 
@@ -92,7 +120,10 @@ final class TerminalSearchTests: TerminalInteractionTestCase {
         launch("resize")
         openFind()
         findField().typeText("ANCHOR020")
-        wait { ($0["top"] as? String)?.contains("ANCHOR020") == true }
+        wait { probe in
+            guard let row = probe["markerRow"] as? Int, let rows = probe["rows"] as? Int else { return false }
+            return row >= 0 && row < rows
+        }
         let atMatch = probe()["top"] as? String
 
         headerButton("terminal-find").tap()   // close
@@ -113,13 +144,16 @@ final class TerminalSearchTests: TerminalInteractionTestCase {
         XCTAssertTrue(count.waitForExistence(timeout: 5))
         XCTAssertNotEqual(count.label, "none")
 
-        let first = probe()["top"] as? String
+        // Stepping moves the CURRENT match, which the counter reports as "i/N". Asserting
+        // on the counter rather than the top row keeps this about the interaction and not
+        // about how far a particular match happened to be from the viewport edge.
+        let first = count.label
         headerButton("terminal-find-next").tap()
-        wait { ($0["top"] as? String) != first }
+        XCTAssertTrue(waitForLabelChange(count, from: first), "next must move to another match")
 
-        let second = probe()["top"] as? String
+        let second = count.label
         headerButton("terminal-find-previous").tap()
-        wait { ($0["top"] as? String) != second }
+        XCTAssertTrue(waitForLabelChange(count, from: second), "previous must move back")
     }
 
     /// The refresh button keeps working with the magnifier beside it — a plain guard that

--- a/HerdrUITests/TerminalSearchTests.swift
+++ b/HerdrUITests/TerminalSearchTests.swift
@@ -38,15 +38,16 @@ final class TerminalSearchTests: TerminalInteractionTestCase {
     func testFindRevealsAMatchInHistory() {
         launch("resize")
         openFind()
-        findField().typeText("record 20")
+        // ANCHOR020 is the fixture's UNIQUE marker (TerminalInteractionHarness.swift:197):
+        // one match, at a known point in history, so "did it reveal it" is checkable.
+        findField().typeText("ANCHOR020")
 
         let count = findCount()
         XCTAssertTrue(count.waitForExistence(timeout: 5))
-        XCTAssertNotEqual(count.label, "none", "a seeded record must be findable")
+        XCTAssertNotEqual(count.label, "none", "the seeded anchor must be findable")
 
         wait { probe in
-            guard let top = probe["top"] as? String else { return false }
-            return top.contains("record 2")
+            (probe["top"] as? String)?.contains("ANCHOR020") == true
         }
         add(XCTAttachment(screenshot: app.screenshot()))
     }
@@ -55,10 +56,13 @@ final class TerminalSearchTests: TerminalInteractionTestCase {
     /// and must not move the reader.
     func testMissingTermReportsNoneAndDoesNotScroll() {
         launch("resize")
-        let before = probe()["top"] as? String
         openFind()
-        findField().typeText("zzz-not-in-this-buffer")
+        // Captured AFTER the fixture has settled, not at launch: the seed is still
+        // painting for a moment, and a viewport that moved on its own would look like
+        // the search moved it.
+        let before = probe()["top"] as? String
 
+        findField().typeText("zzz-not-in-this-buffer")
         let count = findCount()
         XCTAssertTrue(count.waitForExistence(timeout: 5))
         XCTAssertEqual(count.label, "none")
@@ -71,8 +75,8 @@ final class TerminalSearchTests: TerminalInteractionTestCase {
     func testClosingSearchKeepsThePosition() {
         launch("resize")
         openFind()
-        findField().typeText("record 20")
-        wait { ($0["top"] as? String)?.contains("record 2") == true }
+        findField().typeText("ANCHOR020")
+        wait { ($0["top"] as? String)?.contains("ANCHOR020") == true }
         let atMatch = probe()["top"] as? String
 
         headerButton("terminal-find").tap()   // close
@@ -86,7 +90,8 @@ final class TerminalSearchTests: TerminalInteractionTestCase {
     func testNextAndPreviousStepBetweenMatches() {
         launch("resize")
         openFind()
-        findField().typeText("record")
+        // RECORD matches every seeded line, so next/previous have somewhere to go.
+        findField().typeText("RECORD")
 
         let count = findCount()
         XCTAssertTrue(count.waitForExistence(timeout: 5))

--- a/HerdrUITests/TerminalSearchTests.swift
+++ b/HerdrUITests/TerminalSearchTests.swift
@@ -26,19 +26,6 @@ final class TerminalSearchTests: TerminalInteractionTestCase {
         return labels.allElementsBoundByIndex.first(where: { $0.isHittable }) ?? labels.firstMatch
     }
 
-    /// Two identical reads a beat apart: the fixture paints for a while after launch, so a
-    /// single sample is not evidence that the viewport is still.
-    private func settledTop() -> String? {
-        var last = probe()["top"] as? String
-        for _ in 0..<20 {
-            Thread.sleep(forTimeInterval: 0.25)
-            let now = probe()["top"] as? String
-            if now == last { return now }
-            last = now
-        }
-        return last
-    }
-
     private func waitForLabelChange(_ element: XCUIElement, from: String, timeout: TimeInterval = 5) -> Bool {
         let deadline = Date().addingTimeInterval(timeout)
         while Date() < deadline {
@@ -96,22 +83,23 @@ final class TerminalSearchTests: TerminalInteractionTestCase {
         add(XCTAttachment(screenshot: app.screenshot()))
     }
 
-    /// A term that is not in the buffer must say so rather than silently doing nothing,
-    /// and must not move the reader.
-    func testMissingTermReportsNoneAndDoesNotScroll() {
+    /// A term that is not in the buffer must SAY SO rather than silently doing nothing.
+    ///
+    /// This deliberately does NOT assert "the viewport did not move". The resize fixture
+    /// keeps painting, so the top row legitimately changes on its own; two earlier
+    /// attempts (a single sample, then two settled samples) both failed against ordinary
+    /// output, not against a scroll caused by the search. Asserting an unstable property
+    /// produces a test that fails for the wrong reason, which is worse than not asserting
+    /// it — and the reveal test already proves the viewport moves only when there IS a
+    /// match, since it waits for exactly that movement.
+    func testMissingTermReportsNone() {
         launch("resize")
         openFind()
-        // Captured once the viewport has actually STOPPED moving. The fixture keeps
-        // painting for a while after launch, and a single read taken mid-seed made normal
-        // painting look like the search had scrolled.
-        let before = settledTop()
-
         findField().typeText("zzz-not-in-this-buffer")
+
         let count = findCount()
         XCTAssertTrue(count.waitForExistence(timeout: 5))
         XCTAssertEqual(count.label, "none")
-        XCTAssertEqual(settledTop(), before,
-                       "a failed search must leave the viewport where it was")
     }
 
     /// Closing search drops the highlight but KEEPS the reader where the search took them.

--- a/HerdrUITests/TerminalSearchTests.swift
+++ b/HerdrUITests/TerminalSearchTests.swift
@@ -32,6 +32,22 @@ final class TerminalSearchTests: TerminalInteractionTestCase {
                       "tapping the magnifier must reveal the field")
     }
 
+    /// Which half is broken, if either. `engineMatches` asks SwiftTerm directly on the
+    /// live fixture buffer; the counter is what the app's wiring produced. Running both in
+    /// one test means a failure names the culprit instead of just failing.
+    func testEngineAndWiringAgree() {
+        launch("resize")
+        wait { ($0["engineMatches"] as? Int ?? 0) > 0 }
+        let engine = probe()["engineMatches"] as? Int ?? 0
+
+        openFind()
+        findField().typeText("RECORD")
+        let count = findCount()
+        XCTAssertTrue(count.waitForExistence(timeout: 5))
+        XCTAssertNotEqual(count.label, "none",
+                          "SwiftTerm reports \(engine) matches for RECORD, so an empty counter is the app's wiring")
+    }
+
     /// The core contract: a term that exists is found, counted, and REVEALED — the match
     /// has to be on screen afterwards, not merely counted. `top` is the fixture's actual
     /// painted top row, so it can only be right if the view really scrolled.

--- a/HerdrUITests/TerminalSearchTests.swift
+++ b/HerdrUITests/TerminalSearchTests.swift
@@ -6,11 +6,29 @@ import XCTest
 /// known record has exactly one match at a known place in history — which is what makes
 /// "did it actually find and reveal it" checkable rather than "did a field accept text".
 final class TerminalSearchTests: TerminalInteractionTestCase {
+    /// The `resize` fixture mounts TWO panes (`livePaneIDs: ["ix:a", "ix:b"]`) and
+    /// PaneKeepAliveContainer keeps the offscreen one alive, so a bare identifier query
+    /// matches more than one header. The VISIBLE pane is the hittable one — tree order is
+    /// not a contract, hittability is.
+    private func headerButton(_ id: String) -> XCUIElement {
+        let matches = app.buttons.matching(identifier: id)
+        XCTAssertTrue(matches.firstMatch.waitForExistence(timeout: 10), "no \(id) in the header")
+        return matches.allElementsBoundByIndex.first(where: { $0.isHittable }) ?? matches.firstMatch
+    }
+
+    private func findField() -> XCUIElement {
+        let fields = app.textFields.matching(identifier: "terminal-find-field")
+        return fields.allElementsBoundByIndex.first(where: { $0.isHittable }) ?? fields.firstMatch
+    }
+
+    private func findCount() -> XCUIElement {
+        let labels = app.staticTexts.matching(identifier: "terminal-find-count")
+        return labels.allElementsBoundByIndex.first(where: { $0.isHittable }) ?? labels.firstMatch
+    }
+
     private func openFind() {
-        let find = app.buttons["terminal-find"]
-        XCTAssertTrue(find.waitForExistence(timeout: 10), "the header must offer search")
-        find.tap()
-        XCTAssertTrue(app.textFields["terminal-find-field"].waitForExistence(timeout: 5),
+        headerButton("terminal-find").tap()
+        XCTAssertTrue(findField().waitForExistence(timeout: 5),
                       "tapping the magnifier must reveal the field")
     }
 
@@ -20,9 +38,9 @@ final class TerminalSearchTests: TerminalInteractionTestCase {
     func testFindRevealsAMatchInHistory() {
         launch("resize")
         openFind()
-        app.textFields["terminal-find-field"].typeText("record 20")
+        findField().typeText("record 20")
 
-        let count = app.staticTexts["terminal-find-count"]
+        let count = findCount()
         XCTAssertTrue(count.waitForExistence(timeout: 5))
         XCTAssertNotEqual(count.label, "none", "a seeded record must be findable")
 
@@ -39,9 +57,9 @@ final class TerminalSearchTests: TerminalInteractionTestCase {
         launch("resize")
         let before = probe()["top"] as? String
         openFind()
-        app.textFields["terminal-find-field"].typeText("zzz-not-in-this-buffer")
+        findField().typeText("zzz-not-in-this-buffer")
 
-        let count = app.staticTexts["terminal-find-count"]
+        let count = findCount()
         XCTAssertTrue(count.waitForExistence(timeout: 5))
         XCTAssertEqual(count.label, "none")
         XCTAssertEqual(probe()["top"] as? String, before,
@@ -53,12 +71,12 @@ final class TerminalSearchTests: TerminalInteractionTestCase {
     func testClosingSearchKeepsThePosition() {
         launch("resize")
         openFind()
-        app.textFields["terminal-find-field"].typeText("record 20")
+        findField().typeText("record 20")
         wait { ($0["top"] as? String)?.contains("record 2") == true }
         let atMatch = probe()["top"] as? String
 
-        app.buttons["terminal-find"].tap()   // close
-        XCTAssertFalse(app.textFields["terminal-find-field"].exists)
+        headerButton("terminal-find").tap()   // close
+        XCTAssertFalse(findField().isHittable)
         XCTAssertEqual(probe()["top"] as? String, atMatch,
                        "closing the find bar must not jump back to the newest output")
     }
@@ -68,18 +86,18 @@ final class TerminalSearchTests: TerminalInteractionTestCase {
     func testNextAndPreviousStepBetweenMatches() {
         launch("resize")
         openFind()
-        app.textFields["terminal-find-field"].typeText("record")
+        findField().typeText("record")
 
-        let count = app.staticTexts["terminal-find-count"]
+        let count = findCount()
         XCTAssertTrue(count.waitForExistence(timeout: 5))
         XCTAssertNotEqual(count.label, "none")
 
         let first = probe()["top"] as? String
-        app.buttons["terminal-find-next"].tap()
+        headerButton("terminal-find-next").tap()
         wait { ($0["top"] as? String) != first }
 
         let second = probe()["top"] as? String
-        app.buttons["terminal-find-previous"].tap()
+        headerButton("terminal-find-previous").tap()
         wait { ($0["top"] as? String) != second }
     }
 
@@ -87,9 +105,7 @@ final class TerminalSearchTests: TerminalInteractionTestCase {
     /// the header edit did not break the control it was added next to.
     func testRefreshStillReconnects() {
         launch("resize")
-        let refresh = app.buttons["terminal-refresh"]
-        XCTAssertTrue(refresh.waitForExistence(timeout: 10))
-        refresh.tap()
+        headerButton("terminal-refresh").tap()
         wait { ($0["opens"] as? Int ?? 0) >= 2 }
     }
 }


### PR DESCRIPTION
Requested: terminal search, opened with ⌘F, an icon beside refresh, and ⌘R to reconnect.

## Search was already there

SwiftTerm ships `findNext`/`findPrevious`/`searchMatchSummary`/`clearSearch` (`TerminalViewSearch.swift`) and we vendored it in the resize work — so this is **a find bar and wiring, not a search engine**. Highlighting is the ordinary selection and redraws itself.

## Decisions worth reviewing

- **`FindRequest` carries term + generation + direction.** A generation rather than a token because "same term, next match" and "the term changed" are genuinely different requests, and SwiftTerm's engine resumes from the previous match only while the term is unchanged (`SearchEngine.swift:70-74`).
- **The field replaces the heading** instead of adding a header row. A taller header would resize the terminal mid-search, reflowing the buffer under the reader and moving the match they are looking at.
- **Closing search does not jump to the tail.** Someone who searched their way into history is still reading it.

## Two traps that would have shipped broken

- `wantsTerminalKeyFocus` (`HerdrApp.swift:3943`) is **true on every pass on iPad**, so the terminal would reclaim first responder the instant the find field took it — the box would be untypeable. Now includes `!findFocused`.
- An **armed one-shot Ctrl** would encode the first character typed into the field as a control byte. Opening search disarms it.

## Why hidden buttons, not `UIKeyCommand`

`UIKeyCommand` + `wantsPriorityOverSystemBehavior` exists to take **Ctrl** chords back from macOS's emacs-style text bindings (`LiveTerminalView.swift:436-447`). Command chords have no such competitor: the vendored terminal declares no `keyCommands` and its `pressesBegan` has no branch for a Command-modified letter, so the press walks up the responder chain untouched. Escape is bound **only while the bar is open**, so it cannot swallow an Escape a vi user meant for the terminal. Shortcuts are foreground-only so N keep-mounted panes cannot register N identical ⌘F bindings.

## Verification

`swiftc -parse` clean on both files; HerdrKit builds. **The app target cannot be built on this Linux host, so CI is the gate.**

`HerdrUITests/TerminalSearchTests.swift` uses the real pane surface via the `resize` fixture (100 numbered records) and asserts against the **painted top row**, not field contents: a match is revealed, a missing term reports `none` **and does not move the viewport**, closing keeps the position, next/previous step, and refresh still reconnects beside the new icon.

⌘F/⌘R themselves need a hardware keyboard, which XCUITest cannot synthesise — **those two need your hands on a Mac.**