### PR TITLE
Redesign Dynamic Island and Lock Screen Live Activity

### DIFF
--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -25,7 +25,10 @@ struct HerdrApp: App {
     }
 
     var body: some Scene {
-        WindowGroup { RootView() }
+        WindowGroup {
+            RootView()
+                .onOpenURL { PushCenter.shared.openLiveActivityURL($0) }
+        }
     }
 }
 

--- a/App/LiveActivityController.swift
+++ b/App/LiveActivityController.swift
@@ -3,10 +3,9 @@ import Combine
 import ActivityKit
 import HerdrKit
 
-/// Owns the single agent-session Live Activity: starts it when a session connects,
-/// updates it as the agent list changes, ends it on disconnect. Every entry point is
-/// a no-op when the user has Live Activities turned off (Settings) or the platform
-/// can't run them, so callers never have to guard.
+/// Owns the single fleet Live Activity: starts it when the home session connects,
+/// updates it from the federated agent list, and ends it on disconnect. Every entry
+/// point is a no-op when Live Activities are disabled or unavailable.
 ///
 /// A singleton (like `PushCenter.shared`) because two layers drive it: `RootView`
 /// starts/ends it around connect/disconnect, while the agents list view pushes status
@@ -28,10 +27,12 @@ final class LiveActivityController: ObservableObject {
 
     /// Whether the system currently permits Live Activities (user toggle + capability).
     private var enabled: Bool { ActivityAuthorizationInfo().areActivitiesEnabled }
+    /// A missed refresh must become visible instead of leaving an arbitrarily old
+    /// count looking live. Ninety seconds allows one normal poll plus one missed beat.
+    private static var staleDate: Date { Date().addingTimeInterval(90) }
 
-    /// Start the session activity for `hostLabel`, or — if one is already live (e.g. a
-    /// reconnect kept it) — just push the new state. Idempotent: never stacks a second
-    /// banner for one session.
+    /// Start the fleet activity for the connected home, or update the reclaimed
+    /// activity after a reconnect. Idempotent: never stacks a second fleet banner.
     func start(hostLabel: String, state: AgentActivityAttributes.ContentState) {
         guard enabled else { return }
         // ActivityKit PERSISTS activities across app launches: after a kill + relaunch our
@@ -60,7 +61,7 @@ final class LiveActivityController: ObservableObject {
             // still go through update() directly.
             activity = try Activity.request(
                 attributes: attributes,
-                content: ActivityContent(state: state, staleDate: nil),
+                content: ActivityContent(state: state, staleDate: Self.staleDate),
                 pushType: .token
             )
             observePushToken()
@@ -87,7 +88,7 @@ final class LiveActivityController: ObservableObject {
     /// Push a new state to the live activity, if there is one.
     func update(_ state: AgentActivityAttributes.ContentState) {
         guard let activity else { return }
-        Task { await activity.update(ActivityContent(state: state, staleDate: nil)) }
+        Task { await activity.update(ActivityContent(state: state, staleDate: Self.staleDate)) }
     }
 
     /// End and clear the activity immediately (on disconnect / sign-out). Ends EVERY
@@ -132,7 +133,9 @@ final class LiveActivityController: ObservableObject {
             unconfirmedCount: c.unconfirmedCount,
             workingCount: c.workingCount,
             totalCount: c.totalCount,
-            workingSince: c.workingSinceUnixSeconds
+            workingSince: c.workingSinceUnixSeconds,
+            blockedSince: c.blockedSinceUnixSeconds,
+            agentID: c.agentID
         )
     }
 

--- a/App/PushCenter.swift
+++ b/App/PushCenter.swift
@@ -22,14 +22,9 @@ final class PushCenter: ObservableObject {
     /// opens the Gram page then clears it. Held here so a cold-launch tap (app was closed) survives
     /// until the view can act, exactly like `pendingPaneID`.
     @Published var pendingGram: Bool = false
-    /// Handle a Live Activity deep link. Only the app-owned scheme and exact
-    /// `agent` route are accepted; malformed or unrelated URLs are ignored.
+    /// Handle a Live Activity deep link. Malformed or unrelated URLs are ignored.
     func openLiveActivityURL(_ url: URL) {
-        guard url.scheme?.lowercased() == "herdrup", url.host == "agent",
-              let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
-              let paneID = components.queryItems?.first(where: { $0.name == "pane" })?.value,
-              !paneID.isEmpty
-        else { return }
+        guard let paneID = AgentActivityDeepLink.agentID(from: url) else { return }
         tapped(paneID: paneID)
     }
 

--- a/App/PushCenter.swift
+++ b/App/PushCenter.swift
@@ -22,6 +22,16 @@ final class PushCenter: ObservableObject {
     /// opens the Gram page then clears it. Held here so a cold-launch tap (app was closed) survives
     /// until the view can act, exactly like `pendingPaneID`.
     @Published var pendingGram: Bool = false
+    /// Handle a Live Activity deep link. Only the app-owned scheme and exact
+    /// `agent` route are accepted; malformed or unrelated URLs are ignored.
+    func openLiveActivityURL(_ url: URL) {
+        guard url.scheme?.lowercased() == "herdrup", url.host == "agent",
+              let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+              let paneID = components.queryItems?.first(where: { $0.name == "pane" })?.value,
+              !paneID.isEmpty
+        else { return }
+        tapped(paneID: paneID)
+    }
 
     private static let tokenKey = "push.deviceToken"
 

--- a/HerdrWidgets/AgentLiveActivity.swift
+++ b/HerdrWidgets/AgentLiveActivity.swift
@@ -13,13 +13,13 @@ struct AgentLiveActivity: Widget {
                 hostLabel: context.attributes.hostLabel,
                 state: context.state,
                 isStale: context.isStale,
-                destination: ActivityDeepLink.url(for: context.state.agentID)
+                destination: AgentActivityDeepLink.url(for: context.state.agentID)
             )
             .activityBackgroundTint(WidgetPalette.ground)
             .activitySystemActionForegroundColor(WidgetPalette.text)
-            .widgetURL(ActivityDeepLink.url(for: context.state.agentID))
+            .widgetURL(AgentActivityDeepLink.url(for: context.state.agentID))
         } dynamicIsland: { context in
-            let destination = ActivityDeepLink.url(for: context.state.agentID)
+            let destination = AgentActivityDeepLink.url(for: context.state.agentID)
             let staleAttention = context.isStale || context.state.isEntirelyUnconfirmed
 
             return DynamicIsland {
@@ -338,16 +338,6 @@ private struct ElapsedTimer: View {
     }
 }
 
-private enum ActivityDeepLink {
-    static func url(for agentID: String?) -> URL? {
-        guard let agentID, !agentID.isEmpty else { return nil }
-        var components = URLComponents()
-        components.scheme = "herdrup"
-        components.host = "agent"
-        components.queryItems = [URLQueryItem(name: "pane", value: agentID)]
-        return components.url
-    }
-}
 
 private extension AgentActivityState {
     var isEntirelyUnconfirmed: Bool {

--- a/HerdrWidgets/AgentLiveActivity.swift
+++ b/HerdrWidgets/AgentLiveActivity.swift
@@ -1,178 +1,395 @@
+import Foundation
 import SwiftUI
 import WidgetKit
 import ActivityKit
 
-/// The agent-session Live Activity: a lock-screen banner and the Dynamic Island
-/// presentations. It renders `AgentActivityAttributes` — a status dot coloured by
-/// the session's highest-priority agent, that agent's name, and a one-line summary
-/// ("2 need you" / "Working" / "Idle"). Colours mirror the app's status palette
-/// (amber = needs you, blue = working, red = stopped, faint = idle); the widget
-/// keeps its own copy because the app's DesignSystem is app-target only.
+/// Fleet status in the four Live Activity presentations. Space degrades in one
+/// direction: action, detail, machine totals, headline, count, then status mark.
+/// The mark uses shape as well as colour so its meaning survives Always-On.
 struct AgentLiveActivity: Widget {
     var body: some WidgetConfiguration {
         ActivityConfiguration(for: AgentActivityAttributes.self) { context in
-            // Lock screen / notification-banner presentation.
-            LockScreenView(hostLabel: context.attributes.hostLabel, state: context.state)
-                .activityBackgroundTint(WidgetPalette.ground)
-                .activitySystemActionForegroundColor(WidgetPalette.text)
+            LockScreenView(
+                hostLabel: context.attributes.hostLabel,
+                state: context.state,
+                isStale: context.isStale,
+                destination: ActivityDeepLink.url(for: context.state.agentID)
+            )
+            .activityBackgroundTint(WidgetPalette.ground)
+            .activitySystemActionForegroundColor(WidgetPalette.text)
+            .widgetURL(ActivityDeepLink.url(for: context.state.agentID))
         } dynamicIsland: { context in
-            DynamicIsland {
+            let destination = ActivityDeepLink.url(for: context.state.agentID)
+            let staleAttention = context.isStale || context.state.isEntirelyUnconfirmed
+
+            return DynamicIsland {
                 DynamicIslandExpandedRegion(.leading) {
-                    StatusDot(status: context.state.status)
+                    ExpandedHero(state: context.state, isStale: staleAttention)
                         .padding(.leading, 4)
                 }
+                DynamicIslandExpandedRegion(.center) {
+                    ExpandedHeadline(state: context.state, isStale: context.isStale)
+                }
                 DynamicIslandExpandedRegion(.trailing) {
-                    Text(context.attributes.hostLabel)
-                        .font(.caption2)
-                        .foregroundStyle(WidgetPalette.textFaint)
-                        .lineLimit(1)
+                    FleetTotals(hostLabel: context.attributes.hostLabel, state: context.state)
                         .padding(.trailing, 4)
                 }
-                DynamicIslandExpandedRegion(.center) {
-                    VStack(spacing: 2) {
-                        Text(context.state.headline)
-                            .font(.headline)
-                            .foregroundStyle(WidgetPalette.text)
-                            .lineLimit(1)
-                        // The ticking timer shows ONLY when exactly one agent is working, so it
-                        // unambiguously tracks THAT agent and stops the moment it finishes. The
-                        // Live Activity is one aggregate per machine, so with several agents working
-                        // a single "since" is meaningless (and the timer would appear to run on as
-                        // the busiest agent changes) — show the "N working" count instead.
-                        if context.state.status == .working, context.state.workingCount == 1,
-                           let since = context.state.workingSince {
-                            HStack(spacing: 5) {
-                                Text("Working").font(.caption).foregroundStyle(WidgetPalette.color(.working))
-                                WorkingTimer(since: since, font: .caption)
-                            }
-                            .lineLimit(1)
-                        } else {
-                            Text(summary(context.state))
-                                .font(.caption)
-                                .foregroundStyle(WidgetPalette.color(context.state.status))
-                                .lineLimit(1)
-                        }
+                DynamicIslandExpandedRegion(.bottom) {
+                    if let destination {
+                        OpenAgentLink(
+                            destination: destination,
+                            title: "Open \(context.state.headline)",
+                            dimmed: false
+                        )
+                        .padding(.horizontal, 4)
                     }
                 }
             } compactLeading: {
-                StatusDot(status: context.state.status)
+                StatusMark(status: context.state.status, diameter: 10, isStale: staleAttention)
             } compactTrailing: {
-                // ONLY the count that demands action gets the scarce compact slot. A ticking
-                // timer here widened the notch pill (and kept growing as it counted up), so the
-                // working state stays a bare dot in the compact view; its live elapsed timer
-                // lives in the EXPANDED view and the lock screen, where width isn't constrained.
-                if context.state.needsYouCount > 0 {
-                    Text("\(context.state.needsYouCount)")
-                        .font(.caption2).bold()
-                        .foregroundStyle(WidgetPalette.color(.needsYou))
-                }
+                CompactCount(state: context.state)
             } minimal: {
-                StatusDot(status: context.state.status)
+                StatusMark(status: context.state.status, diameter: 14, isStale: staleAttention)
             }
             .keylineTint(WidgetPalette.color(context.state.status))
+            .widgetURL(destination)
         }
-    }
-
-    /// One-line summary line: prefer the actionable count, else the status word.
-    private func summary(_ s: AgentActivityAttributes.ContentState) -> String {
-        AgentActivitySummary.line(s)
     }
 }
 
-/// The lock-screen / banner layout: status dot, agent name + summary, host on the
-/// right. Kept compact and legible on the dark banner tint.
-private struct LockScreenView: View {
+private struct CompactCount: View {
+    let state: AgentActivityAttributes.ContentState
+
+    var body: some View {
+        if state.needsYouCount > 0 {
+            Text(displayCount(state.needsYouCount))
+                .font(WidgetType.machineSemibold(13))
+                .monospacedDigit()
+                .foregroundStyle(WidgetPalette.waiting)
+        } else if state.workingCount > 0 {
+            Text(displayCount(state.workingCount))
+                .font(WidgetType.machineMedium(13))
+                .monospacedDigit()
+                .foregroundStyle(WidgetPalette.working)
+        }
+    }
+}
+
+private struct ExpandedHero: View {
+    let state: AgentActivityAttributes.ContentState
+    let isStale: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            if state.needsYouCount > 1 {
+                Text(displayCount(state.needsYouCount))
+                    .font(WidgetType.machineSemibold(26))
+                    .monospacedDigit()
+                    .foregroundStyle(WidgetPalette.waiting)
+                Text(isStale ? "may need you" : "need you")
+                    .font(WidgetType.app(12))
+                    .foregroundStyle(WidgetPalette.textDim)
+                    .lineLimit(1)
+            } else {
+                StatusMark(status: state.status, diameter: 10, isStale: isStale)
+            }
+        }
+    }
+}
+
+private struct ExpandedHeadline: View {
+    let state: AgentActivityAttributes.ContentState
+    let isStale: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 3) {
+            HStack(spacing: 7) {
+                if state.needsYouCount <= 1 {
+                    StatusMark(
+                        status: state.status,
+                        diameter: 10,
+                        isStale: isStale || state.isEntirelyUnconfirmed
+                    )
+                }
+                Text(state.headline)
+                    .font(WidgetType.appSemibold(16))
+                    .foregroundStyle(WidgetPalette.text)
+                    .lineLimit(1)
+            }
+            ActivityDetail(state: state, isStale: isStale, fontSize: 11)
+        }
+    }
+}
+
+private struct FleetTotals: View {
     let hostLabel: String
     let state: AgentActivityAttributes.ContentState
 
     var body: some View {
-        HStack(spacing: 12) {
-            StatusDot(status: state.status, diameter: 12)
-            VStack(alignment: .leading, spacing: 2) {
-                Text(state.headline)
-                    .font(.headline)
-                    .foregroundStyle(WidgetPalette.text)
-                    .lineLimit(1)
-                // Timer ONLY for a single working agent (see the Dynamic Island note): it then
-                // tracks that agent and stops when it finishes. With several working, the "since"
-                // is ambiguous and looks like it never stops, so show the "N working" count. The
-                // live ticking time IS the motion here — the dot can't animate on a Live Activity.
-                if state.status == .working, state.workingCount == 1, let since = state.workingSince {
-                    HStack(spacing: 5) {
-                        Text("Working").font(.subheadline).foregroundStyle(WidgetPalette.color(.working))
-                        WorkingTimer(since: since)
-                    }
-                    .lineLimit(1)
-                } else {
-                    Text(summary)
-                        .font(.subheadline)
-                        .foregroundStyle(WidgetPalette.color(state.status))
-                        .lineLimit(1)
-                }
+        VStack(alignment: .trailing, spacing: 2) {
+            Text(hostLabel)
+            if state.workingCount > 0 {
+                Text("\(state.workingCount) working")
             }
-            Spacer(minLength: 8)
-            VStack(alignment: .trailing, spacing: 2) {
-                Text(hostLabel)
-                    .font(.caption)
-                    .foregroundStyle(WidgetPalette.textFaint)
-                    .lineLimit(1)
-                if state.totalCount > 0 {
-                    Text(state.totalCount == 1 ? "1 agent" : "\(state.totalCount) agents")
-                        .font(.caption2)
-                        .foregroundStyle(WidgetPalette.textFaint)
-                        .lineLimit(1)
+            if state.totalCount > 0 {
+                Text(state.totalCount == 1 ? "1 agent" : "\(state.totalCount) agents")
+            }
+        }
+        .font(WidgetType.machine(11))
+        .foregroundStyle(WidgetPalette.textFaint)
+        .lineLimit(1)
+    }
+}
+
+private struct LockScreenView: View {
+    let hostLabel: String
+    let state: AgentActivityAttributes.ContentState
+    let isStale: Bool
+    let destination: URL?
+
+    @Environment(\.isLuminanceReduced) private var isLuminanceReduced
+
+    var body: some View {
+        VStack(spacing: 10) {
+            HStack(alignment: .top, spacing: 12) {
+                if state.needsYouCount > 1 {
+                    VStack(alignment: .leading, spacing: 1) {
+                        Text(displayCount(state.needsYouCount))
+                            .font(WidgetType.machineSemibold(34))
+                            .monospacedDigit()
+                            .foregroundStyle(WidgetPalette.waiting)
+                        Text(staleAttention ? "may need you" : "need you")
+                            .font(WidgetType.app(13))
+                            .foregroundStyle(WidgetPalette.textDim)
+                            .lineLimit(1)
+                    }
+                    .frame(minWidth: 64, alignment: .leading)
                 }
+
+                VStack(alignment: .leading, spacing: 4) {
+                    HStack(spacing: 8) {
+                        StatusMark(status: state.status, diameter: 12, isStale: staleAttention)
+                        Text(state.headline)
+                            .font(WidgetType.appSemibold(17))
+                            .foregroundStyle(WidgetPalette.text)
+                            .lineLimit(1)
+                    }
+                    ActivityDetail(state: state, isStale: isStale, fontSize: 12)
+                    if !isLuminanceReduced {
+                        Text(fleetLine)
+                            .font(WidgetType.machine(11))
+                            .foregroundStyle(WidgetPalette.textFaint)
+                            .lineLimit(1)
+                    }
+                }
+
+                Spacer(minLength: 4)
+                Image("AppLogo")
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 28, height: 28)
+                    .clipShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
+            }
+
+            if let destination {
+                OpenAgentLink(
+                    destination: destination,
+                    title: "Open \(state.headline)",
+                    dimmed: isLuminanceReduced
+                )
             }
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 12)
     }
 
-    private var summary: String { AgentActivitySummary.line(state) }
-}
+    private var staleAttention: Bool { isStale || state.isEntirelyUnconfirmed }
 
-/// A filled status circle; colour carries the meaning (amber = needs you, blue =
-/// working, red = stopped, faint = idle). STATIC on purpose: a Live Activity is
-/// rendered from snapshots and iOS frame-interpolates ONLY time-driven views
-/// (`Text(timerInterval:)` / `ProgressView(timerInterval:)`), so a pulsing or
-/// spinning dot genuinely cannot animate here. The working state's MOTION comes
-/// from the live `WorkingTimer` beside the dot, not from the dot itself.
-private struct StatusDot: View {
-    let status: AgentActivityAttributes.Status
-    var diameter: CGFloat = 10
-
-    var body: some View {
-        Circle()
-            .fill(WidgetPalette.color(status))
-            .frame(width: diameter, height: diameter)
+    private var fleetLine: String {
+        var parts = [hostLabel]
+        if state.workingCount > 0 { parts.append("\(state.workingCount) working") }
+        if state.totalCount > 0 {
+            parts.append(state.totalCount == 1 ? "1 agent" : "\(state.totalCount) agents")
+        }
+        return parts.joined(separator: " · ")
     }
 }
 
-/// A live, up-counting elapsed-time readout ("1:23") for the working state — the
-/// one thing iOS actually animates in a Live Activity (`Text(_, style: .timer)` is
-/// frame-interpolated, unlike `symbolEffect`/spinners). `since` is Unix SECONDS.
-private struct WorkingTimer: View {
+private struct ActivityDetail: View {
+    let state: AgentActivityAttributes.ContentState
+    let isStale: Bool
+    let fontSize: CGFloat
+
+    var body: some View {
+        if isStale, state.needsYouCount > 0 {
+            Text("Update delayed")
+                .font(WidgetType.machine(fontSize))
+                .foregroundStyle(WidgetPalette.textFaint)
+                .lineLimit(1)
+        } else if state.status == .needsYou, let since = state.blockedSince {
+            HStack(spacing: 5) {
+                Text(state.isEntirelyUnconfirmed ? "May need you" : "Waiting")
+                ElapsedTimer(since: since, color: WidgetPalette.waiting, fontSize: fontSize)
+            }
+            .font(WidgetType.machine(fontSize))
+            .foregroundStyle(WidgetPalette.textDim)
+            .lineLimit(1)
+        } else if state.status == .working, state.workingCount == 1,
+                  let since = state.workingSince {
+            HStack(spacing: 5) {
+                Text("Working")
+                ElapsedTimer(since: since, color: WidgetPalette.working, fontSize: fontSize)
+            }
+            .font(WidgetType.machine(fontSize))
+            .foregroundStyle(WidgetPalette.textDim)
+            .lineLimit(1)
+        } else {
+            Text(AgentActivitySummary.line(state))
+                .font(WidgetType.machine(fontSize))
+                .foregroundStyle(WidgetPalette.color(state.status))
+                .lineLimit(1)
+        }
+    }
+}
+
+private struct OpenAgentLink: View {
+    let destination: URL
+    let title: String
+    let dimmed: Bool
+
+    var body: some View {
+        Link(destination: destination) {
+            Text(title)
+                .font(WidgetType.appSemibold(14))
+                .foregroundStyle(dimmed ? WidgetPalette.text : WidgetPalette.ground)
+                .lineLimit(1)
+                .frame(maxWidth: .infinity)
+                .frame(height: 44)
+                .background {
+                    if !dimmed {
+                        RoundedRectangle(cornerRadius: 11, style: .continuous)
+                            .fill(WidgetPalette.text)
+                    }
+                }
+                .overlay {
+                    if dimmed {
+                        RoundedRectangle(cornerRadius: 11, style: .continuous)
+                            .stroke(WidgetPalette.textDim, lineWidth: 1)
+                    }
+                }
+        }
+    }
+}
+
+/// Shape is the primary channel: filled = needs you, ring = working, small dot =
+/// idle, barred = stopped. A stale needs-you state becomes hollow.
+private struct StatusMark: View {
+    let status: AgentActivityAttributes.Status
+    var diameter: CGFloat = 10
+    var isStale = false
+
+    var body: some View {
+        ZStack {
+            switch status {
+            case .needsYou:
+                if isStale {
+                    Circle()
+                        .strokeBorder(WidgetPalette.waiting, lineWidth: lineWidth)
+                } else {
+                    Circle().fill(WidgetPalette.waiting)
+                }
+            case .working:
+                Circle()
+                    .strokeBorder(WidgetPalette.working, lineWidth: lineWidth)
+            case .idle:
+                Circle()
+                    .fill(WidgetPalette.idle)
+                    .frame(width: diameter * 0.46, height: diameter * 0.46)
+            case .stopped:
+                Circle()
+                    .strokeBorder(WidgetPalette.died, lineWidth: lineWidth)
+                Capsule()
+                    .fill(WidgetPalette.died)
+                    .frame(width: diameter * 0.72, height: lineWidth)
+            }
+        }
+        .frame(width: diameter, height: diameter)
+        .accessibilityLabel(accessibilityLabel)
+    }
+
+    private var lineWidth: CGFloat { max(1.5, diameter * 0.18) }
+
+    private var accessibilityLabel: String {
+        if status == .needsYou, isStale { return "May need you" }
+        return status.label
+    }
+}
+
+private struct ElapsedTimer: View {
     let since: Double
-    var font: Font = .subheadline
+    let color: Color
+    let fontSize: CGFloat
 
     var body: some View {
         Text(Date(timeIntervalSince1970: since), style: .timer)
-            .font(font)
+            .font(WidgetType.machine(fontSize))
             .monospacedDigit()
-            .foregroundStyle(WidgetPalette.color(.working))
+            .foregroundStyle(color)
     }
 }
 
-/// The widget's own copy of the app's status palette (DesignSystem is app-only).
-/// Hex values match `Palette` in App/DesignSystem.swift.
+private enum ActivityDeepLink {
+    static func url(for agentID: String?) -> URL? {
+        guard let agentID, !agentID.isEmpty else { return nil }
+        var components = URLComponents()
+        components.scheme = "herdrup"
+        components.host = "agent"
+        components.queryItems = [URLQueryItem(name: "pane", value: agentID)]
+        return components.url
+    }
+}
+
+private extension AgentActivityState {
+    var isEntirelyUnconfirmed: Bool {
+        needsYouCount > 0 && unconfirmedCount >= needsYouCount
+    }
+}
+
+private func displayCount(_ count: Int) -> String {
+    count >= 100 ? "99+" : "\(max(0, count))"
+}
+
+private enum WidgetType {
+    static func app(_ size: CGFloat) -> Font {
+        .custom("Geist-Regular", fixedSize: size)
+    }
+
+    static func appSemibold(_ size: CGFloat) -> Font {
+        .custom("Geist-SemiBold", fixedSize: size)
+    }
+
+    static func machine(_ size: CGFloat) -> Font {
+        .custom("IBMPlexMono", fixedSize: size)
+    }
+
+    static func machineMedium(_ size: CGFloat) -> Font {
+        .custom("IBMPlexMono-Medm", fixedSize: size)
+    }
+
+    static func machineSemibold(_ size: CGFloat) -> Font {
+        .custom("IBMPlexMono-SmBld", fixedSize: size)
+    }
+}
+
 enum WidgetPalette {
-    static let ground     = Color(hex6: 0x13162A)
-    static let text       = Color(hex6: 0xEEF0F7)
-    static let textFaint  = Color(hex6: 0x666D91)
-    static let waiting    = Color(hex6: 0xE9A63C) // amber — needs you
-    static let working    = Color(hex6: 0x5B9BE8) // blue — running
-    static let died       = Color(hex6: 0xE2584E) // red — stopped / exited
-    static let idle       = textFaint
+    static let ground      = Color(hex6: 0x13162A)
+    static let text        = Color(hex6: 0xEEF0F7)
+    static let textDim     = Color(hex6: 0x99A0BC)
+    static let textFaint   = Color(hex6: 0x666D91)
+    static let waiting     = Color(hex6: 0xE9A63C)
+    static let working     = Color(hex6: 0x5B9BE8)
+    static let died        = Color(hex6: 0xE2584E)
+    static let idle        = textFaint
 
     static func color(_ status: AgentActivityAttributes.Status) -> Color {
         switch status {
@@ -185,13 +402,12 @@ enum WidgetPalette {
 }
 
 private extension Color {
-    /// Builds a colour from a 0xRRGGBB literal (sRGB), matching DesignSystem's helper.
     init(hex6: UInt32) {
         self.init(
             .sRGB,
-            red:   Double((hex6 >> 16) & 0xFF) / 255,
+            red: Double((hex6 >> 16) & 0xFF) / 255,
             green: Double((hex6 >> 8) & 0xFF) / 255,
-            blue:  Double(hex6 & 0xFF) / 255,
+            blue: Double(hex6 & 0xFF) / 255,
             opacity: 1
         )
     }

--- a/HerdrWidgets/HerdrWidgetBundle.swift
+++ b/HerdrWidgets/HerdrWidgetBundle.swift
@@ -1,9 +1,8 @@
 import SwiftUI
 import WidgetKit
 
-/// The widget extension's entry point. For now it holds only the agent-session
-/// Live Activity (Dynamic Island + lock-screen banner) — no home-screen widgets
-/// yet, so the bundle has a single member.
+/// The widget extension's entry point. It contains the fleet Live Activity
+/// (Dynamic Island + Lock Screen banner); no Home Screen widgets.
 @main
 struct HerdrWidgetBundle: WidgetBundle {
     var body: some Widget {

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ herdr's JSON API exposes both, so panes and agents become real UI objects instea
 
 - **Status board** — every agent grouped by what it needs: *needs you* (amber), *working*, *done*,
   *stopped*. Colour is meaning, not decoration — the one signal that matters reads instantly.
+- **Live Activity** — the Dynamic Island and Lock Screen show how many agents need you, keep working
+  progress visible, and open the exact agent from one quiet fleet-wide status.
 - **Live terminal** — a full SwiftTerm terminal for any pane, one tap behind its card, with gestures
   to page between agents, tail the output, and scroll history.
   Resizing preserves the logical history position; live followers stay at the tail. The on-screen

--- a/Shared/AgentActivityAttributes.swift
+++ b/Shared/AgentActivityAttributes.swift
@@ -1,8 +1,8 @@
 import Foundation
 import ActivityKit
 
-/// The shape of the Herdr agent-session Live Activity — shared verbatim by the app
-/// (which starts / updates / ends it) and the widget extension (which renders it).
+/// The shape of Herdrup's fleet Live Activity — shared verbatim by the app
+/// (which starts, updates, and ends it) and the widget extension (which renders it).
 ///
 /// Deliberately free of SwiftUI and HerdrKit so it compiles into BOTH targets with no
 /// extra dependencies. `State` and `Status` are TYPEALIASES to types declared in
@@ -10,15 +10,13 @@ import ActivityKit
 /// `Status` when it builds a state (see `LiveActivityController`); the widget only
 /// ever reads these plain values.
 ///
-/// One Live Activity represents ONE SSH session (one machine). Its dynamic
-/// `ContentState` summarises the session's agents: a representative *headline* agent
-/// (the highest-priority one — something that needs you outranks something merely
-/// working, which outranks idle) plus counts, so the surface can say "2 need you".
+/// One Live Activity represents the fleet visible through the connected home.
+/// Its dynamic state carries the highest-priority agent plus fleet-wide counts;
+/// the static host label is only secondary context for that connection.
 struct AgentActivityAttributes: ActivityAttributes {
     typealias ContentState = State
 
-    /// Fixed for the life of the activity: which machine this session is on
-    /// (the saved host's nickname if it has one, else the host itself).
+    /// Fixed secondary context: the connected home's nickname, or its host name.
     var hostLabel: String
 
     /// Re-exposed under the names they had while nested here, so `ContentState`,

--- a/Shared/AgentActivityState.swift
+++ b/Shared/AgentActivityState.swift
@@ -43,7 +43,7 @@ struct AgentActivityState: Codable, Hashable {
     var unconfirmedCount: Int = 0
     /// How many agents are actively working right now.
     var workingCount: Int
-    /// Total agents in the session.
+    /// Total agents across the connected fleet.
     var totalCount: Int
     /// When the headline agent's CURRENT turn started (Unix SECONDS), set only
     /// while `status == .working`. Drives a live `Text(timerInterval:)` in the
@@ -52,26 +52,27 @@ struct AgentActivityState: Codable, Hashable {
     /// A plain Double (not Date) so the daemon-pushed JSON decodes identically,
     /// dodging Swift's Date reference-date Codable strategy. `nil` when not working.
     var workingSince: Double?
+    /// When the headline agent entered its blocked state (Unix seconds). Optional so
+    /// activities and daemon pushes from older builds remain decodable.
+    var blockedSince: Double?
+    /// Stable pane target for the headline agent. The activity deep link binds to
+    /// this id instead of resolving the newest blocked agent again when tapped.
+    var agentID: String?
 
-    /// Hand-written for TWO additive directions, both of which otherwise make the whole
-    /// activity undecodable, which ActivityKit answers by DROPPING the activity so it
-    /// can never be reclaimed or ended.
+    /// Hand-written decoding keeps additive payload changes from making the whole
+    /// activity undecodable, which ActivityKit answers by dropping the activity.
     ///
-    /// 1. An absent `unconfirmedCount`, from an activity persisted by, or a payload
-    ///    minted by, a build predating the field. A stored-property default does not
-    ///    help: Codable synthesis never consults it.
-    /// 2. An UNRECOGNISED `status` word, from a newer app or daemon pushing a bucket
-    ///    this widget binary lacks. Raw-value decoding throws `dataCorrupted` there,
-    ///    which is the same drop-the-activity outcome as case 1. HerdrKit already
-    ///    treats this hazard as first-class with `AgentStatus.unrecognised(String)`;
-    ///    this file cannot carry that arm without a new case, so it falls back to
-    ///    `.needsYou`, matching HerdrKit's rule that something uninterpretable
-    ///    SURFACES rather than sinking. A wrongly-attention-grabbing lock screen is
-    ///    recoverable; a silently dropped activity is not.
+    /// `unconfirmedCount`, `workingSince`, `blockedSince`, and `agentID` are absent
+    /// from older persisted activities and older daemon pushes, so each is decoded
+    /// with `decodeIfPresent`. A stored-property default does not help because
+    /// Codable synthesis never consults it.
     ///
-    /// Every OTHER field stays required exactly as synthesis would have it, so a
-    /// genuinely malformed payload still fails loudly instead of decoding into a
-    /// plausible zero.
+    /// An unrecognised `status` word can arrive from a newer app or daemon. Raw-value
+    /// decoding would throw there, so it falls back to `.needsYou`, matching
+    /// HerdrKit's rule that something uninterpretable surfaces rather than sinks.
+    ///
+    /// Every other field stays required, so a genuinely malformed payload still
+    /// fails instead of decoding into a plausible zero.
     init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
         headline = try c.decode(String.self, forKey: .headline)
@@ -82,12 +83,15 @@ struct AgentActivityState: Codable, Hashable {
         workingCount = try c.decode(Int.self, forKey: .workingCount)
         totalCount = try c.decode(Int.self, forKey: .totalCount)
         workingSince = try c.decodeIfPresent(Double.self, forKey: .workingSince)
+        blockedSince = try c.decodeIfPresent(Double.self, forKey: .blockedSince)
+        agentID = try c.decodeIfPresent(String.self, forKey: .agentID)
     }
 
     /// Restored because writing `init(from:)` suppresses the synthesized memberwise
     /// initialiser this type is constructed with everywhere else.
     init(headline: String, status: AgentActivityStatus, needsYouCount: Int, unconfirmedCount: Int = 0,
-         workingCount: Int, totalCount: Int, workingSince: Double?) {
+         workingCount: Int, totalCount: Int, workingSince: Double?,
+         blockedSince: Double? = nil, agentID: String? = nil) {
         self.headline = headline
         self.status = status
         self.needsYouCount = needsYouCount
@@ -95,6 +99,8 @@ struct AgentActivityState: Codable, Hashable {
         self.workingCount = workingCount
         self.totalCount = totalCount
         self.workingSince = workingSince
+        self.blockedSince = blockedSince
+        self.agentID = agentID
     }
 }
 

--- a/Shared/AgentActivityState.swift
+++ b/Shared/AgentActivityState.swift
@@ -125,6 +125,28 @@ enum AgentActivityStatus: String, Codable, Hashable {
     }
 }
 
+/// The one URL contract shared by the widget that emits a pane link and the app
+/// that consumes it. URLComponents preserves federated pane ids containing `/` or `:`.
+enum AgentActivityDeepLink {
+    static func url(for agentID: String?) -> URL? {
+        guard let agentID, !agentID.isEmpty else { return nil }
+        var components = URLComponents()
+        components.scheme = "herdrup"
+        components.host = "agent"
+        components.queryItems = [URLQueryItem(name: "pane", value: agentID)]
+        return components.url
+    }
+
+    static func agentID(from url: URL) -> String? {
+        guard url.scheme?.lowercased() == "herdrup", url.host == "agent",
+              let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+              let paneID = components.queryItems?.first(where: { $0.name == "pane" })?.value,
+              !paneID.isEmpty
+        else { return nil }
+        return paneID
+    }
+}
+
 /// The summary wording for a Live Activity, in ONE place and in the ActivityKit-free file
 /// so it is testable on Linux. Both widget layouts read it.
 ///

--- a/Sources/HerdrKit/AgentList.swift
+++ b/Sources/HerdrKit/AgentList.swift
@@ -331,6 +331,8 @@ public struct AgentList: Equatable, Sendable {
         public let workingCount: Int
         public let totalCount: Int
         public let workingSinceUnixSeconds: Double?
+        public let blockedSinceUnixSeconds: Double?
+        public let agentID: String?
     }
 
     /// THE ATTENTION COUNTS DIVERGE FROM THE ROSTER'S ON PURPOSE, and this is the reason.
@@ -367,6 +369,9 @@ public struct AgentList: Equatable, Sendable {
         let since: Double? = word == "working"
             ? lead?.info.lastCompletedTurn?.completedUnixMs.map { Double($0) / 1000 }
             : nil
+        let blockedSince: Double? = word == "needsYou"
+            ? lead?.info.statusSinceUnixMs.map { Double($0) / 1000 }
+            : nil
         return ActivityContent(
             headline: lead?.title ?? "No agents",
             statusWord: word,
@@ -374,7 +379,9 @@ public struct AgentList: Equatable, Sendable {
             unconfirmedCount: unconfirmed,
             workingCount: rows.filter { $0.group == .working }.count,
             totalCount: rows.count,
-            workingSinceUnixSeconds: since)
+            workingSinceUnixSeconds: since,
+            blockedSinceUnixSeconds: blockedSince,
+            agentID: lead?.info.paneID)
     }
 
     /// THE WORDING SPEC for "N need you", in HerdrKit so every surface can share one rule

--- a/Tests/AgentActivityStateTests/AgentActivityStateTests.swift
+++ b/Tests/AgentActivityStateTests/AgentActivityStateTests.swift
@@ -91,6 +91,20 @@ final class AgentActivityStateTests: XCTestCase {
         XCTAssertEqual(back, original)
     }
 
+    func testLiveActivityDeepLinkRoundTripsFederatedPaneID() throws {
+        let paneID = "remote/w1:p7"
+        let url = try XCTUnwrap(AgentActivityDeepLink.url(for: paneID))
+        XCTAssertEqual(AgentActivityDeepLink.agentID(from: url), paneID)
+    }
+
+    func testLiveActivityDeepLinkRejectsUnownedRoutes() throws {
+        XCTAssertNil(AgentActivityDeepLink.url(for: nil))
+        XCTAssertNil(AgentActivityDeepLink.url(for: ""))
+        XCTAssertNil(AgentActivityDeepLink.agentID(from: try XCTUnwrap(URL(string: "https://agent?pane=w1:p7"))))
+        XCTAssertNil(AgentActivityDeepLink.agentID(from: try XCTUnwrap(URL(string: "herdrup://gram?pane=w1:p7"))))
+        XCTAssertNil(AgentActivityDeepLink.agentID(from: try XCTUnwrap(URL(string: "herdrup://agent"))))
+    }
+
     // MARK: - summary wording
 
     /// The wording table. Duplicated on purpose in HerdrKit's AgentList tests, because the

--- a/Tests/AgentActivityStateTests/AgentActivityStateTests.swift
+++ b/Tests/AgentActivityStateTests/AgentActivityStateTests.swift
@@ -16,20 +16,21 @@ final class AgentActivityStateTests: XCTestCase {
 
     // MARK: - additive-FIELD tolerance
 
-    /// A payload from a build that predates `unconfirmedCount` must still decode. A
-    /// stored-property default does NOT achieve this: Codable synthesis never consults it
-    /// and throws keyNotFound, which ActivityKit answers by DROPPING the activity, after
-    /// which it can never be reclaimed or ended. Only the hand-written decodeIfPresent does.
-    func testAnOldPayloadWithoutUnconfirmedCountDecodesToZero() throws {
+    /// A payload from a build that predates the additive Live Activity fields must
+    /// still decode. ActivityKit drops an activity when its content state cannot be
+    /// decoded, so every additive field uses `decodeIfPresent`.
+    func testAnOldPayloadWithoutAdditiveFieldsDecodes() throws {
         let s = try decode(#"{"headline":"jarvis","status":"needsYou","needsYouCount":2,"workingCount":1,"totalCount":9}"#)
         XCTAssertEqual(s.unconfirmedCount, 0)
         XCTAssertEqual(s.needsYouCount, 2)
         XCTAssertEqual(s.status, .needsYou)
-        XCTAssertNil(s.workingSince, "an absent workingSince is legitimately nil, not an error")
+        XCTAssertNil(s.workingSince)
+        XCTAssertNil(s.blockedSince)
+        XCTAssertNil(s.agentID)
     }
 
-    /// The tolerance is scoped to that ONE key. A genuinely malformed payload must still
-    /// fail loudly rather than decoding into a plausible zero.
+    /// The tolerance is scoped to documented additive fields. A genuinely malformed
+    /// payload must still fail rather than decoding into a plausible zero.
     ///
     /// `status` IS IN THIS LOOP DELIBERATELY, and it is the subtle member. This type treats
     /// an ABSENT status and an UNRECOGNISED status differently on purpose: an unrecognised
@@ -83,7 +84,8 @@ final class AgentActivityStateTests: XCTestCase {
     func testRoundTripThroughEncodeAndDecode() throws {
         let original = AgentActivityState(headline: "jarvis", status: .working, needsYouCount: 2,
                                           unconfirmedCount: 1, workingCount: 3, totalCount: 9,
-                                          workingSince: 1_788_200_000)
+                                          workingSince: 1_788_200_000, blockedSince: 1_788_199_500,
+                                          agentID: "w1:p7")
         let back = try JSONDecoder().decode(AgentActivityState.self,
                                             from: try JSONEncoder().encode(original))
         XCTAssertEqual(back, original)

--- a/Tests/HerdrKitTests/ActivityContentTests.swift
+++ b/Tests/HerdrKitTests/ActivityContentTests.swift
@@ -24,13 +24,14 @@ final class ActivityContentTests: XCTestCase {
     /// AgentInfo can hold a shape the wire cannot produce.
     private func agent(
         pane: String, status: String?, name: String? = nil, completedUnixMs: Int64? = nil,
-        lastKnownStatus: String? = nil, machineID: String? = nil, reachability: String? = nil,
-        archivedBy: String? = nil
+        statusSinceUnixMs: UInt64? = nil, lastKnownStatus: String? = nil,
+        machineID: String? = nil, reachability: String? = nil, archivedBy: String? = nil
     ) throws -> AgentInfo {
         var obj: [String: Any] = ["pane_id": pane]
         if let status { obj["agent_status"] = status }
         if let name { obj["name"] = name }
         if let completedUnixMs { obj["last_completed_turn"] = ["completed_unix_ms": completedUnixMs] }
+        if let statusSinceUnixMs { obj["status_since_unix_ms"] = statusSinceUnixMs }
         if let lastKnownStatus { obj["last_known_status"] = lastKnownStatus }
         if let machineID { obj["machine_id"] = machineID }
         if let reachability { obj["reachability"] = reachability }
@@ -530,5 +531,16 @@ final class ActivityContentTests: XCTestCase {
         let since = try XCTUnwrap(l.activityContent.workingSinceUnixSeconds)
         XCTAssertEqual(since, 1_723_000_000.5, accuracy: 0.0001,
                        "the divide must happen in Double; integer division silently truncates the millisecond remainder")
+    }
+
+    func testBlockedContentCarriesItsWaitStartAndExactPaneTarget() throws {
+        let ms: UInt64 = 1_723_000_000_500
+        let l = AgentList(
+            agents: [try agent(pane: "w1:p7", status: "blocked", name: "api-refactor",
+                               statusSinceUnixMs: ms)],
+            livePaneIDs: ["w1:p7"])
+        let blockedSince = try XCTUnwrap(l.activityContent.blockedSinceUnixSeconds)
+        XCTAssertEqual(blockedSince, 1_723_000_000.5, accuracy: 0.0001)
+        XCTAssertEqual(l.activityContent.agentID, "w1:p7")
     }
 }

--- a/project.yml
+++ b/project.yml
@@ -144,6 +144,10 @@ targets:
         # this via ASSETCATALOG_COMPILER_APPICON_NAME, but this Info.plist is
         # generated (GENERATE_INFOPLIST_FILE: NO), so we set it explicitly too.
         CFBundleIconName: AppIcon
+        # Live Activity deep links open the exact agent pane.
+        CFBundleURLTypes:
+          - CFBundleURLSchemes:
+              - herdrup
         # Live Activities (#90): opt the app in so ActivityKit may start the agent-session
         # activity on the lock screen / Dynamic Island. Required or Activity.request throws.
         NSSupportsLiveActivities: true
@@ -295,6 +299,10 @@ targets:
     sources:
       - path: HerdrWidgets
       - path: Shared
+      # The widget is a separate bundle, so it needs its own copies of the app
+      # logo and the two type families used by the Live Activity design.
+      - path: App/Assets.xcassets
+      - path: App/Fonts
     dependencies:
       - sdk: WidgetKit.framework
       - sdk: SwiftUI.framework
@@ -306,6 +314,15 @@ targets:
         # Must MATCH the app target's, or the App Store rejects the upload. Same
         # reason as the app's: without this, xcodegen writes a default "1.0".
         CFBundleShortVersionString: "$(MARKETING_VERSION)"
+        UIAppFonts:
+          - Geist-Regular.ttf
+          - Geist-Medium.ttf
+          - Geist-SemiBold.ttf
+          - Geist-Bold.ttf
+          - IBMPlexMono-Regular.ttf
+          - IBMPlexMono-Medium.ttf
+          - IBMPlexMono-SemiBold.ttf
+          - IBMPlexMono-Bold.ttf
         NSExtension:
           NSExtensionPointIdentifier: com.apple.widgetkit-extension
     settings:


### PR DESCRIPTION
## What changed
- makes the needs-you count the hero across compact, expanded, and Lock Screen presentations
- replaces colour-only dots with distinct filled, ring, small-dot, barred, and stale-hollow status marks
- carries blocked age and the exact pane target into the ActivityKit state
- marks content stale after 90 seconds and dims secondary Lock Screen detail on Always-On
- adds one explicit Open action plus whole-surface deep links to the named agent
- bundles Geist, IBM Plex Mono, and the app logo in the widget extension

The current daemon does not expose a prompt string or safe default answer. The design's explicit no-default fallback is therefore used: Open the named agent rather than guessing an approval response.

Authorized by owner directive and design attachment `gram-1a08f9cb015-1394e1-5e`.

## Verification
- Linux cannot run Swift/Xcode in this workspace (`swift: command not found`)
- CI must compile the app/widget and run the Swift package tests
- manual device rendering remains required because XCUITest cannot inspect a Live Activity