### PR TITLE
test(store): capture the five App Store screens from the shipping UI

### DIFF
--- a/HerdrUITests/StoreScreenshotTests.swift
+++ b/HerdrUITests/StoreScreenshotTests.swift
@@ -1,0 +1,59 @@
+import XCTest
+
+/// Captures the five App Store screens from the REAL app, at the simulator's native
+/// resolution, so store artwork is regenerated from the shipping UI rather than
+/// re-scaled from whatever was published last.
+///
+/// Not part of the normal suite's job: it asserts almost nothing and exists to produce
+/// attachments. It is dispatched deliberately (`-only-testing:HerdrUITests/StoreScreenshotTests`)
+/// and its output is collected from the result bundle.
+///
+/// Each case waits for a distinctive element of that screen before capturing, so a slow
+/// launch cannot silently produce a screenshot of an empty or half-built view — which is
+/// the failure mode that would quietly ship a broken store image.
+final class StoreScreenshotTests: XCTestCase {
+    private func capture(_ mode: String, named name: String, until: (XCUIApplication) -> Bool) {
+        let app = XCUIApplication()
+        app.launchEnvironment["HERDR_SCREENSHOT_MOCK"] = mode
+        app.launch()
+
+        let deadline = Date().addingTimeInterval(20)
+        var ready = false
+        while Date() < deadline {
+            if until(app) { ready = true; break }
+            Thread.sleep(forTimeInterval: 0.25)
+        }
+        XCTAssertTrue(ready, "\(mode) never reached a capturable state")
+
+        // Let the first paint settle: animations and async rows land after the element
+        // that proves the screen exists.
+        Thread.sleep(forTimeInterval: 1.5)
+
+        let shot = XCUIScreen.main.screenshot()
+        let attachment = XCTAttachment(screenshot: shot)
+        attachment.name = name
+        attachment.lifetime = .keepAlways
+        add(attachment)
+        app.terminate()
+    }
+
+    func testCaptureAgents() {
+        capture("list", named: "store-01-agents") { $0.staticTexts["Agents"].exists }
+    }
+
+    func testCaptureTerminal() {
+        capture("pane", named: "store-02-terminal") { $0.otherElements["terminal-surface"].exists || $0.staticTexts["Terminal"].exists }
+    }
+
+    func testCaptureGram() {
+        capture("gram", named: "store-03-gram") { $0.staticTexts["Gram"].exists }
+    }
+
+    func testCaptureSettings() {
+        capture("settings", named: "store-04-settings") { $0.staticTexts["Settings"].exists }
+    }
+
+    func testCaptureConnect() {
+        capture("onboarding", named: "store-05-connect") { $0.buttons["Connect"].exists || $0.staticTexts["herdrup"].exists }
+    }
+}


### PR DESCRIPTION
Tooling for regenerating store artwork, split out from the fix itself.

## Why

The published iPhone screenshots have the screen content pasted as a **hard rectangle over the mockup**: square corners where the screen's rounded corners belong, inset from the bezel so black shows along two edges. All five.

Repairing the published PNGs was the obvious move and is the wrong one — their content is only **978px wide** inside a 1290px canvas, so refilling the frame's 1178px aperture means a **1.2× upscale** on an App Store page. Capturing fresh avoids that entirely: the simulator produces **1206×2622**, a slight *downscale* into the aperture.

It also fixes a staleness problem nobody had noticed: the published shots were captured in **August**, several UI generations back.

## What this adds

`StoreScreenshotTests` drives the mock modes the app already ships for screenshot work (`list`, `pane`, `gram`, `settings`, `onboarding`) and attaches a full-screen capture of each.

Each case **waits for a distinctive element of that screen** before capturing, so a slow launch cannot quietly produce a half-built view — the failure that would otherwise ship as store artwork.

It is not part of the normal gate: it asserts almost nothing and exists to produce attachments. Run it deliberately:

```
gh workflow run ci.yml --ref <branch> -f only_suite=StoreScreenshotTests -f only_device=iphone
```

The images come back in the `terminal-test-results` artifact, inside the `.xcresult`.

## Verified

Dispatched on this branch: run 34413479217, **success**, five attachments at 1206×2622. Those captures produced the corrected artwork already sent to the owner on Gram.