### PR TITLE
fix(composer): cap multiline inputs above send controls

### DIFF
--- a/App/GramView.swift
+++ b/App/GramView.swift
@@ -911,7 +911,9 @@ struct GramView: View {
                     .foregroundStyle(Palette.text)
                     .tint(Palette.text)
                     .focused($composerFocused)
-                    .lineLimit(1...5)
+                    .lineLimit(1...3)
+                    .frame(minWidth: 0, maxWidth: .infinity)
+                    .accessibilityIdentifier("gram-composer-input")
                     .padding(.horizontal, 12)
                     .padding(.vertical, 9)
                     .background(RoundedRectangle(cornerRadius: 10).fill(Palette.surface))
@@ -919,6 +921,7 @@ struct GramView: View {
                 // Dictate into the draft (on-device); appends, never clobbers typed text.
                 // Disabled during a send so dictation can't race the field-clear.
                 MicButton(text: $draft, recording: $draftDictating)
+                    .fixedSize()
                     .disabled(sending || loadingPhoto)
                 Button {
                     Task { await send() }
@@ -937,6 +940,9 @@ struct GramView: View {
                     .frame(width: 38, height: 38)
                     .background(Circle().fill(canSend ? Palette.text : Palette.surface))
                 }
+                .fixedSize()
+                .accessibilityLabel("Send gram")
+                .accessibilityIdentifier("gram-send-button")
                 .disabled(!canSend)
                 // Keyboard send. The field is `axis: .vertical` so Return inserts a newline
                 // (a gram is often multi-line, and `onSubmit` does not fire for a vertical

--- a/App/GramView.swift
+++ b/App/GramView.swift
@@ -290,6 +290,7 @@ struct GramView: View {
             }
         }
         .background(Palette.ground.ignoresSafeArea())
+        .background { gramKeyboardShortcuts }
         // Poll while the page is open so new agent messages appear without a manual
         // refresh (the gram store has no event stream); the loop ends when the view
         // goes away (task cancellation).
@@ -418,6 +419,8 @@ struct GramView: View {
     private var phoneBody: some View {
         VStack(spacing: 0) {
             header
+                .background(Palette.ground)
+                .zIndex(1)
             Divider().overlay(Palette.hairlineQuiet)
             content
             bannerView
@@ -445,6 +448,8 @@ struct GramView: View {
     private var iPadBody: some View {
         VStack(spacing: 0) {
             iPadSearchRow
+                .layoutPriority(1)
+                .zIndex(1)
             content
             bannerView
             composer
@@ -469,6 +474,7 @@ struct GramView: View {
             }
             .padding(.horizontal, 16)
             .padding(.vertical, 6)
+            .background(Palette.ground)
         }
     }
 
@@ -504,6 +510,20 @@ struct GramView: View {
             searchOpen = true
             searchFocused = true
         }
+    }
+
+    /// Gram is the active page whenever this view is mounted, so one hidden responder
+    /// command is enough. Reuses the terminal's shortcut pattern: Command-F opens search,
+    /// or moves focus back into an already-open field.
+    private var gramKeyboardShortcuts: some View {
+        Button("Find in Gram") {
+            if searchOpen { searchFocused = true } else { toggleSearch() }
+        }
+        .keyboardShortcut("f", modifiers: .command)
+        .frame(width: 0, height: 0)
+        .opacity(0)
+        .accessibilityHidden(true)
+        .disabled(!canFilter)
     }
 
     /// A load error / send error, shown ABOVE the composer in every phase — the

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -3904,7 +3904,7 @@ struct TerminalPaneContent: View {
     // owns delivery then). A pending pre-fill does NOT disable the button once the
     // loop stops — instead the button ROUTES a pre-fill through the prompt-only
     // path (see the replyBar action), so it can never fall to rawKeys send_text.
-    private var canSend: Bool { !reply.trimmingCharacters(in: .whitespaces).isEmpty && !sending && !replyDictating }
+    private var canSend: Bool { !reply.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && !sending && !replyDictating }
 
     /// Whether to offer the one-time "switch to smooth (classic) scrolling" banner:
     /// ONLY for Claude Code panes (agent kind contains "claude") and only until the reader
@@ -4612,7 +4612,7 @@ struct TerminalPaneContent: View {
             // When the input is EMPTY the send arrow is dead, so offer saved prompts in its
             // place; otherwise the normal send arrow (same 40x40 circle, mutually exclusive
             // by the same empty predicate `canSend` uses).
-            if reply.trimmingCharacters(in: .whitespaces).isEmpty {
+            if reply.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                 savedPromptsButton
             } else {
                 // The button dismisses the software keyboard on iPhone; Return now inserts

--- a/App/HerdrApp.swift
+++ b/App/HerdrApp.swift
@@ -4545,7 +4545,7 @@ struct TerminalPaneContent: View {
     }
 
     private var replyBar: some View {
-        HStack(spacing: 8) {
+        HStack(alignment: .bottom, spacing: 8) {
             // Collapse-keyboard button — shown while EITHER input owner holds the
             // keyboard. It lives INSIDE the bar's HStack (laid out beside the field/send),
             // NOT in a `.keyboard` accessory toolbar: that toolbar floated on top of the
@@ -4582,41 +4582,20 @@ struct TerminalPaneContent: View {
                 }
                 .accessibilityLabel("Collapse keyboard")
             }
-            TextField("type a reply…", text: $reply)
+            TextField("type a reply…", text: $reply, axis: .vertical)
                 .font(Typography.app(15)).foregroundStyle(Palette.text)
                 .textInputAutocapitalization(.never).autocorrectionDisabled()
+                .lineLimit(1...3)
+                .frame(minWidth: 0, maxWidth: .infinity)
                 .padding(.horizontal, 16).padding(.vertical, 11)
-                .background(Palette.surface).clipShape(Capsule())
+                .background(Palette.surface).clipShape(RoundedRectangle(cornerRadius: 20))
                 .focused($replyFocused)
+                .accessibilityIdentifier("terminal-reply-input")
                 .disabled(replyDictating)   // dictation owns the field while live
                 // Ctrl-toggle interception: while armed, the next character typed
                 // here becomes a control byte instead of message text.
                 .onChange(of: reply) { oldValue, newValue in
                     handleReplyChange(old: oldValue, new: newValue)
-                }
-                .submitLabel(.send)
-                // Return sends the reply and releases only the TERMINAL's claim on key input,
-                // keeping the reply field focused on every idiom — which is what the pre-PR code
-                // did, and why.
-                //
-                // The problem this has to solve is `wantsTerminalKeyFocus`, which carries
-                // `|| idiom == .pad`: if Return clears BOTH owners, that disjunct re-asserts on
-                // iPad and hands key focus to the terminal, so everything typed after Return goes
-                // to the agent's shell as raw keystrokes instead of composing the next reply.
-                // Clearing `terminalInputFocused` alone fixes that without touching the field.
-                //
-                // AN EARLIER VERSION OF THIS ALSO CLEARED `replyFocused` ON iPHONE, to dismiss the
-                // software keyboard. A review pointed out the cost: the reader then has to tap the
-                // field again for every subsequent message, and pre-PR behaviour deliberately kept
-                // focus so a back-and-forth exchange did not cost a tap per message. Dismissal was
-                // a side effect of needing to release the terminal, not a goal, and this PR already
-                // adds the affordance for doing it on purpose — the collapse chevron now renders
-                // for a terminal-raised keyboard too. So the keyboard stays up and the reader
-                // decides when it goes.
-                .onSubmit {
-                    if canSend { sendTapped() }
-                    replyFocused = true
-                    terminalInputFocused = false
                 }
             // Dictate into the reply (on-device). isActive: isForeground stops the mic
             // if this pane stops being the front one (no hot mic behind a hidden pane);
@@ -4625,6 +4604,7 @@ struct TerminalPaneContent: View {
             MicButton(text: $reply, diameter: 40, iconSize: 15,
                       isActive: isForeground && !autoDelivering, recording: $replyDictating,
                       onStart: { ctrlArmed = false })
+                .fixedSize()
                 // Mutually gated with Send AND the programmatic pre-fill auto-deliver:
                 // isActive drops on autoDelivering so an in-flight dictation stops before
                 // the auto-deliver clears the reply, and it can't be started during either.
@@ -4635,44 +4615,12 @@ struct TerminalPaneContent: View {
             if reply.trimmingCharacters(in: .whitespaces).isEmpty {
                 savedPromptsButton
             } else {
-                // THE BUTTON DISMISSES THE KEYBOARD ON iPHONE; RETURN DELIBERATELY DOES NOT.
-                //
-                // Reported by the owner on a real iPhone: tapping send left the keyboard up over
-                // ~40% of the pane, so the reply you just sent — and the agent's response to it —
-                // were behind the keyboard until you dismissed it by hand.
-                //
-                // The distinction from `.onSubmit` above is intent, not inconsistency. Return is
-                // pressed WITH your thumbs already on the keys, and the note on that path records a
-                // review's reasoning for keeping focus: a back-and-forth exchange should not cost a
-                // tap per message. Reaching for the send BUTTON is a deliberate move away from the
-                // keys, so treating it as "I am done typing" matches what the hand just did.
-                //
-                // iPHONE ONLY, and clearing `replyFocused` is the part that must be gated. On iPad
-                // `wantsTerminalKeyFocus` carries `|| idiom == .pad`, so releasing the field hands
-                // key focus straight to the terminal and everything typed next would go to the
-                // agent's shell as raw keystrokes — the exact hazard documented on `.onSubmit`.
-                // iPad also has no software keyboard to dismiss (zero-frame `emptyInputView`), so
-                // there is nothing to gain there and a real regression to cause.
-                // AND IT MUST BUMP THE COLLAPSE TOKEN, not just clear the flags. Found by review:
-                // clearing the two focus flags alone reproduces the ORIGINAL #203 defect through a
-                // new door. With a word selected, `updateUIView`'s resign is gated on
-                // `deliberateCollapse || !hasActiveSelection`, so it refuses — while clearing the
-                // flags has already hidden the collapse chevron. Net result: keyboard up over the
-                // pane, selection held, and no visible way to dismiss it. That is exactly the state
-                // the chevron fix existed to eliminate, and my send-button change walked back into
-                // it because it copied the flag-clearing and not the token.
-                //
-                // Bumping the token marks this resign DELIBERATE, which is what it is: the reader
-                // pressed send. Same mechanism as the chevron, so there is one way to express
-                // "collapse on purpose" rather than two that disagree. This is the "what did last
-                // round's fix make POSSIBLE" question answered: the chevron fix made a token the
-                // only honest way to resign past a selection, and any new path that clears focus
-                // has to use it.
-                // SCOPED TO iPHONE for the same reason the flag is: on iPad the terminal's
-                // `wantsTerminalKeyFocus` carries the `.pad` disjunct, so the pass after this can
-                // take the become-focus branch and never reach `consumeCollapse` — the token would
-                // sit unconsumed and could fire on some later, unrelated collapse (herdrup#213).
-                // iPad has no software keyboard to dismiss, so there is nothing to request there.
+                // The button dismisses the software keyboard on iPhone; Return now inserts
+                // a newline and Command+Return sends without changing focus. A deliberate
+                // button dismissal must bump the collapse token so SwiftTerm will resign
+                // even while a selection is active. Keep that request phone-only: iPad has
+                // no software keyboard here, and its terminal-focus branch would leave an
+                // unconsumed token that could fire during a later unrelated collapse.
                 Button {
                     sendTapped()
                     terminalInputFocused = false
@@ -4687,6 +4635,12 @@ struct TerminalPaneContent: View {
                         .background(canSend ? Palette.text : Palette.surface).clipShape(Circle())
                 }
                 .disabled(!canSend)
+                .fixedSize()
+                .accessibilityLabel("Send reply")
+                .accessibilityIdentifier("terminal-send-button")
+                // Return inserts a newline in the vertical field; Command+Return sends,
+                // matching Gram and keeping hardware-keyboard submission available.
+                .keyboardShortcut(.return, modifiers: .command)
             }
         }
         .padding(.horizontal, 12).padding(.top, 4).padding(.bottom, 8)

--- a/HerdrUITests/GramTests.swift
+++ b/HerdrUITests/GramTests.swift
@@ -127,4 +127,36 @@ final class GramTests: XCTestCase {
         }
         XCTAssertTrue(cleared, "tapping Read all should drive the unread count to zero")
     }
+
+    func testComposerGrowsUpwardThenScrollsWithoutMovingSend() {
+        let app = XCUIApplication()
+        app.launchEnvironment["HERDR_SCREENSHOT_MOCK"] = "gram"
+        app.launch()
+
+        let field = app.textFields["gram-composer-input"]
+        let send = app.buttons["gram-send-button"]
+        XCTAssertTrue(field.waitForExistence(timeout: 10))
+        XCTAssertTrue(send.waitForExistence(timeout: 5))
+
+        field.tap()
+        field.typeText("one")
+        Thread.sleep(forTimeInterval: 0.3)
+        let oneLine = field.frame
+        let sendBottom = send.frame.maxY
+
+        field.typeText("\ntwo\nthree")
+        Thread.sleep(forTimeInterval: 0.3)
+        let threeLines = field.frame
+        XCTAssertGreaterThan(threeLines.height, oneLine.height)
+        XCTAssertEqual(threeLines.maxY, oneLine.maxY, accuracy: 2)
+        XCTAssertEqual(send.frame.maxY, sendBottom, accuracy: 2)
+        XCTAssertTrue(send.isHittable)
+
+        field.typeText("\nfour")
+        Thread.sleep(forTimeInterval: 0.3)
+        XCTAssertEqual(field.frame.height, threeLines.height, accuracy: 2)
+        XCTAssertEqual(send.frame.maxY, sendBottom, accuracy: 2)
+        XCTAssertTrue((field.value as? String)?.contains("four") == true)
+        XCTAssertTrue(send.isHittable)
+    }
 }

--- a/HerdrUITests/GramTests.swift
+++ b/HerdrUITests/GramTests.swift
@@ -52,15 +52,14 @@ final class GramTests: XCTestCase {
         XCTAssertTrue(app.staticTexts["vetrina"].waitForExistence(timeout: 5),
                       "the second agent->owner message should render before filtering")
 
-        // The search control must remain above the newest message and clickable. Command-F
-        // opens it on Mac/hardware keyboards; the same command path is exercised here.
+        // The search control must remain above the newest message and clickable.
         let toggle = app.buttons["gram-search"]
         XCTAssertTrue(toggle.waitForExistence(timeout: 5), "the header should offer search")
         XCTAssertTrue(toggle.isHittable, "the newest message must not cover the search control")
-        app.typeKey("f", modifierFlags: .command)
+        toggle.tap()
 
         let field = app.textFields["gram-search-field"]
-        XCTAssertTrue(field.waitForExistence(timeout: 5), "Command-F should reveal the search field")
+        XCTAssertTrue(field.waitForExistence(timeout: 5), "the search button should reveal the search field")
         field.tap()
         field.typeText("Digest")
         // Assert the FIELD took the text before asserting anything about the list: an unfocused

--- a/HerdrUITests/GramTests.swift
+++ b/HerdrUITests/GramTests.swift
@@ -52,14 +52,15 @@ final class GramTests: XCTestCase {
         XCTAssertTrue(app.staticTexts["vetrina"].waitForExistence(timeout: 5),
                       "the second agent->owner message should render before filtering")
 
-        // Search is now a magnifier in the header that becomes a field, matching the
-        // terminal pane, instead of a box pinned permanently above the list.
+        // The search control must remain above the newest message and clickable. Command-F
+        // opens it on Mac/hardware keyboards; the same command path is exercised here.
         let toggle = app.buttons["gram-search"]
         XCTAssertTrue(toggle.waitForExistence(timeout: 5), "the header should offer search")
-        toggle.tap()
+        XCTAssertTrue(toggle.isHittable, "the newest message must not cover the search control")
+        app.typeKey("f", modifierFlags: .command)
 
         let field = app.textFields["gram-search-field"]
-        XCTAssertTrue(field.waitForExistence(timeout: 5), "tapping the magnifier should reveal the field")
+        XCTAssertTrue(field.waitForExistence(timeout: 5), "Command-F should reveal the search field")
         field.tap()
         field.typeText("Digest")
         // Assert the FIELD took the text before asserting anything about the list: an unfocused

--- a/HerdrUITests/TerminalControlTests.swift
+++ b/HerdrUITests/TerminalControlTests.swift
@@ -248,4 +248,33 @@ func testDictationStartDisarmsEvenIfPermissionIsDenied() throws {
         input("px", previous: 0)
         attach("typing-cancels-cover-without-input-replay")
     }
+
+    func testReplyComposerGrowsUpwardThenScrollsWithoutMovingSend() {
+        launch("control")
+        let field = app.textFields["terminal-reply-input"]
+        XCTAssertTrue(field.waitForExistence(timeout: 10))
+
+        field.tap()
+        field.typeText("one")
+        let send = app.buttons["terminal-send-button"]
+        XCTAssertTrue(send.waitForExistence(timeout: 5))
+        Thread.sleep(forTimeInterval: 0.3)
+        let oneLine = field.frame
+        let sendBottom = send.frame.maxY
+
+        field.typeText("\ntwo\nthree")
+        Thread.sleep(forTimeInterval: 0.3)
+        let threeLines = field.frame
+        XCTAssertGreaterThan(threeLines.height, oneLine.height)
+        XCTAssertEqual(threeLines.maxY, oneLine.maxY, accuracy: 2)
+        XCTAssertEqual(send.frame.maxY, sendBottom, accuracy: 2)
+        XCTAssertTrue(send.isHittable)
+
+        field.typeText("\nfour")
+        Thread.sleep(forTimeInterval: 0.3)
+        XCTAssertEqual(field.frame.height, threeLines.height, accuracy: 2)
+        XCTAssertEqual(send.frame.maxY, sendBottom, accuracy: 2)
+        XCTAssertTrue((field.value as? String)?.contains("four") == true)
+        XCTAssertTrue(send.isHittable)
+    }
 }

--- a/HerdrUITests/TerminalControlTests.swift
+++ b/HerdrUITests/TerminalControlTests.swift
@@ -249,6 +249,21 @@ func testDictationStartDisarmsEvenIfPermissionIsDenied() throws {
         attach("typing-cancels-cover-without-input-replay")
     }
 
+    func testReplyContainingOnlyNewlinesIsNotSendable() {
+        launch("control")
+        let field = app.textFields["terminal-reply-input"]
+        XCTAssertTrue(field.waitForExistence(timeout: 10))
+
+        field.tap()
+        field.typeText("\n\n")
+        XCTAssertFalse(app.buttons["terminal-send-button"].exists,
+                       "a newline-only reply should stay empty and unsendable")
+
+        field.typeText("message")
+        XCTAssertTrue(app.buttons["terminal-send-button"].waitForExistence(timeout: 5),
+                      "visible text should make the reply sendable")
+    }
+
     func testReplyComposerGrowsUpwardThenScrollsWithoutMovingSend() {
         launch("control")
         let field = app.textFields["terminal-reply-input"]


### PR DESCRIPTION
## What
- let both Gram and terminal reply fields insert newlines
- grow each field upward from one to three visible lines, then scroll internally
- bottom-align and fix-size action controls so send stays visible and stationary
- retain Command+Return as the hardware-keyboard send shortcut
- treat terminal replies containing only spaces or newlines as empty and unsendable
- keep Gram search controls above message content so the icon stays visible and clickable
- bind Command+F to open or refocus Gram search
- add UI regressions for composer layout, overflow editing, newline-only eligibility, and search hit testing

## Verification
- `git diff --check`
- focused Gram and terminal UI regressions
- exact-head simulator CI

Addresses the Gram/macOS composer and search reports.