### PR TITLE
feat(gram): search behind a magnifier, sharing the terminal's field

### DIFF
--- a/App/GramView.swift
+++ b/App/GramView.swift
@@ -100,6 +100,12 @@ struct GramView: View {
     /// Free-text filter over the visible section. Local to the page: it is a transient view
     /// concern, unlike `showingSaved`, which the sidebar owns (a sibling column drives that).
     @State private var search = ""
+    /// Whether the header's search field is showing. Gram's search used to be a box
+    /// pinned permanently above the list; it is now the same magnifier-then-field the
+    /// terminal header uses (`InlineSearchField`), so the list keeps that vertical space
+    /// until someone actually searches.
+    @State private var searchOpen = false
+    @FocusState private var searchFocused: Bool
     /// True while a Read-all pass is running, so the button disables rather than stacking passes.
     @State private var markingAllRead = false
     /// A partial-failure report from a Read-all pass. Its OWN slot rather than `refreshNote`,
@@ -413,7 +419,6 @@ struct GramView: View {
         VStack(spacing: 0) {
             header
             Divider().overlay(Palette.hairlineQuiet)
-            searchFieldIfFilterable
             content
             bannerView
             composer
@@ -439,7 +444,7 @@ struct GramView: View {
     /// every send/attach/poll behaviour is identical.
     private var iPadBody: some View {
         VStack(spacing: 0) {
-            searchFieldIfFilterable
+            iPadSearchRow
             content
             bannerView
             composer
@@ -450,24 +455,55 @@ struct GramView: View {
     /// The message filter, pinned ABOVE the scroll in both layouts (it must not scroll away),
     /// copying the agents list's field verbatim except for the binding and placeholder so the
     /// two search surfaces in the app look and behave identically.
-    private var searchField: some View {
-        TextField("Search messages", text: $search)
-            .font(Typography.app(15)).foregroundStyle(Palette.text)
-            .textInputAutocapitalization(.never).autocorrectionDisabled()
-            .padding(.horizontal, 16).padding(.vertical, 11)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(Palette.surface)
-            .clipShape(RoundedRectangle(cornerRadius: 12))
-            .padding(.horizontal, 16).padding(.top, 4).padding(.bottom, 4)
+    /// iPad/regular width has no header of its own — the host renders Gram's section
+    /// controls in the app's real sidebar — so the magnifier needs a home here. A slim
+    /// right-aligned row: one icon when closed, the field when open. Still far less
+    /// vertical space than the permanent box this replaced.
+    @ViewBuilder
+    private var iPadSearchRow: some View {
+        if canFilter {
+            HStack(spacing: 8) {
+                Spacer(minLength: 0)
+                if searchOpen { searchField.frame(maxWidth: 420) }
+                InlineSearchToggle(isOpen: searchOpen, identifier: "gram-search") { toggleSearch() }
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 6)
+        }
     }
 
-    /// The field, but only where there is something to filter. `content` renders a spinner while
-    /// loading and an error card (with a Retry) when the daemon has no gram, and a search box
-    /// pinned above either of those is a live control over nothing. The agents list's field sits
-    /// above an EMPTY LIST, never above an error state.
-    @ViewBuilder
-    private var searchFieldIfFilterable: some View {
-        if showingSaved || phase == .loaded { searchField }
+    /// The header's inline field, shared with the terminal pane (`InlineSearchField`).
+    /// No match counter or chevrons: Gram FILTERS the list rather than walking matches,
+    /// so the result count is the list itself.
+    private var searchField: some View {
+        InlineSearchField(
+            placeholder: "Search messages",
+            text: $search,
+            focus: $searchFocused,
+            matches: nil,
+            onNext: nil,
+            onPrevious: nil,
+            identifierPrefix: "gram-search"
+        )
+    }
+
+    /// Search is offered only where there is something to filter. `content` shows a
+    /// spinner while loading and an error card when the daemon has no gram, and a search
+    /// control over either is a live control over nothing.
+    private var canFilter: Bool { showingSaved || phase == .loaded }
+
+    /// Opens the field and takes focus, or closes it and clears the term — clearing is
+    /// what restores the unfiltered list, so a hidden field can never leave the list
+    /// silently filtered.
+    private func toggleSearch() {
+        if searchOpen {
+            searchOpen = false
+            search = ""
+            searchFocused = false
+        } else {
+            searchOpen = true
+            searchFocused = true
+        }
     }
 
     /// A load error / send error, shown ABOVE the composer in every phase — the
@@ -489,18 +525,27 @@ struct GramView: View {
 
     private var header: some View {
         HStack(spacing: 10) {
-            Text(showingSaved ? "Saved" : "Gram")
-                .font(Typography.app(20, .semibold))
-                .foregroundStyle(Palette.text)
-            if !showingSaved, unreadCount > 0 {
-                Text("\(unreadCount)")
-                    .font(Typography.machine(11, .semibold))
-                    .foregroundStyle(Palette.ground)
-                    .padding(.horizontal, 6)
-                    .padding(.vertical, 2)
-                    .background(Capsule().fill(Palette.waiting))
+            if searchOpen {
+                // Replaces the title rather than adding a row, exactly as the terminal
+                // header does, so opening search never changes the header's height.
+                searchField
+            } else {
+                Text(showingSaved ? "Saved" : "Gram")
+                    .font(Typography.app(20, .semibold))
+                    .foregroundStyle(Palette.text)
+                if !showingSaved, unreadCount > 0 {
+                    Text("\(unreadCount)")
+                        .font(Typography.machine(11, .semibold))
+                        .foregroundStyle(Palette.ground)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(Capsule().fill(Palette.waiting))
+                }
+                Spacer()
             }
-            Spacer()
+            if canFilter {
+                InlineSearchToggle(isOpen: searchOpen, identifier: "gram-search") { toggleSearch() }
+            }
             // All / Saved toggle — a filled bookmark means the Saved section is showing.
             Button {
                 withAnimation(.easeInOut(duration: 0.15)) { showingSaved.toggle() }

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -4112,13 +4112,7 @@ struct TerminalPaneContent: View {
                         .foregroundStyle(Palette.text).lineLimit(1)
                     Spacer()
                 }
-                Button { toggleFind() } label: {
-                    Image(systemName: "magnifyingglass")
-                        .font(.system(size: 15))
-                        .foregroundStyle(findOpen ? Palette.text : Palette.textDim)
-                }
-                .accessibilityIdentifier("terminal-find")
-                .accessibilityLabel(findOpen ? "Close search" : "Search terminal")
+                InlineSearchToggle(isOpen: findOpen, identifier: "terminal-find") { toggleFind() }
                 Button {
                     streamGen += 1            // reconnect the pane's stream (re-create LiveTerminalView)
                     Task { await refresh() }   // and re-resolve the agent's status/identity
@@ -4294,53 +4288,21 @@ struct TerminalPaneContent: View {
         }
     }
 
-    /// The inline find field. Replaces the heading rather than adding a row, so opening
-    /// search cannot itself change the terminal's height — a resize mid-search would
-    /// reflow the buffer under the reader and move the match they are looking at.
+    /// The inline find field, shared with Gram's header (`InlineSearchField`).
+    ///
+    /// Replaces the heading rather than adding a header row: growing the header would
+    /// resize the terminal mid-search and reflow the buffer under the reader, moving the
+    /// very match they are looking at.
     private var findField: some View {
-        HStack(spacing: 6) {
-            TextField("Find", text: $findTerm)
-                .textFieldStyle(.plain)
-                .font(Typography.app(14))
-                .foregroundStyle(Palette.text)
-                .tint(Palette.text)
-                .focused($findFocused)
-                .submitLabel(.search)
-                .autocorrectionDisabled()
-                .textInputAutocapitalization(.never)
-                .accessibilityIdentifier("terminal-find-field")
-                // Return steps to the next match, the way every find bar behaves.
-                .onSubmit { stepFind(.forward) }
-            if findMatches.1 > 0 {
-                Text("\(findMatches.0)/\(findMatches.1)")
-                    .font(Typography.machine(11))
-                    .foregroundStyle(Palette.textFaint)
-                    .monospacedDigit()
-                    .accessibilityIdentifier("terminal-find-count")
-            } else if !findTerm.isEmpty {
-                Text("none")
-                    .font(Typography.machine(11))
-                    .foregroundStyle(Palette.textFaint)
-                    .accessibilityIdentifier("terminal-find-count")
-            }
-            Button { stepFind(.backward) } label: {
-                Image(systemName: "chevron.up").font(.system(size: 12, weight: .semibold))
-                    .foregroundStyle(findMatches.1 > 0 ? Palette.textDim : Palette.textFaint)
-            }
-            .disabled(findMatches.1 == 0)
-            .accessibilityIdentifier("terminal-find-previous")
-            .accessibilityLabel("Previous match")
-            Button { stepFind(.forward) } label: {
-                Image(systemName: "chevron.down").font(.system(size: 12, weight: .semibold))
-                    .foregroundStyle(findMatches.1 > 0 ? Palette.textDim : Palette.textFaint)
-            }
-            .disabled(findMatches.1 == 0)
-            .accessibilityIdentifier("terminal-find-next")
-            .accessibilityLabel("Next match")
-        }
-        .padding(.horizontal, 10)
-        .padding(.vertical, 6)
-        .background(RoundedRectangle(cornerRadius: 8).fill(Palette.surface))
+        InlineSearchField(
+            placeholder: "Find",
+            text: $findTerm,
+            focus: $findFocused,
+            matches: (index: findMatches.0, total: findMatches.1),
+            onNext: { stepFind(.forward) },
+            onPrevious: { stepFind(.backward) },
+            identifierPrefix: "terminal-find"
+        )
     }
 
     /// Opens the find bar and takes focus, or closes it and hands focus back.

--- a/App/InlineSearchField.swift
+++ b/App/InlineSearchField.swift
@@ -1,0 +1,102 @@
+import SwiftUI
+
+/// The inline search field used by the terminal pane header and the Gram header.
+///
+/// One component rather than two look-alikes: the two surfaces search different things
+/// (the terminal walks matches in a scrollback, Gram filters a list) but they are the
+/// same control to the reader — a magnifier in the header that becomes a field, and
+/// gives the header back when dismissed. Keeping them literally the same view is what
+/// stops them drifting into two slightly different search boxes.
+///
+/// Match navigation is OPTIONAL. Passing `matches` plus the two step closures gives the
+/// terminal's "3/17" counter and chevrons; omitting them gives Gram's plain filter, with
+/// no dead chevrons to explain.
+struct InlineSearchField: View {
+    let placeholder: String
+    @Binding var text: String
+    var focus: FocusState<Bool>.Binding
+    /// `(index, total)` for a walk-the-matches search; nil for a filter.
+    var matches: (index: Int, total: Int)?
+    var onNext: (() -> Void)?
+    var onPrevious: (() -> Void)?
+    /// Identifier prefix so each host's controls are addressable in UI tests.
+    var identifierPrefix: String
+
+    private var hasMatches: Bool { (matches?.total ?? 0) > 0 }
+
+    var body: some View {
+        HStack(spacing: 6) {
+            TextField(placeholder, text: $text)
+                .textFieldStyle(.plain)
+                .font(Typography.app(14))
+                .foregroundStyle(Palette.text)
+                .tint(Palette.text)
+                .focused(focus)
+                .submitLabel(.search)
+                .autocorrectionDisabled()
+                .textInputAutocapitalization(.never)
+                .accessibilityIdentifier("\(identifierPrefix)-field")
+                .onSubmit { onNext?() }
+
+            if let matches {
+                // Only a match-walking search reports a count. A filter's "how many" is
+                // the list itself, and a "0 results" chip above a visibly empty list is
+                // the same fact twice.
+                if matches.total > 0 {
+                    Text("\(matches.index)/\(matches.total)")
+                        .font(Typography.machine(11))
+                        .foregroundStyle(Palette.textFaint)
+                        .monospacedDigit()
+                        .accessibilityIdentifier("\(identifierPrefix)-count")
+                } else if !text.isEmpty {
+                    Text("none")
+                        .font(Typography.machine(11))
+                        .foregroundStyle(Palette.textFaint)
+                        .accessibilityIdentifier("\(identifierPrefix)-count")
+                }
+            }
+
+            if let onPrevious {
+                stepButton("chevron.up", label: "Previous match",
+                           identifier: "\(identifierPrefix)-previous", action: onPrevious)
+            }
+            if let onNext {
+                stepButton("chevron.down", label: "Next match",
+                           identifier: "\(identifierPrefix)-next", action: onNext)
+            }
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .background(RoundedRectangle(cornerRadius: 8).fill(Palette.surface))
+    }
+
+    private func stepButton(_ symbol: String, label: String,
+                            identifier: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Image(systemName: symbol)
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(hasMatches ? Palette.textDim : Palette.textFaint)
+        }
+        .disabled(!hasMatches)
+        .accessibilityIdentifier(identifier)
+        .accessibilityLabel(label)
+    }
+}
+
+/// The magnifier that opens one. Separate from the field so a header can place it
+/// among its other icons without inheriting the field's layout.
+struct InlineSearchToggle: View {
+    let isOpen: Bool
+    let identifier: String
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: "magnifyingglass")
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundStyle(isOpen ? Palette.text : Palette.textDim)
+        }
+        .accessibilityIdentifier(identifier)
+        .accessibilityLabel(isOpen ? "Close search" : "Search")
+    }
+}

--- a/HerdrUITests/GramTests.swift
+++ b/HerdrUITests/GramTests.swift
@@ -52,8 +52,14 @@ final class GramTests: XCTestCase {
         XCTAssertTrue(app.staticTexts["vetrina"].waitForExistence(timeout: 5),
                       "the second agent->owner message should render before filtering")
 
-        let field = app.textFields["Search messages"]
-        XCTAssertTrue(field.waitForExistence(timeout: 5), "the search field should be pinned above the list")
+        // Search is now a magnifier in the header that becomes a field, matching the
+        // terminal pane, instead of a box pinned permanently above the list.
+        let toggle = app.buttons["gram-search"]
+        XCTAssertTrue(toggle.waitForExistence(timeout: 5), "the header should offer search")
+        toggle.tap()
+
+        let field = app.textFields["gram-search-field"]
+        XCTAssertTrue(field.waitForExistence(timeout: 5), "tapping the magnifier should reveal the field")
         field.tap()
         field.typeText("Digest")
         // Assert the FIELD took the text before asserting anything about the list: an unfocused
@@ -75,6 +81,16 @@ final class GramTests: XCTestCase {
         field.typeText(String(repeating: XCUIKeyboardKey.delete.rawValue, count: 4))
         XCTAssertTrue(app.staticTexts["vetrina"].waitForExistence(timeout: 5),
                       "clearing the search should bring the filtered-out messages back")
+
+        // CLOSING must also clear. A hidden field that is still filtering would leave the
+        // list silently short with nothing on screen to explain it - the failure mode a
+        // dismissible search box invites. Re-filter first so the close has work to undo.
+        field.typeText("zzzz")
+        XCTAssertTrue(app.staticTexts["No matches"].waitForExistence(timeout: 5))
+        toggle.tap()
+        XCTAssertFalse(field.exists, "closing should dismiss the field")
+        XCTAssertTrue(app.staticTexts["vetrina"].waitForExistence(timeout: 5),
+                      "closing search should restore the unfiltered list")
     }
 
     /// Read all marks the unread messages read: the button is present while something is unread


### PR DESCRIPTION
Requested: make Gram's search an icon too, reusing the terminal's.

## Shared, not copied

`App/InlineSearchField.swift` is **one view used by both headers**. Two look-alike search boxes drift into two slightly different ones; keeping them literally the same view is what prevents that.

Match navigation is **optional**:

| Surface | Passes | Gets |
|---|---|---|
| Terminal | `matches` + step closures | `3/17` counter, up/down chevrons |
| Gram | neither | plain filter — no dead chevrons to explain |

Gram *filters a list*, so its result count is the list itself; a "0 results" chip above a visibly empty list is the same fact twice.

## Layout

- **Phone:** the field replaces the title, exactly as in the terminal header, so opening search never changes the header's height.
- **Regular width:** Gram has no header of its own — the host renders its controls in the app's real sidebar — so it gets a slim right-aligned row. Still far less vertical space than the permanent box it replaces.
- The magnifier appears **only where there is something to filter** (`canFilter`), preserving the old `searchFieldIfFilterable` rule: no live control over a spinner or an error card.

## Closing clears the term

A hidden field that is still filtering would leave the list silently short with nothing on screen to explain it — the failure a dismissible search box invites. `GramTests` now covers it: filter, close, assert the filtered-out message returns.

## Verification

`swiftc -parse` clean, HerdrKit builds. The existing Gram filter test was driving the old always-visible field by placeholder; it now opens search first and addresses `gram-search-field`. **CI is the gate for the app target.**